### PR TITLE
chore(cursor): chuyen sang solo-dev model + nang cap skills

### DIFF
--- a/.cursor/commands/build.md
+++ b/.cursor/commands/build.md
@@ -1,0 +1,24 @@
+# /build — Incremental Implementation (TDD)
+
+Implement task từ `tasks/todo-<feature>.md`. Mỗi task = 1 chu kỳ Red-Green-Refactor. Mỗi commit để codebase ở trạng thái working.
+
+## Cách dùng
+
+Gõ trong chat: `/build` hoặc `/build T2.1` (chỉ định task cụ thể).
+
+## Hành động
+
+Apply rule `.cursor/rules/workflow-build.mdc`. Bắt buộc:
+
+1. Pre-flight: invoke skills `tdd`, `karpathy-guidelines`, `flutter-firebase-patterns` (Flutter) hoặc `nodejs-ts-backend` (BE).
+2. Confirm branch là `feature/<DevName>/<short-desc>` (KHÔNG phải `develop`/`deploy`).
+3. Infra-file guard: nếu touch `.cursor/`, `.windsurf/`, `.github/`, `docs/adr/`, `scripts/` → STOP, đổi branch `chore/<DevName>/...`.
+4. Identify task tiếp theo (first `- [ ]` chưa tick).
+5. Run TDD cycle (RED → GREEN → REFACTOR).
+6. Verify (skill `verification-before-completion`).
+7. Commit theo Conventional Commits + tiếng Việt, scope nhỏ.
+8. Tick todo box.
+
+## Khi tất cả task done
+
+Run `/review` TRƯỚC khi tạo PR. Không bao giờ `gh pr create` trước `/review`.

--- a/.cursor/commands/review.md
+++ b/.cursor/commands/review.md
@@ -1,0 +1,34 @@
+# /review — Five-Axis Self Review
+
+Self-review code đã viết TRƯỚC khi tạo PR. Bắt buộc trước `gh pr create`.
+
+## Cách dùng
+
+Gõ trong chat: `/review`
+
+## Hành động
+
+Apply rule `.cursor/rules/workflow-review.mdc`. Invoke skill `code-review-five-axis`. Đầy đủ 5 phase:
+
+1. Read context (spec, plan, commit messages).
+2. Run automated checks: `flutter test`, `flutter analyze`, `dart format --set-exit-if-changed`, `npm test`, `npm run lint` (phù hợp stack).
+3. Manual 5-axis pass: Correctness / Readability / Architecture / Security / Performance.
+4. Output: 🔴 Critical / 🟡 Important / 🟢 Suggestion / ✅ Highlights + Summary.
+5. Action: 🔴/🟡 → return `/build` hoặc `/fix-issue`. Sạch → ready for PR.
+
+## Meep-specific check (xem rule chi tiết)
+
+- Firestore rules change → có rules unit test owner / friend / stranger / unauthenticated?
+- Cloud Function trigger → region `asia-southeast1`, `maxInstances`, `timeoutSeconds` explicit?
+- Image upload → size + MIME validate **server-side**, không chỉ client?
+- PII trong logs (email, phone, displayName, caption)?
+- Hardcoded secret trong Dart source?
+- Native widget code → có call Firebase trực tiếp không (KHÔNG được)?
+- Cross-module touch → có ping leader chưa?
+
+## Sau review sạch
+
+```bash
+git push origin <branch>
+gh pr create --base develop --title "<type>(<scope>): <mô tả tiếng Việt>" --body "$(cat .github/pull_request_template.md)"
+```

--- a/.cursor/commands/start.md
+++ b/.cursor/commands/start.md
@@ -1,0 +1,28 @@
+# /start — Task Kickoff
+
+Khởi động làm việc trên 1 GitHub issue. Mọi lần dev pull task mới phải chạy command này TRƯỚC khi code.
+
+## Cách dùng
+
+Gõ trong chat: `/start <issue-id>`
+
+Ví dụ: `/start 23` → load issue #23, check blockers, create branch, set status In Progress.
+
+## Hành động
+
+Apply rule `.cursor/rules/workflow-start.mdc` cho issue mà user truyền vào. Follow đầy đủ 7 step:
+
+1. Fetch issue details (`gh issue view <id>`).
+2. Check blockers (issue dependencies).
+3. Load context files (read "Files phải đọc trước").
+4. Identify module + load rule context.
+5. Verify contract exists trên `develop`.
+6. Create feature branch + set Project status "In Progress".
+7. Print summary, sẵn sàng `/build`.
+
+Nếu blocker chưa close hoặc contract chưa có → STOP, không tự ý code.
+
+## Khi nào KHÔNG dùng
+
+- Bug fix nhanh (không có issue) → dùng `/fix-issue` trực tiếp.
+- Sửa infra/config (rule, hook, workflow) → tạo branch `chore/<DevName>/...` thủ công, không qua `/start`.

