### PR TITLE
chore(infra): đồng bộ .windsurf từ .cursor — solo-dev model + skill figma-to-flutter

### DIFF
--- a/.windsurf/hooks/block_dangerous_commands.py
+++ b/.windsurf/hooks/block_dangerous_commands.py
@@ -37,8 +37,8 @@ HARD_BLOCK_PATTERNS: list[tuple[str, str]] = [
 # Block unless the command line itself contains an explicit confirmation token.
 CONFIRMED_PATTERNS: list[tuple[str, str, str]] = [
     (
-        r"\bgit\s+push\s+(?:.*\s)?(?:-f|--force|--force-with-lease)\b.*\b(main|master|production|prod)\b",
-        "git push --force on main/master/prod",
+        r"\bgit\s+push\s+(?:.*\s)?(?:-f|--force|--force-with-lease)\b.*\b(main|master|production|prod|develop|deploy)\b",
+        "git push --force on protected branch (main/master/prod/develop/deploy)",
         "Add `# CONFIRMED-FORCE-PUSH` to the command, OR work on a feature branch.",
     ),
     (

--- a/.windsurf/mcp_config.example.json
+++ b/.windsurf/mcp_config.example.json
@@ -1,18 +1,48 @@
 {
-  "_comment_1": "Sample MCP config for Meep. Windsurf reads MCPs from ~/.codeium/windsurf/mcp_config.json (USER-LEVEL, not workspace-level).",
+  "_comment_1": "Sample MCP config for Meep. Windsurf reads MCPs from USER-LEVEL path (not workspace-level).",
   "_comment_2": "To activate: copy this file to ~/.codeium/windsurf/mcp_config.json (Windows: C:\\Users\\<you>\\.codeium\\windsurf\\mcp_config.json), then restart Windsurf or click 'Refresh' on the MCPs panel in Cascade.",
-  "_comment_3": "Curated minimal set. See `AGENTS.md` §8 for what was DELIBERATELY left out (filesystem, github, memory, postgres) and why.",
+  "_comment_3": "Curated set — same as .cursor/mcp.example.json. See AGENTS.md §8 for what was DELIBERATELY left out and why.",
+  "_comment_4": "SECRETS WARNING: NEVER commit the real mcp_config.json. Each dev fills their own tokens locally at the user-level path.",
 
   "mcpServers": {
     "context7": {
-      "_comment_1": "Up-to-date library documentation lookup from upstash/context7. Free tier, no API key needed.",
-      "_comment_2": "Useful when working with rapidly-evolving SDKs (Flutter, Firebase, Riverpod, freezed) — prevents the agent hallucinating outdated APIs.",
-      "_comment_3": "In a prompt, just say 'use context7' or the agent will call it automatically when relevant.",
+      "_comment_1": "Up-to-date library documentation (Flutter, Firebase, Riverpod, freezed). Free tier, no API key.",
+      "_comment_2": "Prevents the agent hallucinating outdated APIs. Say 'use context7' or let agent auto-call.",
       "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    },
+
+    "github": {
+      "_comment_1": "GitHub official MCP server — issues, PRs, repos, code search, workflows.",
+      "_comment_2": "Two install options. Pick ONE per dev based on what's available locally.",
+      "_comment_3": "OPTION A (recommended) — remote hosted by GitHub, requires Windsurf with remote MCP support:",
+      "_option_a_url": "https://api.githubcopilot.com/mcp/",
+      "_option_a_headers": {
+        "Authorization": "Bearer ghp_REPLACE_WITH_YOUR_PAT"
+      },
+      "_comment_4": "OPTION B (below — active by default) — local Docker container. Requires Docker Desktop running.",
+      "_comment_5": "PAT scopes needed: repo, read:org, read:user, workflow.",
+      "command": "docker",
       "args": [
-        "-y",
-        "@upstash/context7-mcp"
-      ]
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_REPLACE_WITH_YOUR_PAT"
+      }
+    },
+
+    "figma-mcp-go": {
+      "_comment_1": "Figma MCP via plugin bridge (vkhanhqui/figma-mcp-go) — NO Figma API token, NO rate limits.",
+      "_comment_2": "73 tools: read + write + create frames/components/variables/styles, export, prototype reactions.",
+      "_comment_3": "Why this over figma-developer-mcp: free plan only allows 6 tool calls/month via REST API. This bridges through a Figma plugin instead → unlimited.",
+      "_comment_4": "ONE-TIME SETUP — install Figma plugin: download plugin.zip from https://github.com/vkhanhqui/figma-mcp-go/releases → Figma Desktop → Plugins → Development → Import plugin from manifest → select manifest.json. Run plugin in any Figma file before asking the agent to use it.",
+      "command": "npx",
+      "args": ["-y", "@vkhanhqui/figma-mcp-go"]
     }
   }
 }

--- a/.windsurf/rules/00-personal-operating-mode.md
+++ b/.windsurf/rules/00-personal-operating-mode.md
@@ -2,8 +2,6 @@
 trigger: always_on
 ---
 
-> ⚠️ **DEPRECATED 2026-05-21** — Project đã migrate sang Cursor. File này freeze, KHÔNG sync với `.cursor/rules/00-personal-operating-mode.mdc`. Dev mới dùng Cursor → đọc `.cursor/rules/` thay. Windsurf còn giữ file này chỉ để dev nào còn dùng Cascade không bị break ngay.
-
 # Personal Operating Mode
 
 Bạn là pair programmer của một **team leader** (anh). Anh dẫn team 4 dev student capstone (project Meep). Hành xử như đồng nghiệp senior nói thẳng — không phải concierge.
@@ -63,4 +61,4 @@ Khi anh planning sprint: em là tech lead giúp anh chia task khả thi.
 - Commit message English mô tả (chỉ type prefix English) — phải tiếng Việt.
 - Branch name không đúng format `<type>/<DevName>/<desc>` (CI sẽ block).
 - **`gh pr create` trước khi `/review` sạch** — thứ tự bắt buộc: implement → `/review` → fix → push → PR. Không có ngoại lệ.
-- **Commit file infra/config trên feature branch** — `.windsurf/`, `.github/`, `docs/adr/`, `scripts/` KHÔNG thuộc feature branch. Trước khi commit, kiểm tra `git branch --show-current`. Nếu đang ở `feature/*` mà muốn commit infra → stash → tạo branch `chore/<Dev>/<desc>` từ `develop` → commit ở đó.
+- **Commit file infra/config trên feature branch** — `.windsurf/`, `.cursor/`, `.github/`, `docs/adr/`, `scripts/` KHÔNG thuộc feature branch. Trước khi commit, kiểm tra `git branch --show-current`. Nếu đang ở `feature/*` mà muốn commit infra → stash → tạo branch `chore/<Dev>/<desc>` từ `develop` → commit ở đó.

--- a/.windsurf/rules/05-domain-language.md
+++ b/.windsurf/rules/05-domain-language.md
@@ -1,0 +1,114 @@
+---
+trigger: always_on
+---
+
+# Domain Language — Meep
+
+Shared vocabulary giữa anh và agent. Dùng đúng terms khi discuss system hoặc viết code. Disambiguate overloaded words + lock naming consistency.
+
+## Core entities
+
+| Term | Definition | Lives at |
+|---|---|---|
+| **User** | Authenticated person, identified by `uid` (Firebase Auth UID, string). Có `displayName`, `avatarUrl`. | Firestore: `/users/{uid}` |
+| **Post** | One photo + optional caption shared bởi User cho friends. NEVER public. Always tied to one author. | Firestore: `/posts/{postId}` |
+| **Caption** | Text accompanying a Post. ≤ 200 chars. Optional (post can be photo-only). | Field `caption` in `/posts/{postId}` |
+| **Friend** | User khác có mutual accepted friendship với current User. Bidirectional. | Derived from `/friendships/{pairId}` |
+| **Friend graph** | Set của tất cả friendships across Users. Bidirectional, no public following. | Firestore: `/friendships` |
+| **Friend request** | Pending invite từ User này đến User khác. Becomes Friend khi accepted. | Firestore: `/friend_requests/{requestId}` |
+| **Feed** | Chronological list của friends' Posts visible cho current User. Cursor-paginated, latest first. | Computed by querying `/posts` filtered by friend `authorId`s |
+| **Notification** | Push message về friend's activity (new post, accepted request). Persisted per user. | Firestore: `/users/{uid}/notifications/{notifId}` + FCM push |
+
+## Identifiers
+
+| Term | Format | Example |
+|---|---|---|
+| `uid` | Firebase Auth UID — opaque string, ≤ 128 chars | `7Mk9x2QR8vN3yL4pHzAj` |
+| `postId` | Auto-generated Firestore doc ID, 20 chars | `aB3xKzqrL5MnPq7Ws2Yd` |
+| `pairId` | **Sorted** `uidA_uidB` cho friendship lookup. Always `min < max` để deterministic. | `7Mk9x2QR_xZ1fGh4Bp9Q` |
+| `requestId` | Auto-generated Firestore doc ID for friend requests | `cD9zLmrqW3NpKj5Rs8Yt` |
+| `notifId` | Auto-generated Firestore doc ID for notifications | `eF2hQrsbT8VnLk6Zp4Mw` |
+
+```dart
+// Pair ID computation — must be deterministic
+String pairIdOf(String a, String b) {
+  return a.compareTo(b) < 0 ? '${a}_$b' : '${b}_$a';
+}
+```
+
+## Architectural patterns
+
+| Pattern | What it means | Where it appears |
+|---|---|---|
+| **Fan-out** | Cloud Function pattern: khi Post được tạo, Function enumerate author's Friends + push Notification cho mỗi người. NOT done client-side. | `firebase/functions/src/index.ts` `onPostCreated` |
+| **Denormalize** | Copy value (vd `authorName`, `authorAvatarUrl`) vào Post document để Feed query không cần JOIN. Trade write complexity cho read speed. | `/posts/{postId}` fields `authorName`, `authorAvatarUrl` |
+| **Repository** | Class abstract Firebase calls để widgets/controllers KHÔNG touch `FirebaseFirestore.instance` directly. Lives in `lib/features/<feature>/data/`. | e.g. `AuthRepository`, `PostRepository` |
+| **Cursor pagination** | Dùng `startAfterDocument(lastDoc)` thay vì `offset()` (Firestore không có efficient offset). | Feed query, friend list |
+| **ServerTimestamp** | Dùng `FieldValue.serverTimestamp()` cho `createdAt`/`updatedAt`. Never trust client clocks. | Every doc với timestamps |
+
+## Disambiguation — overloaded terms
+
+Cùng một từ có nghĩa khác nhau theo context. Always specify which.
+
+### "Widget"
+
+| Term | Meaning | Where the code lives |
+|---|---|---|
+| **Widget (Flutter)** | UI component (`StatelessWidget`, `ConsumerWidget`, `StatefulWidget`). Building block của mọi screen. | `apps/mobile/lib/features/<feature>/presentation/` |
+| **Widget (home-screen)** | Native Android AppWidget hiển thị latest Meep images trên user's home screen. The headline differentiator. iOS WidgetKit deferred per ADR-0002. | `apps/widget/` (Android Kotlin) |
+
+Khi unclear, write **"home-screen widget"** cho native, just **"widget"** cho Flutter UI.
+
+### "Provider"
+
+| Term | Meaning | Library |
+|---|---|---|
+| **Provider (Riverpod)** | `Provider<T>` / `StreamProvider<T>` / `FutureProvider<T>` / `NotifierProvider<T>`. Riverpod 2 idiom. | `flutter_riverpod` |
+| **Provider (Firebase Auth)** | OAuth identity provider — Google, email/password. (Apple deferred per ADR-0002.) | `firebase_auth` |
+
+Khi unclear, write **"Riverpod provider"** vs **"auth provider"**.
+
+### "Storage"
+
+| Term | Meaning |
+|---|---|
+| **Storage (Firebase)** | Cloud Storage for Firebase — nơi images live. Bucket: `<project>.appspot.com`. |
+| **Storage (local)** | On-device cache (SharedPreferences / Hive / SQLite). For offline / widget data. |
+
+Khi unclear, write **"Cloud Storage"** vs **"local cache"**.
+
+### "Rule"
+
+| Term | Meaning |
+|---|---|
+| **Rule (Firestore)** | `.rules` file declaring per-collection access policy. |
+| **Rule (Windsurf agent)** | `.windsurf/rules/*.md` file giving agent instructions. |
+| **Rule (lint)** | Entry trong `analysis_options.yaml` hoặc ESLint config. |
+
+Write **"Firestore rules"**, **"agent rules"**, **"lint rules"** để explicit.
+
+## Anti-terms — words to AVOID
+
+| Avoid | Use instead | Why |
+|---|---|---|
+| `user_id` | `uid` | Inconsistent với Firebase Auth field name |
+| `friend_id` | `pairId` (cho friendship doc) hoặc `friendUid` (cho friend's User) | Ambiguous |
+| `image` | `imageUrl` (cho URL string) hoặc `image bytes` (cho raw data) | Both meanings clash |
+| "the database" | "Firestore" | Không có "a database" — có specific products (Firestore, Storage, Auth) |
+| "the backend" | "Cloud Functions" / "the (optional) Node BE in `services/api/`" | Same reason |
+| "save" | "create" / "update" / "upsert" | Vague — say which write op |
+| "fetch" | "read once" (`get()`) / "watch" (`snapshots()`) | Different perf characteristics |
+
+## Status fields enum
+
+| Field | Values |
+|---|---|
+| `friend_requests.status` | `pending` / `accepted` / `declined` / `cancelled` |
+| `posts.uploadStatus` (if used) | `uploading` / `uploaded` / `failed` |
+| `notifications.read` | `true` / `false` (boolean, default false) |
+
+## Update policy
+
+- **When to update:** new entity introduced, new disambiguation needed, naming convention change.
+- **When NOT to update:** transient implementation details, internal helper names.
+- **Review:** quick re-read at start of each `/spec` session — if a new term appears trong spec discovery, add nó ở đây BEFORE coding.

--- a/.windsurf/rules/10-project-context.md
+++ b/.windsurf/rules/10-project-context.md
@@ -2,7 +2,7 @@
 trigger: always_on
 ---
 
-> ⚠️ **DEPRECATED 2026-05-21** — Source of truth ở `.cursor/rules/10-project-context.mdc`. File này freeze, không sync solo-dev model + ADR-0004.
+
 
 # Project Context — Meep
 
@@ -37,12 +37,25 @@ In every other case → keep it in Firebase. Reduces ops surface for the team (4
 ## Team
 
 - **4 devs** (including the team leader).
-- Dev name format: PascalCase + abbreviation, e.g. `ThienPDM`, `KhoaLND`.
-- Leader is default reviewer (CODEOWNERS).
-- Branching: `develop` (integration) → `deploy` (production releases). Feature branch format: `<type>/<DevName>/<short-desc>`.
-- Commit messages in Vietnamese (Conventional Commits with Vietnamese descriptions).
-- Task tracking: GitHub Projects v2.
-- Full team workflow doc: `docs/team-workflow.md`.
+- **Solo-dev model:** mỗi dev own một (hoặc vài) module **end-to-end** — data + logic + UI + test. Không tách FE/BE.
+- **Leader define contract upfront:** spec + freezed model + abstract interface + stub provider merge vào `develop` trước khi giao module cho dev.
+- **Strict gate:** dev đụng module khác hoặc chệch contract → khoá lại, leader duyệt mới đi tiếp.
+- **HanDHG + NganTNK** kiêm UI/UX design (Figma) cho cả app — module nào do họ design, ưu tiên họ implement Flutter.
+- Dev name format: PascalCase + abbreviation — `ThienPDM`, `KhoaLND`, `HanDHG`, `NganTNK`.
+- Leader (anh) là default reviewer (CODEOWNERS). Sau khi chốt module → thêm module owner làm co-required reviewer.
+- Branching: `develop` → `deploy`. Feature branch: `<type>/<DevName>/<short-desc>`.
+- Commit messages: Conventional Commits + Vietnamese descriptions.
+- Task tracking: GitHub Projects v2. Full workflow: `docs/team-workflow.md`.
+- Detail role + ownership: `.windsurf/rules/25-dev-code-standards.md`.
+
+### DevName mapping
+
+| GitHub handle | DevName | Role |
+|---|---|---|
+| `manhthien2005` | `ThienPDM` | Leader (define contracts, review PR) |
+| `CatS1mp` | `KhoaLND` | Module Owner |
+| `katheramp` | `HanDHG` | Module Owner + UI/UX (Figma) |
+| `JanaKimmm` | `NganTNK` | Module Owner + UI/UX (Figma) |
 
 ## Repository layout
 

--- a/.windsurf/rules/25-dev-code-standards.md
+++ b/.windsurf/rules/25-dev-code-standards.md
@@ -2,44 +2,82 @@
 trigger: always_on
 ---
 
-# Dev Code Standards — Walking Skeleton Pattern
+# Dev Code Standards — Walking Skeleton (Solo-Dev Model)
 
-Meep uses **Walking Skeleton**: the leader creates a runnable shell at the start of each
-sprint; FE and BE fill it in parallel. The app must compile and run at every commit.
+Meep dùng **solo-dev model**: mỗi dev own một (hoặc vài) module **end-to-end** — data + logic + UI + test. Không tách FE/BE. Leader define contract upfront để app luôn compile + run, dev cầm contract về implement full-stack module mình.
 
 ## Role responsibilities
 
 | Role | Does | Does NOT do |
 |---|---|---|
-| **Leader** | Define freezed models + abstract interfaces + stub providers + wire router | Implement Firebase / UI screens |
-| **KhoaLND (BE)** | Implement Firebase repositories + controllers | Define new models / change interfaces unilaterally |
-| **HanDHG / NganTNK (FE)** | Implement UI screens using typed mock data | Call Firebase directly / invent ad-hoc models |
+| **Leader (ThienPDM)** | Define spec + freezed models + abstract interfaces + stub providers + wire router; review tất cả PR; gatekeep contract changes | Implement chi tiết module (trừ khi pickup làm safety net) |
+| **Module Owner** (mọi dev) | Full-stack implement module được giao: data layer, application layer (controllers), presentation layer (UI Flutter), test, native code (nếu module có widget Android) | Đụng module dev khác, đổi contract leader đã chốt, tự thêm field/interface không qua leader |
+| **Designer** (HanDHG, NganTNK — kèm role Module Owner) | Vẽ Figma frame + design system + theme token cho cả app TRƯỚC khi leader export contract | Vẽ ad-hoc trong code (hardcode color/font không qua design token) |
 
-## 3 non-negotiable rules
+> **Designer note:** HanDHG + NganTNK kiêm thêm Figma. Module nào do họ design Figma, ưu tiên chính họ implement Flutter để giữ design fidelity. Detail mapping Figma → Flutter: xem `24-flutter-ui-patterns.md`.
+
+## 4 non-negotiable rules
 
 ### 1. Skeleton rule — App always runs
 
-Every commit must compile cleanly and the app must launch. Stubs return mock data or
-throw `UnimplementedError` — no broken imports, no commented-out code to bypass errors.
+Mọi commit phải compile clean và app launch được. Stub trả mock data hoặc throw `UnimplementedError` — không broken import, không comment-out code để bypass error.
 
 ```dart
-// ✅ Correct stub
+// ✅ Correct stub (leader pre-defined trước khi giao module)
 @Riverpod(keepAlive: true)
 AuthRepository authRepository(Ref ref) => throw UnimplementedError(
-  'wire FirebaseAuthRepository in main.dart',
+  'wire FirebaseAuthRepository in main.dart — assigned to <DevName>',
 );
-
-// ❌ Never do this
-// import 'package:meep/features/auth/data/firebase_auth_repository.dart';
 ```
 
-### 2. Typed mock rule — FE uses the leader-defined freezed model
+### 2. Contract-first rule — Leader chốt contract trước khi dev start
 
-FE mock data must use the exact type defined by the leader. Never invent a
-`Map<String, dynamic>`. The Dart compiler catches mismatches at compile time — not runtime.
+Trước khi giao module cho dev, leader phải merge vào `develop`:
+
+- Spec đầy đủ tại `docs/specs/<feature>.md` (acceptance criteria đo được).
+- Freezed models + abstract interfaces (data layer contract).
+- Stub Riverpod providers (throw `UnimplementedError`).
+- Route stub trong router.
+- TODO marker `// TODO(<task-id>/<DevName>): ...` trên mọi stub.
+
+Dev pull `develop` về → contract đã sẵn → implement không cần đoán.
+
+```
+Leader: spec → models → interfaces → stubs → merge develop
+        ↓
+Module Owner pull develop → implement full-stack module
+        ↓
+Module Owner mở PR → leader review → merge develop
+        ↓
+Leader: wire real implementation in main.dart (integration check)
+```
+
+### 3. Strict gate — Đụng module khác hoặc chệch contract phải qua leader
+
+**Khoá lại + báo leader** khi:
+
+- Cần đổi field trong freezed model leader đã chốt (kể cả thêm field mới).
+- Cần đổi signature của abstract interface.
+- Cần touch file thuộc module dev khác (không phải module mình own).
+- Cần thêm Firestore collection / index mới.
+- Cần thêm pub package vào `pubspec.yaml` hoặc npm package vào `firebase/functions/package.json`.
+- Phát hiện contract không khớp Figma / spec.
+- Cần đổi shared code (`core/`, `shared/widgets/`, `core/theme/`).
+
+**Cách xử lý:**
+
+1. Stop. Không tự sửa.
+2. Comment trên GitHub issue đang làm: `Block: cần đổi <X> trong module <Y>, ping @manhthien2005`.
+3. Leader xem xét → cập nhật spec/contract → merge contract change vào `develop` qua PR riêng → ping dev tiếp tục.
+
+> Vì sao strict: contract là source of truth chung. Mỗi solo-dev tự quyết → conflict + drift + integration crash. Leader gate giữ tốc độ team đồng bộ.
+
+### 4. Typed everything — không `Map<String, dynamic>` ad-hoc
+
+Mọi data flow giữa các layer phải dùng freezed model leader đã định nghĩa. Mock data trong test cũng dùng đúng type đó.
 
 ```dart
-// ✅ Typed mock
+// ✅ Typed
 final mockUser = UserProfile(
   uid: 'mock-uid',
   displayName: 'Thien',
@@ -47,35 +85,17 @@ final mockUser = UserProfile(
   createdAt: DateTime.now(),
 );
 
-// ❌ Ad-hoc map — compiler cannot catch mismatches
+// ❌ Ad-hoc map — compiler không catch được mismatch
 final mockUser = {'name': 'Thien', 'avatar': 'url'};
-```
-
-### 3. Freeze-before-FE rule — Models land on develop before FE starts
-
-Freezed models and abstract interfaces must be merged into `develop` before any FE dev
-begins implementing a screen that depends on them. FE devs do not define models.
-
-Mandatory order per feature:
-```
-Leader: define models + interfaces → merge into develop
-    ↓
-FE and BE start in parallel (pull from develop)
-    ↓
-Leader: wire real implementation in main.dart (integration)
 ```
 
 ## Ownership principle
 
-Every file the agent creates or modifies is **that dev's code**. Read and understand it
-before committing. Do not accept a file just because "the agent probably got it right".
-
-When starting a task: read the relevant files first, understand the context, then prompt
-the agent.
+Mỗi file dev tạo hoặc sửa là **code của dev đó** (kể cả AI agent generate). Đọc + hiểu trước khi commit. Code mình own → mình chịu trách nhiệm review, debug, maintain.
 
 ## Stub / placeholder standard
 
-Every stub must have a TODO that identifies the assignee and task:
+Mọi stub phải có TODO identify task ID + module owner:
 
 ```dart
 // TODO(T8/HanDHG): implement IntroPage per Figma — intro screen
@@ -84,27 +104,50 @@ Every stub must have a TODO that identifies the assignee and task:
 
 Format: `// TODO(<task-id>/<DevName>): <short description>`
 
-A TODO without `<task-id>/<DevName>` is **invalid** and will be flagged in review.
+TODO không có `<task-id>/<DevName>` → **invalid**, sẽ bị flag trong `/review`.
 
-## When to ask the leader before proceeding
+## Module ownership tracking
 
-Always ask the leader (do not decide unilaterally) when:
+Hiện tại module list **chưa chốt**. Khi anh finalize:
 
-- Adding a new field to a freezed model that affects multiple devs
-- Changing the signature of an abstract interface
-- Adding a new Firestore collection or index
-- Adding a new pub package dependency to `pubspec.yaml`
-- Discovering that the contract does not match Figma (report it — do not fix unilaterally)
+1. Anh update `docs/specs/modules.md` (hoặc tương đương) — bảng module → owner.
+2. Update `.github/CODEOWNERS` — mỗi module path có module owner + leader required.
+3. Update file này — thêm bảng module owner reference.
 
-## Complex screens — leader defines extra context before FE mocks
+Cho đến lúc đó: leader assign từng task qua GitHub issue, owner = assignee của issue.
 
-Some patterns are not visible in Figma and require a leader decision before FE starts:
+## Cross-module touch — FORBIDDEN by default
 
-| Screen | Leader must decide first |
+Module Owner A KHÔNG được tự ý sửa code thuộc module Owner B. Kể cả:
+
+- Bug fix nhỏ trong module B (kể cả 1 dòng).
+- Format / rename "tiện thể".
+- Thêm field vào model dùng chung.
+
+**Trừ ngoại lệ duy nhất:** leader explicit assign cross-module task qua issue (vd "fix #42: Khoa fix bug trong Auth module của Han") → tạo branch + PR review bởi cả Han + leader.
+
+## Definition of Done — solo-dev module
+
+Module được mark Done chỉ khi:
+
+- [ ] Spec acceptance criteria pass (đo được, không "should work").
+- [ ] Data layer: repository implement đúng abstract interface, có unit test với `fake_cloud_firestore`.
+- [ ] Application layer: controller có unit test cover happy + edge + error.
+- [ ] Presentation layer: widget test cho critical flow + design tokens (no hardcoded color/font).
+- [ ] Native code (nếu có): Android widget test hoặc manual smoke test trên device.
+- [ ] `flutter analyze` + `dart format` clean.
+- [ ] Functions test (nếu module có Cloud Function): `npm test` + `npm run lint` clean.
+- [ ] PR review: leader approve + module owner self-review qua `/review` framework.
+- [ ] CI pass: `pr-check.yml` green.
+- [ ] Merged vào `develop`, issue auto-close qua `Closes #N`.
+
+## Anti-patterns
+
+| Anti-pattern | Vấn đề |
 |---|---|
-| Feed, Space | Fan-out vs query strategy → Firestore collection path |
-| Reaction | Optimistic UI contract → error rollback behavior |
-| Pagination | Cursor strategy → `startAfterDocument` field in model |
-
-For these screens: FE checks with the leader (30 min sync) before starting to mock.
-For Auth, Profile, Diary, Camera UI: the freezed model is sufficient — FE can start immediately.
+| Tự đổi field trong shared model "vì cần" | Break module dev khác → integration fail |
+| Hardcode color/font trong screen | Design system drift, dark mode broken |
+| Push code thẳng `develop` "vì gấp" | Branch protection block + bypass review = bug lọt prod |
+| Skip spec, code thẳng "tạm" | Không có acceptance → không biết khi nào done |
+| Module A pickup task module B "tiện thể" | Vi phạm ownership, owner B mất context |
+| Commit `feat(auth):` từ module Feed | Scope sai → changelog rối, history khó truy |

--- a/.windsurf/rules/60-windsurf-features.md
+++ b/.windsurf/rules/60-windsurf-features.md
@@ -1,0 +1,143 @@
+---
+trigger: manual
+description: Windsurf/Cascade features cheatsheet — workflows, skills, MCP setup, hooks, rule modes. Load when user asks about Windsurf features/setup, or when agent needs to suggest a Windsurf-native workflow.
+---
+
+# Windsurf / Cascade Features Cheatsheet
+
+> Windsurf có nhiều tính năng native mà em phải tận dụng để tiết kiệm token và làm nhanh hơn. File này nhắc em (và anh) các surface chính.
+
+## Rule activation modes (Windsurf)
+
+Windsurf dùng frontmatter trong `.windsurf/rules/*.md`:
+
+| Mode | Frontmatter | Khi nào |
+|---|---|---|
+| **Always On** | `trigger: always_on` | Load mỗi message — cho rule core (operating mode, project context, security). |
+| **Glob-scoped** | `trigger: glob` + `globs: <pattern>` | Tự load khi file match được mở/edit — cho stack-specific rule (Flutter, Functions). |
+| **Manual** | `trigger: manual` | Chỉ load khi user gọi tên rule trong chat — cho reference hiếm dùng. |
+
+**Meep dùng:**
+- `trigger: always_on` — `00`, `05`, `10`, `20`, `25`, `30`, `40`, `50`
+- `trigger: glob` — `21` (Flutter), `22` (Functions), `23` (Firestore), `24` (UI patterns)
+- `trigger: manual` — `60` (file này)
+
+## Skills system (Windsurf)
+
+- Skills nằm ở `.windsurf/skills/<name>/SKILL.md`.
+- Cascade đọc `description:` trong frontmatter để biết khi nào invoke.
+- Em invoke bằng cách read `SKILL.md` đó **trước khi** làm task tương ứng.
+- User có thể request trực tiếp bằng tên skill trong chat.
+
+**Skills hiện có (11):**
+- `tdd`, `systematic-debugging`, `verification-before-completion` — discipline
+- `karpathy-guidelines`, `brainstorming`, `writing-plans` — methodology
+- `code-review-five-axis` — review framework
+- `flutter-firebase-patterns`, `nodejs-ts-backend` — stack patterns
+- `figma-to-flutter` — Figma → Flutter widget (strict design token mapping)
+- `caveman-vi` — opt-in compressed mode
+
+## Workflows / Slash commands (Windsurf)
+
+Workflows nằm ở `.windsurf/workflows/*.md`. Cascade dùng `description:` field để tự match.
+
+| Command | File | Khi nào |
+|---|---|---|
+| `/start <issue-id>` | `workflows/start.md` | Kickoff task mới từ GitHub issue |
+| `/spec` | `workflows/spec.md` | Viết PRD/spec cho feature mới |
+| `/plan` | `workflows/plan.md` | Chia spec → ordered task list |
+| `/build` | `workflows/build.md` | TDD cycle implement task |
+| `/test` | `workflows/test.md` | Write/extend tests |
+| `/review` | `workflows/review.md` | 5-axis self review trước PR |
+| `/debug` | `workflows/debug.md` | Systematic root cause investigation |
+| `/fix-issue` | `workflows/fix-issue.md` | Fix specific GitHub issue end-to-end |
+| `/deploy` | `workflows/deploy.md` | Deploy workflow với pre-flight checklist |
+
+## Hooks (project-level)
+
+`.windsurf/hooks.json` chạy script Python để guard agent action:
+
+| Hook | Script | Mục đích |
+|---|---|---|
+| `pre_run_command` | `block_dangerous_commands.py` | Block `rm -rf /`, `git push --force` lên main, `firebase deploy prod`, etc. |
+| `pre_read_code` | `protect_secrets.py` | Block đọc `.env`, `*.pem`, service account JSON, ... |
+| `pre_write_code` | `protect_secrets.py` | Block ghi vào file secret. |
+
+**Nếu hook block** → em phải dừng + báo anh, không được bypass.
+
+## MCP servers (Windsurf)
+
+Windsurf đọc MCP từ **user-level** (không phải workspace-level):
+- **Path:** `~/.codeium/windsurf/mcp_config.json` (Windows: `C:\Users\<you>\.codeium\windsurf\mcp_config.json`)
+- Template commit trong repo: `.windsurf/mcp_config.example.json`
+
+**Setup:**
+```pwsh
+# 1. Copy template ra user-level
+Copy-Item .windsurf\mcp_config.example.json "$env:USERPROFILE\.codeium\windsurf\mcp_config.json"
+
+# 2. Edit file: điền GitHub PAT thật vào chỗ ghp_REPLACE_...
+# 3. Restart Windsurf → MCP panel reload.
+```
+
+**MCPs hiện tại enable cho Meep:**
+
+| MCP | Mục đích |
+|---|---|
+| `context7` | Live docs cho Flutter, Firebase, Riverpod, freezed — prevents hallucinating outdated APIs |
+| `github` | Issues, PRs, repos, code search, workflows |
+| `figma-mcp-go` | Figma frame → code (bridge qua plugin, không cần API key) |
+
+**KHÔNG enable:** `filesystem`, `memory`, `postgres` — ops surface quá lớn cho 4-dev capstone.
+
+## Custom @Docs trong Windsurf
+
+Cascade có thể index docs phổ biến. Anh có thể add docs riêng qua Windsurf Settings.
+
+**Khuyến nghị add cho Meep (Android-only, ADR-0002):**
+
+| Doc | URL |
+|---|---|
+| Riverpod 2 | `https://riverpod.dev/` |
+| Riverpod code-gen | `https://riverpod.dev/docs/concepts/about_code_generation` |
+| Flutter CustomPainter | `https://api.flutter.dev/flutter/rendering/CustomPainter-class.html` |
+| home_widget package | `https://pub.dev/packages/home_widget` |
+| Android AppWidget | `https://developer.android.com/develop/ui/views/appwidgets/overview` |
+| Firebase Functions v2 | `https://firebase.google.com/docs/functions/2nd-gen-upgrade` |
+| Firestore Security Rules | `https://firebase.google.com/docs/firestore/security/rules-conditions` |
+
+Diary feature cần canvas draw → Flutter CustomPainter doc là core. KHÔNG add iOS WidgetKit / Apple Sign-In (defer per ADR-0002).
+
+## Team onboarding cho `.windsurf/`
+
+Mọi thứ trong `.windsurf/` (trừ `mcp_config.json` thật) đều commit git. Team member mới chỉ cần:
+
+```pwsh
+# 1. Pull repo về
+git clone <repo>
+
+# 2. Copy MCP template → user-level path + điền token
+Copy-Item .windsurf\mcp_config.example.json "$env:USERPROFILE\.codeium\windsurf\mcp_config.json"
+# Edit file: thay ghp_REPLACE_... bằng GitHub PAT cá nhân
+
+# 3. (Optional) Figma MCP — download plugin.zip từ GitHub, import vào Figma Desktop
+
+# 4. Restart Windsurf → done
+```
+
+## Token discipline khi dùng Windsurf
+
+- **Đính file cụ thể** (cite `@file`) thay vì ask thứ mơ hồ cho task định scope rõ.
+- **Tránh đọc file > 1000 dòng full** — dùng `grep` hoặc read với offset/limit.
+- **Tận dụng glob-scoped rules** — không cần nhắc lại nội dung Flutter rules khi đang edit Dart file.
+
+Xem thêm `50-token-discipline.md`.
+
+## Windsurf-specific anti-patterns
+
+| Anti-pattern | Vì sao xấu |
+|---|---|
+| Không invoke skill khi task match `description` | Skill là discipline, không phải optional. |
+| Edit `.windsurf/rules/*.md` trong feature branch | Infra file — phải ở `chore/` branch (xem `00-personal-operating-mode.md`). |
+| Copy MCP token vào `.windsurf/mcp_config.example.json` và commit | Secret leak — file example gitignored hay không gitignored đều nguy hiểm. User-level path thôi. |
+| Dùng `pre_write_code` hook bypass với env var | Hook có lý do — discuss với anh trước. |

--- a/.windsurf/skills/figma-to-flutter/SKILL.md
+++ b/.windsurf/skills/figma-to-flutter/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: figma-to-flutter
+description: Convert Figma frame/node → Flutter widget với strict design token mapping + dual-source verification (MCP data + PNG image). Use when user pastes a Figma node URL or attaches a Figma screenshot and asks to generate a Flutter widget. Scope: 1 frame = 1 widget (compose multiple widgets sau). Strict gate: KHÔNG inline hex/font — token thiếu → ping leader.
+---
+
+# Figma → Flutter Widget — Strict Mapping Skill
+
+> Solo-dev model: HanDHG + NganTNK kiêm Figma + module owner. Skill này guide họ (và mọi dev khác đụng UI) chuyển 1 Figma node → 1 Flutter widget **clean, không drift design token**.
+
+## Core principle
+
+**KHÔNG có Figma → Flutter pixel-perfect.** Mỗi Figma node convert qua 3 round:
+1. Extract (MCP + image cross-check) → widget v1.
+2. Verify (test + visual diff) → list lệch điểm.
+3. Refine (specific fix) → widget final.
+
+Sau 3 round vẫn lệch → designer review Figma (overflow / missing constraint).
+
+## Scope (strict)
+
+- ✅ **1 frame Figma = 1 widget Flutter class.** Không attempt full screen 1 lần.
+- ✅ **Compose nhiều widget nhỏ thành page** ở 1 PR riêng, sau khi từng widget đã merge.
+- ❌ KHÔNG generate `MaterialApp`, route config, navigation logic — đây là responsibility của leader (`core/router/`).
+- ❌ KHÔNG generate Riverpod controller / business logic — chỉ presentation layer.
+
+## Strict gate — Design token
+
+**Color / font / spacing / radius KHÔNG có trong `core/theme/` → STOP.** KHÔNG inline hex, KHÔNG hardcode font size. Quy trình unblock:
+
+1. Skill liệt kê token thiếu trong output.
+2. Module owner ping leader: "Cần thêm token X vào `core/theme/`".
+3. Leader đánh giá → nếu OK → merge token vào `develop` qua PR riêng (chore branch).
+4. Module owner pull develop → resume widget generation.
+
+Lý do strict: `core/theme/` là shared code (rule 25 §Cross-module touch). 1 dev tự thêm token = drift design system.
+
+## Pre-flight
+
+Trước khi extract:
+
+- [ ] Verify Figma MCP active (`figma-mcp-go` trong `.windsurf/mcp_config.example.json`).
+- [ ] Verify đang trên feature branch `feature/<DevName>/<short-desc>` (KHÔNG develop/deploy).
+- [ ] Read `core/theme/`:
+  - `core/theme/color_scheme.dart` — color tokens
+  - `core/theme/text_theme.dart` — typography tokens
+  - `core/theme/spacing.dart` — spacing tokens
+  - `core/theme/radii.dart` — border radius tokens
+- [ ] User đã attach 2 nguồn:
+  1. **Figma node URL** (cho MCP extract).
+  2. **PNG @2x hoặc SVG** của node (cho agent "nhìn"). PNG @1x quá nhỏ, JPG có compression artifacts → KHÔNG dùng.
+
+## Phase 1 — Extract (dual source)
+
+### 1.1. MCP extract (số liệu)
+
+```
+mcp.call("figma_get_node", { nodeId: "<id>", url: "<paste URL>" })
+```
+
+Output expected:
+- Layer tree (frame → child → child).
+- Auto-Layout config (direction, spacing, padding, alignment).
+- Color values (hex format).
+- Text styles (font family, size, weight, line height).
+- Constraints (stretch / fixed / hug).
+- Component variants nếu có.
+
+### 1.2. Image "look at" (intent)
+
+Agent đọc PNG/SVG attached:
+- Visual layout intent (whitespace, alignment "feel").
+- Catch lỗi MCP (layer ẩn, overlay missing).
+- Confirm component hierarchy match MCP tree.
+
+### 1.3. Cross-check
+
+- MCP nói có 5 children → image phải thấy 5 phần tử.
+- MCP nói color `#1A73E8` → image phải xuất hiện màu xanh đó ở vị trí khớp.
+- **Nếu lệch → STOP**, báo user: "MCP data và image không khớp — Figma có overlay ẩn hoặc layer hidden?"
+
+## Phase 2 — Map (strict rules table)
+
+Bảng quy đổi cố định. Agent KHÔNG tự đoán. Có rule → follow. Không có → STOP.
+
+### Layout
+
+| Figma | Flutter |
+|---|---|
+| Frame Auto-Layout vertical | `Column` |
+| Frame Auto-Layout horizontal | `Row` |
+| Stack (overlap) | `Stack` + `Positioned` |
+| Auto-Layout padding | `Padding(padding: EdgeInsets.all(Spacing.md))` |
+| Item spacing | `SizedBox(height: Spacing.sm)` between children, hoặc `Column(spacing: Spacing.sm)` (Flutter 3.27+) |
+| Constraint Stretch | `Expanded` |
+| Constraint Fixed (W,H) | `SizedBox(width: X, height: Y)` |
+| Constraint Hug | default (no wrapper) |
+
+### Color
+
+| Figma | Flutter |
+|---|---|
+| Hex `#1A73E8` | **Tra `core/theme/color_scheme.dart`** → `Theme.of(context).colorScheme.primary` (hoặc token đúng tên) |
+| Token thiếu | **STOP** — ping leader thêm token |
+
+### Typography
+
+| Figma | Flutter |
+|---|---|
+| Style "Headline/Large" | `Theme.of(context).textTheme.headlineLarge` |
+| Custom font size không match style | **STOP** — Figma có style chưa? Nếu chưa → designer adjust Figma trước |
+
+### Spacing & Radius
+
+| Figma | Flutter |
+|---|---|
+| Spacing 4/8/16/24/32px | `Spacing.xs/sm/md/lg/xl` token |
+| Border radius 4/8/12/16px | `Radii.xs/sm/md/lg` token |
+| Value không match scale | **STOP** — propose round to nearest token, ping leader |
+
+### Component variants
+
+| Figma | Flutter |
+|---|---|
+| Component variant "primary/secondary/ghost" | Factory constructor: `Button.primary()`, `Button.secondary()`, `Button.ghost()` |
+| Component variant "size: sm/md/lg" | Enum + named constructor: `Button.primary(size: ButtonSize.lg)` |
+
+## Phase 3 — Validate before generate
+
+Trước khi generate code, agent print summary:
+
+```
+Figma node: <name>
+File: <feature>/presentation/widgets/<widget_name>.dart
+Layout: Column / Row / Stack
+Children: <count>
+
+Tokens used:
+  ✅ colorScheme.primary
+  ✅ textTheme.headlineLarge
+  ✅ Spacing.md, Spacing.sm
+  ✅ Radii.md
+
+Tokens MISSING (must add to core/theme first):
+  ❌ <none> — proceed
+  
+  HOẶC
+  
+  ❌ colorScheme.tertiary (hex #FF6B35) — STOP, ping leader
+  ❌ textTheme.labelXLarge (custom 20px bold) — STOP, ping leader
+
+Proceed? (yes / wait for tokens)
+```
+
+Nếu có MISSING → KHÔNG continue Phase 4. Output instructions cho user ping leader.
+
+## Phase 4 — Generate widget code
+
+### File location
+
+`apps/mobile/lib/features/<my-module>/presentation/widgets/<widget_name>.dart`
+
+Naming rule:
+- Figma layer name `btn_primary_lg` → class `PrimaryButtonLarge`, file `primary_button_large.dart`.
+- snake_case file, UpperCamelCase class.
+
+### Widget template
+
+```dart
+import 'package:flutter/material.dart';
+
+/// <Brief description from Figma layer comment>
+///
+/// Generated from Figma node: <node-name>
+/// Module: <module-name>
+class <WidgetName> extends StatelessWidget {
+  const <WidgetName>({
+    super.key,
+    // required params
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final textStyles = theme.textTheme;
+
+    return <root layout>;
+  }
+}
+```
+
+### Const constructors mandatory
+
+Mọi widget tĩnh → `const` constructor. Linter check sẽ catch nếu miss.
+
+### No business logic
+
+- KHÔNG `ref.watch(provider)` trong widget — consume controller có sẵn qua callback hoặc parameter.
+- KHÔNG `async` method trong widget — pass callback `VoidCallback onTap`.
+- KHÔNG hardcoded text strings — hoặc pass via param, hoặc dùng `AppLocalizations` (nếu i18n đã setup).
+
+### Component with variants — factory pattern
+
+```dart
+class MeepButton extends StatelessWidget {
+  const MeepButton._({
+    required this.label,
+    required this.onPressed,
+    required this._variant,
+  });
+
+  factory MeepButton.primary({
+    required String label,
+    required VoidCallback onPressed,
+  }) =>
+      MeepButton._(label: label, onPressed: onPressed, _variant: _Variant.primary);
+
+  factory MeepButton.secondary({...}) => ...;
+
+  final String label;
+  final VoidCallback onPressed;
+  final _Variant _variant;
+
+  @override
+  Widget build(BuildContext context) {...}
+}
+
+enum _Variant { primary, secondary, ghost }
+```
+
+## Phase 5 — Generate widget test (mandatory)
+
+Test file: `apps/mobile/test/features/<my-module>/presentation/widgets/<widget_name>_test.dart`
+
+### Test template
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/<my-module>/presentation/widgets/<widget_name>.dart';
+
+void main() {
+  group('<WidgetName>', () {
+    testWidgets('renders without overflow', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: <WidgetName>(/* test params */),
+          ),
+        ),
+      );
+      expect(find.byType(<WidgetName>), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('finds expected text/elements', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: <WidgetName>(...))),
+      );
+      expect(find.text('<expected text from Figma>'), findsOneWidget);
+    });
+
+    testWidgets('respects design tokens (no hardcoded colors)', (tester) async {
+      // Verify widget uses Theme.of(context) — not hex literals.
+      // Spot check via finder: widget with key X has colorScheme.primary background.
+    });
+  });
+}
+```
+
+### Mandatory test cases per widget
+
+- [ ] Renders without throwing.
+- [ ] No layout overflow (RenderFlex error).
+- [ ] Critical text/buttons findable.
+- [ ] Tap callbacks invoke (if interactive).
+
+Optional (for component widget):
+- [ ] Variant rendering (primary/secondary).
+- [ ] Disabled state.
+- [ ] Loading state.
+
+## Phase 6 — Verify (3-round iteration)
+
+### Round 1 — Automated check
+
+```bash
+flutter test test/features/<my-module>/presentation/widgets/<widget_name>_test.dart
+flutter analyze
+dart format --set-exit-if-changed lib/features/<my-module>/presentation/widgets/<widget_name>.dart
+```
+
+Tất cả pass → Round 2. Fail → fix lỗi cụ thể, repeat Round 1.
+
+### Round 2 — Visual diff (manual)
+
+User render trên emulator + so sánh:
+
+```bash
+cd apps/mobile
+flutter run -d android
+```
+
+User chụp screenshot Flutter widget → attach lại vào chat cùng Figma image. Agent compare:
+
+| Element | Figma | Flutter | Match? |
+|---|---|---|---|
+| Layout direction | Column | Column | ✅ |
+| Primary button color | colorScheme.primary | colorScheme.primary | ✅ |
+| Vertical spacing | Spacing.md (16px) | Spacing.md | ✅ |
+| Title font | textTheme.headlineLarge | textTheme.titleLarge | ❌ MISMATCH |
+
+Output diff list cho user. Agent fix specific items, KHÔNG rewrite full widget.
+
+### Round 3 — Refine
+
+Sau Round 2 fix, repeat Round 1 + Round 2. Nếu vẫn lệch:
+
+- < 3 round: agent fix tiếp.
+- = 3 round vẫn lệch: STOP. Designer review Figma xem có overflow / missing constraint / sai style không. KHÔNG ép code match Figma sai.
+
+## Output format
+
+Sau khi skill chạy xong, output structured:
+
+```markdown
+## Figma → Flutter: <WidgetName>
+
+### Files generated
+- `apps/mobile/lib/features/<m>/presentation/widgets/<w>.dart` (XX lines)
+- `apps/mobile/test/features/<m>/presentation/widgets/<w>_test.dart` (XX lines)
+
+### Tokens used
+- colorScheme.primary, textTheme.headlineLarge, Spacing.md, Radii.md
+
+### Tokens MISSING (PR riêng cần thiết)
+- <none — proceed>
+  HOẶC
+- ❌ colorScheme.tertiary (hex #FF6B35) — leader chưa thêm. Wait.
+
+### Verification
+- ✅ flutter test passed (3/3)
+- ✅ flutter analyze clean
+- ✅ Round 1 automated done
+- ⏸ Round 2 visual diff — user chụp screenshot trên emulator + attach
+
+### Next steps
+1. `flutter run -d android` → render widget
+2. Screenshot widget Flutter
+3. Attach + ping agent: "compare với Figma"
+```
+
+## Anti-patterns
+
+| Anti-pattern | Vấn đề |
+|---|---|
+| Inline hex `Color(0xFF1A73E8)` vì `core/theme` chưa có token | Drift design system, dark mode vỡ |
+| Hardcode `TextStyle(fontSize: 16)` | Bypass textTheme → inconsistent |
+| Generate full screen 1 lần | Risk lệch cao, khó review |
+| Generate widget + Riverpod controller cùng PR | Mix concerns, vi phạm solo-dev contract |
+| Force code match Figma sai (overflow, missing constraint) | Designer phải fix Figma trước, không ép code |
+| Skip widget test | Solo-dev model: presentation layer test là mandatory |
+| Auto-add token vào `core/theme` tự động | `core/` là shared code, cần leader gate |
+| Skip image, chỉ dùng MCP | Miss visual intent, layer ẩn không catch |
+| Generate vượt scope (vd touch `data/` hoặc `application/`) | Skill chỉ generate `presentation/` |
+
+## Quick reference card
+
+```
+Trigger: user paste Figma node URL + image PNG/SVG @2x
+
+Pre-flight:
+  [ ] MCP active (figma-mcp-go)
+  [ ] Feature branch
+  [ ] Read core/theme/* tokens
+  [ ] Image quality check (PNG @2x hoặc SVG)
+
+Phase 1 Extract:
+  - MCP figma_get_node → layer tree + values
+  - "Look at" image → layout intent
+  - Cross-check, STOP nếu lệch
+
+Phase 2 Map:
+  - Strict table (layout / color / typography / spacing / radius / variants)
+  - Token thiếu → STOP
+
+Phase 3 Validate:
+  - Print summary tokens used + missing
+  - Wait approval nếu missing
+
+Phase 4 Generate:
+  - Widget class theo Figma layer naming
+  - Const constructor mandatory
+  - No business logic
+
+Phase 5 Test:
+  - Widget test mandatory (renders, no overflow, find elements)
+  - Variant test nếu có
+
+Phase 6 Verify:
+  - Round 1: flutter test + analyze + format
+  - Round 2: user screenshot + visual diff
+  - Round 3: refine specific items
+  - >3 round lệch → escalate designer
+```
+
+## Related skills/rules
+
+- `24-flutter-ui-patterns.md` (rule, glob-scoped) — design token rules + accessibility checklist khi edit `presentation/`.
+- `25-dev-code-standards.md` (rule, alwaysApply) — cross-module gate + shared code rule.
+- `flutter-firebase-patterns` (skill) — Riverpod + Firestore patterns (consume từ widget).
+- `code-review-five-axis` (skill) — 5-axis review trước PR (bao gồm no-hardcoded-color check).

--- a/.windsurf/workflows/build.md
+++ b/.windsurf/workflows/build.md
@@ -16,7 +16,7 @@ Implement task by task from `tasks/todo-<feature>.md`. Each task = one Red-Green
    ```bash
    git branch --show-current   # must NOT be develop or deploy
    ```
-4. **Infra-file guard** — before touching ANY file under `.windsurf/`, `.github/`, `docs/adr/`, `scripts/`:
+4. **Infra-file guard** — before touching ANY file under `.windsurf/`, `.cursor/`, `.github/`, `docs/adr/`, `scripts/`:
    - Verify current branch is `chore/<DevName>/...` (not a `feature/` branch).
    - If on a `feature/` branch → **STOP**. Stash changes, create `chore/<DevName>/<desc>` from `develop`, commit infra there, open a separate PR.
    - Lesson: PR #27 mixed infra + feature → required painful cherry-pick to untangle.
@@ -65,7 +65,7 @@ git add <specific files>
 git commit -m "feat(<scope>): <description>"
 ```
 
-**Before `git add`:** scan staged files. If any path starts with `.windsurf/`, `.github/`, `docs/adr/`, `scripts/` → do NOT add on a `feature/` branch. Move them to a `chore/` branch first.
+**Before `git add`:** scan staged files. If any path starts with `.windsurf/`, `.cursor/`, `.github/`, `docs/adr/`, `scripts/` → do NOT add on a `feature/` branch. Move them to a `chore/` branch first.
 
 Allowed types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `perf`, `style`. Body (optional) explains **why**, not what.
 


### PR DESCRIPTION
## Thay đổi

Sync toàn bộ kiến trúc .windsurf/ với .cursor/ để Windsurf/Cascade hoạt động ngang tầm Cursor.

### Rules mới / cập nhật
- **05-domain-language.md** [MỚI] — domain vocab, entity definitions, pairId, disambiguation (Widget/Provider/Storage/Rule)
- **60-windsurf-features.md** [MỚI] — Windsurf cheatsheet (trigger modes, MCP user-level path, workflows, skills)
- **25-dev-code-standards.md** [OVERWRITE] — FE/BE model cũ → solo-dev model đầy đủ (4 non-negotiable rules, contract-first, strict gate, Definition of Done)
- **00-personal-operating-mode.md** — xóa DEPRECATED banner, thêm \.cursor/\ vào infra-file guard
- **10-project-context.md** — xóa DEPRECATED banner, thêm solo-dev model + DevName mapping

### Skills mới
- **skills/figma-to-flutter/SKILL.md** [MỚI] — 6-phase Figma→Flutter với strict design token gate, dual-source verify (MCP + PNG), 3-round iteration

### Config / Hooks
- **mcp_config.example.json** — thêm \github\ + \igma-mcp-go\ servers (ngang với \.cursor/mcp.example.json\)
- **hooks/block_dangerous_commands.py** — thêm \develop\/\deploy\ vào force-push guard
- **workflows/build.md** — thêm \.cursor/\ vào infra-file guard list

## Kiểm tra
- [x] Pre-commit hook pass (commitlint + format)
- [x] Branch name đúng format \chore/<DevName>/<desc>\
- [x] Chỉ có file \.windsurf/\ trong commit — không lẫn feature code

## Issue liên quan
Không có issue — infra sync task theo yêu cầu leader.