--- a/.cursor/rules/05-domain-language.mdc
+++ b/.cursor/rules/05-domain-language.mdc
@@ -1,0 +1,115 @@
+---
+description: Domain language for Meep — entity names, identifier formats, disambiguation of overloaded terms (Widget, Provider, Storage, Rule)
+alwaysApply: true
+---
+
+# Domain Language — Meep
+
+Shared vocabulary giữa anh và agent. Dùng đúng terms khi discuss system hoặc viết code. Disambiguate overloaded words + lock naming consistency.
+
+## Core entities
+
+| Term | Definition | Lives at |
+|---|---|---|
+| **User** | Authenticated person, identified by `uid` (Firebase Auth UID, string). Có `displayName`, `avatarUrl`. | Firestore: `/users/{uid}` |
+| **Post** | One photo + optional caption shared bởi User cho friends. NEVER public. Always tied to one author. | Firestore: `/posts/{postId}` |
+| **Caption** | Text accompanying a Post. ≤ 200 chars. Optional (post can be photo-only). | Field `caption` in `/posts/{postId}` |
+| **Friend** | User khác có mutual accepted friendship với current User. Bidirectional. | Derived from `/friendships/{pairId}` |
+| **Friend graph** | Set của tất cả friendships across Users. Bidirectional, no public following. | Firestore: `/friendships` |
+| **Friend request** | Pending invite từ User này đến User khác. Becomes Friend khi accepted. | Firestore: `/friend_requests/{requestId}` |
+| **Feed** | Chronological list của friends' Posts visible cho current User. Cursor-paginated, latest first. | Computed by querying `/posts` filtered by friend `authorId`s |
+| **Notification** | Push message về friend's activity (new post, accepted request). Persisted per user. | Firestore: `/users/{uid}/notifications/{notifId}` + FCM push |
+
+## Identifiers
+
+| Term | Format | Example |
+|---|---|---|
+| `uid` | Firebase Auth UID — opaque string, ≤ 128 chars | `7Mk9x2QR8vN3yL4pHzAj` |
+| `postId` | Auto-generated Firestore doc ID, 20 chars | `aB3xKzqrL5MnPq7Ws2Yd` |
+| `pairId` | **Sorted** `uidA_uidB` cho friendship lookup. Always `min < max` để deterministic. | `7Mk9x2QR_xZ1fGh4Bp9Q` |
+| `requestId` | Auto-generated Firestore doc ID for friend requests | `cD9zLmrqW3NpKj5Rs8Yt` |
+| `notifId` | Auto-generated Firestore doc ID for notifications | `eF2hQrsbT8VnLk6Zp4Mw` |
+
+```dart
+// Pair ID computation — must be deterministic
+String pairIdOf(String a, String b) {
+  return a.compareTo(b) < 0 ? '${a}_$b' : '${b}_$a';
+}
+```
+
+## Architectural patterns
+
+| Pattern | What it means | Where it appears |
+|---|---|---|
+| **Fan-out** | Cloud Function pattern: khi Post được tạo, Function enumerate author's Friends + push Notification cho mỗi người. NOT done client-side. | `firebase/functions/src/index.ts` `onPostCreated` |
+| **Denormalize** | Copy value (vd `authorName`, `authorAvatarUrl`) vào Post document để Feed query không cần JOIN. Trade write complexity cho read speed. | `/posts/{postId}` fields `authorName`, `authorAvatarUrl` |
+| **Repository** | Class abstract Firebase calls để widgets/controllers KHÔNG touch `FirebaseFirestore.instance` directly. Lives in `lib/features/<feature>/data/`. | e.g. `AuthRepository`, `PostRepository` |
+| **Cursor pagination** | Dùng `startAfterDocument(lastDoc)` thay vì `offset()` (Firestore không có efficient offset). | Feed query, friend list |
+| **ServerTimestamp** | Dùng `FieldValue.serverTimestamp()` cho `createdAt`/`updatedAt`. Never trust client clocks. | Every doc với timestamps |
+
+## Disambiguation — overloaded terms
+
+Cùng một từ có nghĩa khác nhau theo context. Always specify which.
+
+### "Widget"
+
+| Term | Meaning | Where the code lives |
+|---|---|---|
+| **Widget (Flutter)** | UI component (`StatelessWidget`, `ConsumerWidget`, `StatefulWidget`). Building block của mọi screen. | `apps/mobile/lib/features/<feature>/presentation/` |
+| **Widget (home-screen)** | Native Android AppWidget hiển thị latest Meep images trên user's home screen. The headline differentiator. iOS WidgetKit deferred per ADR-0002. | `apps/widget/` (Android Kotlin) |
+
+Khi unclear, write **"home-screen widget"** cho native, just **"widget"** cho Flutter UI.
+
+### "Provider"
+
+| Term | Meaning | Library |
+|---|---|---|
+| **Provider (Riverpod)** | `Provider<T>` / `StreamProvider<T>` / `FutureProvider<T>` / `NotifierProvider<T>`. Riverpod 2 idiom. | `flutter_riverpod` |
+| **Provider (Firebase Auth)** | OAuth identity provider — Google, email/password. (Apple deferred per ADR-0002.) | `firebase_auth` |
+
+Khi unclear, write **"Riverpod provider"** vs **"auth provider"**.
+
+### "Storage"
+
+| Term | Meaning |
+|---|---|
+| **Storage (Firebase)** | Cloud Storage for Firebase — nơi images live. Bucket: `<project>.appspot.com`. |
+| **Storage (local)** | On-device cache (SharedPreferences / Hive / SQLite). For offline / widget data. |
+
+Khi unclear, write **"Cloud Storage"** vs **"local cache"**.
+
+### "Rule"
+
+| Term | Meaning |
+|---|---|
+| **Rule (Firestore)** | `.rules` file declaring per-collection access policy. |
+| **Rule (Cursor agent)** | `.cursor/rules/*.mdc` file giving agent instructions. |
+| **Rule (lint)** | Entry trong `analysis_options.yaml` hoặc ESLint config. |
+
+Write **"Firestore rules"**, **"agent rules"**, **"lint rules"** để explicit.
+
+## Anti-terms — words to AVOID
+
+| Avoid | Use instead | Why |
+|---|---|---|
+| `user_id` | `uid` | Inconsistent với Firebase Auth field name |
+| `friend_id` | `pairId` (cho friendship doc) hoặc `friendUid` (cho friend's User) | Ambiguous |
+| `image` | `imageUrl` (cho URL string) hoặc `image bytes` (cho raw data) | Both meanings clash |
+| "the database" | "Firestore" | Không có "a database" — có specific products (Firestore, Storage, Auth) |
+| "the backend" | "Cloud Functions" / "the (optional) Node BE in `services/api/`" | Same reason |
+| "save" | "create" / "update" / "upsert" | Vague — say which write op |
+| "fetch" | "read once" (`get()`) / "watch" (`snapshots()`) | Different perf characteristics |
+
+## Status fields enum
+
+| Field | Values |
+|---|---|
+| `friend_requests.status` | `pending` / `accepted` / `declined` / `cancelled` |
+| `posts.uploadStatus` (if used) | `uploading` / `uploaded` / `failed` |
+| `notifications.read` | `true` / `false` (boolean, default false) |
+
+## Update policy
+
+- **When to update:** new entity introduced, new disambiguation needed, naming convention change.
+- **When NOT to update:** transient implementation details, internal helper names.
+- **Review:** quick re-read at start of each `/spec` session — if a new term appears trong spec discovery, add nó ở đây BEFORE coding.

--- a/.cursor/rules/10-project-context.mdc
+++ b/.cursor/rules/10-project-context.mdc
@@ -30,11 +30,16 @@ Standalone Node/TypeScript BE added only when: long-running work, heavy 3rd-part
 ## Team
 
 - **4 devs** (including the team leader).
+- **Solo-dev model:** mỗi dev own một (hoặc vài) module end-to-end (data + logic + UI + test). Không tách FE/BE.
+- **Leader define contract upfront:** spec + freezed model + abstract interface + stub provider merge vào `develop` trước khi giao module cho dev.
+- **Strict gate:** dev đụng module khác hoặc chệch contract → khoá lại, leader duyệt mới đi tiếp.
+- **HanDHG + NganTNK** kiêm UI/UX design (Figma) cho cả app — module nào do họ design, ưu tiên họ implement Flutter.
 - Dev name format: PascalCase + abbreviation — `ThienPDM`, `KhoaLND`, `HanDHG`, `NganTNK`.
-- Leader is default reviewer (CODEOWNERS).
+- Leader (anh) là default reviewer (CODEOWNERS). Sau khi chốt module → thêm module owner làm co-required reviewer.
 - Branching: `develop` → `deploy`. Feature branch: `<type>/<DevName>/<short-desc>`.
 - Commit messages: Conventional Commits + Vietnamese descriptions.
 - Task tracking: GitHub Projects v2. Full workflow: `docs/team-workflow.md`.
+- Detail role + ownership: `.cursor/rules/25-dev-code-standards.mdc`.
 
 ## Core MVP scope
 

--- a/.cursor/rules/20-stack-conventions.mdc
+++ b/.cursor/rules/20-stack-conventions.mdc
@@ -56,10 +56,12 @@ For language/framework-specific rules, see:
 
 | GitHub handle | DevName | Role |
 |---|---|---|
-| `manhthien2005` | `ThienPDM` | Leader |
-| `CatS1mp` | `KhoaLND` | BE |
-| `katheramp` | `HanDHG` | FE |
-| `JanaKimmm` | `NganTNK` | FE |
+| `manhthien2005` | `ThienPDM` | Leader (define contracts, review PR) |
+| `CatS1mp` | `KhoaLND` | Module Owner |
+| `katheramp` | `HanDHG` | Module Owner + UI/UX (Figma) |
+| `JanaKimmm` | `NganTNK` | Module Owner + UI/UX (Figma) |
+
+> Solo-dev model — không tách FE/BE. Mỗi dev own module end-to-end. Detail: `25-dev-code-standards.mdc`.
 
 ## Naming
 

--- a/.cursor/rules/24-flutter-ui-patterns.mdc
+++ b/.cursor/rules/24-flutter-ui-patterns.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # Flutter UI Patterns — Presentation Layer
 
-Loaded when editing `presentation/`, `core/theme/`, or `shared/widgets/`. Supplements `21-flutter-rules.mdc` — this file focuses on **UI patterns** for the 2 FE-bridge devs (Figma → Flutter).
+Loaded when editing `presentation/`, `core/theme/`, or `shared/widgets/`. Supplements `21-flutter-rules.mdc` — this file focuses on **UI patterns** áp dụng cho mọi solo-dev khi implement screen (đặc biệt important cho HanDHG + NganTNK khi map Figma → Flutter).
 
 **Widget split / function split / file length thresholds** — see `21-flutter-rules.mdc` §Code organization. Not duplicated here.
 
@@ -22,15 +22,24 @@ Loaded when editing `presentation/`, `core/theme/`, or `shared/widgets/`. Supple
 
 If Figma has a new color/font not yet in theme → **add to `core/theme/` first**, then use it. Never inline.
 
-## Layering — DO NOT exceed scope
+## Layering — solo-dev module owner
 
-FE-bridge devs may only touch:
-- ✅ `apps/mobile/lib/features/<feature>/presentation/` — widgets, pages, theme application.
-- ✅ `apps/mobile/lib/core/theme/` — design tokens, theme system.
-- ✅ `apps/mobile/lib/shared/widgets/` — shared reusable widgets.
-- ⚠️ `apps/mobile/lib/features/<feature>/application/` — only **consume** existing controllers. DO NOT create new Riverpod controllers — ask FS dev.
-- ❌ `apps/mobile/lib/features/<feature>/data/` — FS dev only.
-- ❌ `firebase/functions/`, `apps/mobile/android/app/src/main/kotlin/` — FS dev only.
+Module Owner own full-stack module → được touch tất cả layer trong module mình:
+
+- ✅ `apps/mobile/lib/features/<my-module>/data/` — repositories, mappers.
+- ✅ `apps/mobile/lib/features/<my-module>/application/` — controllers, services.
+- ✅ `apps/mobile/lib/features/<my-module>/presentation/` — widgets, pages.
+- ✅ `firebase/functions/src/<my-module>/` — Cloud Functions của module mình.
+- ✅ `apps/mobile/android/app/src/main/kotlin/<my-module>/` — native code của module mình.
+
+**Khoá lại + ping leader** khi cần touch:
+- ❌ `apps/mobile/lib/core/theme/` — design token shared cho cả app.
+- ❌ `apps/mobile/lib/shared/widgets/` — widget reuse cross-module.
+- ❌ `apps/mobile/lib/core/error/`, `core/router/`, `core/di/` — shared infra.
+- ❌ `firebase/firestore.rules`, `storage.rules`, `firestore.indexes.json` — security rules + indexes.
+- ❌ `features/<other-module>/**` — module dev khác (xem `25-dev-code-standards.mdc` §Cross-module touch).
+
+Lý do: shared code đụng vào sẽ break nhiều module → leader gate review impact.
 
 ## Accessibility — minimum required
 

--- a/.cursor/rules/25-dev-code-standards.mdc
+++ b/.cursor/rules/25-dev-code-standards.mdc
@@ -1,40 +1,84 @@
 ---
-description: Dev code standards — Walking Skeleton pattern, role responsibilities, stub rules
+description: Dev code standards — Walking Skeleton (solo-dev model), module ownership, leader-defined contracts
 alwaysApply: true
 ---
 
-# Dev Code Standards — Walking Skeleton Pattern
+# Dev Code Standards — Walking Skeleton (Solo-Dev Model)
 
-Meep uses **Walking Skeleton**: the leader creates a runnable shell at the start of each sprint; FE and BE fill it in parallel. The app must compile and run at every commit.
+Meep dùng **solo-dev model**: mỗi dev own một (hoặc vài) module **end-to-end** — data + logic + UI + test. Không tách FE/BE. Leader define contract upfront để app luôn compile + run, dev cầm contract về implement full-stack module mình.
 
 ## Role responsibilities
 
 | Role | Does | Does NOT do |
 |---|---|---|
-| **Leader** | Define freezed models + abstract interfaces + stub providers + wire router | Implement Firebase / UI screens |
-| **KhoaLND (BE)** | Implement Firebase repositories + controllers | Define new models / change interfaces unilaterally |
-| **HanDHG / NganTNK (FE)** | Implement UI screens using typed mock data | Call Firebase directly / invent ad-hoc models |
+| **Leader (ThienPDM)** | Define spec + freezed models + abstract interfaces + stub providers + wire router; review tất cả PR; gatekeep contract changes | Implement chi tiết module (trừ khi pickup làm safety net) |
+| **Module Owner** (mọi dev) | Full-stack implement module được giao: data layer, application layer (controllers), presentation layer (UI Flutter), test, native code (nếu module có widget Android) | Đụng module dev khác, đổi contract leader đã chốt, tự thêm field/interface không qua leader |
+| **Designer** (HanDHG, NganTNK — kèm role Module Owner) | Vẽ Figma frame + design system + theme token cho cả app TRƯỚC khi leader export contract | Vẽ ad-hoc trong code (hardcode color/font không qua design token) |
 
-## 3 non-negotiable rules
+> **Designer note:** HanDHG + NganTNK kiêm thêm Figma. Module nào do họ design Figma, ưu tiên chính họ implement Flutter để giữ design fidelity. Detail mapping Figma → Flutter: xem `24-flutter-ui-patterns.mdc`.
+
+## 4 non-negotiable rules
 
 ### 1. Skeleton rule — App always runs
 
-Every commit must compile cleanly and the app must launch. Stubs return mock data or throw `UnimplementedError` — no broken imports, no commented-out code to bypass errors.
+Mọi commit phải compile clean và app launch được. Stub trả mock data hoặc throw `UnimplementedError` — không broken import, không comment-out code để bypass error.
 
 ```dart
-// ✅ Correct stub
+// ✅ Correct stub (leader pre-defined trước khi giao module)
 @Riverpod(keepAlive: true)
 AuthRepository authRepository(Ref ref) => throw UnimplementedError(
-  'wire FirebaseAuthRepository in main.dart',
+  'wire FirebaseAuthRepository in main.dart — assigned to <DevName>',
 );
 ```
 
-### 2. Typed mock rule — FE uses the leader-defined freezed model
+### 2. Contract-first rule — Leader chốt contract trước khi dev start
 
-FE mock data must use the exact type defined by the leader. Never invent a `Map<String, dynamic>`.
+Trước khi giao module cho dev, leader phải merge vào `develop`:
+
+- Spec đầy đủ tại `docs/specs/<feature>.md` (acceptance criteria đo được).
+- Freezed models + abstract interfaces (data layer contract).
+- Stub Riverpod providers (throw `UnimplementedError`).
+- Route stub trong router.
+- TODO marker `// TODO(<task-id>/<DevName>): ...` trên mọi stub.
+
+Dev pull `develop` về → contract đã sẵn → implement không cần đoán.
+
+```
+Leader: spec → models → interfaces → stubs → merge develop
+        ↓
+Module Owner pull develop → implement full-stack module
+        ↓
+Module Owner mở PR → leader review → merge develop
+        ↓
+Leader: wire real implementation in main.dart (integration check)
+```
+
+### 3. Strict gate — Đụng module khác hoặc chệch contract phải qua leader
+
+**Khoá lại + báo leader** khi:
+
+- Cần đổi field trong freezed model leader đã chốt (kể cả thêm field mới).
+- Cần đổi signature của abstract interface.
+- Cần touch file thuộc module dev khác (không phải module mình own).
+- Cần thêm Firestore collection / index mới.
+- Cần thêm pub package vào `pubspec.yaml` hoặc npm package vào `firebase/functions/package.json`.
+- Phát hiện contract không khớp Figma / spec.
+- Cần đổi shared code (`core/`, `shared/widgets/`, `core/theme/`).
+
+**Cách xử lý:**
+
+1. Stop. Không tự sửa.
+2. Comment trên GitHub issue đang làm: `Block: cần đổi <X> trong module <Y>, ping @manhthien2005`.
+3. Leader xem xét → cập nhật spec/contract → merge contract change vào `develop` qua PR riêng → ping dev tiếp tục.
+
+> Vì sao strict: contract là source of truth chung. Mỗi solo-dev tự quyết → conflict + drift + integration crash. Leader gate giữ tốc độ team đồng bộ.
+
+### 4. Typed everything — không `Map<String, dynamic>` ad-hoc
+
+Mọi data flow giữa các layer phải dùng freezed model leader đã định nghĩa. Mock data trong test cũng dùng đúng type đó.
 
 ```dart
-// ✅ Typed mock
+// ✅ Typed
 final mockUser = UserProfile(
   uid: 'mock-uid',
   displayName: 'Thien',
@@ -42,29 +86,17 @@ final mockUser = UserProfile(
   createdAt: DateTime.now(),
 );
 
-// ❌ Ad-hoc map — compiler cannot catch mismatches
+// ❌ Ad-hoc map — compiler không catch được mismatch
 final mockUser = {'name': 'Thien', 'avatar': 'url'};
-```
-
-### 3. Freeze-before-FE rule — Models land on develop before FE starts
-
-Freezed models and abstract interfaces must be merged into `develop` before any FE dev begins implementing a screen that depends on them.
-
-```
-Leader: define models + interfaces → merge into develop
-    ↓
-FE and BE start in parallel (pull from develop)
-    ↓
-Leader: wire real implementation in main.dart (integration)
 ```
 
 ## Ownership principle
 
-Every file the agent creates or modifies is **that dev's code**. Read and understand it before committing.
+Mỗi file dev tạo hoặc sửa là **code của dev đó** (kể cả AI agent generate). Đọc + hiểu trước khi commit. Code mình own → mình chịu trách nhiệm review, debug, maintain.
 
 ## Stub / placeholder standard
 
-Every stub must have a TODO that identifies the assignee and task:
+Mọi stub phải có TODO identify task ID + module owner:
 
 ```dart
 // TODO(T8/HanDHG): implement IntroPage per Figma — intro screen
@@ -73,24 +105,50 @@ Every stub must have a TODO that identifies the assignee and task:
 
 Format: `// TODO(<task-id>/<DevName>): <short description>`
 
-A TODO without `<task-id>/<DevName>` is **invalid** and will be flagged in review.
+TODO không có `<task-id>/<DevName>` → **invalid**, sẽ bị flag trong `/review`.
 
-## When to ask the leader before proceeding
+## Module ownership tracking
 
-Always ask (do not decide unilaterally) when:
+Hiện tại module list **chưa chốt**. Khi anh finalize:
 
-- Adding a new field to a freezed model that affects multiple devs.
-- Changing the signature of an abstract interface.
-- Adding a new Firestore collection or index.
-- Adding a new pub package dependency to `pubspec.yaml`.
-- Discovering that the contract does not match Figma.
+1. Anh update `docs/specs/modules.md` (hoặc tương đương) — bảng module → owner.
+2. Update `.github/CODEOWNERS` — mỗi module path có module owner + leader required.
+3. Update file này — thêm bảng module owner reference.
 
-## Complex screens — leader defines extra context before FE mocks
+Cho đến lúc đó: leader assign từng task qua GitHub issue, owner = assignee của issue.
 
-| Screen | Leader must decide first |
+## Cross-module touch — FORBIDDEN by default
+
+Module Owner A KHÔNG được tự ý sửa code thuộc module Owner B. Kể cả:
+
+- Bug fix nhỏ trong module B (kể cả 1 dòng).
+- Format / rename "tiện thể".
+- Thêm field vào model dùng chung.
+
+**Trừ ngoại lệ duy nhất:** leader explicit assign cross-module task qua issue (vd "fix #42: Khoa fix bug trong Auth module của Han") → tạo branch + PR review bởi cả Han + leader.
+
+## Definition of Done — solo-dev module
+
+Module được mark Done chỉ khi:
+
+- [ ] Spec acceptance criteria pass (đo được, không "should work").
+- [ ] Data layer: repository implement đúng abstract interface, có unit test với `fake_cloud_firestore`.
+- [ ] Application layer: controller có unit test cover happy + edge + error.
+- [ ] Presentation layer: widget test cho critical flow + design tokens (no hardcoded color/font).
+- [ ] Native code (nếu có): Android widget test hoặc manual smoke test trên device.
+- [ ] `flutter analyze` + `dart format` clean.
+- [ ] Functions test (nếu module có Cloud Function): `npm test` + `npm run lint` clean.
+- [ ] PR review: leader approve + module owner self-review qua `/review` framework.
+- [ ] CI pass: `pr-check.yml` green.
+- [ ] Merged vào `develop`, issue auto-close qua `Closes #N`.
+
+## Anti-patterns
+
+| Anti-pattern | Vấn đề |
 |---|---|
-| Feed, Space | Fan-out vs query strategy → Firestore collection path |
-| Reaction | Optimistic UI contract → error rollback behavior |
-| Pagination | Cursor strategy → `startAfterDocument` field in model |
-
-For Auth, Profile, Diary, Camera UI: the freezed model is sufficient — FE can start immediately.
+| Tự đổi field trong shared model "vì cần" | Break module dev khác → integration fail |
+| Hardcode color/font trong screen | Design system drift, dark mode broken |
+| Push code thẳng `develop` "vì gấp" | Branch protection block + bypass review = bug lọt prod |
+| Skip spec, code thẳng "tạm" | Không có acceptance → không biết khi nào done |
+| Module A pickup task module B "tiện thể" | Vi phạm ownership, owner B mất context |
+| Commit `feat(auth):` từ module Feed | Scope sai → changelog rối, history khó truy |

--- a/.cursor/rules/60-cursor-features.mdc
+++ b/.cursor/rules/60-cursor-features.mdc
@@ -1,6 +1,6 @@
 ---
-description: Cursor-specific features — @-mentions, Composer, agent modes, tab autocomplete. Loaded always so the agent knows how to leverage Cursor's native capabilities.
-alwaysApply: true
+description: Cursor features cheatsheet — slash commands, @-mentions, MCP setup, hooks, skills, indexing, custom @Docs, memories. Load when user asks about Cursor features/setup, or when agent needs to suggest a Cursor-native workflow.
+alwaysApply: false
 ---
 
 # Cursor Features Cheatsheet
@@ -137,9 +137,17 @@ Copy-Item .cursor\mcp.example.json .cursor\mcp.json
 
 | Command | Khi nào |
 |---|---|
-| `/worktree` | Cô lập task lớn vào git worktree riêng — không ảnh hưởng working tree hiện tại. |
-| `/best-of-n` | Chạy task song song trên nhiều model, so sánh outcome. Dùng cho task khó (architecture decision, complex algo). |
-| `/Await` | Đợi background shell/subagent hoàn thành trước khi tiếp tục. |
+| `/start <issue-id>` | Custom (`.cursor/commands/start.md`) — kickoff task mới. |
+| `/build` | Custom (`.cursor/commands/build.md`) — TDD cycle implement task. |
+| `/review` | Custom (`.cursor/commands/review.md`) — 5-axis self review trước PR. |
+| `/worktree` | Native — cô lập task lớn vào git worktree riêng. |
+| `/best-of-n` | Native — chạy task song song trên nhiều model, so sánh. |
+| `/Await` | Native — đợi background shell/subagent hoàn thành. |
+
+**Custom slash commands** (`.cursor/commands/<name>.md`):
+- File markdown chứa prompt cho command. Cursor scan folder này khi gõ `/`.
+- Khác với `workflow-*.mdc` rule (`description:` field — agent-requested mode): command file là cho **dev gõ trực tiếp** trong chat.
+- Restart Cursor sau khi add file mới để re-scan.
 
 **Khi nào em dùng:**
 - Task ≥ 30 phút có rủi ro break working tree → đề xuất `/worktree`.

--- a/.cursor/rules/workflow-start.mdc
+++ b/.cursor/rules/workflow-start.mdc
@@ -15,13 +15,13 @@ gh issue view <issue-id> --repo manhthien2005/Meep
 
 Read and extract:
 - **Title** — task name + scope
-- **Assignee** — who owns this task
-- **Lane label** — `lane:specialty-be-native` (BE) or `lane:specialty-ui-design` (FE) or `lane:open`
+- **Assignee** — module owner của task
+- **Module** — module nào (xem label `module:<name>` nếu đã có, hoặc đọc trong issue body)
 - **Acceptance criteria** — what done looks like
 - **Files có thể chạm** — output scope
 - **Files phải đọc trước** — context files (read these in Step 3)
 - **Dependencies / blockers** — issue numbers that must be closed first
-- **Plan reference** — `docs/plans/` path
+- **Spec / plan reference** — `docs/specs/` + `docs/plans/` path
 
 ## Step 2 — Check blockers
 
@@ -51,24 +51,25 @@ If the section is empty or missing:
 
 **Goal:** Understand the existing contract before writing a single line.
 
-## Step 4 — Determine role + load rule context
+## Step 4 — Identify module + load rule context
 
-Check the lane label from Step 1:
+Check the `Module` field in issue (or label `module:<name>`):
 
-| Label | Role | Key rules to internalize |
-|---|---|---|
-| `lane:specialty-ui-design` | FE | Scope: `presentation/` only. Read `24-flutter-ui-patterns.mdc`. Use typed mock from leader's freezed models. Never call Firebase directly. |
-| `lane:specialty-be-native` | BE | Scope: `data/` + `application/`. Implement abstract interface exactly. Never touch `presentation/`. |
-| `lane:open` | Open | Check task scope in issue — follow whichever rules apply. |
+- Read `docs/specs/<module>.md` if exists — module spec + acceptance.
+- Read `25-dev-code-standards.mdc` — solo-dev contract rules.
+- If task touches presentation/theme/shared widgets → `24-flutter-ui-patterns.mdc` auto-loads via glob.
 
-If no lane label is set → ask: "Bạn là FE hay BE dev cho task này?"
+If no Module field set → ask: "Module nào của task này? (auth/feed/post/...)"
 
-## Step 5 — Verify contract exists (FE only)
+## Step 5 — Verify contract exists
 
-If role = FE:
-- Confirm that the freezed models and providers needed by this screen exist on `develop`.
-- Check: `git log --oneline origin/develop -- lib/features/<feature>/data/`
-- If models not yet merged → **STOP**. Report: "Contract chưa có trên develop. Hỏi leader trước khi start."
+Confirm leader đã merge contract vào `develop`:
+
+- Spec: `docs/specs/<module>.md` exists.
+- Models: `git log --oneline origin/develop -- apps/mobile/lib/features/<module>/data/` có commit từ leader.
+- Stub providers throw `UnimplementedError` (chưa wire real impl).
+
+If contract chưa có → **STOP**. Report: "Contract module `<X>` chưa có trên develop. Ping @manhthien2005 trước khi start."
 
 ## Step 6 — Create branch + update project status
 
@@ -77,10 +78,10 @@ Branch format: `feature/<DevName>/<short-desc>`
 DevName mapping:
 | GitHub handle | DevName | Role |
 |---|---|---|
-| `manhthien2005` | `ThienPDM` | Leader |
-| `CatS1mp` | `KhoaLND` | BE |
-| `katheramp` | `HanDHG` | FE |
-| `JanaKimmm` | `NganTNK` | FE |
+| `manhthien2005` | `ThienPDM` | Leader (define contracts, review PR) |
+| `CatS1mp` | `KhoaLND` | Module Owner |
+| `katheramp` | `HanDHG` | Module Owner + UI/UX (Figma) |
+| `JanaKimmm` | `NganTNK` | Module Owner + UI/UX (Figma) |
 
 ```bash
 # 1. Create and switch to the feature branch
@@ -96,12 +97,13 @@ Print a concise summary:
 
 ```
 Issue:    #<id> <title>
-Role:     FE / BE / Open
+Module:   <module-name>
+Owner:    <DevName> (assignee)
 Blockers: ✅ all closed / ❌ blocked by #X
-Contract: ✅ models on develop / ⚠️ missing (stop + ask leader)
+Contract: ✅ spec + models on develop / ⚠️ missing (stop + ping leader)
 Branch:   feature/<DevName>/<short-desc>
 Status:   ✅ set to "In Progress" on project board
-Scope:    <list of files allowed to touch>
+Scope:    <module folder> + <related> (cross-module touch → ping leader first)
 
 Context loaded:
   - <file1> — <why>

--- a/.cursor/skills/code-review-five-axis/SKILL.md
+++ b/.cursor/skills/code-review-five-axis/SKILL.md
@@ -1,126 +1,303 @@
 ---
 name: code-review-five-axis
-description: Five-axis code review framework. Use when reviewing your own changes before merge, or reviewing PR. Evaluates correctness, readability, architecture, security, performance.
+description: Six-axis code review framework (folder name "five-axis" kept for backward compat) — Fast/Deep paths + precision-first output. Use when reviewing your own changes before PR or reviewing teammate's PR. Evaluates contract adherence, correctness, readability, architecture, security, performance — but defaults to flagging only real bugs (🔴 + 🟡), not nits.
 ---
 
-# Code Review — Five-Axis Framework
+# Code Review — Six-Axis (Solo-Dev Calibrated)
 
-> Combined from `class-ai-agent/.claude/commands/review.md` + `superpowers/skills/requesting-code-review`. Used for both self-review before opening a PR and reviewing teammates' PRs (anh là default reviewer).
+> Updated 2026-05-21: upgraded từ 5-axis generic sang 6-axis tuned cho Meep solo-dev model. Inspiration: Bugbot (precision-first), CodeRabbit (noise dials), Greptile (severity threshold), Google eng-practices ("improves overall health" not perfection).
 
 ## When to use
 
-- **After finishing a feature task / bug fix**, before commit or PR.
-- **Before merging a branch** into `develop` (or `develop` → `deploy` for releases).
-- **When stuck** — fresh perspective on the code you just wrote.
-- **Before a large refactor** — baseline check.
+- **Self-review** trước khi `gh pr create`. Bắt buộc qua `/review` (xem `workflow-review.mdc`).
+- **Reviewer review** — anh là default CODEOWNERS, co-required với module owner.
+- **Stuck** — fresh perspective.
 
-## 5 evaluation axes
+## Pre-flight — Detect path (Fast vs Deep)
 
-### 1. Correctness — does the code do the right thing?
+Run trước khi bắt đầu axes:
 
-- [ ] Logic matches the spec/plan acceptance criteria.
-- [ ] Edge cases covered: empty, null, max-size, boundary, negative.
-- [ ] Error paths handled correctly — no swallowing, no panic.
-- [ ] Async / concurrency: no race conditions, no deadlocks.
-- [ ] State management: clear source of truth, no stale state.
-- [ ] Off-by-one, fence post, timezone, encoding bugs?
+```bash
+git diff develop...HEAD --stat
+```
 
-**Verify:** re-read the spec → checklist each requirement → trace the code that covers it.
+| Diff size | Path | Time | Coverage |
+|---|---|---|---|
+| ≤ 50 lines | **Fast** | ~5 phút | Axes 0+1+4 (Contract / Correctness / Security). Skip Readability/Architecture/Performance unless code touches hot points. |
+| 50-500 lines | **Standard** | ~10 phút | Full 6 axes. |
+| > 500 lines | **STOP** | — | Recommend split PR trước khi review. ≥ 200 lines/PR = ideal industry. |
 
-### 2. Readability — will another person (or future-you) understand?
+**Override:**
+- `/review --deep` → force Deep path bất kể size.
+- `/review --fast` → force Fast path (chỉ dùng cho hotfix mà anh đã hiểu rõ).
 
-- [ ] Naming describes intent, not implementation detail (`fetchUserById` ✓, `doDbStuff` ✗).
-- [ ] Functions/methods are small, single-responsibility (≤ 50 lines baseline).
-- [ ] Magic numbers → named constants.
-- [ ] Comments explain **why** (not **what** — the code already says what).
-- [ ] No "clever" code that takes work to decode — Dart/TS have nice syntax, use it.
-- [ ] Files < 300 lines, or there's a clear reason they're long.
+## Severity & precision rules
 
-### 3. Architecture — does the code fit the system?
+Bugbot pattern: **chỉ flag bug thật**. Default output:
 
-- [ ] Clear layering: data → application → presentation. UI doesn't call Firestore directly.
-- [ ] Dependency direction is right: feature imports shared, not the reverse.
-- [ ] Reuses existing patterns rather than introducing ad-hoc new ones.
-- [ ] Boundaries through interfaces — can the implementation be swapped?
-- [ ] DI is explicit — no hidden singletons, no global mutable state.
-- [ ] No premature abstraction (single-implementation interface, factory without reason).
+| Tier | Khi flag | Default? |
+|---|---|---|
+| 🔴 Critical | Bugs, security holes, breaking changes, contract violation | Always |
+| 🟡 Important | Performance issue, maintainability blocker, missing test | Always |
+| 🟢 Suggestion | Nit, naming, micro-optimization, style | **Skip default** — only on `/review --deep` |
+| ✅ Highlights | Good pattern dev did | **Skip default** — only on `/review --deep` |
 
-### 4. Security — any holes?
+**Stop conditions:**
 
-- [ ] No hardcoded secrets / API keys.
-- [ ] User input validated thoroughly (zod / form validator). Don't trust the client.
-- [ ] Authentication check on every protected endpoint / Firestore rule.
-- [ ] Authorization check enforces ownership (`isOwner(uid)`) — not just "is authenticated".
-- [ ] PII not logged to console / Crashlytics / production logs.
-- [ ] SQL/NoSQL injection (parametrized queries, no string concat).
-- [ ] XSS (sanitize HTML user-generated before render).
-- [ ] File upload: check MIME + size **server-side**.
-- [ ] Rate limiting on auth endpoints.
+- Có ≥ 1 🔴 → **STOP output 🟢/✅**. Focus dev fix Critical trước. Re-review sau.
+- Fast path → max 5 findings tổng. Không liệt kê quá nhiều.
+- KHÔNG bikeshed naming/style khi `flutter analyze` + `dart format` đã clean — linter làm rồi.
 
-### 5. Performance — is the code fast and cheap enough?
+---
 
-- [ ] No N+1 queries (Firestore: 1 query for 50 users instead of 50 queries for 1 user).
-- [ ] Pagination on large lists — no `.get()` of the whole collection.
-- [ ] Images: resized before upload, lazy-loaded, cached (`cached_network_image`).
-- [ ] Firestore: indexes exist for every compound query.
-- [ ] Cloud Function cold start: dependencies are light, expensive imports lazy.
-- [ ] Flutter: `const` constructors, `ListView.builder`, no rebuilds of the whole tree.
-- [ ] Memory: stream subscriptions disposed, controllers disposed.
-- [ ] Network: retries with backoff, sensible timeouts.
+## Axis 0 — Contract Adherence (HIGHEST PRIORITY)
+
+> Solo-dev model của Meep: leader define spec + freezed model + abstract interface upfront. Code lệch contract = automatic 🔴, dù logic "đúng".
+
+**Read first:**
+- `docs/specs/<module>.md` — acceptance criteria.
+- Freezed model file của module — field signature.
+- Abstract interface file — method signature.
+
+**Checklist:**
+
+- [ ] Code đáp ứng đầy đủ acceptance criteria trong spec? (trace từng AC → code).
+- [ ] Freezed model: KHÔNG đổi field name/type/required-ness mà không qua leader?
+- [ ] Abstract interface: KHÔNG đổi method signature, return type, exception?
+- [ ] Module owner KHÔNG touch code module khác? (cross-module strict — xem `25-dev-code-standards.mdc`).
+- [ ] KHÔNG touch shared code (`core/`, `shared/widgets/`, `firestore.rules`) nếu chưa ping leader?
+- [ ] Spec mention "no Firestore collection mới" → code KHÔNG tạo collection mới?
+- [ ] TODO marker `// TODO(<task-id>/<DevName>): ...` đã wire correct DevName?
+
+**🔴 Critical examples:**
+- Spec yêu cầu username unique nhưng code không check → contract violation.
+- Dev thêm field `bio` vào `UserProfile` model mà spec không có → tự ý đổi contract.
+- Dev sửa 1 dòng trong `features/auth/` khi đang làm task module `feed/` → cross-module touch.
+
+---
+
+## Axis 1 — Correctness (does it work?)
+
+**Checklist:**
+
+- [ ] Logic đúng cho happy path?
+- [ ] Edge cases: empty/null/max/boundary/negative?
+- [ ] Error path: throw `AppError` đúng type, không swallow?
+- [ ] Async/concurrency: race condition? `mounted` check sau await?
+- [ ] State: clear source of truth, no stale state?
+- [ ] Off-by-one / timezone / encoding?
+
+**🔴 Critical:**
+- `await` rồi `setState()` không check `mounted` → crash sau dispose.
+- Throw raw `Exception` thay vì `AppError` typed → caller không catch được.
+
+**🟡 Important:**
+- Empty list handling missing.
+- Edge case max-length boundary chưa test.
+
+---
+
+## Axis 2 — Readability (auto-skip nếu lint clean)
+
+> Skip nếu `flutter analyze` + `dart format --set-exit-if-changed` exit 0 — linter đã catch syntax/style.
+
+**Chỉ flag:**
+
+- [ ] Naming describe intent, KHÔNG implementation (`fetchUserById` ✓, `doDbStuff` ✗).
+- [ ] Function > 80 lines → split (xem rule 21 §Code organization).
+- [ ] Comment giải thích **why**, không **what**.
+- [ ] Magic number → named constant.
+
+**🟡 Important:** Function 200 lines, 5 nested if.
+**🟢 Suggestion (skip default):** rename biến `temp` → `imageBytes`, extract magic number `200` → `kCaptionMaxLength`.
+
+---
+
+## Axis 3 — Architecture (does it fit the system?)
+
+**Checklist:**
+
+- [ ] Layering: data → application → presentation. UI KHÔNG call `FirebaseFirestore.instance` directly.
+- [ ] Dependency direction: feature import shared, không reverse.
+- [ ] Reuse existing pattern (Repository, Riverpod provider) — không invent ad-hoc.
+- [ ] Boundary qua interface — implementation swap-able.
+- [ ] DI explicit — KHÔNG hidden singleton, KHÔNG global mutable state.
+- [ ] No premature abstraction (single-impl interface, factory không lý do).
+
+**🔴 Critical:**
+- Widget call `FirebaseFirestore.instance.collection(...)` trực tiếp → bypass repository.
+- Native widget Android (apps/widget/) call Firebase SDK trực tiếp → KHÔNG được. Phải qua `home_widget` package.
+
+**🟡 Important:**
+- Tạo Riverpod controller mới khi có thể consume controller existing.
+- Singleton `GetIt` lookup giữa controller — phải inject qua provider.
+
+---
+
+## Axis 4 — Security (Meep-specific)
+
+**Generic:**
+- [ ] No hardcoded secret / API key / FCM server key trong source.
+- [ ] User input validate qua zod (TS) hoặc form validator (Flutter). KHÔNG trust client.
+- [ ] Auth check trên mọi protected endpoint / Firestore rule (`request.auth != null`).
+- [ ] Authz check: ownership (`isOwner(uid)`) — không chỉ "is authenticated".
+- [ ] PII (email, phone, displayName, caption) KHÔNG log vào `console.log`/`logger.*`/`print`/Crashlytics.
+
+**Meep-specific (7 hot points):**
+- [ ] Firestore rules change → có rules unit test cover **owner / friend / stranger / unauthenticated**?
+- [ ] Image upload → MIME (`image/.*`) + size (≤ 10 MB) validate **server-side** (Storage rule hoặc Cloud Function), không chỉ client?
+- [ ] EXIF data strip trong resize Function? (location lộ → privacy issue cho Meep).
+- [ ] Pair ID computation deterministic? (`min < max` sort — xem `05-domain-language.mdc`).
+- [ ] Cloud Function trigger → region `asia-southeast1` explicit?
+- [ ] Cloud Function timeout + maxInstances explicit?
+- [ ] Native widget code (`apps/widget/`) → KHÔNG call Firebase trực tiếp, qua `home_widget` only.
+
+**🔴 Critical:**
+- Firestore rule `allow read, write: if true` (kể cả tạm).
+- Hardcoded `ghp_xxx` trong source.
+- Caption body log vào logger.
+
+---
+
+## Axis 5 — Performance (Meep hot points)
+
+**Checklist:**
+
+- [ ] Firestore: KHÔNG N+1 query (1 query 50 users, không 50 queries 1 user).
+- [ ] Pagination on large list — không `.get()` whole collection.
+- [ ] Compound query → index declared trong `firestore.indexes.json`?
+- [ ] Image: resize trước upload, lazy-load, cache (`cached_network_image`).
+- [ ] Cloud Function cold start: heavy import (`sharp`, `firebase-admin/messaging`) lazy inside handler, không top-level.
+- [ ] Flutter rebuild: `const` constructor, `ListView.builder` (không `ListView(children: [...])` cho list > 5).
+- [ ] Riverpod: `ref.watch(provider.select(...))` nếu chỉ cần subset.
+- [ ] Stream/controller dispose: `ref.onDispose(() => sub.cancel())` cho mọi subscription.
+
+**🔴 Critical:**
+- `ListView(children: List.generate(1000, ...))` — render off-screen widgets.
+- Firestore query không có index → fail trên prod (works trên emulator).
+
+**🟡 Important:**
+- Stream subscription không dispose → memory leak.
+- Function top-level `import sharp` → cold start +500ms.
+
+
+---
 
 ## Output format
 
-Report by severity:
-
-- 🔴 **Critical** — must fix before merge. Bugs, security holes, breaking changes.
-- 🟡 **Important** — should fix before merge. Performance issues, maintainability.
-- 🟢 **Suggestion** — nice-to-have. Naming, DRY, micro-optimization.
-- ✅ **Good** — highlight what was done well (preserves morale, reinforces good patterns).
-
-Example:
+### Default (precision-first — Fast or Standard path)
 
 ```markdown
-## Code Review: PostRepository
+## Code Review: <module/scope>
 
 ### 🔴 Critical
-- `createPost` doesn't validate `authorId` ≠ null before the query → crash if the user logs out racing with upload. Fix: throw `AppError.unauthenticated()` early.
+- <file:line> <issue> → <fix>
 
 ### 🟡 Important
-- Field `imageUrl` is stored raw from the client. If the client sends a URL outside Firebase Storage (third-party CDN) → loss of control. Suggest: validate the prefix `gs://meep-prod.appspot.com/` or upload via a Function.
+- <file:line> <issue> → <fix>
 
-### 🟢 Suggestion
-- Magic string `'posts'` appears 3 times. Extract `static const _collection = 'posts'`.
-
-### ✅ Good
-- Tests cover empty caption, max length, server timestamp.
-- Clear naming `createPost` instead of `add`.
+### Summary
+- Path: Fast / Standard / Deep
+- Diff: <X> lines, <Y> files
+- Verdict: BLOCK (có 🔴) / NEEDS-FIX (có 🟡) / READY-TO-MERGE
 ```
 
-## Anti-patterns in review
+### Deep path output (chỉ khi user gõ `/review --deep`)
 
-| Anti-pattern | Problem |
+```markdown
+## Code Review: <module/scope>
+
+### 🔴 Critical
+- ...
+
+### 🟡 Important
+- ...
+
+### 🟢 Suggestion (nit — fix nếu thuận tiện, không block)
+- ...
+
+### ✅ Highlights
+- <good pattern dev did, reinforce>
+
+### Summary
+- ...
+```
+
+### Stop conditions
+
+- Có ≥ 1 🔴 → output **CHỈ** 🔴 + Summary. KHÔNG output 🟡/🟢/✅. Focus dev fix Critical, re-review sau.
+- Fast path → max 5 findings tổng. Nếu vượt → recommend chuyển sang Standard/Deep.
+
+---
+
+## Example outputs
+
+### Fast path output
+
+```markdown
+## Code Review: PostRepository fix
+
+### 🔴 Critical
+- `post_repository.dart:45`: `createPost` không validate `authorId != null` trước query → crash khi user logout race với upload. Fix: throw `AppError.unauthenticated()` early.
+
+### Summary
+- Path: Fast (32 lines, 2 files)
+- Verdict: BLOCK — fix Critical trước.
+```
+
+### Standard path with multiple issues
+
+```markdown
+## Code Review: Feed pagination
+
+### 🔴 Critical
+- `feed_repository.dart:78`: Compound query `where('authorId', whereIn: ids).orderBy('createdAt', desc)` chưa có index trong `firestore.indexes.json` → fail prod, works emulator.
+
+### 🟡 Important
+- `feed_controller.dart:23`: Stream subscription không dispose. Add `ref.onDispose(() => sub.cancel())`.
+- `feed_page.dart:56`: `ListView(children: List.generate(...))` cho 100 items → render off-screen. Đổi `ListView.builder`.
+
+### Summary
+- Path: Standard (180 lines, 4 files)
+- Verdict: BLOCK — Critical (index missing) phải fix trước deploy.
+```
+
+---
+
+## Anti-patterns trong review
+
+| Anti-pattern | Vấn đề |
 |---|---|
-| "Looks good to me" without reading carefully | Rubber-stamp = no review |
-| Bikeshedding naming when there's an unresolved 🔴 | Loses focus on the real issue |
-| Suggesting a rewrite of a whole module in a small PR | Scope creep |
-| Blocking PRs over style preference (`if` vs ternary) | Going religious, not shipping |
+| "Looks good to me" không đọc kỹ | Rubber-stamp = no review |
+| Bikeshed naming khi có 🔴 chưa fix | Lạc focus |
+| Suggest rewrite cả module trong PR nhỏ | Scope creep |
+| Block PR vì style preference (`if` vs ternary) | Religious, không ship |
+| Flag 🟢 khi đã có 🔴 | Distract dev khỏi Critical |
+| Liệt kê 20 findings cho PR 50 dòng | Token waste, dev nản |
+
+---
 
 ## Self-review = ship faster
 
-15 minutes of self-review saves:
+15 phút self-review tiết kiệm:
+- 30 phút debug post-merge.
+- 2 giờ rollback nếu break prod.
+- Reputation với team.
 
-- 30 minutes of debugging post-merge.
-- 2 hours of rollback if it breaks prod.
-- Reputation with the team.
+---
 
-## Quick checklist (run fast before commit)
+## Quick checklist (run trước commit, không thay axis review)
 
 ```
-[ ] Tests pass: ran the command, read the output (skill `verification-before-completion`)
+[ ] Tests pass: `flutter test` / `npm test` ran, output read (skill `verification-before-completion`)
 [ ] Lint clean: `flutter analyze` / `npm run lint` exit 0
-[ ] No commented-out dead code blocks
-[ ] No console.log / print debug statements left over
-[ ] No TODO without a linked issue
-[ ] Diff focused — only changes for this task, no "while I'm here" 5-file edits
-[ ] Commit message is conventional + describes WHY
+[ ] Format clean: `dart format --set-exit-if-changed .`
+[ ] Branch name: `<type>/<DevName>/<short-desc>`
+[ ] No commented-out dead code
+[ ] No `console.log` / `print` debug
+[ ] No `// TODO` không link issue
+[ ] Diff focused — chỉ thay đổi cho task này, không "while I'm here"
+[ ] Commit message conventional + tiếng Việt mô tả WHY
+[ ] Cross-module touch: KHÔNG đụng module dev khác (xem rule 25)
 ```
+

--- a/.cursor/skills/figma-to-flutter/SKILL.md
+++ b/.cursor/skills/figma-to-flutter/SKILL.md
@@ -1,0 +1,434 @@
+---
+name: figma-to-flutter
+description: Convert Figma frame/node → Flutter widget với strict design token mapping + dual-source verification (MCP data + PNG image). Use when user pastes a Figma node URL or attaches a Figma screenshot and asks to generate a Flutter widget. Scope: 1 frame = 1 widget (compose multiple widgets sau). Strict gate: KHÔNG inline hex/font — token thiếu → ping leader.
+---
+
+# Figma → Flutter Widget — Strict Mapping Skill
+
+> Solo-dev model: HanDHG + NganTNK kiêm Figma + module owner. Skill này guide họ (và mọi dev khác đụng UI) chuyển 1 Figma node → 1 Flutter widget **clean, không drift design token**.
+
+## Core principle
+
+**KHÔNG có Figma → Flutter pixel-perfect.** Mỗi Figma node convert qua 3 round:
+1. Extract (MCP + image cross-check) → widget v1.
+2. Verify (test + visual diff) → list lệch điểm.
+3. Refine (specific fix) → widget final.
+
+Sau 3 round vẫn lệch → designer review Figma (overflow / missing constraint).
+
+## Scope (strict)
+
+- ✅ **1 frame Figma = 1 widget Flutter class.** Không attempt full screen 1 lần.
+- ✅ **Compose nhiều widget nhỏ thành page** ở 1 PR riêng, sau khi từng widget đã merge.
+- ❌ KHÔNG generate `MaterialApp`, route config, navigation logic — đây là responsibility của leader (`core/router/`).
+- ❌ KHÔNG generate Riverpod controller / business logic — chỉ presentation layer.
+
+## Strict gate — Design token
+
+**Color / font / spacing / radius KHÔNG có trong `core/theme/` → STOP.** KHÔNG inline hex, KHÔNG hardcode font size. Quy trình unblock:
+
+1. Skill liệt kê token thiếu trong output.
+2. Module owner ping leader: "Cần thêm token X vào `core/theme/`".
+3. Leader đánh giá → nếu OK → merge token vào `develop` qua PR riêng (chore branch).
+4. Module owner pull develop → resume widget generation.
+
+Lý do strict: `core/theme/` là shared code (rule 25 §Cross-module touch). 1 dev tự thêm token = drift design system.
+
+## Pre-flight
+
+Trước khi extract:
+
+- [ ] Verify Figma MCP active (`figma-mcp-go` hoặc `figma-developer-mcp`).
+- [ ] Verify đang trên feature branch `feature/<DevName>/<short-desc>` (KHÔNG develop/deploy).
+- [ ] Read `core/theme/`:
+  - `core/theme/color_scheme.dart` — color tokens
+  - `core/theme/text_theme.dart` — typography tokens
+  - `core/theme/spacing.dart` — spacing tokens
+  - `core/theme/radii.dart` — border radius tokens
+- [ ] User đã attach 2 nguồn:
+  1. **Figma node URL** (cho MCP extract).
+  2. **PNG @2x hoặc SVG** của node (cho agent "nhìn"). PNG @1x quá nhỏ, JPG có compression artifacts → KHÔNG dùng.
+
+## Phase 1 — Extract (dual source)
+
+### 1.1. MCP extract (số liệu)
+
+```
+mcp.call("figma_get_node", { nodeId: "<id>", url: "<paste URL>" })
+```
+
+Output expected:
+- Layer tree (frame → child → child).
+- Auto-Layout config (direction, spacing, padding, alignment).
+- Color values (hex format).
+- Text styles (font family, size, weight, line height).
+- Constraints (stretch / fixed / hug).
+- Component variants nếu có.
+
+### 1.2. Image "look at" (intent)
+
+Agent đọc PNG/SVG attached:
+- Visual layout intent (whitespace, alignment "feel").
+- Catch lỗi MCP (layer ẩn, overlay missing).
+- Confirm component hierarchy match MCP tree.
+
+### 1.3. Cross-check
+
+- MCP nói có 5 children → image phải thấy 5 phần tử.
+- MCP nói color `#1A73E8` → image phải xuất hiện màu xanh đó ở vị trí khớp.
+- **Nếu lệch → STOP**, báo user: "MCP data và image không khớp — Figma có overlay ẩn hoặc layer hidden?"
+
+## Phase 2 — Map (strict rules table)
+
+Bảng quy đổi cố định. Agent KHÔNG tự đoán. Có rule → follow. Không có → STOP.
+
+### Layout
+
+| Figma | Flutter |
+|---|---|
+| Frame Auto-Layout vertical | `Column` |
+| Frame Auto-Layout horizontal | `Row` |
+| Stack (overlap) | `Stack` + `Positioned` |
+| Auto-Layout padding | `Padding(padding: EdgeInsets.all(Spacing.md))` |
+| Item spacing | `SizedBox(height: Spacing.sm)` between children, hoặc `Column(spacing: Spacing.sm)` (Flutter 3.27+) |
+| Constraint Stretch | `Expanded` |
+| Constraint Fixed (W,H) | `SizedBox(width: X, height: Y)` |
+| Constraint Hug | default (no wrapper) |
+
+### Color
+
+| Figma | Flutter |
+|---|---|
+| Hex `#1A73E8` | **Tra `core/theme/color_scheme.dart`** → `Theme.of(context).colorScheme.primary` (hoặc token đúng tên) |
+| Token thiếu | **STOP** — ping leader thêm token |
+
+### Typography
+
+| Figma | Flutter |
+|---|---|
+| Style "Headline/Large" | `Theme.of(context).textTheme.headlineLarge` |
+| Custom font size không match style | **STOP** — Figma có style chưa? Nếu chưa → designer adjust Figma trước |
+
+### Spacing & Radius
+
+| Figma | Flutter |
+|---|---|
+| Spacing 4/8/16/24/32px | `Spacing.xs/sm/md/lg/xl` token |
+| Border radius 4/8/12/16px | `Radii.xs/sm/md/lg` token |
+| Value không match scale | **STOP** — propose round to nearest token, ping leader |
+
+### Component variants
+
+| Figma | Flutter |
+|---|---|
+| Component variant "primary/secondary/ghost" | Factory constructor: `Button.primary()`, `Button.secondary()`, `Button.ghost()` |
+| Component variant "size: sm/md/lg" | Enum + named constructor: `Button.primary(size: ButtonSize.lg)` |
+
+## Phase 3 — Validate before generate
+
+Trước khi generate code, agent print summary:
+
+```
+Figma node: <name>
+File: <feature>/presentation/widgets/<widget_name>.dart
+Layout: Column / Row / Stack
+Children: <count>
+
+Tokens used:
+  ✅ colorScheme.primary
+  ✅ textTheme.headlineLarge
+  ✅ Spacing.md, Spacing.sm
+  ✅ Radii.md
+
+Tokens MISSING (must add to core/theme first):
+  ❌ <none> — proceed
+  
+  HOẶC
+  
+  ❌ colorScheme.tertiary (hex #FF6B35) — STOP, ping leader
+  ❌ textTheme.labelXLarge (custom 20px bold) — STOP, ping leader
+
+Proceed? (yes / wait for tokens)
+```
+
+Nếu có MISSING → KHÔNG continue Phase 4. Output instructions cho user ping leader.
+
+## Phase 4 — Generate widget code
+
+### File location
+
+`apps/mobile/lib/features/<my-module>/presentation/widgets/<widget_name>.dart`
+
+Naming rule:
+- Figma layer name `btn_primary_lg` → class `PrimaryButtonLarge`, file `primary_button_large.dart`.
+- snake_case file, UpperCamelCase class.
+
+### Widget template
+
+```dart
+import 'package:flutter/material.dart';
+
+/// <Brief description from Figma layer comment>
+///
+/// Generated from Figma node: <node-name>
+/// Module: <module-name>
+class <WidgetName> extends StatelessWidget {
+  const <WidgetName>({
+    super.key,
+    // required params
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final textStyles = theme.textTheme;
+
+    return <root layout>;
+  }
+}
+```
+
+### Const constructors mandatory
+
+Mọi widget tĩnh → `const` constructor. Linter check sẽ catch nếu miss.
+
+### No business logic
+
+- KHÔNG `ref.watch(provider)` trong widget — consume controller có sẵn qua callback hoặc parameter.
+- KHÔNG `async` method trong widget — pass callback `VoidCallback onTap`.
+- KHÔNG hardcoded text strings — hoặc pass via param, hoặc dùng `AppLocalizations` (nếu i18n đã setup).
+
+### Component with variants — factory pattern
+
+```dart
+class MeepButton extends StatelessWidget {
+  const MeepButton._({
+    required this.label,
+    required this.onPressed,
+    required this._variant,
+  });
+
+  factory MeepButton.primary({
+    required String label,
+    required VoidCallback onPressed,
+  }) =>
+      MeepButton._(label: label, onPressed: onPressed, _variant: _Variant.primary);
+
+  factory MeepButton.secondary({...}) => ...;
+
+  final String label;
+  final VoidCallback onPressed;
+  final _Variant _variant;
+
+  @override
+  Widget build(BuildContext context) {...}
+}
+
+enum _Variant { primary, secondary, ghost }
+```
+
+## Phase 5 — Generate widget test (mandatory)
+
+Test file: `apps/mobile/test/features/<my-module>/presentation/widgets/<widget_name>_test.dart`
+
+### Test template
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/<my-module>/presentation/widgets/<widget_name>.dart';
+
+void main() {
+  group('<WidgetName>', () {
+    testWidgets('renders without overflow', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: <WidgetName>(/* test params */),
+          ),
+        ),
+      );
+      expect(find.byType(<WidgetName>), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('finds expected text/elements', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: <WidgetName>(...))),
+      );
+      expect(find.text('<expected text from Figma>'), findsOneWidget);
+    });
+
+    testWidgets('respects design tokens (no hardcoded colors)', (tester) async {
+      // Verify widget uses Theme.of(context) — not hex literals.
+      // Spot check via finder: widget with key X has colorScheme.primary background.
+    });
+  });
+}
+```
+
+### Mandatory test cases per widget
+
+- [ ] Renders without throwing.
+- [ ] No layout overflow (RenderFlex error).
+- [ ] Critical text/buttons findable.
+- [ ] Tap callbacks invoke (if interactive).
+
+Optional (for component widget):
+- [ ] Variant rendering (primary/secondary).
+- [ ] Disabled state.
+- [ ] Loading state.
+
+## Phase 6 — Verify (3-round iteration)
+
+### Round 1 — Automated check
+
+```bash
+flutter test test/features/<my-module>/presentation/widgets/<widget_name>_test.dart
+flutter analyze
+dart format --set-exit-if-changed lib/features/<my-module>/presentation/widgets/<widget_name>.dart
+```
+
+Tất cả pass → Round 2. Fail → fix lỗi cụ thể, repeat Round 1.
+
+### Round 2 — Visual diff (manual)
+
+User render trên emulator + so sánh:
+
+```bash
+cd apps/mobile
+flutter run -d android
+```
+
+User chụp screenshot Flutter widget → attach lại vào chat cùng Figma image. Agent compare:
+
+| Element | Figma | Flutter | Match? |
+|---|---|---|---|
+| Layout direction | Column | Column | ✅ |
+| Primary button color | colorScheme.primary | colorScheme.primary | ✅ |
+| Vertical spacing | Spacing.md (16px) | Spacing.md | ✅ |
+| Title font | textTheme.headlineLarge | textTheme.titleLarge | ❌ MISMATCH |
+| ... | ... | ... | ... |
+
+Output diff list cho user. Agent fix specific items, KHÔNG rewrite full widget.
+
+### Round 3 — Refine
+
+Sau Round 2 fix, repeat Round 1 + Round 2. Nếu vẫn lệch:
+
+- < 3 round: agent fix tiếp.
+- = 3 round vẫn lệch: STOP. Designer review Figma xem có overflow / missing constraint / sai style không. KHÔNG ép code match Figma sai.
+
+### Escalation
+
+Khi escalate đến designer:
+
+```
+Figma node: <name>
+Round: 3
+Persistent diffs:
+  - <element>: Figma <X> vs Flutter <Y>
+  - ...
+
+Suspected causes:
+  - Figma constraint missing (e.g., text node có Auto-Layout không?)
+  - Figma style không define (vd custom font size không match style)
+  - Figma component variant chưa cover edge case
+
+Need designer to: <specific action>
+```
+
+## Output format
+
+Sau khi skill chạy xong, output structured:
+
+```markdown
+## Figma → Flutter: <WidgetName>
+
+### Files generated
+- `apps/mobile/lib/features/<m>/presentation/widgets/<w>.dart` (XX lines)
+- `apps/mobile/test/features/<m>/presentation/widgets/<w>_test.dart` (XX lines)
+
+### Tokens used
+- colorScheme.primary, textTheme.headlineLarge, Spacing.md, Radii.md
+
+### Tokens MISSING (PR riêng cần thiết)
+- <none — proceed>
+  HOẶC
+- ❌ colorScheme.tertiary (hex #FF6B35) — leader chưa thêm. Wait.
+
+### Verification
+- ✅ flutter test passed (3/3)
+- ✅ flutter analyze clean
+- ✅ Round 1 automated done
+- ⏸ Round 2 visual diff — user chụp screenshot trên emulator + attach
+
+### Next steps
+1. `flutter run -d android` → render widget
+2. Screenshot widget Flutter
+3. Attach + ping agent: "compare với Figma"
+```
+
+
+## Anti-patterns
+
+| Anti-pattern | V\u1ea5n \u0111\u1ec1 |
+|---|---|
+| Inline hex `Color(0xFF1A73E8)` v\u00ec `core/theme` ch\u01b0a c\u00f3 token | Drift design system, dark mode v\u1ee1 |
+| Hardcode `TextStyle(fontSize: 16)` | Bypass textTheme \u2192 inconsistent |
+| Generate full screen 1 l\u1ea7n | Risk l\u1ec7ch cao, kh\u00f3 review |
+| Generate widget + Riverpod controller c\u00f9ng PR | Mix concerns, vi ph\u1ea1m solo-dev contract |
+| Force code match Figma sai (overflow, missing constraint) | Designer ph\u1ea3i fix Figma tr\u01b0\u1edbc, kh\u00f4ng \u00e9p code |
+| Skip widget test | Solo-dev model: presentation layer test l\u00e0 mandatory |
+| Auto-add token v\u00e0o `core/theme` t\u1ef1 \u0111\u1ed9ng | `core/` l\u00e0 shared code, c\u1ea7n leader gate |
+| Skip image, ch\u1ec9 d\u00f9ng MCP | Miss visual intent, layer \u1ea9n kh\u00f4ng catch |
+| Generate v\u01b0\u1ee3t scope (vd touch `data/` ho\u1eb7c `application/`) | Skill ch\u1ec9 generate `presentation/` |
+
+## Quick reference card
+
+```
+Trigger: user paste Figma node URL + image PNG/SVG @2x
+
+Pre-flight:
+  [ ] MCP active
+  [ ] Feature branch
+  [ ] Read core/theme/* tokens
+  [ ] Image quality check (PNG @2x ho\u1eb7c SVG)
+
+Phase 1 Extract:
+  - MCP figma_get_node \u2192 layer tree + values
+  - "Look at" image \u2192 layout intent
+  - Cross-check, STOP n\u1ebfu l\u1ec7ch
+
+Phase 2 Map:
+  - Strict table (layout / color / typography / spacing / radius / variants)
+  - Token thi\u1ebfu \u2192 STOP
+
+Phase 3 Validate:
+  - Print summary tokens used + missing
+  - Wait approval n\u1ebfu missing
+
+Phase 4 Generate:
+  - Widget class theo Figma layer naming
+  - Const constructor mandatory
+  - No business logic
+
+Phase 5 Test:
+  - Widget test mandatory (renders, no overflow, find elements)
+  - Variant test n\u1ebfu c\u00f3
+
+Phase 6 Verify:
+  - Round 1: flutter test + analyze + format
+  - Round 2: user screenshot + visual diff
+  - Round 3: refine specific items
+  - >3 round l\u1ec7ch \u2192 escalate designer
+```
+
+## Related skills/rules
+
+- `24-flutter-ui-patterns.mdc` (rule, glob-scoped) \u2014 design token rules + accessibility checklist khi edit `presentation/`.
+- `25-dev-code-standards.mdc` (rule, alwaysApply) \u2014 cross-module gate + shared code rule.
+- `flutter-firebase-patterns` (skill) \u2014 Riverpod + Firestore patterns (consume t\u1eeb widget).
+- `code-review-five-axis` (skill) \u2014 6-axis review tr\u01b0\u1edbc PR (Axis 0 Contract Adherence + Axis 4 Security with no-hardcoded-color check).
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS — Meep
 # Mỗi PR cần approval từ CODEOWNERS tương ứng.
-# Anh là default reviewer cho mọi thứ. Khi 3 dev khác có GitHub username,
-# anh chia ownership theo module để giảm bottleneck.
+# Solo-dev model: leader (anh) là default. Module owner = co-required reviewer
+# khi anh đã chốt module → owner mapping (TODO ở dưới).
 #
 # QUAN TRỌNG — phân biệt 2 khái niệm:
 #   - Dev name (theo AGENTS.md convention): PascalCase + abbreviation, vd `ThienPDM`, `KhoaLND`.
@@ -19,41 +19,39 @@
 
 # ============================================================
 # Module-specific ownership
-# Phân chia theo specialty + giảm bottleneck. Multi-owner = ANY ONE owner approve được.
+# Solo-dev model: mỗi module có 1 owner full-stack. Leader luôn co-required.
+# Multi-owner = ANY ONE owner approve được, NHƯNG leader vẫn cần approve riêng.
+#
+# TODO(setup): cập nhật bảng dưới khi anh chốt module → dev assignment.
+# Hiện tại tất cả features default về leader-only — anh assign owner sau khi
+# finalize module list. Format mục tiêu khi đã chốt:
+#
+#   /apps/mobile/lib/features/<module>/        @manhthien2005 @<owner-github>
+#   /firebase/functions/src/<module>/          @manhthien2005 @<owner-github>
 # ============================================================
 
-# BE-heavy features (Firebase + Native Android logic): leader + KhoaLND (Open)
-/apps/mobile/lib/features/auth/             @manhthien2005 @CatS1mp
-/apps/mobile/lib/features/friend/           @manhthien2005 @CatS1mp
-/apps/mobile/lib/features/camera/           @manhthien2005 @CatS1mp
-/apps/mobile/lib/features/post/             @manhthien2005 @CatS1mp
-/apps/mobile/lib/features/space/            @manhthien2005 @CatS1mp
-/apps/mobile/lib/features/rollcall/         @manhthien2005 @CatS1mp
-/apps/mobile/lib/features/notification/     @manhthien2005 @CatS1mp
+# Features (placeholder — leader-only cho đến khi chốt owner)
+/apps/mobile/lib/features/                  @manhthien2005
 
-# UI-heavy features (Figma → Flutter widgets): leader + NganTNK + HanDHG
-/apps/mobile/lib/features/feed/             @manhthien2005 @JanaKimmm @katheramp
-/apps/mobile/lib/features/profile/          @manhthien2005 @JanaKimmm @katheramp
-/apps/mobile/lib/features/reaction/         @manhthien2005 @JanaKimmm @katheramp
-/apps/mobile/lib/features/diary/            @manhthien2005 @JanaKimmm @katheramp
+# Cloud Functions (placeholder — leader-only cho đến khi chốt owner)
+/firebase/functions/                        @manhthien2005
 
-# Native Android (Kotlin AppWidget) — leader only (specialized)
+# Native Android widget — leader (specialized)
 /apps/widget/                               @manhthien2005
 
-# Cloud Functions (BE): leader + KhoaLND
-/firebase/functions/                        @manhthien2005 @CatS1mp
-
-# Security-sensitive (rules + indexes) — leader only
+# Security-sensitive (rules + indexes) — leader only, KHÔNG share
 /firebase/firestore.rules                   @manhthien2005
 /firebase/storage.rules                     @manhthien2005
 /firebase/firestore.indexes.json            @manhthien2005
 
-# Core architecture (DI, theme, error, routing) — leader only
+# Core architecture (DI, theme, error, routing) — leader only, gate shared code
 /apps/mobile/lib/core/                      @manhthien2005
+/apps/mobile/lib/shared/                    @manhthien2005
 
 # Infra / config — chỉ leader review
 /.github/                                   @manhthien2005
 /.husky/                                    @manhthien2005
+/.cursor/                                   @manhthien2005
 /.windsurf/                                 @manhthien2005
 /AGENTS.md                                  @manhthien2005
 /CONTEXT.md                                 @manhthien2005

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -39,22 +39,24 @@ Nếu là bug → dùng template "Báo cáo bug".
 - [ ] **M** — 1 ngày, ~8h (1 feature screen có state, 1 Cloud Function + tests)
 - [ ] **L** — 2-3 ngày (1 module phức tạp: friend graph, post + storage)
 
-## Lane
+## Module ownership
 
-<!-- Leader assign cho 2 specialty lanes; Open lane dev tự pull theo skill match. -->
+<!-- Module nào của task này. Module owner = assignee. Cross-module touch (đụng module dev khác) phải qua leader trước. -->
 
-- [ ] **Specialty — BE/Native** (FS owns: Cloud Functions, Firestore rules, Android widget Kotlin, data layer)
-- [ ] **Specialty — UI/Design** (FE-bridge owns: screen từ Figma, design system, theme, reusable widget)
-- [ ] **Open** (dev pull theo priority + skill match — docs, simple test, config tweak, small refactor)
+- **Module:** `<auth | feed | post | friend | camera | diary | space | rollcall | profile | widget | notification | reaction | core | functions>`
+- **Module owner (assignee):** @<github-username>
 
 ## Files có thể chạm
 
-<!-- Preview scope cho reviewer. Không cần exhaustive — list module/folder chính. -->
+<!-- Preview scope cho reviewer. Solo-dev → owner full-stack module mình. -->
 
-- `apps/mobile/lib/features/<feature>/...`
-- `firebase/functions/src/...`
-- `firebase/firestore.rules` / `firebase/storage.rules`
-- `apps/mobile/android/app/src/main/kotlin/...` (nếu touch widget native)
+- Data layer: `apps/mobile/lib/features/<module>/data/`
+- Application layer: `apps/mobile/lib/features/<module>/application/`
+- Presentation layer: `apps/mobile/lib/features/<module>/presentation/`
+- Cloud Functions (nếu module có): `firebase/functions/src/<module>/`
+- Native (nếu module có widget Android): `apps/mobile/android/app/src/main/kotlin/<module>/`
+
+> ⚠️ **Đụng `core/`, `shared/widgets/`, `firestore.rules`, hoặc module dev khác → khoá lại, ping leader trước.** Chi tiết: `.cursor/rules/25-dev-code-standards.mdc` §Cross-module touch.
 
 ## Files phải đọc trước (context)
 

--- a/.windsurf/rules/00-personal-operating-mode.md
+++ b/.windsurf/rules/00-personal-operating-mode.md
@@ -2,6 +2,8 @@
 trigger: always_on
 ---
 
+> ⚠️ **DEPRECATED 2026-05-21** — Project đã migrate sang Cursor. File này freeze, KHÔNG sync với `.cursor/rules/00-personal-operating-mode.mdc`. Dev mới dùng Cursor → đọc `.cursor/rules/` thay. Windsurf còn giữ file này chỉ để dev nào còn dùng Cascade không bị break ngay.
+
 # Personal Operating Mode
 
 Bạn là pair programmer của một **team leader** (anh). Anh dẫn team 4 dev student capstone (project Meep). Hành xử như đồng nghiệp senior nói thẳng — không phải concierge.

--- a/.windsurf/rules/10-project-context.md
+++ b/.windsurf/rules/10-project-context.md
@@ -2,6 +2,8 @@
 trigger: always_on
 ---
 
+> ⚠️ **DEPRECATED 2026-05-21** — Source of truth ở `.cursor/rules/10-project-context.mdc`. File này freeze, không sync solo-dev model + ADR-0004.
+
 # Project Context — Meep
 
 ## What Meep is

--- a/.windsurf/rules/21-flutter-rules.md
+++ b/.windsurf/rules/21-flutter-rules.md
@@ -51,7 +51,7 @@ A widget that touches `FirebaseFirestore.instance` directly is a bug. Push the c
 
 ## Code organization & widget split
 
-Applies to **all Dart files** in `apps/mobile/**` (not just presentation). FE-bridge devs editing `presentation/` also follow these rules — plus FE-specific rules in `24-flutter-ui-patterns.md`.
+Applies to **all Dart files** in `apps/mobile/**`. Solo-dev module owner editing `presentation/` cũng follow rule này — plus UI-specific rule trong `24-flutter-ui-patterns.md`.
 
 ### When to split (split threshold)
 

--- a/.windsurf/rules/24-flutter-ui-patterns.md
+++ b/.windsurf/rules/24-flutter-ui-patterns.md
@@ -5,7 +5,7 @@ globs: apps/mobile/lib/features/**/presentation/**/*.dart,apps/mobile/lib/core/t
 
 # Flutter UI Patterns — Presentation Layer
 
-Loaded when editing `presentation/`, `core/theme/`, or `shared/widgets/`. Supplements `21-flutter-rules.md` (general mobile rules) — this file focuses on **UI patterns** for the 2 FE-bridge devs (Figma → Flutter).
+Loaded when editing `presentation/`, `core/theme/`, or `shared/widgets/`. Supplements `21-flutter-rules.md` (general mobile rules) — this file focuses on **UI patterns** áp dụng cho mọi solo-dev khi implement screen (đặc biệt important cho HanDHG + NganTNK khi map Figma → Flutter).
 
 **General rules for splitting widgets / functions / classes** (size threshold, reuse threshold, file length) — see `21-flutter-rules.md` §Code organization & widget split. This file does NOT duplicate those; it only covers FE-specific patterns below.
 
@@ -23,18 +23,25 @@ Loaded when editing `presentation/`, `core/theme/`, or `shared/widgets/`. Supple
 
 If Figma has a new color/font not yet in theme → **add to `core/theme/` first**, then use it. Never inline.
 
-## Layering — DO NOT exceed scope
+## Layering — solo-dev module owner
 
-FE-bridge devs may only touch:
+Module Owner own full-stack module → được touch tất cả layer trong module mình:
 
-- ✅ `apps/mobile/lib/features/<feature>/presentation/` — widgets, pages, theme application.
-- ✅ `apps/mobile/lib/core/theme/` — design tokens, theme system.
-- ✅ `apps/mobile/lib/shared/widgets/` — shared reusable widgets.
-- ⚠️ `apps/mobile/lib/features/<feature>/application/` — only **consume** existing controllers (`ref.watch(authControllerProvider)`). DO NOT create new Riverpod controllers — ask FS dev.
-- ❌ `apps/mobile/lib/features/<feature>/data/` — repositories, mappers. FS dev only.
-- ❌ `firebase/functions/`, `apps/mobile/android/app/src/main/kotlin/` — FS dev only.
+- ✅ `apps/mobile/lib/features/<my-module>/data/` — repositories, mappers.
+- ✅ `apps/mobile/lib/features/<my-module>/application/` — controllers, services.
+- ✅ `apps/mobile/lib/features/<my-module>/presentation/` — widgets, pages.
+- ✅ `firebase/functions/src/<my-module>/` — Cloud Functions của module mình.
+- ✅ `apps/mobile/android/app/src/main/kotlin/<my-module>/` — native code của module mình.
 
-If Cascade suggests code outside ✅/⚠️ scope → flag user: "outside FE-bridge scope, should I ask FS dev?".
+**Khoá lại + ping leader** khi cần touch:
+
+- ❌ `apps/mobile/lib/core/theme/` — design token shared cho cả app.
+- ❌ `apps/mobile/lib/shared/widgets/` — widget reuse cross-module.
+- ❌ `apps/mobile/lib/core/error/`, `core/router/`, `core/di/` — shared infra.
+- ❌ `firebase/firestore.rules`, `storage.rules`, `firestore.indexes.json` — security rules + indexes.
+- ❌ `features/<other-module>/**` — module dev khác (xem `25-dev-code-standards.md` §Cross-module touch).
+
+If Cascade suggests code outside ✅ scope → flag user: "outside my module scope, should I ping leader?".
 
 ## Accessibility — minimum required
 

--- a/.windsurf/workflows/start.md
+++ b/.windsurf/workflows/start.md
@@ -14,13 +14,13 @@ gh issue view <issue-id> --repo manhthien2005/Meep
 
 Read and extract:
 - **Title** — task name + scope
-- **Assignee** — who owns this task
-- **Lane label** — `lane:specialty-be-native` (BE) or `lane:specialty-ui-design` (FE) or `lane:open`
+- **Assignee** — module owner của task
+- **Module** — module nào (xem field `Module` hoặc label `module:<name>` trong issue body)
 - **Acceptance criteria** — what done looks like
 - **Files có thể chạm** — output scope
 - **Files phải đọc trước** — context files (read these in Step 3)
 - **Dependencies / blockers** — issue numbers that must be closed first
-- **Plan reference** — `docs/plans/` path
+- **Spec / plan reference** — `docs/specs/` + `docs/plans/` path
 
 ## Step 2 — Check blockers
 
@@ -50,24 +50,25 @@ If the section is empty or missing:
 
 **Goal:** Understand the existing contract before writing a single line.
 
-## Step 4 — Determine role + load rule context
+## Step 4 — Identify module + load rule context
 
-Check the lane label from Step 1:
+Check the `Module` field in issue (or label `module:<name>`):
 
-| Label | Role | Key rules to internalize |
-|---|---|---|
-| `lane:specialty-ui-design` | FE | Scope: `presentation/` only. Read `24-flutter-ui-patterns.md`. Use typed mock from leader's freezed models. Never call Firebase directly. |
-| `lane:specialty-be-native` | BE | Scope: `data/` + `application/`. Implement abstract interface exactly. Never touch `presentation/`. |
-| `lane:open` | Open | Check task scope in issue — follow whichever rules apply. |
+- Read `docs/specs/<module>.md` if exists — module spec + acceptance.
+- Read `25-dev-code-standards.md` — solo-dev contract rules.
+- If task touches presentation/theme/shared widgets → `24-flutter-ui-patterns.md` auto-loads via glob.
 
-If no lane label is set → ask: "Bạn là FE hay BE dev cho task này?"
+If no Module field set → ask: "Module nào của task này? (auth/feed/post/...)"
 
-## Step 5 — Verify contract exists (FE only)
+## Step 5 — Verify contract exists
 
-If role = FE:
-- Confirm that the freezed models and providers needed by this screen exist on `develop`.
-- Check: `git log --oneline origin/develop -- lib/features/<feature>/data/` for recent model commits.
-- If models not yet merged → **STOP**. Report: "Contract chưa có trên develop. Hỏi leader trước khi start."
+Confirm leader đã merge contract vào `develop`:
+
+- Spec: `docs/specs/<module>.md` exists.
+- Models: `git log --oneline origin/develop -- apps/mobile/lib/features/<module>/data/` có commit từ leader.
+- Stub providers throw `UnimplementedError` (chưa wire real impl).
+
+If contract chưa có → **STOP**. Report: "Contract module `<X>` chưa có trên develop. Ping @manhthien2005 trước khi start."
 
 ## Step 6 — Create branch + update project status
 
@@ -76,10 +77,10 @@ Branch format: `feature/<DevName>/<short-desc>`
 DevName mapping (GitHub handle → DevName):
 | GitHub handle | DevName | Role |
 |---|---|---|
-| `manhthien2005` | `ThienPDM` | Leader |
-| `CatS1mp` | `KhoaLND` | BE |
-| `katheramp` | `HanDHG` | FE |
-| `JanaKimmm` | `NganTNK` | FE |
+| `manhthien2005` | `ThienPDM` | Leader (define contracts, review PR) |
+| `CatS1mp` | `KhoaLND` | Module Owner |
+| `katheramp` | `HanDHG` | Module Owner + UI/UX (Figma) |
+| `JanaKimmm` | `NganTNK` | Module Owner + UI/UX (Figma) |
 
 Resolve DevName from the assignee fetched in Step 1. If the assignee is not in this table → ask: "DevName của bạn là gì?"
 
@@ -99,12 +100,13 @@ Print a concise summary:
 
 ```
 Issue:    #<id> <title>
-Role:     FE / BE / Open
+Module:   <module-name>
+Owner:    <DevName> (assignee)
 Blockers: ✅ all closed / ❌ blocked by #X
-Contract: ✅ models on develop / ⚠️ missing (stop + ask leader)
+Contract: ✅ spec + models on develop / ⚠️ missing (stop + ping leader)
 Branch:   feature/<DevName>/<short-desc>
 Status:   ✅ set to "In Progress" on project board
-Scope:    <list of files allowed to touch>
+Scope:    <module folder> + <related> (cross-module touch → ping leader first)
 
 Context loaded:
   - <file1> — <why>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Meep is a private/intimate photo-sharing app for close friends — small, focuse
 - **Home-screen widget** showing latest images is a key differentiator. **MVP target: Android AppWidget only.** iOS WidgetKit is deferred post-MVP — see `docs/adr/0002-android-first-defer-ios.md`.
 - **Meep ≠ Locket clone.** Defining differentiator features (must ship M3): Diary, Space, RollCall, Camera. See Tier 0+ in `.windsurf/rules/10-project-context.md` §Core MVP scope.
 - **Firebase-first backend:** Auth, Firestore, Storage, Cloud Functions, FCM. A self-hosted Node/TypeScript service is added only when something genuinely cannot be done in Firebase.
-- **Team capstone:** 4 dev student (anh là leader). Every decision must keep onboarding low (a new dev productive in <1 day) and ops surface small.
+- **Team capstone:** 4 student devs (anh là leader). **Solo-dev model** — mỗi dev own module end-to-end (data + logic + UI + test), không tách FE/BE. Leader define contract upfront, dev cầm contract về implement. HanDHG + NganTNK kiêm UI/UX Figma. Detail: `.cursor/rules/25-dev-code-standards.mdc` + `docs/team-workflow.md` §8.4. Decisions must keep onboarding low (a new dev productive in <1 day) and ops surface small.
 - **MVP scope:** 12 firm features (Tier 0 + Tier 0+) + 3 stretch (Tier 1) + 11 cut (Tier 2). Detail: `.windsurf/rules/10-project-context.md` §Core MVP scope, `docs/product/features.md`, `docs/roadmap/milestones.md`, memory `mvp-tier-priority`.
 
 ## 2. Repository layout (current)
@@ -122,10 +122,12 @@ Full table + rationale lives in:
 - `.windsurf/rules/10-project-context.md` — high-level decisions + Firebase-first rationale.
 - `.windsurf/rules/20-stack-conventions.md` — naming + cross-cutting conventions.
 - `.windsurf/rules/21-flutter-rules.md` (loaded when editing `apps/mobile/**`).
-- `.windsurf/rules/22-functions-rules.md` (loaded when editing `firebase/functions/**`).
-- `.windsurf/rules/23-firestore-rules.md` (loaded when editing rules / indexes).
-- `.windsurf/rules/24-flutter-ui-patterns.md` (loaded when editing `presentation/`, `core/theme/`, `shared/widgets/`).
+- `.cursor/rules/22-functions-rules.mdc` (loaded when editing `firebase/functions/**`).
+- `.cursor/rules/23-firestore-rules.mdc` (loaded when editing rules / indexes).
+- `.cursor/rules/24-flutter-ui-patterns.mdc` (loaded when editing `presentation/`, `core/theme/`, `shared/widgets/`).
+- `.cursor/rules/25-dev-code-standards.mdc` (always loaded — solo-dev model rules).
 - `docs/adr/0001-firebase-first-backend.md` — why Firebase over self-host.
+- `docs/adr/0004-solo-dev-module-ownership.md` — solo-dev model decisions.
 
 Default deploy region for Functions + Storage: `asia-southeast1`.
 
@@ -219,162 +221,14 @@ Full onboarding doc lives at `docs/team-workflow.md`. Quick reference:
 
 Detail rules: `.windsurf/rules/20-stack-conventions.md` §Git — Team Workflow.
 
-## 8. First-run setup checklist
 
-Tooling currently installed on this machine:
+## 8. Setup, MCP, and reference kits
 
-- ✅ **Flutter 3.41.4** (stable channel)
-- ✅ **Node 22.17.0** (local OK — backward-compat với Node 20. **CI + Cloud Functions runtime = Node 20** để match production engine. Test BE features cần Node 20 trước khi push để tránh CI fail.)
-- ✅ **Git 2.51**
-- ✅ **Java 21 LTS** (Android dev)
-- ✅ **Python 3.13.4** (used by Cascade hooks)
-- ❌ **Firebase CLI** — needs `npm install -g firebase-tools`
-- ❌ **flutterfire CLI** — needs `dart pub global activate flutterfire_cli`
-- ❌ **MCP servers** — see §8 below
-- ❌ **RTK** (token-killer proxy) — optional, see §9 below
+Setup commands, MCP server config, RTK install, và source kits ref đã move sang **[docs/setup.md](docs/setup.md)** để giảm context bloat (setup info là one-time, không cần load mỗi message).
 
-### One-time setup commands
-
-```bash
-# Firebase CLI + login
-npm install -g firebase-tools
-firebase login
-
-# flutterfire CLI (used to wire google-services.json / GoogleService-Info.plist)
-dart pub global activate flutterfire_cli
-
-# Flutter app deps + code generation
-cd apps/mobile
-flutter pub get
-flutterfire configure --project=<your-firebase-project-id>
-dart run build_runner build --delete-conflicting-outputs
-cd ../..
-
-# Functions deps
-cd firebase/functions
-npm install
-cd ../..
-
-# Project alias
-cp firebase/.firebaserc.example firebase/.firebaserc
-# Edit firebase/.firebaserc with your real project IDs
-
-# Local env
-cp .env.example .env
-# Edit .env with your real values
-
-# Smoke test the emulator suite
-firebase emulators:start --project default
-```
-
-## 9. MCP servers — curated minimal set
-
-**Windsurf/Cascade** reads MCP servers from a **user-level** file:
-
-- macOS / Linux: `~/.codeium/windsurf/mcp_config.json`
-- Windows: `C:\Users\<you>\.codeium\windsurf\mcp_config.json`
-
-(There is **no** workspace-level MCP config — Windsurf only supports the user-level file.)
-
-**Cursor/Kiro** reads MCP servers from:
-
-- **Workspace-level (preferred for team-shared servers):** `.cursor/mcp.json` at the repo root. Copy from `.cursor/mcp.example.json` (committed) to `.cursor/mcp.json` (gitignored) and adapt.
-- **User-level:** `C:\Users\<you>\.cursor\mcp.json` (Windows) / `~/.cursor/mcp.json` (macOS/Linux).
-
-To activate Cursor workspace MCP:
-
-```pwsh
-# Windows
-Copy-Item .cursor\mcp.example.json .cursor\mcp.json
-```
-
-```bash
-# macOS / Linux
-cp .cursor/mcp.example.json .cursor/mcp.json
-```
-
-Then restart Cursor or reload the MCP panel. Format is identical to Claude Desktop (`mcpServers` key).
-
-A starting point lives at `.windsurf/mcp_config.example.json`. To activate:
-
-```pwsh
-# Windows
-$mcpDir = "$env:USERPROFILE\.codeium\windsurf"
-New-Item -ItemType Directory -Force -Path $mcpDir | Out-Null
-Copy-Item .windsurf\mcp_config.example.json "$mcpDir\mcp_config.json"
-```
-
-```bash
-# macOS / Linux
-mkdir -p ~/.codeium/windsurf
-cp .windsurf/mcp_config.example.json ~/.codeium/windsurf/mcp_config.json
-```
-
-Then restart Windsurf or click "Refresh" on the MCPs panel in Cascade.
-
-### Enabled by default
-
-- **context7** — up-to-date library docs (Flutter / Firebase / Riverpod / freezed). Prevents the agent hallucinating outdated APIs. Free tier, no API key.
-- **github** — official `ghcr.io/github/github-mcp-server`. Issues, PRs, repos, code search, workflows. Requires Docker + GitHub PAT (scopes: `repo`, `read:org`, `read:user`, `workflow`). Alternative: remote `https://api.githubcopilot.com/mcp/` (no Docker needed, requires Cursor v0.48.0+).
-- **figma** — `figma-developer-mcp` (GLips). Paste a Figma frame URL → MCP returns layout/text/colors → agent generates Flutter widget. Requires `FIGMA_API_KEY` from Figma → Settings → Personal access tokens.
-
-### Setup steps for Cursor
-
-```pwsh
-# Windows
-Copy-Item .cursor\mcp.example.json .cursor\mcp.json
-# Edit .cursor\mcp.json: replace ghp_REPLACE_WITH_YOUR_PAT and figd_REPLACE_WITH_YOUR_FIGMA_TOKEN
-# Restart Cursor or click Refresh on the MCP panel.
-```
-
-`.cursor/mcp.json` is gitignored — each dev fills their own tokens. Never commit the real file.
-
-### Deliberately NOT enabled (and why)
-
-| MCP | Why skipped |
-|---|---|
-| `filesystem` | Redundant — Cursor already has `read_file`, `write_to_file`, `edit`, `find_by_name`, `grep_search`, `list_dir` natively (faster, no extra hop). |
-| `memory` | Redundant — Cursor has built-in Memories (GA from 1.2), persists across sessions with user approval gate. |
-| `postgres` | Project uses Firestore (see ADR `0001-firebase-first-backend`). Add only when a real Postgres dependency appears. |
-| `firebase` | No audited official server yet (as of 2026-04). Prefer the `firebase` CLI directly — already guarded by `block_dangerous_commands.py` for prod targets. |
-
-If you later need any of these, add the entry to `~/.codeium/windsurf/mcp_config.json` and restart Cascade.
-
-## 10. RTK (Rust Token Killer) — optional
-
-RTK proxies shell commands and compresses noisy output before it enters the Cascade context (60–90% token saving on `git status`, test runners, etc.). Not installed yet — `.windsurf/rules/50-token-discipline.md` already has fallback flags for noisy commands, so this is purely an optimization.
-
-If you want to install it later, three options:
-
-**Option 1 — Pre-built binary (fastest, no Rust needed):**
-1. Download `rtk-x86_64-pc-windows-msvc.zip` from the [releases page](https://github.com/rtk-ai/rtk/releases).
-2. Extract `rtk.exe` to `C:\Users\<user>\.local\bin\` (create the folder if missing).
-3. Add that folder to `PATH` (System Properties → Environment Variables).
-4. Restart Windsurf, verify with `rtk --version`.
-5. Activate: `rtk init --agent windsurf`.
-
-**Option 2 — Cargo (if you install Rust first):**
-```pwsh
-winget install Rustlang.Rustup
-rustup default stable
-cargo install --git https://github.com/rtk-ai/rtk
-rtk init --agent windsurf
-```
-
-**Option 3 — WSL** (Linux native, full hook system): see [docs](https://github.com/rtk-ai/rtk#windows).
-
-## 11. Source kits (reference only)
-
-The `.agent-kits/` folder (gitignored) contains seven cloned reference repos. They were inspected during the bootstrap of this project's `.windsurf/` setup. **Do not edit anything inside `.agent-kits/`.** If a skill needs an update, edit the file in `.windsurf/skills/` directly.
-
-| Folder | Origin | What was kept |
-|---|---|---|
-| `superpowers/` | obra/superpowers | Methodology skills: TDD, systematic-debugging, verification, brainstorming, writing-plans |
-| `class-ai-agent/` | bahdotsh/class-ai-agent | Slash-command workflow scaffolds (rewritten for Flutter/Firebase) |
-| `andrej-karpathy-skills/` | karpathy | `karpathy-guidelines` skill, near-verbatim |
-| `caveman/` | JuliusBrussee/caveman | Windsurf `.windsurf/` format reference + adapted into `caveman-vi` |
-| `everything-claude-code/` | hesreallyhim/everything-claude-code | Inspected; not used wholesale (Claude-Code-specific plugin system) |
-| `mattpocock-skills/` | mattpocock | Inspected; not cherry-picked (overlaps with superpowers) |
-| `rtk/` | rtk-ai/rtk | Documented install path only; not auto-installed |
-
-The folder is ~150MB on disk. Safe to delete with `Remove-Item -Recurse -Force .agent-kits` once you're comfortable with what's in `.windsurf/`.
+Khi bạn cần:
+- **First-run setup** (Firebase CLI, flutterfire, deps) → `docs/setup.md` §1-§2.
+- **MCP servers** (context7, github, figma) → `docs/setup.md` §3.
+- **RTK token-killer** (optional) → `docs/setup.md` §4.
+- **.agent-kits/ source kits** → `docs/setup.md` §5.
+- **Restart checklist sau setup** → `docs/setup.md` §6.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,110 +1,11 @@
 # CONTEXT.md — Domain Language for Meep
 
-> Shared vocabulary between the human and the agent. Use these terms exactly when discussing the system or writing code. Disambiguates overloaded words and locks naming consistency.
-
-## Core entities
-
-| Term | Definition | Lives at |
-|---|---|---|
-| **User** | An authenticated person, identified by `uid` (Firebase Auth UID, string). Has `displayName`, `avatarUrl`. | Firestore: `/users/{uid}` |
-| **Post** | One photo + optional caption shared by a User to their friends. NEVER public. Always tied to one author. | Firestore: `/posts/{postId}` |
-| **Caption** | The text accompanying a Post. ≤ 200 chars. Optional (a post can be photo-only). | Field `caption` in `/posts/{postId}` |
-| **Friend** | Another User with whom the current User has a mutual accepted friendship. Bidirectional. | Derived from `/friendships/{pairId}` |
-| **Friend graph** | The set of all friendships across all Users. Bidirectional, no public following. | Firestore: `/friendships` |
-| **Friend request** | A pending invite from one User to another. Becomes a Friend when accepted. | Firestore: `/friend_requests/{requestId}` |
-| **Feed** | The chronological list of friends' Posts visible to the current User. Cursor-paginated, latest first. | Computed by querying `/posts` filtered by friend `authorId`s |
-| **Notification** | A push message about a friend's activity (new post, accepted request). Persisted per user. | Firestore: `/users/{uid}/notifications/{notifId}` + FCM push |
-
-## Identifiers
-
-| Term | Format | Example |
-|---|---|---|
-| `uid` | Firebase Auth UID — opaque string, ≤ 128 chars | `7Mk9x2QR8vN3yL4pHzAj` |
-| `postId` | Auto-generated Firestore doc ID, 20 chars | `aB3xKzqrL5MnPq7Ws2Yd` |
-| `pairId` | **Sorted** `uidA_uidB` for friendship lookup. Always `min < max` to make it deterministic. | `7Mk9x2QR_xZ1fGh4Bp9Q` |
-| `requestId` | Auto-generated Firestore doc ID for friend requests | `cD9zLmrqW3NpKj5Rs8Yt` |
-| `notifId` | Auto-generated Firestore doc ID for notifications | `eF2hQrsbT8VnLk6Zp4Mw` |
-
-```dart
-// Pair ID computation — must be deterministic
-String pairIdOf(String a, String b) {
-  return a.compareTo(b) < 0 ? '${a}_$b' : '${b}_$a';
-}
-```
-
-## Architectural patterns
-
-| Pattern | What it means | Where it appears |
-|---|---|---|
-| **Fan-out** | Cloud Function pattern: when a Post is created, the Function enumerates the author's Friends and pushes a Notification to each. NOT done client-side. | `firebase/functions/src/index.ts` `onPostCreated` |
-| **Denormalize** | Copy a value (e.g. `authorName`, `authorAvatarUrl`) into a Post document so the Feed query needs no JOIN. Trade write complexity for read speed. | `/posts/{postId}` fields `authorName`, `authorAvatarUrl` |
-| **Repository** | Class abstracting Firebase calls so widgets/controllers do NOT touch `FirebaseFirestore.instance` directly. Lives in `lib/features/<feature>/data/`. | e.g. `AuthRepository`, `PostRepository` |
-| **Cursor pagination** | Use `startAfterDocument(lastDoc)` instead of `offset()` (Firestore has no efficient offset). | Feed query, friend list |
-| **ServerTimestamp** | Use `FieldValue.serverTimestamp()` for `createdAt`/`updatedAt`. Never trust client clocks. | Every doc with timestamps |
-
-## Disambiguation — terms with overloaded meanings
-
-The same word means different things depending on context. Always specify which.
-
-### "Widget"
-
-| Term | Meaning | Where the code lives |
-|---|---|---|
-| **Widget (Flutter)** | A UI component (`StatelessWidget`, `ConsumerWidget`, `StatefulWidget`). Building block of every screen. | `apps/mobile/lib/features/<feature>/presentation/` |
-| **Widget (home-screen)** | The native iOS WidgetKit / Android AppWidget showing latest Meep images on the user's home screen. The headline differentiator. | `apps/widget/` (iOS Swift + Android Kotlin) — not yet scaffolded |
-
-When unclear, write **"home-screen widget"** for native, just **"widget"** for Flutter UI.
-
-### "Provider"
-
-| Term | Meaning | Library |
-|---|---|---|
-| **Provider (Riverpod)** | A `Provider<T>` / `StreamProvider<T>` / `FutureProvider<T>` / `NotifierProvider<T>`. Riverpod 2 idiom. | `flutter_riverpod` |
-| **Provider (Firebase Auth)** | An OAuth identity provider — Google, Apple, email/password. | `firebase_auth` |
-
-When unclear, write **"Riverpod provider"** vs **"auth provider"**.
-
-### "Storage"
-
-| Term | Meaning |
-|---|---|
-| **Storage (Firebase)** | Cloud Storage for Firebase — where images live. Bucket: `<project>.appspot.com`. |
-| **Storage (local)** | On-device cache (SharedPreferences / Hive / SQLite). For offline / widget data. |
-
-When unclear, write **"Cloud Storage"** vs **"local cache"**.
-
-### "Rule"
-
-| Term | Meaning |
-|---|---|
-| **Rule (Firestore)** | A `.rules` file declaring per-collection access policy. |
-| **Rule (Cascade)** | A `.windsurf/rules/*.md` file giving the agent instructions. |
-| **Rule (lint)** | An entry in `analysis_options.yaml` or ESLint config. |
-
-Write **"Firestore rules"**, **"agent rules"**, **"lint rules"** to be explicit.
-
-## Anti-terms — words to AVOID
-
-| Avoid | Use instead | Why |
-|---|---|---|
-| `user_id` | `uid` | Inconsistent with Firebase Auth field name |
-| `friend_id` | `pairId` (for friendship doc) or `friendUid` (for the friend's User) | Ambiguous what "friend ID" refers to |
-| `image` | `imageUrl` (for the URL string) or `image bytes` (for raw data) | Both meanings clash |
-| "the database" | "Firestore" | We don't have "a database" — we have specific products (Firestore, Storage, Auth) |
-| "the backend" | "Cloud Functions" / "the (optional) Node BE in `services/api/`" | Same reason |
-| "save" | "create" / "update" / "upsert" | Vague — say which write op |
-| "fetch" | "read once" (`get()`) / "watch" (`snapshots()`) | Different perf characteristics |
-
-## Status fields enum
-
-| Field | Values |
-|---|---|
-| `friend_requests.status` | `pending` / `accepted` / `declined` / `cancelled` |
-| `posts.uploadStatus` (if used) | `uploading` / `uploaded` / `failed` |
-| `notifications.read` | `true` / `false` (boolean, default false) |
-
-## Update policy for this file
-
-- **When to update:** new entity introduced, new disambiguation needed, naming convention changes.
-- **When NOT to update:** transient implementation details, internal helper names.
-- **Review:** quick re-read at start of each `/spec` session — if a new term appears in the spec discovery phase, add it here BEFORE coding.
+> ⚠️ **2026-05-21 — Content moved to `.cursor/rules/05-domain-language.mdc`** (auto-loaded by Cursor agent on every message via `alwaysApply: true`).
+>
+> Đọc file này: `.cursor/rules/05-domain-language.mdc`.
+>
+> Lý do move:
+> - Cursor agent giờ tự load domain language mỗi message → giảm risk hiểu sai term (Pair ID, Fan-out, Widget native vs Flutter widget).
+> - File này (CONTEXT.md ở root) trước đây phải được agent request thủ công → đôi khi miss.
+>
+> File này giữ lại làm **human-facing entry point** — dev mới đọc README → click link sang đây → click sang rule file. KHÔNG đồng bộ content với rule (single source of truth = rule file).

--- a/README.md
+++ b/README.md
@@ -37,16 +37,22 @@ Chi tiết tech decisions: [`docs/adr/`](docs/adr/).
 
 ## Team
 
-4 dev student capstone. Branch + commit format track per dev (PascalCase + abbrev).
+4 dev student capstone, **solo-dev model** — mỗi người own một (hoặc vài) module end-to-end (data + logic + UI). Không tách FE/BE. Module phức tạp có thể nhiều người cùng làm, nhưng ưu tiên 1 người 1 module để rõ ownership.
 
-| Dev name | GitHub | Tên đầy đủ | Specialty |
+| Dev name | GitHub | Tên đầy đủ | Vai trò |
 |---|---|---|---|
-| `ThienPDM` | [@manhthien2005](https://github.com/manhthien2005) | Phan Điền Mạnh Thiên | Leader, default CODEOWNERS |
-| `KhoaLND` | [@CatS1mp](https://github.com/CatS1mp) | Lê Ngọc Đăng Khoa | Open (BE/UI flexible) |
-| `NganTNK` | [@JanaKimmm](https://github.com/JanaKimmm) | Trần Nguyễn Kim Ngân | UI / Design |
-| `HanDHG` | [@katheramp](https://github.com/katheramp) | Đào Huỳnh Gia Hân | UI / Design |
+| `ThienPDM` | [@manhthien2005](https://github.com/manhthien2005) | Phan Điền Mạnh Thiên | Leader, default CODEOWNERS, define contracts upfront |
+| `KhoaLND` | [@CatS1mp](https://github.com/CatS1mp) | Lê Ngọc Đăng Khoa | Module owner |
+| `HanDHG` | [@katheramp](https://github.com/katheramp) | Đào Huỳnh Gia Hân | Module owner + UI/UX design (Figma) |
+| `NganTNK` | [@JanaKimmm](https://github.com/JanaKimmm) | Trần Nguyễn Kim Ngân | Module owner + UI/UX design (Figma) |
+
+> **Solo-dev workflow:** leader define spec + freezed model + abstract interface upfront, dev cầm contract về implement full-stack module mình. Đụng module người khác hoặc chệch contract → khoá lại, leader duyệt mới đi tiếp. Chi tiết: [`.cursor/rules/25-dev-code-standards.mdc`](.cursor/rules/25-dev-code-standards.mdc).
+>
+> **UI/UX design:** HanDHG + NganTNK chịu trách nhiệm vẽ Figma (frame, design system, theme tokens) cho cả app, trước khi anh export contract cho tất cả module. Module Figma đó của ai → người đó implement Flutter.
 
 > **Phân biệt** — `Dev name` (PascalCase) dùng cho branch + commit (vd `feature/KhoaLND/...`). `GitHub username` dùng trong CODEOWNERS + PR @mention. Hai cái KHÔNG giống nhau, không cần match.
+
+> **Module ownership:** chưa pre-assign. Sẽ chốt khi anh finalize module list (`docs/specs/` + ADR). Đến lúc đó update `.github/CODEOWNERS` per-module path.
 
 ## Setup nhanh
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -52,5 +52,5 @@ export default {
   },
 
   helpUrl:
-    'Xem .windsurf/rules/20-stack-conventions.md §Git — Team Workflow để biết format chi tiết.',
+    'Xem .cursor/rules/20-stack-conventions.mdc (hoặc .windsurf/rules/20-stack-conventions.md) §Git — Team Workflow để biết format chi tiết.',
 };

--- a/docs/adr/0003-task-management-process.md
+++ b/docs/adr/0003-task-management-process.md
@@ -1,7 +1,9 @@
 # 0003. Task management process — sprint cadence + hybrid assignment
 
 **Date:** 2026-04-30
-**Status:** Accepted
+**Status:** Accepted (partial — §3, §4, §9 superseded by ADR-0004 on 2026-05-21)
+
+> **Lưu ý:** §3 (Team skill spread FE/BE), §4 (Hybrid lane assignment), §9 (Lane field trong task template) đã bị superseded bởi [ADR-0004](0004-solo-dev-module-ownership.md) sau khi giảng viên yêu cầu solo-dev model. Các section khác (sprint cadence, DoD, estimation, review SLA, daily check-in, milestone reporting, GitHub Projects) vẫn áp dụng.
 
 ## Context
 

--- a/docs/adr/0004-solo-dev-module-ownership.md
+++ b/docs/adr/0004-solo-dev-module-ownership.md
@@ -1,0 +1,202 @@
+# 0004. Solo-dev module ownership — supersede §3, §4, §9 of ADR-0003
+
+**Date:** 2026-05-21
+**Status:** Accepted
+**Supersedes:** ADR-0003 §3 (Team skill spread), §4 (Task assignment — Hybrid lane), §9 (Task template lane field)
+
+## Context
+
+ADR-0003 (2026-04-30) phân chia team theo "specialty lane": 2 dev full-stack (FS) + 2 dev FE-bridge (Figma → Flutter UI). Backlog có 3 lane: Specialty-BE/Native, Specialty-UI/Design, Open. Phân chia này phản ánh thực tế kỹ năng thời điểm đó.
+
+**Trigger thay đổi (2026-05-21):**
+
+Giảng viên yêu cầu mỗi dev phải tham gia hoàn thiện **một module end-to-end**, không tách FE/BE. Lý do từ giảng viên (capstone evaluation): mỗi sinh viên cần demo được khả năng full-stack ownership, không chỉ "tôi vẽ UI" hoặc "tôi viết Cloud Function".
+
+Hệ quả với ADR-0003:
+
+- §3 (FE-bridge scope giới hạn `presentation/` + `theme/`) → không còn áp dụng. FE-bridge phải implement luôn `data/` + `application/` cho module mình.
+- §4 (lane Specialty-BE/Native vs Specialty-UI/Design) → không còn ý nghĩa. Mỗi task thuộc về **module owner**, không phải lane.
+- §9 (task template field "Lane") → đổi sang field "Module".
+
+## Decision
+
+Áp dụng **solo-dev module ownership model**:
+
+### 1. Mỗi dev own module end-to-end
+
+Mỗi dev được assign 1 (hoặc vài) module của Meep. Module owner chịu trách nhiệm full-stack:
+
+- `data/` — repository, Firestore mapper.
+- `application/` — controller, service, Riverpod provider.
+- `presentation/` — widget, page, design token application.
+- Cloud Function (nếu module có) — `firebase/functions/src/<module>/`.
+- Native code (nếu module có widget Android) — `apps/mobile/android/app/src/main/kotlin/<module>/`.
+- Test — unit + widget + integration cho module mình.
+
+**Ưu tiên 1 dev 1 module.** Module phức tạp (vd `feed` cả pagination + cache + UI) có thể assign 2 dev nhưng phải chia sub-task rõ ràng trong issue.
+
+**Phân chia theo độ khó (skill-based):**
+
+| Dev | Module type | Số module ước tính |
+|---|---|---|
+| `ThienPDM` (Leader) | Module phức tạp: Auth, Widget native (Kotlin), Cloud Functions infra, Post + storage | 3-4 module |
+| `KhoaLND` | Module phức tạp/medium: Friend graph, Feed (pagination + cache), Space, Notification, RollCall | 3-4 module |
+| `HanDHG` | Module M (medium) hoặc dễ: Profile, Diary, Reaction (UI-leaning) | 2 module |
+| `NganTNK` | Module M (medium) hoặc dễ: Camera UI, các UI screen có Figma sẵn | 2 module |
+
+Lý do: HanDHG + NganTNK code skill còn yếu + kiêm Figma cả app → ít module hơn để đổi thời gian Figma. Anh + KhoaLND own nhiều hơn để bù.
+
+### 2. Leader define contract upfront (with KhoaLND pair-contract backup)
+
+Leader (anh) giữ vai trò **architect + gatekeeper**, KhoaLND là **pair-contract backup**:
+
+- Trước khi giao module cho dev, leader merge vào `develop`:
+  - Spec đầy đủ tại `docs/specs/<module>.md` với acceptance criteria đo được.
+  - Freezed models + abstract interfaces (data layer contract).
+  - Stub Riverpod providers (throw `UnimplementedError`).
+  - Route stub trong router.
+  - TODO marker `// TODO(<task-id>/<DevName>): ...` trên mọi stub.
+- Dev pull `develop` → contract đã có sẵn → implement không cần đoán.
+
+**Pair-contract với KhoaLND** (giảm leader bottleneck):
+
+- Leader pair với KhoaLND khi viết contract module phức tạp (Auth, Post + storage, Widget, Cloud Functions infra).
+- Sau khi pair, KhoaLND có quyền approve PR contract change cho module đã pair (co-required reviewer cùng leader).
+- Khi leader busy/sick: KhoaLND có thể giải block dev khác bằng cách clarify contract đã pair, KHÔNG được tự ý đổi contract chưa pair.
+
+Lý do: 4 dev solo-dev tự define contract → drift, conflict, integration crash. Leader gate giữ team đồng bộ. KhoaLND pair tránh leader thành single point of failure.
+
+### 3. Strict cross-module gate
+
+Module Owner A KHÔNG được tự ý sửa code thuộc module Owner B. Bao gồm cả:
+
+- Bug fix nhỏ trong module B (1 dòng cũng vậy).
+- Format / rename "tiện thể".
+- Thêm field vào freezed model dùng chung.
+
+**Khoá lại + ping leader** khi cần:
+
+- Đổi field/interface trong contract leader đã chốt.
+- Touch shared code: `core/`, `shared/widgets/`, `core/theme/`, `firestore.rules`, `storage.rules`, `firestore.indexes.json`.
+- Touch module dev khác.
+- Thêm pub/npm package.
+- Phát hiện contract không khớp Figma / spec.
+
+**Quy trình unblock:**
+
+1. Dev stop, không tự sửa.
+2. Comment trên GitHub issue: `Block: cần đổi <X> trong module <Y>, ping @manhthien2005`.
+3. Leader xem xét → cập nhật spec/contract → merge contract change vào `develop` qua PR riêng → ping dev tiếp tục, hoặc tạo task riêng cho owner B.
+
+**Ngoại lệ duy nhất:** leader explicit assign cross-module task (vd "fix #42: Khoa fix bug Auth của Han") → tạo branch + PR review bởi cả Han + leader.
+
+### 4. Designer role (HanDHG + NganTNK)
+
+HanDHG + NganTNK kiêm thêm **UI/UX design (Figma)** cho cả app, song song với role module owner:
+
+- Vẽ Figma frame + design system + theme token cho cả 12 module **trước khi** leader export contract.
+- Module Figma do họ design → ưu tiên chính họ implement Flutter để giữ design fidelity.
+- Tracking task design qua label `module:<name>` + assignee, không lane riêng.
+
+### 5. Lane labels — drop hết
+
+Bỏ toàn bộ lane labels cũ (`lane:specialty-be-native`, `lane:specialty-ui-design`, `lane:open`). Thay bằng:
+
+- **`module:<name>`** — phân loại task theo module (auth, feed, post, friend, ...).
+- **Assignee** — module owner (= dev được leader assign hoặc volunteer rồi leader confirm).
+
+GitHub Projects v2 field `Lane` → đổi thành `Module` (single-select enum).
+
+### 6. CODEOWNERS — leader + module owner co-required
+
+`.github/CODEOWNERS`:
+
+- Default `* @manhthien2005`.
+- Mỗi module: `/apps/mobile/lib/features/<module>/   @manhthien2005 @<owner-github>` → cả leader VÀ module owner đều phải approve.
+- Shared code (`core/`, `shared/`, `firestore.rules`, infra) → leader-only.
+
+**Hiện tại module list chưa chốt** → CODEOWNERS để placeholder leader-only cho `features/`. Update khi anh finalize module → owner mapping.
+
+### 7. Task template — đổi field "Lane" → "Module"
+
+`.github/ISSUE_TEMPLATE/task.md`: thay section "Lane" bằng "Module ownership":
+
+- `Module:` enum (auth / feed / post / friend / camera / diary / space / rollcall / profile / widget / notification / reaction / core / functions).
+- `Module owner (assignee):` @<github-username>.
+- Cảnh báo cross-module touch — phải ping leader.
+
+### 8. Module list (initial)
+
+12 module mapping với MVP scope từ `10-project-context.mdc`:
+
+| Module | Type | Scope |
+|---|---|---|
+| `auth` | Tier 0 | Email + Google sign-in, auto-login |
+| `friend` | Tier 0 | Invite + accept + friend list |
+| `camera` | Tier 0 | Back/front + capture + caption |
+| `post` | Tier 0 | Upload + metadata + push trigger |
+| `feed` | Tier 0 | Vertical list + cache + pagination |
+| `notification` | Tier 0 | FCM Android |
+| `reaction` | Tier 0 | Single emoji react |
+| `widget` | Tier 0 | Android AppWidget native (Kotlin) |
+| `diary` | Tier 0+ | Text + 1-3 ảnh, no canvas |
+| `space` | Tier 0+ | Group + send photo |
+| `rollcall` | Tier 0+ | Weekly notif + special post + multi-react |
+| `profile` | Tier 0+ | Avatar + bio + grid |
+
+12 module / 4 dev → ~3 module/dev. Anh chia khi finalize spec từng module.
+
+## Alternatives considered
+
+### Option A — Giữ lane FE/BE như ADR-0003
+
+Pros: ổn định, đã setup, AI agent rule đã calibrate cho lane.
+Cons: trái yêu cầu giảng viên — không demo được full-stack ownership của từng dev. **Bác bỏ.**
+
+### Option B — Solo-dev hoàn toàn, mỗi dev tự define contract
+
+Pros: maximally autonomous, dev học architect skill.
+Cons: 4 contract drift song song → integration nightmare, defense yếu vì tài liệu rời rạc. **Bác bỏ.**
+
+### Option C — Solo-dev + leader-define-contract (chosen)
+
+Pros: dev demo full-stack được; contract centralized → docs nhất quán cho giảng viên; leader gate keep tốc độ team đồng bộ.
+Cons: leader trở thành critical path cho contract — nếu leader busy/sick, team block. Mitigation: leader ưu tiên contract work đầu sprint, dev có buffer task không depend contract khi chờ.
+
+### Option D — Pair programming
+
+Pros: knowledge sharing, ít drift.
+Cons: 4 dev chia 2 cặp → mỗi cặp 6 module → workload cao. Capstone yêu cầu individual contribution rõ ràng. **Bác bỏ.**
+
+## Consequences
+
+### Positive
+
+- Mỗi dev demo được full-stack module → match yêu cầu giảng viên.
+- Contract centralized → docs/specs/ thành tài liệu defense rõ ràng.
+- Strict gate giảm drift → CI green stable hơn.
+- HanDHG + NganTNK tận dụng skill Figma → design fidelity cao hơn.
+- Cross-module conflict giảm vì owner rõ ràng.
+
+### Negative
+
+- Leader workload tăng đầu sprint (define contract cho mọi module trước khi giao).
+- Dev chờ contract → có downtime nếu leader chậm. Mitigation: dev có buffer task (test, docs, refactor module mình đã có contract).
+- Mỗi dev phải học stack rộng hơn (FE + BE + native nếu module có) → onboarding cost cao hơn ADR-0003.
+- Module phức tạp (`feed`, `post` cần fan-out) có thể quá tải 1 dev → cần leader pair hoặc split sub-task.
+
+### Neutral / unknowns
+
+- Module assignment chưa chốt — anh sẽ finalize sau khi viết spec từng module. Có thể phát hiện 1 module nên 2-dev (split sub-task), 1 module nên gộp với module khác.
+- Leader bandwidth define contract: chưa có data. Đo sau M1.
+
+## Verification
+
+Re-visit ADR này khi:
+
+- Cuối M1 retro: leader có bottleneck define contract không? Adjust ratio.
+- Dev báo block contract > 24h liên tục: review process unblock.
+- Module assignment cần đổi (vd dev drop): re-balance.
+- Giảng viên feedback đánh giá ownership: confirm process work hay không.
+
+Cho đến khi xảy ra một trong các trigger trên, các quyết định trong ADR này là binding cho cả team. ADR-0003 §1, §2, §5, §6, §7, §8, §10, §11 vẫn áp dụng (sprint cadence, DoD, estimation, review SLA, daily check-in, milestone reporting, GitHub Projects).

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -62,7 +62,7 @@ apps/mobile/lib/
 │   ├── auth/
 │   │   ├── data/                  # AuthRepository (Firebase Auth wrapping)
 │   │   ├── application/           # Riverpod controllers
-│   │   └── presentation/          # Screens + widgets (FE-bridge owns)
+│   │   └── presentation/          # Screens + widgets (module owner full-stack)
 │   ├── friends/
 │   ├── camera/
 │   ├── feed/

--- a/docs/product/modules.md
+++ b/docs/product/modules.md
@@ -4,7 +4,17 @@
 
 | Status | Owner | Last update |
 |---|---|---|
-| 🟢 Active | `ThienPDM` (Leader) | 2026-05-03 |
+| 🟡 Outdated (đợi rewrite) | `ThienPDM` (Leader) | 2026-05-03 |
+
+> ⚠️ **2026-05-21 — File này đang outdated sau ADR-0004.**
+>
+> - Trường `Lane: BE-heavy / UI-heavy + BE` không còn áp dụng — solo-dev model không tách FE/BE.
+> - Pre-assignment "Owner: ThienPDM + KhoaLND (BE) + NganTNK + HanDHG (UI)" sẽ được rewrite theo nguyên tắc:
+>   - **ThienPDM (Leader) + KhoaLND** → module phức tạp (Auth, Post + storage, Widget native, Cloud Functions infra). Mỗi người own nhiều module hơn.
+>   - **HanDHG + NganTNK** → module M (medium) hoặc dễ. Ít module hơn (đổi thời gian Figma).
+>   - 1 module = 1 owner duy nhất (không pair). Cross-module touch strict gate qua leader.
+> - Anh (Leader) sẽ rewrite full file này trong sprint tới. Tới khi đó, KHÔNG dùng các trường `Lane` / `Owner` ở đây làm source of truth.
+> - Source of truth hiện tại cho assignment: GitHub issue assignee + ADR-0004.
 
 ## 0. Quick navigation
 

--- a/docs/product/non-functional.md
+++ b/docs/product/non-functional.md
@@ -101,7 +101,7 @@ PII includes: email, phone, display name, photos, captions, friend graph, FCM to
 
 ## 4. Accessibility
 
-Theo `.windsurf/rules/24-flutter-ui-patterns.md` §"Accessibility (a11y)".
+Theo `.cursor/rules/24-flutter-ui-patterns.mdc` §"Accessibility (a11y)".
 
 - [ ] Touch target ≥ 48x48 dp
 - [ ] Text contrast ratio ≥ 4.5:1 (WCAG AA)
@@ -167,7 +167,7 @@ MVP capstone scale: target ~100-500 users (4 dev + close friends + giảng viên
 
 ### Loading / error / empty / data states (4 trạng thái bắt buộc)
 
-Theo `.windsurf/rules/24-flutter-ui-patterns.md`. Mọi screen phải implement.
+Theo `.cursor/rules/24-flutter-ui-patterns.mdc`. Mọi screen phải implement.
 
 ### Vietnamese UX standard
 
@@ -216,5 +216,5 @@ Theo `.windsurf/rules/24-flutter-ui-patterns.md`. Mọi screen phải implement.
 
 - **Security detail:** [`../architecture/security-model.md`](../architecture/security-model.md)
 - **Rules cấm hardcoding:** `.windsurf/rules/40-security-guardrails.md`
-- **Testing discipline:** `.windsurf/rules/30-testing-and-verification.md`
-- **UI accessibility:** `.windsurf/rules/24-flutter-ui-patterns.md`
+- **Testing discipline:** `.cursor/rules/30-testing-and-verification.mdc`
+- **UI accessibility:** `.cursor/rules/24-flutter-ui-patterns.mdc`

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -55,7 +55,7 @@ Detail: [`docs/product/features.md`](features.md). Day estimates: memory `mvp-ti
 
 ## Team & timeline
 
-- **Team:** 4 dev student capstone (anh là leader). 2 FS dev (Flutter + Cloud Functions + Firestore rules + native Kotlin) + 2 FE-bridge (Figma → Flutter UI).
+- **Team:** 4 dev student capstone (anh là leader). **Solo-dev model** — mỗi dev own 1+ module end-to-end (data + logic + UI + test). Không tách FE/BE. HanDHG + NganTNK kiêm UI/UX Figma. Detail: [ADR-0004](../adr/0004-solo-dev-module-ownership.md).
 - **Timeline:** 6 tuần hard deadline, 30/4 → 9/6/2026.
 - **3 milestones:** M1 (Setup + Auth) → M2 (Social core) → M3 (Differentiator + Demo).
 

--- a/docs/roadmap/demo-script.md
+++ b/docs/roadmap/demo-script.md
@@ -24,7 +24,7 @@ E2E acceptance test cho M3 demo (9/6/2026). Story 3 nhân vật Aldo + Beatrice 
   - Tốt nhất: 3 phone khác model + screen size để show responsive
   - Aldo: phone chính anh
   - Beatrice: phone dev FS-2
-  - Charlie: phone dev FE-bridge
+  - Charlie: phone dev module owner UI
 - **Projector / TV screencast**: cast 1 phone screen lên (Aldo) chính, 2 phone còn lại physical hold up theo turn
 - **Backup laptop**: APK + recording video sẵn sàng
 - **Wi-Fi office + mobile hotspot backup**
@@ -218,7 +218,7 @@ E2E acceptance test cho M3 demo (9/6/2026). Story 3 nhân vật Aldo + Beatrice 
 
 **Trả lời:**
 - Cross-platform ready cho post-MVP iOS (codebase reuse 80%)
-- Single team Dart skillset (FE-bridge dễ tham gia)
+- Single team Dart skillset (mọi dev đều full-stack module → tham gia dễ)
 - Material 3 default UI tốt, ít boilerplate
 - Performance gần native (especially scrolling)
 - Hot reload boost dev velocity 2-3x

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -21,9 +21,10 @@ Foundation  Social Core  Differentiator
 
 ## Team allocation
 
-- **2 FS dev (anh + 1):** Cloud Functions + Firestore rules + native Kotlin widget + data layer + complex business logic
-- **2 FE-bridge:** Figma → Flutter UI (presentation layer + theme + reusable widgets)
-- Cross-lane PR review: FE-bridge PR → anh review default
+- **Solo-dev model (ADR-0004):** mỗi dev own 1+ module end-to-end (data + logic + UI + test). Không tách FE/BE.
+- **Leader (anh):** define spec + freezed model + abstract interface + stub provider trước khi giao module. Review tất cả PR.
+- **HanDHG + NganTNK** kiêm UI/UX Figma + module owner. Module họ design Figma → ưu tiên họ implement Flutter.
+- Module assignment chưa pre-assign — anh chốt khi finalize từng spec.
 
 ## Velocity baseline
 
@@ -100,7 +101,7 @@ End of M1: 4 dev signup được + login được + có CI/CD chạy stage deplo
 | 8-9 | UI/Design | UI placeholder Signup 5-screen flow | FE-2 | L |
 | 10 | UI/Design | UI placeholder Profile screen scaffold | FE-1 | S |
 | 10 | UI/Design | UI placeholder Home placeholder + AuthGate | FE-2 | S |
-| 11-12 | All | Widget tests + integration test login flow | FE-bridge + FS | M |
+| 11-12 | All | Widget tests + integration test login flow | All | M |
 | 12 | All | M1 demo prep (run through scenario, fix critical bug) | All | S |
 | 13 | All | M1 demo + retro (giảng viên review) | All | — |
 
@@ -273,7 +274,7 @@ End of M3: Demo M3 story Aldo+Beatrice+Charlie chạy mượt trước giảng v
 ### 7. Polish + Demo prep ✅
 - Bug fix critical from M2
 - Loading/error/empty states across all screens
-- Re-skin với design tokens (FE-bridge)
+- Re-skin với design tokens (HanDHG + NganTNK)
 - Demo rehearsal 3+ lần
 - Backup video record
 

--- a/docs/roadmap/risks.md
+++ b/docs/roadmap/risks.md
@@ -10,7 +10,7 @@ Top risks cho 6-tuần capstone. Mỗi risk có likelihood, impact, mitigation, 
 |---|---|---|---|---|---|
 | R1 | M3 overflow do quá nhiều task differentiator | High | High | 🔴 Critical | Anh (leader) |
 | R2 | Native Kotlin Widget Android phức tạp | Med | High | 🟡 Med | FS-1 (anh) |
-| R3 | Design tokens land trễ → FE-bridge idle | Med | Med | 🟡 Med | Anh (coordination) |
+| R3 | Design tokens land trễ → module owner UI idle | Med | Med | 🟡 Med | Anh (coordination) |
 | R4 | Velocity 4 dev không đều | High | Med | 🟡 Med | Anh (planning) |
 | R5 | Camera package compatibility issues trên một số Android | Med | Med | 🟡 Med | FS-1 |
 | R6 | AI hallucination tạo bug subtle | High | Med | 🟡 Med | All dev |
@@ -68,9 +68,9 @@ Top risks cho 6-tuần capstone. Mỗi risk có likelihood, impact, mitigation, 
 
 ---
 
-## R3 🟡 — Design tokens land trễ → FE-bridge idle
+## R3 🟡 — Design tokens land trễ → module owner UI idle
 
-**Mô tả:** Design team chưa hoàn thiện design pattern (color, typography, spacing, component variants). FE-bridge dev có thể bị block khi build UI screens.
+**Mô tả:** HanDHG + NganTNK (kiêm UI/UX) chưa hoàn thiện design pattern (color, typography, spacing, component variants) trong Figma. Module owner phụ thuộc design tokens có thể bị block khi build UI screens.
 
 **Trigger conditions:**
 - M1 day 5 (5/5) — design tokens chưa có
@@ -78,9 +78,9 @@ Top risks cho 6-tuần capstone. Mỗi risk có likelihood, impact, mitigation, 
 
 **Mitigation:**
 
-1. **Communicate sớm (today):** Anh discuss với design team — request ưu tiên design tokens deliver trong tuần này.
-2. **FE-bridge work với Material 3 baseline:** Dùng `Theme.of(context).colorScheme.primary` + `textTheme.headlineSmall` (rule 24 cấm hardcode hex/font). Re-skin sau khi tokens land = update `core/theme/` only, KHÔNG refactor widget.
-3. **FE-bridge alternative tasks nếu idle:**
+1. **Communicate sớm (today):** Anh discuss với HanDHG + NganTNK — request ưu tiên design tokens deliver trong tuần này.
+2. **Module owner work với Material 3 baseline:** Dùng `Theme.of(context).colorScheme.primary` + `textTheme.headlineSmall` (rule 24 cấm hardcode hex/font). Re-skin sau khi tokens land = update `core/theme/` only, KHÔNG refactor widget.
+3. **Module owner alternative tasks nếu idle:**
    - Viết widget tests cho UI placeholder
    - Learn Riverpod consume pattern
    - Scaffold `shared/widgets/` từ wireframe (placeholder common components)
@@ -94,8 +94,8 @@ Top risks cho 6-tuần capstone. Mỗi risk có likelihood, impact, mitigation, 
 ## R4 🟡 — Velocity 4 dev không đều
 
 **Mô tả:** 4 dev student capstone với skill levels khác nhau:
-- Anh + 1 FS dev mạnh
-- 2 FE-bridge skill basic (Figma → Flutter)
+- Anh + 1 dev mạnh (skill backend/native vững)
+- 2 dev còn lại skill basic (cần ramp-up Flutter + Firebase)
 - AI boost factor: senior 3-4x, junior 1-2x
 
 **Trigger conditions:**
@@ -104,14 +104,14 @@ Top risks cho 6-tuần capstone. Mỗi risk có likelihood, impact, mitigation, 
 
 **Mitigation:**
 
-1. **Pair-programming AI early:** 2 FE-bridge pair với anh hoặc FS dev mạnh tuần 1. Học pattern.
-2. **Task allocation:**
-   - Anh + FS dev mạnh → core path (Auth, Share photo, Widget)
-   - 2 dev còn lại → support path (Friends, Feed, UI placeholder, tests)
-   - Pair-programming các milestone-critical task
+1. **Pair-programming AI early:** 2 dev junior pair với anh hoặc dev senior tuần 1. Học pattern.
+2. **Module assignment theo skill:**
+   - Anh + dev senior → module phức tạp (Auth, Post + storage, Widget native)
+   - 2 dev junior → module UI-heavy + đã có Figma sẵn (Profile, Diary, Reaction)
+   - Pair-programming các module milestone-critical
 3. **Code review chặt:** Anh review tất cả PR. Catch bug + teach pattern.
-4. **Daily check-in async:** Phát hiện block sớm. Re-allocate task nếu dev stuck.
-5. **Specialty fallback:** BE/Native tasks → anh + FS dev pickup; UI/Design → FE-bridge kia pickup hoặc anh.
+4. **Daily check-in async:** Phát hiện block sớm. Re-allocate module nếu dev stuck.
+5. **Cross-module fallback (ADR-0004):** dev nghỉ → leader pickup module hoặc explicit assign cross-module task cho dev khác. Strict gate vẫn áp dụng — không tự ý sửa module owner khác.
 
 **Owner:** Anh (planning + coordination).
 
@@ -212,7 +212,7 @@ M3 demo + giảng viên test cùng lúc + 4 dev test = có thể spike traffic.
 
 **Mitigation:**
 
-1. **Specialty fallback (đã spec ADR-0003):** BE/Native dev nghỉ → anh + FS dev kia pickup; UI/Design → FE-bridge kia hoặc anh.
+1. **Cross-module fallback (ADR-0004):** dev nghỉ → leader pickup module owner hoặc explicit assign cross-module task. Strict gate vẫn áp dụng.
 2. **WIP limit ≤ 2 task/dev:** Limit task mỗi dev. Khi 1 dev nghỉ, task của họ 1-2 cái OK pickup.
 3. **Documentation:** Mỗi task có `Test plan` + `Files affected` trong issue → dev khác pickup dễ.
 4. **Pair-programming:** Pair giảm bus factor. Mỗi feature có 2 người hiểu code.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,142 @@
+# Setup Guide — Meep
+
+> Tài liệu setup môi trường dev cho Meep. Tách khỏi `AGENTS.md` để giảm context bloat cho AI agent (setup info là one-time, không cần load mỗi message).
+
+## 1. Tooling currently installed
+
+| Tool | Status | Notes |
+|---|---|---|
+| Flutter 3.41.4 | ✅ Stable channel | |
+| Node 22.17.0 | ✅ Local | CI + Cloud Functions runtime = **Node 20**. Test BE features với Node 20 trước khi push tránh CI fail. |
+| Git 2.51 | ✅ | |
+| Java 21 LTS | ✅ | Android dev |
+| Python 3.13.4 | ✅ | Used by hooks |
+| Firebase CLI | ❌ | `npm install -g firebase-tools` |
+| flutterfire CLI | ❌ | `dart pub global activate flutterfire_cli` |
+| MCP servers | ❌ | Xem §3 |
+| RTK (token-killer) | ❌ Optional | Xem §4 |
+
+## 2. One-time setup commands
+
+```bash
+# Firebase CLI + login
+npm install -g firebase-tools
+firebase login
+
+# flutterfire CLI (wire google-services.json)
+dart pub global activate flutterfire_cli
+
+# Flutter app deps + code generation
+cd apps/mobile
+flutter pub get
+flutterfire configure --project=<your-firebase-project-id>
+dart run build_runner build --delete-conflicting-outputs
+cd ../..
+
+# Functions deps
+cd firebase/functions
+npm install
+cd ../..
+
+# Project alias
+cp firebase/.firebaserc.example firebase/.firebaserc
+# Edit firebase/.firebaserc với project IDs thật
+
+# Local env
+cp .env.example .env
+# Edit .env
+
+# Smoke test the emulator suite
+firebase emulators:start --project default
+```
+
+## 3. MCP servers — curated minimal set
+
+**Cursor** đọc MCP servers từ:
+
+- **Workspace-level (preferred for team):** `.cursor/mcp.json` ở repo root. Copy từ `.cursor/mcp.example.json` (committed) → `.cursor/mcp.json` (gitignored).
+- **User-level:** `C:\Users\<you>\.cursor\mcp.json` (Windows) / `~/.cursor/mcp.json` (macOS/Linux).
+
+### Activate Cursor workspace MCP
+
+```pwsh
+# Windows
+Copy-Item .cursor\mcp.example.json .cursor\mcp.json
+```
+
+```bash
+# macOS / Linux
+cp .cursor/mcp.example.json .cursor/mcp.json
+```
+
+Edit `.cursor/mcp.json`: thay `ghp_REPLACE_WITH_YOUR_PAT` + `figd_REPLACE_WITH_YOUR_FIGMA_TOKEN` bằng token thật. Restart Cursor → MCP panel reload.
+
+### Enabled by default
+
+- **context7** — up-to-date library docs (Flutter / Firebase / Riverpod / freezed). Free tier, no API key.
+- **github** — official `ghcr.io/github/github-mcp-server`. Issues, PRs, repos, code search. Requires Docker + GitHub PAT (scopes: `repo`, `read:org`, `read:user`, `workflow`). Alternative remote: `https://api.githubcopilot.com/mcp/`.
+- **figma** — `figma-developer-mcp` (GLips). Figma frame URL → layout/text/colors → agent generates Flutter widget. Requires `FIGMA_API_KEY`.
+
+`.cursor/mcp.json` is gitignored — mỗi dev tự fill token. Never commit file thật.
+
+### Deliberately NOT enabled
+
+| MCP | Lý do skip |
+|---|---|
+| `filesystem` | Redundant — Cursor đã có read/write/edit/grep natively. |
+| `memory` | Redundant — Cursor có built-in Memories (GA từ 1.2). |
+| `postgres` | Project dùng Firestore (ADR-0001). |
+| `firebase` | Chưa có audited official server (2026-04). Dùng `firebase` CLI trực tiếp. |
+
+### Windsurf user (legacy)
+
+Nếu dev dùng Windsurf thay vì Cursor: copy `.windsurf/mcp_config.example.json` → `~/.codeium/windsurf/mcp_config.json` (user-level, không có workspace-level). Chỉ recommend cho ai chưa migrate Cursor.
+
+## 4. RTK (Rust Token Killer) — optional
+
+RTK proxies shell commands và compress noisy output trước khi vào agent context (60–90% token saving trên `git status`, test runners). Chưa install — rule `50-token-discipline.mdc` đã có fallback flags cho noisy commands.
+
+### Option 1 — Pre-built binary (fastest)
+
+1. Download `rtk-x86_64-pc-windows-msvc.zip` từ [releases page](https://github.com/rtk-ai/rtk/releases).
+2. Extract `rtk.exe` → `C:\Users\<user>\.local\bin\`.
+3. Add folder vào PATH.
+4. Restart IDE, verify `rtk --version`.
+5. Activate: `rtk init --agent cursor` (hoặc `--agent windsurf`).
+
+### Option 2 — Cargo
+
+```pwsh
+winget install Rustlang.Rustup
+rustup default stable
+cargo install --git https://github.com/rtk-ai/rtk
+rtk init --agent cursor
+```
+
+### Option 3 — WSL
+
+Linux native, full hook system. Xem [docs](https://github.com/rtk-ai/rtk#windows).
+
+## 5. Source kits (reference only)
+
+`.agent-kits/` folder (gitignored) chứa 7 cloned reference repos. Inspected khi bootstrap project. **Do not edit anything inside `.agent-kits/`.** Nếu cần update skill → edit trực tiếp `.cursor/skills/` (hoặc `.windsurf/skills/`).
+
+| Folder | Origin | Used for |
+|---|---|---|
+| `superpowers/` | obra/superpowers | Methodology skills: TDD, systematic-debugging, verification, brainstorming, writing-plans |
+| `class-ai-agent/` | bahdotsh/class-ai-agent | Slash-command scaffolds (rewritten for Flutter/Firebase) |
+| `andrej-karpathy-skills/` | karpathy | `karpathy-guidelines` skill |
+| `caveman/` | JuliusBrussee/caveman | Format reference + adapted thành `caveman-vi` |
+| `everything-claude-code/` | hesreallyhim | Inspected (Claude-Code plugin system, not portable) |
+| `mattpocock-skills/` | mattpocock | Inspected (overlap với superpowers) |
+| `rtk/` | rtk-ai/rtk | Documented install path |
+
+Folder ~150 MB. Safe to delete: `Remove-Item -Recurse -Force .agent-kits`.
+
+## 6. Restart checklist sau mọi setup
+
+- [ ] Restart Cursor (hoặc Windsurf) sau khi add MCP/skill/rule mới.
+- [ ] Verify `gh auth status` → authenticated.
+- [ ] Verify `firebase projects:list` → có project staging + prod.
+- [ ] Run `flutter doctor` → no errors.
+- [ ] Run `firebase emulators:start` → smoke test.

--- a/docs/team-onboarding/dev-memory-bootstrap.md
+++ b/docs/team-onboarding/dev-memory-bootstrap.md
@@ -1,141 +1,175 @@
 # Dev Memory Bootstrap — Meep
 
-Mỗi dev chạy bước này **một lần duy nhất** khi setup Windsurf IDE trên máy.
-Mục đích: bơm identity context vào Windsurf Memory để agent luôn biết bạn là ai, scope của bạn là gì, mà không cần khai báo mỗi lần chat.
+Mỗi dev chạy bước này **một lần duy nhất** khi setup Cursor / Windsurf trên máy.
+Mục đích: bơm identity context vào AI Memory để agent luôn biết bạn là ai, role gì, mà không cần khai báo mỗi lần chat.
 
 ## Cách setup
 
-1. Mở Windsurf IDE.
-2. Mở chat với Cascade.
+1. Mở Cursor (hoặc Windsurf).
+2. Mở chat với agent.
 3. Paste đúng đoạn memory của bạn (xem bên dưới) vào chat và gửi.
-4. Cascade sẽ tự tạo memory entry. Verify bằng cách hỏi: "Em biết anh là ai không?"
+4. Agent sẽ tự tạo memory entry. Verify bằng cách hỏi: "Em biết anh là ai không?"
+
+> **Cập nhật 2026-05-21:** Team chuyển sang **solo-dev model** (xem [ADR-0004](../adr/0004-solo-dev-module-ownership.md)). Mỗi dev own module end-to-end (data + logic + UI + test), không tách FE/BE. Memory bootstrap đã được rewrite tương ứng. Nếu memory cũ (FE/BE scope) còn trong Cascade/Cursor → xóa và paste lại entry mới.
 
 ---
 
-## KhoaLND (BE)
+## KhoaLND (Module Owner)
 
 ```
 Please remember this about me permanently:
 
 DevName: KhoaLND
 GitHub handle: CatS1mp
-Role: BE Developer
+Role: Module Owner (full-stack solo-dev) — own 1+ module end-to-end
 
-Allowed file scope:
-  ✅ apps/mobile/lib/features/*/data/         — implement repositories
-  ✅ apps/mobile/lib/features/*/application/  — implement controllers
-  ✅ apps/mobile/test/features/*/data/        — repository tests
-  ✅ apps/mobile/test/features/*/application/ — controller tests
-  ✅ firebase/functions/src/                  — Cloud Functions
+Allowed file scope (cho module mình own):
+  ✅ apps/mobile/lib/features/<my-module>/data/         — repositories, mappers
+  ✅ apps/mobile/lib/features/<my-module>/application/  — controllers, services
+  ✅ apps/mobile/lib/features/<my-module>/presentation/ — widgets, pages
+  ✅ apps/mobile/test/features/<my-module>/             — unit + widget tests
+  ✅ firebase/functions/src/<my-module>/                — Cloud Functions của module
+  ✅ apps/mobile/android/app/src/main/kotlin/<my-module>/ — native code nếu module có
 
-  ❌ apps/mobile/lib/features/*/presentation/ — FE scope, never touch
-  ❌ apps/mobile/lib/core/router/             — Leader scope
-  ❌ firebase/firestore.rules                 — ask ThienPDM first
-  ❌ .windsurf/, .github/, docs/adr/, scripts/ — chore branch only, ask leader
+Khoá lại + ping ThienPDM khi cần touch:
+  ❌ apps/mobile/lib/features/<other-module>/  — module dev khác (cross-module strict)
+  ❌ apps/mobile/lib/core/                     — shared infra (theme, error, router, di)
+  ❌ apps/mobile/lib/shared/widgets/           — widget reuse cross-module
+  ❌ firebase/firestore.rules, storage.rules, firestore.indexes.json — security rules
+  ❌ .cursor/, .windsurf/, .github/, docs/adr/, scripts/ — infra, chore branch only
 
 Non-negotiables:
-- Never create a Firestore collection or index without leader approval
-- Never change an abstract interface unilaterally — ask ThienPDM first
-- Never add a pub package without discussion
-- Branch format: feature/KhoaLND/<desc>
+- Never change a freezed model field or abstract interface unilaterally — ping ThienPDM first
+- Never create a Firestore collection / index without leader approval
+- Never add a pub/npm package without discussion
+- Never touch module of another dev — kể cả bug fix nhỏ. Ping leader, mở task riêng cho owner kia
+- Branch format: feature/KhoaLND/<desc> hoặc chore/KhoaLND/<desc>
 - /review before gh pr create — no exceptions
-- Commit message: Vietnamese description, English type prefix
+- Commit message: Vietnamese description, English type prefix (feat, fix, chore, ...)
 ```
 
 ---
 
-## HanDHG (FE)
+## HanDHG (Module Owner + UI/UX Designer)
 
 ```
 Please remember this about me permanently:
 
 DevName: HanDHG
 GitHub handle: katheramp
-Role: FE Developer
+Role: Module Owner (full-stack solo-dev) + UI/UX Designer (Figma)
 
-Allowed file scope:
-  ✅ apps/mobile/lib/features/*/presentation/ — build UI screens
-  ✅ apps/mobile/lib/shared/widgets/           — shared UI components
-  ✅ apps/mobile/test/features/*/presentation/ — widget tests
+Responsibilities:
+- Own 1+ module end-to-end (data + logic + UI + test) — same as KhoaLND/NganTNK
+- Vẽ Figma frame + design system + theme token cho cả app (trước khi leader export contract)
+- Module mình design Figma → ưu tiên mình implement Flutter để giữ design fidelity
 
-  ❌ apps/mobile/lib/features/*/data/          — BE scope, never touch
-  ❌ apps/mobile/lib/features/*/application/   — BE scope, never touch
-  ❌ firebase/                                 — never touch Firebase config/rules
-  ❌ .windsurf/, .github/, docs/adr/, scripts/ — chore branch only, ask leader
+Allowed file scope (cho module mình own):
+  ✅ apps/mobile/lib/features/<my-module>/data/         — repositories, mappers
+  ✅ apps/mobile/lib/features/<my-module>/application/  — controllers, services
+  ✅ apps/mobile/lib/features/<my-module>/presentation/ — widgets, pages
+  ✅ apps/mobile/test/features/<my-module>/             — unit + widget tests
+  ✅ firebase/functions/src/<my-module>/                — Cloud Functions của module
+  ✅ apps/mobile/android/app/src/main/kotlin/<my-module>/ — native code nếu module có
+
+Khoá lại + ping ThienPDM khi cần touch:
+  ❌ apps/mobile/lib/features/<other-module>/  — module dev khác (cross-module strict)
+  ❌ apps/mobile/lib/core/                     — shared infra (theme, error, router, di)
+  ❌ apps/mobile/lib/shared/widgets/           — widget reuse cross-module
+  ❌ firebase/firestore.rules, storage.rules, firestore.indexes.json
+  ❌ .cursor/, .windsurf/, .github/, docs/adr/, scripts/ — infra, chore branch only
 
 Non-negotiables:
-- Never call Firebase directly from UI — use Riverpod providers only
+- Module được giao là M (medium) hoặc dễ — module phức tạp do ThienPDM/KhoaLND own
+- Never call Firebase directly from UI — use Riverpod providers in application/
 - Never invent a model — use the freezed model leader defined (compiler catches mismatches)
 - Never use Map<String, dynamic> for mock data — typed mock only
-- Contract check: before starting a screen, confirm freezed model exists on develop
-- If model missing on develop → STOP, ping ThienPDM (do not start implementation)
-- Branch format: feature/HanDHG/<desc>
+- Design token: never hardcode color/font — dùng Theme.of(context).colorScheme.* + textTheme.*
+- Contract check: before starting module, confirm spec + freezed model on develop. If missing → STOP, ping ThienPDM
+- Branch format: feature/HanDHG/<desc> hoặc chore/HanDHG/<desc>
 - /review before gh pr create — no exceptions
 - Commit message: Vietnamese description, English type prefix
 ```
 
 ---
 
-## NganTNK (FE)
+## NganTNK (Module Owner + UI/UX Designer)
 
 ```
 Please remember this about me permanently:
 
 DevName: NganTNK
 GitHub handle: JanaKimmm
-Role: FE Developer
+Role: Module Owner (full-stack solo-dev) + UI/UX Designer (Figma)
 
-Allowed file scope:
-  ✅ apps/mobile/lib/features/*/presentation/ — build UI screens
-  ✅ apps/mobile/lib/shared/widgets/           — shared UI components
-  ✅ apps/mobile/test/features/*/presentation/ — widget tests
+Responsibilities:
+- Own 1+ module end-to-end (data + logic + UI + test) — same as KhoaLND/HanDHG
+- Vẽ Figma frame + design system + theme token cho cả app (trước khi leader export contract)
+- Module mình design Figma → ưu tiên mình implement Flutter để giữ design fidelity
 
-  ❌ apps/mobile/lib/features/*/data/          — BE scope, never touch
-  ❌ apps/mobile/lib/features/*/application/   — BE scope, never touch
-  ❌ firebase/                                 — never touch Firebase config/rules
-  ❌ .windsurf/, .github/, docs/adr/, scripts/ — chore branch only, ask leader
+Allowed file scope (cho module mình own):
+  ✅ apps/mobile/lib/features/<my-module>/data/         — repositories, mappers
+  ✅ apps/mobile/lib/features/<my-module>/application/  — controllers, services
+  ✅ apps/mobile/lib/features/<my-module>/presentation/ — widgets, pages
+  ✅ apps/mobile/test/features/<my-module>/             — unit + widget tests
+  ✅ firebase/functions/src/<my-module>/                — Cloud Functions của module
+  ✅ apps/mobile/android/app/src/main/kotlin/<my-module>/ — native code nếu module có
+
+Khoá lại + ping ThienPDM khi cần touch:
+  ❌ apps/mobile/lib/features/<other-module>/  — module dev khác (cross-module strict)
+  ❌ apps/mobile/lib/core/                     — shared infra (theme, error, router, di)
+  ❌ apps/mobile/lib/shared/widgets/           — widget reuse cross-module
+  ❌ firebase/firestore.rules, storage.rules, firestore.indexes.json
+  ❌ .cursor/, .windsurf/, .github/, docs/adr/, scripts/ — infra, chore branch only
 
 Non-negotiables:
-- Never call Firebase directly from UI — use Riverpod providers only
+- Module được giao là M (medium) hoặc dễ — module phức tạp do ThienPDM/KhoaLND own
+- Never call Firebase directly from UI — use Riverpod providers in application/
 - Never invent a model — use the freezed model leader defined (compiler catches mismatches)
 - Never use Map<String, dynamic> for mock data — typed mock only
-- Contract check: before starting a screen, confirm freezed model exists on develop
-- If model missing on develop → STOP, ping ThienPDM (do not start implementation)
-- Branch format: feature/NganTNK/<desc>
+- Design token: never hardcode color/font — dùng Theme.of(context).colorScheme.* + textTheme.*
+- Contract check: before starting module, confirm spec + freezed model on develop. If missing → STOP, ping ThienPDM
+- Branch format: feature/NganTNK/<desc> hoặc chore/NganTNK/<desc>
 - /review before gh pr create — no exceptions
 - Commit message: Vietnamese description, English type prefix
 ```
 
 ---
 
-## ThienPDM (Leader)
+## ThienPDM (Leader + Module Owner)
 
 ```
 Please remember this about me permanently:
 
 DevName: ThienPDM
 GitHub handle: manhthien2005
-Role: Leader / Full-stack
-Project: Meep — private photo-sharing app, Firebase-first, Flutter mobile
+Role: Leader (architect + gatekeeper) + Module Owner (own complex modules)
+Project: Meep — private photo-sharing app, Firebase-first, Flutter mobile, Android-only MVP
 
-Responsibilities:
-- Define freezed models + abstract interfaces BEFORE FE/BE starts
-- Wire real implementations in main.dart (integration step)
-- Review all PRs (CODEOWNERS)
-- Firestore rules + indexes changes — sole owner
+Responsibilities (Leader):
+- Define spec + freezed models + abstract interfaces + stub providers BEFORE giao module cho dev
+- Merge contract vào develop trước khi dev start (Contract-first rule)
+- Review all PRs (CODEOWNERS, co-required với module owner)
+- Gatekeep cross-module touch + contract change + shared code (core/, shared/, rules)
 - Architecture decisions → ADR in docs/adr/
+- Pair với KhoaLND khi viết contract phức tạp → backup khi leader busy
 
-Team members:
-  KhoaLND (CatS1mp)   — BE developer
-  HanDHG (katheramp)  — FE developer
-  NganTNK (JanaKimmm) — FE developer
+Responsibilities (Module Owner):
+- Own modules phức tạp: Auth, Post + storage, Widget native (Kotlin), Cloud Functions infra
+- Module dễ → assign cho HanDHG/NganTNK; module medium → KhoaLND
+
+Team members (solo-dev model — ADR-0004):
+  KhoaLND (CatS1mp)   — Module Owner, dev senior, pair-contract với leader
+  HanDHG (katheramp)  — Module Owner + UI/UX (Figma), nhận module M/dễ
+  NganTNK (JanaKimmm) — Module Owner + UI/UX (Figma), nhận module M/dễ
 
 Key rules:
-- Freeze-before-FE: models must land on develop before FE starts
+- Contract-first: spec + models + interfaces + stub merged develop trước khi dev start
 - Walking skeleton: app must compile and run at every commit
+- Strict cross-module gate: dev chệch contract / đụng module khác → khoá lại, leader duyệt
 - /review before gh pr create — no exceptions
-- Infra changes (.windsurf/, .github/, docs/adr/, scripts/) → chore branch, not feature branch
-- Branch format: feature/ThienPDM/<desc> or chore/ThienPDM/<desc>
+- Infra changes (.cursor/, .windsurf/, .github/, docs/adr/, scripts/) → chore branch, not feature branch
+- Branch format: feature/ThienPDM/<desc> hoặc chore/ThienPDM/<desc>
 ```
 
 ---
@@ -143,6 +177,8 @@ Key rules:
 ## Lưu ý
 
 Memory này chỉ capture **identity cố định**: role, file scope, non-negotiables.
-Sprint context (feature đang làm, milestone, plan) được load tự động bởi `/start <issue-id>` từ GitHub issue — không cần cập nhật memory khi chuyển sprint.
+Sprint context (module đang làm, milestone, plan) được load tự động bởi `/start <issue-id>` từ GitHub issue — không cần cập nhật memory khi chuyển sprint.
 
-Chỉ cần update memory khi **role hoặc file scope thực sự thay đổi** (ví dụ: dev chuyển từ BE sang FE, hoặc onboard feature mới với scope khác).
+Chỉ cần update memory khi **role hoặc scope thực sự thay đổi** (ví dụ: dev được giao thêm module mới, hoặc leader giao module khác từ HanDHG → KhoaLND).
+
+**Migration từ memory cũ (FE/BE scope):** nếu memory cũ còn trong Cascade/Cursor (vd "Role: BE Developer", scope `data/` + `application/` only) → xóa entry cũ, paste entry mới ở trên. Solo-dev model bắt buộc full-stack scope cho module mình own.

--- a/docs/team-workflow.md
+++ b/docs/team-workflow.md
@@ -327,8 +327,8 @@ Anh hỏi em khi tới lúc setup, em hướng dẫn chi tiết.
    - `Status`: Backlog / In Progress / Review / Done (single-select)
    - `Sprint`: Sprint 1 / Sprint 2 / Sprint 3 (single-select)
    - `Type`: feature / fix / chore / refactor / docs / test (single-select)
-   - `Lane`: Specialty-BE-Native / Specialty-UI-Design / Open (single-select) — xem §8.4
-   - `Assignee`: link với GitHub user
+   - `Module`: auth / feed / post / friend / camera / diary / space / rollcall / profile / widget / notification / reaction / core / functions (single-select) — xem §8.4
+   - `Assignee`: link với GitHub user (= module owner)
    - `Effort`: XS / S / M / L (single-select) — task > L phải break nhỏ hơn
 4. Auto-add: mọi issue mới + PR mới của repo → tự thêm vào board.
 
@@ -396,40 +396,55 @@ Task phải dùng template `.github/ISSUE_TEMPLATE/task.md`. Bắt buộc fields
 - **Mô tả** (1-2 câu).
 - **Acceptance criteria** ≥ 3 bullet, đo được.
 - **Estimate** T-shirt size (XS/S/M/L).
-- **Lane** (Specialty BE/Native, Specialty UI/Design, hoặc Open).
+- **Module** (auth / feed / post / ... — xem §8.4 module list) + **assignee** (= module owner).
 - **Files có thể chạm** (preview scope).
 - **Test plan** (test file + manual repro).
 
 Thiếu các field này → task chưa ready để pull. Anh sẽ flag trong sprint planning.
 
-### 8.4 Phân chia task — Hybrid lane
+### 8.4 Phân chia task — Solo-dev module ownership
 
-Team mix: **2 FS** (anh + 1, full-stack) + **2 FE-bridge** (Figma → Flutter UI, scope `presentation/` + `theme/` + `shared/widgets/`). Chi tiết scope code mỗi role: xem [ADR-0003 §3](adr/0003-task-management-process.md).
+Team **solo-dev model**: 4 dev, mỗi người own 1+ module **end-to-end** (data + logic + UI + test). Không tách FE/BE. Module phức tạp có thể nhiều người làm chung, nhưng **ưu tiên 1 người 1 module** để rõ ownership. Detail role: [ADR-0004](adr/0004-solo-dev-module-ownership.md) (sẽ thêm) + `.cursor/rules/25-dev-code-standards.mdc`.
 
-Backlog có 3 lane:
+**Module list** (chưa pre-assign — anh chốt khi finalize spec):
 
-| Lane | Cách phân | Loại task |
+| Module | Type | Ghi chú |
 |---|---|---|
-| **Specialty — BE/Native** | Anh assign cho 2 FS | Cloud Functions phức tạp, Firestore rules, Android widget Kotlin, data layer (repositories, mappers), native integration |
-| **Specialty — UI/Design** | Anh assign cho 2 FE-bridge | Screen từ Figma, design system extraction, theme tokens, reusable widget, animation phức tạp |
-| **Open** | Backlog có priority order. Dev pull theo thứ tự khi rảnh (theo skill match) | Docs, simple test, config tweak, small refactor, ADR draft |
+| `auth` | Tier 0 | Email + Google sign-in |
+| `friend` | Tier 0 | Invite + accept + friend list |
+| `camera` | Tier 0 | Back/front + capture + caption |
+| `post` | Tier 0 | Upload + metadata + push trigger |
+| `feed` | Tier 0 | Vertical list + cache + pagination |
+| `notification` | Tier 0 | FCM Android |
+| `reaction` | Tier 0 | Single emoji react |
+| `widget` | Tier 0 | Android AppWidget native |
+| `diary` | Tier 0+ | Text + 1-3 ảnh, no canvas |
+| `space` | Tier 0+ | Group + send photo |
+| `rollcall` | Tier 0+ | Weekly notif + special post |
+| `profile` | Tier 0+ | Avatar + bio + grid |
+
+**Designer role** (HanDHG + NganTNK kiêm):
+
+- Vẽ Figma frame + design system + theme token cho **cả app** trước khi anh export contract.
+- Module nào do họ design → ưu tiên họ implement Flutter để giữ design fidelity.
+- Tracking task design qua label `module:<name>` + assignee.
 
 **Rules:**
 
 - **WIP limit:** mỗi dev tối đa **2 task** `In Progress`.
-- **Pull workflow:** dev comment trong issue "lấy task này" → tự assign mình → move card sang `In Progress` → tạo branch theo §3.
-- **Specialty fallback:** task specialty không có owner kịp →
-  - **BE/Native:** anh hoặc FS dev thứ 2 pickup. Cả 2 FS đầy WIP → task giữ Backlog, anh re-prioritize.
-  - **UI/Design:** FE-bridge dev kia pickup, hoặc anh pickup nếu cả 2 FE-bridge đầy WIP.
-- **Anh là default safety net:** task quá khó cho dev student → anh pickup hoặc pair.
-- **AI agent guard cho FE-bridge:** Cascade tự load `.windsurf/rules/24-flutter-ui-patterns.md` (glob-scoped) khi edit `presentation/` hoặc `theme/`. Rule reminder design tokens, widget patterns, accessibility, Figma mapping.
+- **Assignment:** anh assign trực tiếp module owner cho từng task qua issue → owner = assignee.
+- **Cross-module strict:** dev A cần đụng module B → khoá lại, ping leader, leader xem xét + cập nhật contract → mở task riêng cho owner B (hoặc explicit assign cross-module task). Detail: `25-dev-code-standards.mdc` §Cross-module touch.
+- **Spec-driven:** mọi module phải có `docs/specs/<module>.md` + freezed models + abstract interfaces merged vào `develop` TRƯỚC khi giao dev. Dev không tự đoán contract.
+- **Multi-owner module phức tạp:** nếu module quá lớn (vd `feed` cả pagination + cache + UI), anh có thể assign 2 dev — chia sub-task rõ ràng (vd dev A: data + controller, dev B: UI + widget test) trong issue.
+- **Anh là safety net:** task quá khó cho dev student → anh pickup hoặc pair-program.
+- **AI agent guard:** Cursor tự load `.cursor/rules/24-flutter-ui-patterns.mdc` khi edit `presentation/` / `core/theme/` / `shared/widgets/`. Tự load `.cursor/rules/25-dev-code-standards.mdc` mọi message (`alwaysApply: true`) để remind solo-dev contract.
 
 ### 8.5 Definition of Done
 
 Một task được mark `Done` chỉ khi đầy đủ 7 mục:
 
 - [ ] Code committed theo Conventional Commits + tiếng Việt.
-- [ ] Tests added (unit cho logic; widget cho UI critical path; theo `.windsurf/rules/30-testing-and-verification.md`).
+- [ ] Tests added (unit cho logic; widget cho UI critical path; theo `.cursor/rules/30-testing-and-verification.mdc`).
 - [ ] `flutter analyze` + `dart format` clean (auto via husky pre-commit).
 - [ ] PR mở, description theo `.github/pull_request_template.md`.
 - [ ] ≥ 1 reviewer approve (anh là default CODEOWNERS).

--- a/scripts/setup-github-project.ps1
+++ b/scripts/setup-github-project.ps1
@@ -10,6 +10,12 @@
   - Tạo 12 epic issues từ docs/roadmap/milestones.md (Tier 0 + 0+)
   - Add issues vào project với field values (Sprint/Lane/Effort)
 
+  ⚠️ DEPRECATED PARTIAL (2026-05-21) — sau ADR-0004 (solo-dev module ownership):
+  - Lane field + lane:* labels không còn dùng. Mọi `Lane` trong script này là LEGACY.
+  - Khi tạo issue mới: dùng template `task.md` với field "Module" thay vì Lane.
+  - Đã chạy 1 lần rồi → labels tồn tại trên GitHub. Không cần re-run.
+  - Để giữ board sạch: vào GitHub Projects → Settings → đổi field "Lane" thành "Module" (hoặc thêm field "Module" mới và archive Lane).
+
 .NOTES
   Idempotent: safe re-run. Skip resource đã tồn tại.
   Requires: gh CLI ≥2.40, authenticated với scopes repo + project.

--- a/scripts/sync-epic-issues.ps1
+++ b/scripts/sync-epic-issues.ps1
@@ -8,6 +8,14 @@
   - Assign #14 vào milestone M2 + add vào Project #2
   - Idempotent: re-run safe
 
+  ⚠️ DEPRECATED PARTIAL (2026-05-21) — sau ADR-0004 (solo-dev module ownership):
+  - Field "Lane" + giá trị "Specialty-BE-Native" / "Specialty-UI-Design" không còn dùng.
+  - `modules.md` cũng đã mark outdated, đợi leader rewrite.
+  - KHÔNG re-run script này cho đến khi:
+    1. Leader rewrite `modules.md` với owner mới (solo-dev assignment).
+    2. Project board đổi field "Lane" → "Module".
+    3. Block "Module = X" trong file này được rewrite tương ứng.
+
 .EXAMPLE
   pwsh ./scripts/sync-epic-issues.ps1
 #>


### PR DESCRIPTION
## Mô tả
PR này chuyển workflow AI của Meep sang Cursor-first, đồng bộ solo-dev model theo ADR-0004, và dọn lại rules/skills/commands để agent làm việc đúng hơn, ít bloat context hơn.

## Refs
- Closes #30
- Closes #31
- Spec: `docs/specs/`
- Plan: `docs/plans/`
- ADR: `docs/adr/0004-solo-dev-module-ownership.md`

## Thay đổi chính
- `.cursor/`: thêm commands `/start`, `/build`, `/review`; thêm rule `05-domain-language`; thêm skill `figma-to-flutter`; nâng cấp skill `code-review-five-axis`
- `AGENTS.md`, `docs/setup.md`, `docs/team-workflow.md`: trim setup info, đồng bộ Cursor-first + solo-dev model
- `README.md`, `docs/roadmap/*`, `docs/product/*`, `docs/team-onboarding/dev-memory-bootstrap.md`: sync role model mới, freeze FE/BE split cũ
- `.windsurf/`: freeze legacy files bằng deprecated note, giữ tương thích tạm thời

## Loại thay đổi
- [ ] feat — Tính năng mới
- [ ] fix — Sửa bug
- [x] chore — Maintenance, deps, config
- [ ] refactor — Refactor không thêm feature/fix bug
- [x] docs — Tài liệu
- [ ] test — Thêm/sửa test
- [ ] style — Format/lint, không ảnh hưởng logic
- [ ] perf — Cải thiện performance

## Test
- [ ] Đã chạy `flutter test` PASS
- [ ] Đã chạy `flutter analyze` clean (0 warning)
- [ ] Đã chạy `dart format --set-exit-if-changed .` PASS
- [ ] (Nếu sửa Functions) `npm test` + `npm run lint` PASS
- [ ] (Nếu sửa Firestore rules) Rules tests PASS
- [x] Đã verify thủ công cấu trúc branch, stash split, commit separation, và clean git state cho reset AUTH

### Cách test thủ công
1. Checkout branch này trong Cursor, verify `.cursor/commands/` có `/start`, `/build`, `/review`
2. Mở `.cursor/rules/05-domain-language.mdc`, `docs/setup.md`, `docs/adr/0004-solo-dev-module-ownership.md` để verify source of truth mới
3. Kiểm tra `docs/team-onboarding/dev-memory-bootstrap.md` đã bỏ role FE/BE cũ, chuyển sang module owner full-stack
4. Kiểm tra `AGENTS.md` giảm setup bloat, trỏ sang `docs/setup.md`

## Screenshot / video (bắt buộc nếu có UI thay đổi)
Không có thay đổi UI runtime.

## Lưu ý cho reviewer
- Branch này chỉ chứa infra/docs/skills/rules. AUTH reset được tách sang branch `feature/ThienPDM/auth-clean-reset`
- `.windsurf/` được freeze chứ không xóa ngay để tránh break dev cũ còn dùng Windsurf

## Self-review checklist
- [x] Branch name đúng format `<type>/<DevName>/<desc>`
- [x] Commit message tiếng Việt, theo Conventional Commits
- [x] Không có file lớn vô tình (`.env`, keystore, service account)
- [x] Không có `console.log` / `print` debug còn sót
- [x] Không có `// TODO` chưa link issue
- [x] Không có code comment-out dead code
- [x] Đã review chính diff của mình một lần trước khi mở PR