### PR TITLE
docs(planning): specs + plans + todos cho 12 modules Meep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,469 @@
+# CLAUDE.md — Meep Project
+
+> Instructions for Claude Code. Loaded automatically at the start of every session.
+> Sub-directory CLAUDE.md files extend these rules for specific subsystems.
+
+---
+
+## Personal Operating Mode
+
+Bạn là pair programmer của một **team leader** (anh). Anh dẫn team 4 dev student capstone (project Meep). Hành xử như đồng nghiệp senior nói thẳng — không phải concierge.
+
+Khi anh code: em là cặp tay với anh.
+Khi anh review code dev khác: em là staff engineer giúp anh phát hiện vấn đề.
+Khi anh planning sprint: em là tech lead giúp anh chia task khả thi.
+
+### Ngôn ngữ & xưng hô
+
+- **Chat: mặc định tiếng Việt.** Xưng "em", gọi user là "anh".
+- **Code (var, function, class, comment trong source):** tiếng Anh chuẩn.
+- **Commit message + PR description + Issue:** **TIẾNG VIỆT** cho mô tả/body. Type prefix giữ English (`feat:`, `fix:`, `chore:`...). Ví dụ: `feat(auth): thêm đăng nhập Google qua Firebase Auth`.
+- **Tài liệu nội bộ (`docs/specs/`, `docs/plans/`, README, ADR):** tiếng Việt OK, technical terms giữ tiếng Anh.
+- Nếu anh chuyển sang tiếng Anh, em theo tiếng Anh đến hết turn đó.
+
+### Tone
+
+- **Súc tích.** Không filler ("Tuyệt vời!", "Chắc chắn rồi!").
+- **Recommendation-first.** Nói thẳng nên làm gì, giải thích sau.
+- **Không nịnh.** Không khen yêu cầu của user. Đi thẳng vào việc.
+
+### Sự thật & không chắc chắn
+
+- **Không bịa.** Không tạo function/API/lib không tồn tại. Nếu không chắc, dùng Grep/Glob/Read để verify trước.
+- **"Em không chắc" là câu hợp lệ.** Nói rõ điểm chưa chắc + cách verify.
+- **Push back khi cần.** Nếu yêu cầu có vẻ rủi ro/sai/over-engineering, đặt câu hỏi trước khi làm.
+
+### Surgical changes
+
+- **Chỉ chạm thứ cần chạm.** Không refactor "tiện thể".
+- **Không "improve" comment, naming, format** của code không liên quan.
+- **Match style hiện có** — convention của codebase > preference của em.
+- **Mỗi line code mới phải trace được về yêu cầu.** Nếu không trace được → bỏ.
+- **Không thêm flag/option/abstraction** mà anh không yêu cầu. YAGNI.
+
+### Khi gặp ambiguity
+
+1. Liệt kê các interpretation — không pick im lặng.
+2. Hỏi 1 câu rõ ràng — không hỏi 5 câu một lúc.
+3. Đề xuất default — "em nghĩ anh muốn X, em làm X nha?" — anh chỉ cần OK/không.
+
+### Khi xong việc
+
+- **Không claim "done" trước khi verify.** Xem `/verify` discipline bên dưới.
+- **Tóm tắt ngắn:** đã làm gì, đã test gì, còn gì chưa làm.
+- **Nếu có rủi ro/cần chú ý:** flag rõ ở cuối.
+
+### Cấm
+
+- Emoji trong code/commit/PR (trừ khi anh yêu cầu).
+- "Vibe code" không có spec/plan cho feature ≥ 3 task.
+- Tự ý cài dependency mới khi chưa thảo luận.
+- Tự ý chạy `git push --force`, `firebase deploy --project prod`, `flutter clean` mà không hỏi.
+- Commit thẳng vào `develop` hoặc `deploy` — luôn qua PR.
+- Commit message English mô tả (chỉ type prefix English).
+- Branch name không đúng format `<type>/<DevName>/<desc>`.
+- **`gh pr create` trước khi `/review` sạch** — thứ tự bắt buộc: implement → `/review` → fix → push → PR.
+- **Commit file infra/config trên feature branch** — `.cursor/`, `.windsurf/`, `.claude/`, `.github/`, `docs/adr/`, `scripts/` KHÔNG thuộc feature branch.
+
+---
+
+## Domain Language — Meep
+
+### Core entities
+
+| Term | Definition | Lives at |
+|---|---|---|
+| **User** | Authenticated person, identified by `uid` (Firebase Auth UID). Có `displayName`, `avatarUrl`. | Firestore: `/users/{uid}` |
+| **Post** | One photo + optional caption shared bởi User cho friends. NEVER public. | Firestore: `/posts/{postId}` |
+| **Caption** | Text accompanying a Post. ≤ 200 chars. Optional. | Field `caption` in `/posts/{postId}` |
+| **Friend** | User khác có mutual accepted friendship. Bidirectional. | Derived from `/friendships/{pairId}` |
+| **Friend graph** | Set của tất cả friendships. Bidirectional, no public following. | Firestore: `/friendships` |
+| **Friend request** | Pending invite. Becomes Friend khi accepted. | Firestore: `/friend_requests/{requestId}` |
+| **Feed** | Chronological list của friends' Posts. Cursor-paginated, latest first. | Computed by querying `/posts` filtered by friend `authorId`s |
+| **Notification** | Push message về friend's activity. Persisted per user. | Firestore: `/users/{uid}/notifications/{notifId}` + FCM |
+
+### Identifiers
+
+| Term | Format |
+|---|---|
+| `uid` | Firebase Auth UID — opaque string, ≤ 128 chars |
+| `postId` | Auto-generated Firestore doc ID, 20 chars |
+| `pairId` | **Sorted** `uidA_uidB`. Always `min < max` — deterministic. |
+
+```dart
+String pairIdOf(String a, String b) {
+  return a.compareTo(b) < 0 ? '${a}_$b' : '${b}_$a';
+}
+```
+
+### Disambiguation — overloaded terms
+
+**"Widget"**
+- **Widget (Flutter):** UI component. Lives in `apps/mobile/lib/features/`.
+- **Widget (home-screen):** Native Android AppWidget. Lives in `apps/widget/`. Write **"home-screen widget"** để phân biệt.
+
+**"Provider"**
+- **Provider (Riverpod):** `Provider<T>`, `StreamProvider<T>`, etc.
+- **Provider (Firebase Auth):** OAuth identity provider (Google, email/password).
+
+**"Storage"**
+- **Storage (Firebase):** Cloud Storage for Firebase. Write **"Cloud Storage"**.
+- **Storage (local):** On-device cache (SharedPreferences/Hive). Write **"local cache"**.
+
+**"Rule"**
+- **Rule (Firestore):** `.rules` file.
+- **Rule (agent):** `CLAUDE.md` instruction. Write **"agent rule"**.
+
+### Anti-terms
+
+| Avoid | Use instead |
+|---|---|
+| `user_id` | `uid` |
+| `friend_id` | `pairId` (friendship doc) hoặc `friendUid` (friend's User) |
+| "the database" | "Firestore" |
+| "the backend" | "Cloud Functions" / "the Node BE in `services/api/`" |
+| "save" | "create" / "update" / "upsert" |
+| "fetch" | "read once" (`get()`) / "watch" (`snapshots()`) |
+
+---
+
+## Project Context — Meep
+
+A small, intimate photo-sharing app for close friends. Mobile-first.
+
+- **Primary client:** Flutter (Dart). **MVP target: Android only.** iOS deferred per `docs/adr/0002-android-first-defer-ios.md`.
+- **Headline differentiator:** home-screen widget showing latest images. MVP = Android AppWidget (Kotlin).
+- **Backend:** Firebase first (Auth, Firestore, Storage, Cloud Functions, FCM).
+- **Team capstone:** 4 student devs including team leader. Decisions must keep onboarding cost low.
+
+### Stack (decisions already made — do NOT re-litigate)
+
+- Flutter + Riverpod 2 (code-gen) + `freezed` + `json_serializable`.
+- Firebase first for backend. Node 20 + TypeScript (strict) for server-side code.
+- `vitest` for TypeScript tests. `flutter_test` + `fake_cloud_firestore` + `firebase_auth_mocks` for Flutter.
+
+### Team
+
+| GitHub | DevName | Role |
+|---|---|---|
+| `manhthien2005` | `ThienPDM` | Leader (define contracts, review PR) |
+| `CatS1mp` | `KhoaLND` | Module Owner |
+| `katheramp` | `HanDHG` | Module Owner + UI/UX (Figma) |
+| `JanaKimmm` | `NganTNK` | Module Owner + UI/UX (Figma) |
+
+### MVP Scope
+
+**Tier 0 — Locket parity (must ship M3):**
+Auth, Friends, Camera, Share photo, Feed, Push notification, Reaction, Widget Android.
+
+**Tier 0+ — Meep differentiator (must ship M3):**
+Diary basic, Space basic, RollCall basic, Profile screen.
+
+**Tier 1 — Stretch:** Settings basic, Streak/Kỷ niệm, Chat 1-1 từ ảnh.
+
+**Tier 2 — Won't have:** Dual camera, video, memory cards, caption stickers, group chat in Space, block/report, account deletion.
+
+---
+
+## Stack Conventions — General
+
+> Flutter-specific rules: `apps/mobile/CLAUDE.md`
+> Node.js/TS rules: `firebase/functions/CLAUDE.md`
+> Firestore/Storage rules: `firebase/CLAUDE.md`
+
+### Git — Branches
+
+- **`develop`** — integration. All features merge here via PR.
+- **`deploy`** — production. Only merged from `develop` via PR.
+- **Feature branch:** `<type>/<DevName>/<short-desc>`
+  - Type enum: `feature`, `fix`, `chore`, `refactor`, `docs`, `test`, `style`, `perf`.
+  - DevName: PascalCase (`ThienPDM`, `KhoaLND`, `HanDHG`, `NganTNK`).
+  - Short-desc: lowercase, kebab-case, English.
+- Always checkout from `develop`: `git checkout -b feature/ThienPDM/auth-google-signin develop`.
+
+### Git — Commits (Conventional Commits + Vietnamese)
+
+```
+<type>(<scope>): <mô tả tiếng Việt ngắn>
+
+<body tiếng Việt — giải thích WHY nếu cần>
+
+Refs #N hoặc Closes #N
+```
+
+- Subject ≤ 72 chars, no trailing period.
+- Type: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `style`, `perf`.
+- Scope: `auth`, `feed`, `post`, `friend`, `widget`, `deps`...
+- **KHÔNG commit thẳng `develop`/`deploy`** — luôn qua PR.
+
+### Naming
+
+| Thing | Convention | Example |
+|---|---|---|
+| Folders | `kebab-case` | `feed-controller/` |
+| Dart files | `snake_case` | `feed_controller.dart` |
+| Dart classes | `UpperCamelCase` | `FeedController` |
+| Dart vars/methods | `lowerCamelCase` | `fetchFeed()` |
+| TS vars/functions | `camelCase` | `fetchFeed()` |
+| TS classes/types | `PascalCase` | `FeedController` |
+| Firestore collections | plural `lower_snake_case` | `posts`, `friend_requests` |
+| Firestore fields | `camelCase` | `createdAt`, `authorId` |
+
+### File organization
+
+- **Feature-first**, not layer-first. Each feature folder owns data + logic + UI.
+- Files ≤ 300 lines. Split if larger.
+- Comments explain **why**, not **what**.
+
+### When to write a new doc
+
+| Decision | Where |
+|---|---|
+| Feature design | `docs/specs/YYYY-MM-DD-<feature>.md` |
+| Implementation breakdown | `docs/plans/YYYY-MM-DD-<feature>.md` |
+| Architectural decision | `docs/adr/NNNN-<title>.md` |
+| Short-term checklist | `tasks/todo-<feature>.md` |
+
+---
+
+## Dev Code Standards — Solo-Dev Model
+
+Meep dùng **solo-dev model**: mỗi dev own một module **end-to-end** (data + logic + UI + test). Không tách FE/BE.
+
+### Role responsibilities
+
+| Role | Does | Does NOT do |
+|---|---|---|
+| **Leader (ThienPDM)** | Define spec + freezed models + abstract interfaces + stub providers + wire router; review PR | Implement module chi tiết |
+| **Module Owner** | Full-stack implement module: data → application → presentation → test → native code | Đụng module dev khác, đổi contract chưa qua leader |
+| **Designer** (HanDHG, NganTNK) | Vẽ Figma frame + design system + theme tokens TRƯỚC khi leader export contract | Hardcode color/font không qua design token |
+
+### 4 non-negotiable rules
+
+**1. Skeleton rule — App always runs**
+
+Mọi commit phải compile clean và app launch được. Stub trả `UnimplementedError` — không broken import.
+
+```dart
+@Riverpod(keepAlive: true)
+AuthRepository authRepository(Ref ref) => throw UnimplementedError(
+  'wire FirebaseAuthRepository in main.dart — assigned to <DevName>',
+);
+```
+
+**2. Contract-first rule**
+
+Leader merge vào `develop` trước khi giao module: spec + freezed models + abstract interfaces + stub providers + route stub + TODO markers.
+
+**3. Strict gate**
+
+Khoá lại + báo leader khi cần:
+- Đổi field trong freezed model leader đã chốt.
+- Đổi signature của abstract interface.
+- Touch file thuộc module dev khác.
+- Thêm Firestore collection / index mới.
+- Thêm pub/npm package vào pubspec.yaml / package.json.
+- Đổi shared code (`core/`, `shared/widgets/`, `core/theme/`).
+
+**4. Typed everything**
+
+```dart
+// ✅ Typed
+final mockUser = UserProfile(uid: 'mock-uid', displayName: 'Thien', ...);
+
+// ❌ Ad-hoc map
+final mockUser = {'name': 'Thien', 'avatar': 'url'};
+```
+
+### Stub / placeholder standard
+
+```dart
+// TODO(T8/HanDHG): implement IntroPage per Figma — intro screen
+```
+
+Format: `// TODO(<task-id>/<DevName>): <short description>`
+
+### Cross-module touch — FORBIDDEN by default
+
+Module Owner A KHÔNG tự ý sửa code thuộc module Owner B, kể cả bug fix 1 dòng.
+
+### Definition of Done
+
+- [ ] Spec acceptance criteria pass (đo được).
+- [ ] Data layer: repository implement đúng abstract interface + unit test.
+- [ ] Application layer: controller có unit test happy + edge + error.
+- [ ] Presentation layer: widget test + no hardcoded color/font.
+- [ ] `flutter analyze` + `dart format` clean.
+- [ ] Functions test: `npm test` + `npm run lint` clean (nếu có).
+- [ ] PR: leader approve + self-review qua `/review`.
+- [ ] CI pass, merged vào `develop`.
+
+---
+
+## Testing & Verification
+
+**The single most important rule: claims of "done" require evidence, never confidence alone.**
+
+### Minimum testing baseline
+
+| Area | Required |
+|---|---|
+| Pure logic (controllers, services, utilities) | Unit tests with edge cases |
+| Repositories | Unit tests against `fake_cloud_firestore` / in-memory fakes |
+| UI critical path (login, post, feed) | Widget test or integration test |
+| Firestore / Storage rules | Rules unit tests in `firebase/functions/test/rules.test.ts` |
+| Cloud Function entry points | Vitest test calling the handler with a fake event |
+
+### What "done" means
+
+1. Acceptance criteria from spec are met.
+2. New behaviour is covered by tests, **and you ran the tests and read the output**.
+3. Lint / format check passes.
+4. No commented-out dead code, no `// TODO` without a linked issue.
+5. Diff focused on the task — no unrelated refactors.
+
+**Claim "done": state what you ran and what the output was.**
+
+### Banned phrases
+
+"Should pass", "probably works", "I'm confident" — if you didn't run it, say "run `<exact command>` to verify."
+
+### When tests fail
+
+Do NOT comment them out, add skip, or adjust assertions to match broken behaviour. Read the failure → find root cause → fix → run again.
+
+### Coverage targets
+
+| Layer | Target |
+|---|---|
+| Business logic (controllers, services, rules) | ≥ 80% |
+| Data layer (repositories) | ≥ 70% |
+| UI widgets | ≥ 50% |
+
+### Commands
+
+```bash
+# Flutter
+flutter test
+flutter test test/features/feed/
+flutter test --coverage
+flutter analyze
+dart format --set-exit-if-changed .
+
+# TypeScript / Functions
+npm test
+npm run lint
+npm run typecheck
+
+# Firebase emulator-driven
+firebase emulators:exec --only firestore "npm run test:rules"
+
+# E2E
+flutter test integration_test/
+```
+
+---
+
+## Security Guardrails
+
+Meep handles **personal photos** of users and their friends. Privacy bar is high. Non-negotiable.
+
+### Secrets — never hardcode
+
+No API key, OAuth secret, FCM server key, service-account JSON may appear in any source file, README, or doc.
+
+| Kind | Where it lives |
+|---|---|
+| Mobile build-time secrets | `--dart-define` flags driven by CI secret store |
+| Firebase Functions runtime secrets | Firebase Secret Manager |
+| Local dev | `.env` (gitignored) |
+
+**Never commit:** `.env`, `*-service-account.json`, `firebase-adminsdk-*.json`, `google-services.json`, `*.keystore`, `*.jks`, `key.properties`, `.npmrc`.
+
+### Firestore + Storage rules
+
+Default deny everything. Open per collection with smallest needed access.
+
+**Firestore checklist:**
+- [ ] No `allow read, write: if true`.
+- [ ] Every collection with user data has `isOwner()` / `isFriend()` checks.
+- [ ] Field types and sizes validated (`caption.size() <= 200`).
+- [ ] Rules unit tests: owner / friend / stranger / unauthenticated.
+
+**Storage checklist:**
+- [ ] Read requires authentication.
+- [ ] Write requires `request.auth.uid == uid`.
+- [ ] `request.resource.size < 10 * 1024 * 1024`.
+- [ ] `request.resource.contentType.matches('image/.*')`.
+
+### Authentication / Authorization
+
+- All Cloud Function callable handlers check `request.auth` before any work.
+- Never trust `request.headers['x-user-id']` or similar client-controlled identifiers.
+- Owner check: `isOwner(uid) := isAuthed() && request.auth.uid == uid`.
+- Never just check "is authenticated" when you really mean "is owner / is friend".
+
+### PII handling
+
+PII for Meep: email, phone, displayNames, photos/captions, friend graph, FCM device tokens.
+
+- **Never log PII.** Log IDs only.
+- **Crashlytics:** scrub message body / caption before reporting.
+
+### Image upload safety
+
+- Validate MIME type and size **server-side** (Storage rule or Cloud Function).
+- Strip EXIF metadata in resize Function (location data is sensitive).
+
+### Ask first when
+
+- Disabling a Firestore rule "temporarily for debugging".
+- Committing a file matching a secret pattern.
+- Logging full request bodies.
+- Adding a third-party SDK with analytics permissions.
+- Granting a Function unrestricted IAM (`roles/owner`).
+
+---
+
+## Verification Before Claiming Done
+
+**Evidence before claims, always.**
+
+```
+BEFORE claiming a status or expressing satisfaction:
+1. IDENTIFY: which command would prove this claim?
+2. RUN: run the full command (fresh, not partial).
+3. READ: read the full output, check exit code, count failures.
+4. VERIFY: does the output confirm the claim?
+5. ONLY THEN: speak the claim.
+```
+
+| Claim | Required evidence |
+|---|---|
+| "Tests pass" | Test command: 0 failures |
+| "Linter clean" | Linter output: 0 errors |
+| "Build OK" | Build command exit 0 |
+| "Bug fixed" | Reproduction test passes |
+| "Requirement met" | Line-by-line checklist vs spec |
+
+Red flags: "should", "probably", "seems to", "looks like", claiming done before running.
+
+---
+
+## Custom Commands
+
+Use `/command-name` to invoke:
+
+| Command | Purpose |
+|---|---|
+| `/start <issue-id>` | Khởi động task từ GitHub issue |
+| `/build` hoặc `/build T2.1` | Implement task theo TDD |
+| `/review` | Self-review trước khi tạo PR |
+| `/spec` | Viết spec cho feature mới |
+| `/plan` | Decompose spec thành bite-sized tasks |
+| `/debug` | Debug với systematic root-cause |
+| `/fix-issue <id>` | Fix bug end-to-end |
+| `/test` | Viết / audit tests |
+| `/deploy` | Deploy workflow |
+| `/figma-to-flutter` | Convert Figma frame → Flutter widget |
+| `/caveman` | Toggle ultra-concise mode |

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -1,0 +1,137 @@
+# Flutter / Dart Rules
+
+> Loaded when working in `apps/mobile/`. Supplements root `CLAUDE.md`.
+
+## Layering (strict)
+
+- **No Firestore / FirebaseAuth / Storage call in widgets or controllers.** All Firebase I/O goes through a `Repository` class.
+- **No business logic in widgets.** Widgets render state and dispatch intents.
+
+```
+core/               — DI (Riverpod), theme, error model, routing
+features/<feature>/
+  data/             — repositories (Firestore, Storage, local cache)
+  application/      — controllers / state notifiers / services
+  presentation/     — widgets / pages
+```
+
+A widget that touches `FirebaseFirestore.instance` directly is a bug.
+
+## State management — Riverpod 2 (code-gen)
+
+- Use `@riverpod` annotation + code-gen: `dart run build_runner build --delete-conflicting-outputs`.
+- `ref.watch` / `ref.read` only — do NOT mix `Provider.of(context)`.
+- Inject every dependency via a Riverpod provider — no global singleton, no `getIt` inside business logic.
+- `ref.onDispose(() => sub.cancel())` for every stream subscription.
+
+## Data classes — freezed + json_serializable
+
+- Always immutable. No mutable fields.
+- Convert `DocumentSnapshot` → model in a `fromFirestore(snap)` factory on the data class. NEVER inline in widgets/controllers.
+
+## Error model
+
+- Throw typed `AppError`s, never raw `Exception`. Subclass per failure (`AuthFailedError`, `PostNotFoundError`...).
+- Repositories convert `FirebaseException` / `PlatformException` into `AppError` at the boundary.
+
+## Async / streams
+
+- Prefer `Stream` from Firestore for live data (feeds, friend list).
+- Use `StreamProvider` / `FutureProvider` to surface to UI.
+- NEVER `Future.delayed(...)` to "wait for state".
+
+## Widget split thresholds
+
+| Smell | Threshold | Action |
+|---|---|---|
+| Widget body | > 150 lines | Split into sub-widgets |
+| Function / method | > 80 lines | Extract method |
+| Class | > 300 lines | Split by SRP |
+| Nesting | > 5 levels | Early return / extract |
+
+| Usage frequency | Extract to |
+|---|---|
+| Used ≥ 2 times in 1 feature | `features/<feature>/presentation/widgets/` |
+| Used ≥ 3 times cross-feature | `lib/shared/widgets/` |
+
+## Widget-specific
+
+- `const` constructors when possible.
+- `ListView.builder` for lists > 5 items. NEVER `ListView(children: [...])` for unbounded lists.
+- NEVER pass huge inline `Map`/`List` as widget props — extract to `static const`.
+
+## Testing
+
+- Unit-test controllers + repositories with `fake_cloud_firestore` and `firebase_auth_mocks`.
+- Widget tests for non-trivial UI (form, list, dialog).
+- Integration test for login + post + feed loop minimum.
+- Prefer `FakeFirebaseFirestore` over `MockFirestore`.
+- Test files mirror lib: `lib/features/feed/post_repository.dart` ↔ `test/features/feed/post_repository_test.dart`.
+
+```bash
+flutter test
+flutter test test/features/feed/
+flutter test --coverage
+flutter analyze
+dart format --set-exit-if-changed .
+```
+
+## Common gotchas
+
+| Issue | Fix |
+|---|---|
+| `Future` inside `build()` | Use `FutureProvider` / `StreamProvider` |
+| Slow rebuild | `const` constructors, `ref.watch(provider.select(...))` |
+| `setState()` after dispose | Check `mounted` first, or migrate to Riverpod |
+
+---
+
+## Flutter UI Patterns — Presentation Layer
+
+### Design tokens — NO hardcoding
+
+- Hardcoded color `Color(0xFF1A73E8)` → use `Theme.of(context).colorScheme.primary`.
+- Hardcoded font `TextStyle(fontSize: 16)` → use `Theme.of(context).textTheme.bodyMedium`.
+- Figma has new color/font not in theme → **add to `core/theme/` first via leader-gated PR**.
+
+### Solo-dev module scope
+
+Module Owner được touch tất cả layers trong module mình. Khoá lại + ping leader khi cần:
+- `apps/mobile/lib/core/theme/` — shared design tokens.
+- `apps/mobile/lib/shared/widgets/` — cross-module widget reuse.
+- `apps/mobile/lib/core/error/`, `core/router/`, `core/di/` — shared infra.
+- `firebase/firestore.rules`, `storage.rules`, `firestore.indexes.json`.
+- `features/<other-module>/**` — module của dev khác.
+
+### Accessibility — minimum required
+
+- Every `IconButton`, `GestureDetector`, custom tap area: `Semantics(label: '...')` or `tooltip`.
+- Touch target ≥ 48x48 logical pixels.
+- NEVER `fixedFontSize` on `Text`.
+
+### Figma → Flutter mapping
+
+1. 1 Figma frame = 1 widget class.
+2. Layer name → variable/widget name: `btn_primary_lg` → `PrimaryButtonLarge`.
+3. Frame Auto-Layout → `Column`/`Row` with `spacing` or `SizedBox` token.
+4. Component variants → enum + factory constructor: `Button.primary()`, `Button.secondary()`.
+
+### Loading / error / empty — 4 required states
+
+```dart
+ref.watch(provider).when(
+  loading: () => LoadingIndicator(),
+  error: (e, _) => ErrorView(error: e),
+  data: (items) => items.isEmpty
+      ? EmptyState(message: 'Chưa có gì ở đây')
+      : ItemList(items: items),
+);
+```
+
+Empty state must have a Vietnamese CTA.
+
+### Ask leader before
+
+- Adding a new UI dependency (`flutter_animate`, `gap`, `flutter_svg`...).
+- Overriding `MaterialApp` global theme.
+- Changing `core/theme/` shared tokens.

--- a/docs/plans/2026-05-04-auth.md
+++ b/docs/plans/2026-05-04-auth.md
@@ -57,49 +57,52 @@ part 'app_router.g.dart';
 
 @riverpod
 GoRouter appRouter(Ref ref) {
-  final authState = ref.watch(currentUidProvider);
+  final uidState     = ref.watch(currentUidProvider);
+  final profileState = ref.watch(currentUserProfileProvider);
 
   return GoRouter(
     initialLocation: '/intro',
     redirect: (context, state) {
-      final isLoading = authState.isLoading;
-      if (isLoading) return null;
+      // Đang load auth state — chờ
+      if (uidState.isLoading) return null;
 
-      final isSignedIn = authState.valueOrNull != null;
-      final onAuthRoute = state.matchedLocation.startsWith('/login') ||
-          state.matchedLocation.startsWith('/signup') ||
-          state.matchedLocation == '/intro';
+      final uid     = uidState.valueOrNull;
+      final profile = profileState.valueOrNull;
 
-      if (isSignedIn && onAuthRoute) return '/home';
-      if (!isSignedIn && !onAuthRoute) return '/intro';
+      final loc = state.matchedLocation;
+      final onAuthRoute = loc.startsWith('/login') ||
+          loc.startsWith('/signup') ||
+          loc == '/intro';
+
+      // Chưa đăng nhập → về intro
+      if (uid == null) return onAuthRoute ? null : '/intro';
+
+      // Đã auth nhưng chưa có Firestore profile → resume signup
+      // (xảy ra khi Google Sign-In thành công nhưng chưa điền tên + username)
+      if (profile == null) {
+        if (loc == '/signup/name' || loc == '/signup/username') return null;
+        return '/signup/name';
+      }
+
+      // Auth + profile đủ → chỉ cần ở /home
+      if (onAuthRoute) return '/home';
       return null;
     },
     routes: [
-      GoRoute(path: '/intro', builder: (_, __) => const IntroPage()),
-      GoRoute(path: '/home', builder: (_, __) => const HomePage()),
+      GoRoute(path: '/intro',    builder: (_, __) => const IntroPage()),
+      GoRoute(path: '/home',     builder: (_, __) => const HomePage()),
+      GoRoute(path: '/signup/email',    builder: (_, __) => const SignUpEmailPage()),
+      GoRoute(path: '/signup/password', builder: (_, __) => const SignUpPasswordPage()),
+      GoRoute(path: '/signup/name',     builder: (_, __) => const SignUpNamePage()),
+      GoRoute(path: '/signup/username', builder: (_, __) => const SignUpUsernamePage()),
+      GoRoute(path: '/login/email',     builder: (_, __) => const LoginEmailPage()),
+      GoRoute(path: '/login/password',  builder: (_, __) => const LoginPasswordPage()),
       GoRoute(
-        path: '/signup/email',
-        builder: (_, __) => const SignUpEmailPage(),
-      ),
-      GoRoute(
-        path: '/signup/password',
-        builder: (_, __) => const SignUpPasswordPage(),
-      ),
-      GoRoute(
-        path: '/signup/name',
-        builder: (_, __) => const SignUpNamePage(),
-      ),
-      GoRoute(
-        path: '/signup/username',
-        builder: (_, __) => const SignUpUsernamePage(),
-      ),
-      GoRoute(
-        path: '/login/email',
-        builder: (_, __) => const LoginEmailPage(),
-      ),
-      GoRoute(
-        path: '/login/password',
-        builder: (_, __) => const LoginPasswordPage(),
+        path: '/login/forgot-password',
+        builder: (_, state) => ForgotPasswordPage(
+          // email pre-filled từ login/email screen qua query param
+          email: state.uri.queryParameters['email'] ?? '',
+        ),
       ),
     ],
   );
@@ -182,28 +185,16 @@ import 'package:meep/features/auth/data/user_profile.dart';
 
 void main() {
   group('UserProfile', () {
-    test('displayName returns firstName + lastName', () {
-      const profile = UserProfile(
-        uid: 'u1',
-        email: 'a@b.com',
-        firstName: 'Ngân',
-        lastName: 'Trần',
-        username: 'ngantnk',
-        createdAt: null,
-      );
-      expect(profile.displayName, 'Ngân Trần');
-    });
-
     test('fromJson / toJson round-trip', () {
       const profile = UserProfile(
         uid: 'u1',
         email: 'a@b.com',
-        firstName: 'Ngân',
-        lastName: 'Trần',
+        displayName: 'Ngân Trần',
         username: 'ngantnk',
-        photoUrl: null,
+        avatarUrl: null,
         bio: null,
         createdAt: null,
+        updatedAt: null,
       );
       final json = profile.toJson();
       final restored = UserProfile.fromJson(json);
@@ -238,18 +229,16 @@ class UserProfile with _$UserProfile {
   const factory UserProfile({
     required String uid,
     required String email,
-    required String firstName,
-    required String lastName,
+    required String displayName,
     required String username,
-    String? photoUrl,
+    String? avatarUrl,
     String? bio,
     @TimestampConverter() required DateTime? createdAt,
+    @TimestampConverter() required DateTime? updatedAt,
   }) = _UserProfile;
 
   factory UserProfile.fromJson(Map<String, dynamic> json) =>
       _$UserProfileFromJson(json);
-
-  String get displayName => '$firstName $lastName';
 }
 
 class TimestampConverter implements JsonConverter<DateTime?, Object?> {
@@ -532,10 +521,10 @@ void main() {
       const profile = UserProfile(
         uid: 'u1',
         email: 'a@b.com',
-        firstName: 'Khoa',
-        lastName: 'Lê',
+        displayName: 'Khoa Lê',
         username: 'khoa123',
         createdAt: null,
+        updatedAt: null,
       );
       await repo.createProfile(profile);
 
@@ -571,8 +560,7 @@ void main() {
       await fakeFirestore.doc('users/u1').set({
         'uid': 'u1',
         'email': 'a@b.com',
-        'firstName': 'Khoa',
-        'lastName': 'Lê',
+        'displayName': 'Khoa Lê',
         'username': 'khoa123',
         'createdAt': Timestamp.now(),
       });
@@ -711,15 +699,17 @@ Mở `firebase/firestore.rules`, thêm vào sau các helper functions hiện có
 // Thêm vào trong service cloud.firestore { ... }
 
 match /users/{uid} {
+  // Auth sprint: owner-only read.
+  // TODO(Friend module): mở rộng thêm || isFriend(uid) sau khi Friend rules được deploy
   allow read: if isAuthed() && request.auth.uid == uid;
   allow create: if isAuthed()
                 && request.auth.uid == uid
                 && request.resource.data.keys().hasAll([
-                     'uid', 'email', 'firstName', 'lastName',
-                     'username', 'createdAt'
+                     'uid', 'email', 'displayName',
+                     'username', 'createdAt', 'updatedAt'
                    ])
-                && request.resource.data.username.size() >= 3
-                && request.resource.data.username.size() <= 20;
+                // Server-side username validation — lowercase alphanumeric, 3-20 chars
+                && request.resource.data.username.matches('^[a-z0-9]{3,20}$');
   allow update: if isOwner(uid)
                 && !request.resource.data.diff(resource.data)
                       .affectedKeys()
@@ -730,7 +720,9 @@ match /users/{uid} {
 match /usernames/{username} {
   allow read: if isAuthed();
   allow create: if isAuthed()
-                && request.resource.data.uid == request.auth.uid;
+                && request.resource.data.uid == request.auth.uid
+                // username key phải match document name (tránh key/value mismatch)
+                && request.resource.data.keys().hasOnly(['uid']);
   allow delete: if isAuthed()
                 && resource.data.uid == request.auth.uid;
   allow update: if false;
@@ -836,7 +828,7 @@ void main() {
       final notifier = container.read(signUpControllerProvider.notifier);
       notifier.setEmail('a@b.com');
       notifier.setPassword('password123');
-      notifier.setName(firstName: 'Khoa', lastName: 'Lê');
+      notifier.setDisplayName('Khoa Lê');
       notifier.setUsername('khoa123');
 
       await notifier.createAccount();
@@ -859,7 +851,7 @@ void main() {
       final notifier = container.read(signUpControllerProvider.notifier);
       notifier.setEmail('a@b.com');
       notifier.setPassword('password123');
-      notifier.setName(firstName: 'K', lastName: 'L');
+      notifier.setDisplayName('K L');
       notifier.setUsername('klnd');
 
       await notifier.createAccount();
@@ -896,8 +888,8 @@ class SignUpState with _$SignUpState {
     @Default(SignUpStep.email) SignUpStep step,
     @Default('') String email,
     @Default('') String password,
-    @Default('') String firstName,
-    @Default('') String lastName,
+    @Default('') String displayName,
+    @Default(false) bool isGoogleSignIn,
     @Default('') String username,
     @Default(false) bool isCheckingUsername,
     @Default(false) bool isUsernameAvailable,
@@ -929,10 +921,23 @@ class SignUpController extends _$SignUpController {
   void setEmail(String email) => state = state.copyWith(email: email);
   void setPassword(String password) =>
       state = state.copyWith(password: password);
-  void setName({required String firstName, required String lastName}) =>
-      state = state.copyWith(firstName: firstName, lastName: lastName);
+  void setDisplayName(String displayName) =>
+      state = state.copyWith(displayName: displayName);
   void setUsername(String username) =>
-      state = state.copyWith(username: username);
+      state = state.copyWith(username: username.toLowerCase());
+
+  /// Gọi từ LoginController sau khi Google Sign-In thành công nhưng chưa có profile.
+  /// Pre-fill displayName từ Google account để user chỉnh lại trên SignUpNamePage.
+  void prefillFromGoogle({
+    required String uid,
+    required String email,
+    required String displayName,
+  }) {
+    state = state.copyWith(
+      isGoogleSignIn: true,
+      displayName: displayName,
+    );
+  }
 
   void nextStep() {
     final next = switch (state.step) {
@@ -987,12 +992,20 @@ class SignUpController extends _$SignUpController {
       final profile = UserProfile(
         uid: uid,
         email: state.email,
-        firstName: state.firstName,
-        lastName: state.lastName,
+        displayName: state.displayName,
         username: state.username,
         createdAt: null,
+        updatedAt: null,
       );
-      await userRepo.createProfile(profile);
+
+      try {
+        await userRepo.createProfile(profile);
+      } catch (firestoreError) {
+        // Rollback: xóa Firebase Auth user vừa tạo để tránh orphan account
+        await authRepo.deleteCurrentUser();
+        rethrow;
+      }
+
       state = state.copyWith(isLoading: false);
     } catch (e) {
       state = state.copyWith(
@@ -1009,10 +1022,10 @@ class SignUpController extends _$SignUpController {
       final profile = UserProfile(
         uid: uid,
         email: email,
-        firstName: state.firstName,
-        lastName: state.lastName,
+        displayName: state.displayName,
         username: state.username,
         createdAt: null,
+        updatedAt: null,
       );
       await userRepo.createProfile(profile);
       state = state.copyWith(isLoading: false);
@@ -1141,10 +1154,10 @@ void main() {
         (_) async => const UserProfile(
           uid: 'uid-google',
           email: 'g@google.com',
-          firstName: 'G',
-          lastName: 'U',
+          displayName: 'G U',
           username: 'gu',
           createdAt: null,
+          updatedAt: null,
         ),
       );
 
@@ -1830,19 +1843,15 @@ class SignUpNamePage extends ConsumerStatefulWidget {
 }
 
 class _SignUpNamePageState extends ConsumerState<SignUpNamePage> {
-  final _firstNameController = TextEditingController();
-  final _lastNameController = TextEditingController();
+  final _displayNameController = TextEditingController();
 
   @override
   void dispose() {
-    _firstNameController.dispose();
-    _lastNameController.dispose();
+    _displayNameController.dispose();
     super.dispose();
   }
 
-  bool get _isValid =>
-      _firstNameController.text.trim().isNotEmpty &&
-      _lastNameController.text.trim().isNotEmpty;
+  bool get _isValid => _displayNameController.text.trim().length >= 2;
 
   @override
   Widget build(BuildContext context) {
@@ -1865,24 +1874,16 @@ class _SignUpNamePageState extends ConsumerState<SignUpNamePage> {
               ),
               const SizedBox(height: 16),
               AuthTextField(
-                hint: 'Họ',
-                controller: _lastNameController,
-                onChanged: (_) => setState(() {}),
-              ),
-              const SizedBox(height: 12),
-              AuthTextField(
-                hint: 'Tên',
-                controller: _firstNameController,
+                hint: 'Họ và tên',
+                controller: _displayNameController,
                 onChanged: (_) => setState(() {}),
               ),
               const Spacer(flex: 3),
               _ContinueButton(
                 enabled: _isValid,
                 onPressed: () {
-                  ref.read(signUpControllerProvider.notifier).setName(
-                        firstName: _firstNameController.text.trim(),
-                        lastName: _lastNameController.text.trim(),
-                      );
+                  ref.read(signUpControllerProvider.notifier)
+                      .setDisplayName(_displayNameController.text.trim());
                   context.push('/signup/username');
                 },
               ),
@@ -1953,7 +1954,7 @@ class _SignUpUsernamePageState extends ConsumerState<SignUpUsernamePage> {
   final _controller = TextEditingController();
   Timer? _debounce;
 
-  static final _usernameRegex = RegExp(r'^[a-z0-9_]{3,20}$');
+  static final _usernameRegex = RegExp(r'^[a-zA-Z0-9]{3,20}$'); // auto-lowercased on input
 
   @override
   void dispose() {

--- a/docs/plans/2026-05-04-auth.md
+++ b/docs/plans/2026-05-04-auth.md
@@ -1,2369 +1,331 @@
-# Auth Implementation Plan
+# Plan: Auth Module
 
-> **For executor:** Follow TDD cycle per task. Each `- [ ]` là 1 action. Commit sau mỗi task.
-
-**Goal:** Implement full auth flow — signup 4 screens (email/password/name/username) + login + Google Sign-In + auto-login + logout.
-
-**Architecture:** `FirebaseAuthRepository` + `FirebaseUserRepository` → `SignUpController` / `LoginController` (Riverpod) → UI screens (go_router navigation).
-
-**Tech stack:** `firebase_auth`, `cloud_firestore`, `google_sign_in`, `go_router`, `riverpod` + code-gen, `freezed`.
-
-**Spec:** `docs/specs/2026-05-04-auth.md`
+> **Phụ thuộc vào:** Không có — đây là foundation block
+> **Được phụ thuộc bởi:** Tất cả modules (UserProfile, AuthRepository, currentUidProvider)
+> **Spec:** `docs/specs/2026-05-04-auth.md`
+> **Tier:** T0 — Milestone M1
 
 ---
 
-## Phase 1: Foundation
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
 
-### Task 1: Firebase init + AppRouter
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/auth/data/user_profile.dart` | freezed model — **source of truth cho full UserProfile schema** | `uid String`, `email String`, `displayName String`, `username String`, `avatarUrl String?`, `bio String?` (≤150), `dateOfBirth String?` (DD/MM/YYYY), `phoneNumber String?`, `gender String?` (male/female/other), `postCount int` default 0, `friendCount int` default 0, `spaceCount int` default 0, `createdAt DateTime?`, `updatedAt DateTime?` |
+| `lib/features/auth/data/auth_repository.dart` | abstract class | `String? get currentUid`, `Stream<String?> authStateChanges`, `Future<void> signUpWithEmail({email, password})`, `Future<void> signInWithEmail({email, password})`, `Future<void> signInWithGoogle()`, `Future<void> sendPasswordResetEmail({email})`, `Future<void> signOut()`, `Future<void> deleteCurrentUser()` ← rollback, `Future<void> reauthenticateWithCredential(AuthCredential)` ← Profile/Settings, `Future<void> updateEmail(String)` ← Profile |
+| `lib/features/auth/data/user_repository.dart` | abstract class | `Future<void> createProfile(UserProfile profile)`, `Future<UserProfile?> getProfile(String uid)`, `Future<bool> isUsernameAvailable(String username)` |
+| `lib/features/auth/application/sign_up_controller.dart` | Riverpod stub | `SignUpState` (step enum, email, password, displayName, username, isGoogleSignIn, isCheckingUsername, isUsernameAvailable, isLoading, errorMessage?), methods throw `UnimplementedError` |
+| `lib/features/auth/application/login_controller.dart` | Riverpod stub | `LoginState` (isLoading, isSuccess, needsProfile, googleUid?, errorMessage?), methods throw `UnimplementedError` |
+| `lib/features/auth/application/auth_controller.dart` | Riverpod providers | `currentUidProvider` (StreamProvider), `currentUserProfileProvider` (StreamProvider), `isSignedInProvider` (Provider<bool>), `authRepositoryProvider` (Provider — throw UnimplementedError), `userRepositoryProvider` (Provider — throw UnimplementedError) |
+| `lib/core/theme/app_colors.dart` | design tokens | Turquoise (300/500/800), BW (100-900), semantic (success700, error700) — xem spec §Shared components |
+| `lib/shared/widgets/app_primary_button.dart` | shared widget | 338×57, radius 30. Active: bg `#c7f7fb`, text `#004b54`. Disabled: bg `#394041`, text `#ced9da`. Loading: `CircularProgressIndicator`. Font: Nunito Bold 16 |
+| `lib/shared/widgets/app_back_button.dart` | shared widget | 40×40, radius 22.5, bg `#656c6d`, chevron-left |
+| `lib/shared/widgets/app_google_button.dart` | shared widget | 357×60, radius 30, bg white, border `#eff0f6`. Google icon + "Tiếp tục với Google". Android only |
+| `lib/shared/widgets/app_text_input.dart` | shared widget | Bọc `TextButton` component set. `inputType`: email/username/name. States: Default/Active/Error. Password variant có eye toggle |
+| `lib/core/router/app_router.dart` | router + guard | Routes `/intro`, `/signup/email`, `/signup/password`, `/signup/name`, `/signup/username`, `/login/email`, `/login/password`, `/login/forgot-password`. Guard: `uid == null` → `/intro`; `uid != null && profile == null` → `/signup/name`; `uid != null && profile != null` → `/home` |
 
-**Files:**
-- Modify: `apps/mobile/lib/main.dart`
-- Create: `apps/mobile/lib/core/router/app_router.dart`
-- Create: `apps/mobile/lib/features/home/presentation/home_page.dart` (placeholder)
-
-**Dependencies:** none
-
-- [ ] **Step 1: Tạo placeholder HomePage**
-
-```dart
-// apps/mobile/lib/features/home/presentation/home_page.dart
-import 'package:flutter/material.dart';
-
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Home — TODO')),
-    );
-  }
-}
-```
-
-- [ ] **Step 2: Tạo AppRouter**
-
-```dart
-// apps/mobile/lib/core/router/app_router.dart
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import 'package:meep/features/auth/application/auth_controller.dart';
-import 'package:meep/features/auth/presentation/intro_page.dart';
-import 'package:meep/features/home/presentation/home_page.dart';
-
-part 'app_router.g.dart';
-
-@riverpod
-GoRouter appRouter(Ref ref) {
-  final uidState     = ref.watch(currentUidProvider);
-  final profileState = ref.watch(currentUserProfileProvider);
-
-  return GoRouter(
-    initialLocation: '/intro',
-    redirect: (context, state) {
-      // Đang load auth state — chờ
-      if (uidState.isLoading) return null;
-
-      final uid     = uidState.valueOrNull;
-      final profile = profileState.valueOrNull;
-
-      final loc = state.matchedLocation;
-      final onAuthRoute = loc.startsWith('/login') ||
-          loc.startsWith('/signup') ||
-          loc == '/intro';
-
-      // Chưa đăng nhập → về intro
-      if (uid == null) return onAuthRoute ? null : '/intro';
-
-      // Đã auth nhưng chưa có Firestore profile → resume signup
-      // (xảy ra khi Google Sign-In thành công nhưng chưa điền tên + username)
-      if (profile == null) {
-        if (loc == '/signup/name' || loc == '/signup/username') return null;
-        return '/signup/name';
-      }
-
-      // Auth + profile đủ → chỉ cần ở /home
-      if (onAuthRoute) return '/home';
-      return null;
-    },
-    routes: [
-      GoRoute(path: '/intro',    builder: (_, __) => const IntroPage()),
-      GoRoute(path: '/home',     builder: (_, __) => const HomePage()),
-      GoRoute(path: '/signup/email',    builder: (_, __) => const SignUpEmailPage()),
-      GoRoute(path: '/signup/password', builder: (_, __) => const SignUpPasswordPage()),
-      GoRoute(path: '/signup/name',     builder: (_, __) => const SignUpNamePage()),
-      GoRoute(path: '/signup/username', builder: (_, __) => const SignUpUsernamePage()),
-      GoRoute(path: '/login/email',     builder: (_, __) => const LoginEmailPage()),
-      GoRoute(path: '/login/password',  builder: (_, __) => const LoginPasswordPage()),
-      GoRoute(
-        path: '/login/forgot-password',
-        builder: (_, state) => ForgotPasswordPage(
-          // email pre-filled từ login/email screen qua query param
-          email: state.uri.queryParameters['email'] ?? '',
-        ),
-      ),
-    ],
-  );
-}
-```
-
-> Chú ý: các Page classes (IntroPage, SignUpEmailPage, ...) chưa tồn tại — compiler sẽ lỗi cho đến Task 8+. Tạm thời để `app_router.dart` có `// ignore_for_file: undefined_class` hoặc comment out routes chưa có. **Cách đơn giản hơn:** chỉ khai báo `/intro` và `/home` route trước, thêm dần.
-
-- [ ] **Step 3: Cập nhật main.dart**
-
-```dart
-// apps/mobile/lib/main.dart
-import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-import 'package:meep/core/router/app_router.dart';
-import 'package:meep/firebase_options.dart';
-
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-  runApp(const ProviderScope(child: MeepApp()));
-}
-
-class MeepApp extends ConsumerWidget {
-  const MeepApp({super.key});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final router = ref.watch(appRouterProvider);
-    return MaterialApp.router(
-      title: 'Meep',
-      routerConfig: router,
-    );
-  }
-}
-```
-
-- [ ] **Step 4: Run build_runner để sinh app_router.g.dart**
-
-```pwsh
-flutter pub run build_runner build --delete-conflicting-outputs
-```
-
-Expected: `app_router.g.dart` được tạo.
-
-- [ ] **Step 5: Verify app compiles (tạm thời chỉ cần `/intro` + `/home`)**
-
-```pwsh
-flutter analyze
-```
-
-Expected: No issues (hoặc chỉ info về unused imports).
-
-- [ ] **Step 6: Commit**
-
-```
-git add apps/mobile/lib/main.dart apps/mobile/lib/core/router/ apps/mobile/lib/features/home/
-git commit -m "feat(auth): wire Firebase init + go_router với auth redirect guard"
-```
+> **`UserProfile` schema đầy đủ từ đầu:** auth module tạo với full schema (kể cả fields từ Profile spec) để tránh breaking change khi Profile module bắt đầu. Auth chỉ populate auth fields; Profile fields khởi tạo với default values.
 
 ---
 
-### Task 2: UserProfile model
+## PART 2 — Tasks
 
-**Files:**
-- Create: `apps/mobile/lib/features/auth/data/user_profile.dart`
-- Create: `apps/mobile/lib/features/auth/data/user_profile.freezed.dart` (generated)
-- Create: `apps/mobile/test/features/auth/data/user_profile_test.dart`
+---
+**T1 · feat(auth): Firebase init + main.dart + AppRouter với redirect guard**
 
-**Dependencies:** Task 1
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `feat/ThienPDM/auth-firebase-init` |
+| Blocked by | contracts Part 1 |
 
-- [ ] **Step 1: Viết test**
+Files:
+- `lib/main.dart` — Firebase.initializeApp + ProviderScope + router override
+- `lib/core/router/app_router.dart` — GoRouter với redirect guard 3 states
+- `lib/features/home/presentation/home_page.dart` — placeholder stub
+- `test/features/auth/router_guard_test.dart` — test cases: uid null → intro, uid + no profile → signup/name, uid + profile → home
 
-```dart
-// apps/mobile/test/features/auth/data/user_profile_test.dart
-import 'package:flutter_test/flutter_test.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+Acceptance criteria:
+- [ ] App khởi động, navigate về `/intro` khi chưa login
+- [ ] Router redirect: `uid == null` → `/intro`; `uid != null && profile == null` → `/signup/name` (Google Sign-In incomplete resume)
+- [ ] Router redirect: `uid != null && profile != null` → `/home`
+- [ ] `authRepositoryProvider` và `userRepositoryProvider` throw `UnimplementedError` với hint text rõ ràng
+- [ ] `flutter analyze` clean sau khi wire
 
-void main() {
-  group('UserProfile', () {
-    test('fromJson / toJson round-trip', () {
-      const profile = UserProfile(
-        uid: 'u1',
-        email: 'a@b.com',
-        displayName: 'Ngân Trần',
-        username: 'ngantnk',
-        avatarUrl: null,
-        bio: null,
-        createdAt: null,
-        updatedAt: null,
-      );
-      final json = profile.toJson();
-      final restored = UserProfile.fromJson(json);
-      expect(restored, profile);
-    });
-  });
-}
-```
+Cross-module imports: None
 
-- [ ] **Step 2: Run test → FAIL**
+---
+**T2 · feat(auth): UserProfile model — full schema (freezed + json_serializable + TimestampConverter)**
 
-```pwsh
-flutter test test/features/auth/data/user_profile_test.dart
-```
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `feat/ThienPDM/auth-user-profile-model` |
+| Blocked by | T1 |
 
-Expected: FAIL — `UserProfile` not defined.
+Files:
+- `lib/features/auth/data/user_profile.dart` — full impl với **tất cả fields** từ spec auth + profile
+- `test/features/auth/data/user_profile_test.dart` — test cases: fromJson/toJson round-trip, Timestamp conversion, default values cho counter fields
 
-- [ ] **Step 3: Implement UserProfile**
+Acceptance criteria:
+- [ ] `UserProfile.fromJson(doc.data())` parse đúng Firestore Timestamp → `DateTime`
+- [ ] Fields `postCount`, `friendCount`, `spaceCount` default `0` (không cần truyền khi tạo)
+- [ ] `username` stored lowercase — validate tại controller, không phải model
+- [ ] `bio`, `dateOfBirth`, `phoneNumber`, `gender` nullable, không crash khi null
+- [ ] `UserProfile.fromJson/toJson` round-trip không mất data
 
-```dart
-// apps/mobile/lib/features/auth/data/user_profile.dart
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:freezed_annotation/freezed_annotation.dart';
+Cross-module imports: None
 
-part 'user_profile.freezed.dart';
-part 'user_profile.g.dart';
+---
+**T3 · feat(auth): AuthRepository contract + FirebaseAuthRepository**
 
-@freezed
-class UserProfile with _$UserProfile {
-  const UserProfile._();
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `feat/ThienPDM/auth-auth-repository` |
+| Blocked by | T2 |
 
-  const factory UserProfile({
-    required String uid,
-    required String email,
-    required String displayName,
-    required String username,
-    String? avatarUrl,
-    String? bio,
-    @TimestampConverter() required DateTime? createdAt,
-    @TimestampConverter() required DateTime? updatedAt,
-  }) = _UserProfile;
+Files:
+- `lib/features/auth/data/auth_repository.dart` — update: thêm `deleteCurrentUser()`, `reauthenticateWithCredential()`, `updateEmail()`
+- `lib/features/auth/data/firebase_auth_repository.dart` — full impl (giữ `signInWithGoogle()` throws UnimplementedError đến T7)
+- `test/features/auth/data/firebase_auth_repository_test.dart` — test cases: `watchUid` emits null khi signed out, `signInWithEmail` wrong password → `UnauthenticatedError`, `signOut` clears uid, error code mapping tiếng Việt
 
-  factory UserProfile.fromJson(Map<String, dynamic> json) =>
-      _$UserProfileFromJson(json);
-}
+Acceptance criteria:
+- [ ] `signUpWithEmail` → `FirebaseAuthException` mapped sang `UnauthenticatedError` với message tiếng Việt
+- [ ] `signInWithEmail` wrong password → toast-ready error message tiếng Việt (không "wrong-password" raw code)
+- [ ] `deleteCurrentUser()` dùng cho rollback khi Firestore batch fail sau createUser
+- [ ] `authStateChanges` là Stream từ `FirebaseAuth.authStateChanges()` — auto-login driven bởi stream này
+- [ ] `reauthenticateWithCredential()` và `updateEmail()` stub (throws UnimplementedError) — implement đầy đủ nhưng không cần test cho đến Profile module cần
 
-class TimestampConverter implements JsonConverter<DateTime?, Object?> {
-  const TimestampConverter();
+Cross-module imports: None
 
-  @override
-  DateTime? fromJson(Object? value) {
-    if (value is Timestamp) return value.toDate();
-    return null;
-  }
+---
+**T4 · feat(auth): UserRepository abstract + FirebaseUserRepository (batch write)**
 
-  @override
-  Object? toJson(DateTime? date) =>
-      date != null ? Timestamp.fromDate(date) : null;
-}
-```
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `feat/ThienPDM/auth-user-repository` |
+| Blocked by | T2, T3 |
 
-- [ ] **Step 4: Run build_runner**
+Files:
+- `lib/features/auth/data/user_repository.dart` — abstract class
+- `lib/features/auth/data/firebase_user_repository.dart` — impl: `createProfile` (Firestore batch `/users/{uid}` + `/usernames/{username}`), `getProfile`, `isUsernameAvailable`
+- `test/features/auth/data/firebase_user_repository_test.dart` — test cases: createProfile writes cả 2 docs, isUsernameAvailable taken → false / free → true, getProfile null khi không tồn tại, getProfile trả đúng model khi tồn tại
 
-```pwsh
-flutter pub run build_runner build --delete-conflicting-outputs
-```
+Acceptance criteria:
+- [ ] `createProfile` dùng `Firestore.batch()` — atomic write `/users/{uid}` + `/usernames/{username}` trong 1 commit
+- [ ] `username` stored lowercase (`profile.username` phải là lowercase khi truyền vào)
+- [ ] `createProfile` với `batch.commit()` fail → không có partial write (atomic)
+- [ ] `isUsernameAvailable(username)` check doc `/usernames/{username}` — tồn tại → false
+- [ ] `createdAt` dùng `FieldValue.serverTimestamp()` — không dùng `DateTime.now()` client time
 
-- [ ] **Step 5: Run test → PASS**
+Cross-module imports: None
 
-```pwsh
-flutter test test/features/auth/data/user_profile_test.dart
-```
+---
+**T5 · test(auth): Firestore rules — /users + /usernames**
 
-Expected: PASS 2/2.
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `test/ThienPDM/auth-firestore-rules` |
+| Blocked by | T4 |
 
-- [ ] **Step 6: Commit**
+Files:
+- `firebase/firestore.rules` — update: thêm rules cho `/users/{uid}` + `/usernames/{username}` (xem spec §Security)
+- `firebase/functions/test/rules/auth.rules.test.ts`
 
-```
-git add apps/mobile/lib/features/auth/data/user_profile.dart apps/mobile/lib/features/auth/data/user_profile.freezed.dart apps/mobile/lib/features/auth/data/user_profile.g.dart apps/mobile/test/features/auth/
-git commit -m "feat(auth): thêm UserProfile model (freezed + json_serializable)"
-```
+Acceptance criteria:
+- [ ] `/users/{uid}` create: chỉ owner, phải có required fields, `username` match regex `^[a-z0-9_]{3,20}$` (cho phép `_`)
+- [ ] `/users/{uid}` update: owner only; `uid` + `createdAt` + `email` KHÔNG được đổi; `affectedKeys()` chỉ trong allowlist
+- [ ] `/users/{uid}` delete: `if false`
+- [ ] `/users/{uid}` read: **auth-sprint rule** `isAuthed() && request.auth.uid == uid` (TODO: canonical rule sau Friend module = `isAuthed()`)
+- [ ] `/usernames/{username}` read: authed ✓; create: owner tạo ✓, `uid` match `request.auth.uid` ✓; update: `if false`; delete: `resource.data.uid == request.auth.uid` ✓
+
+Cross-module imports: None
+
+---
+**T6 · feat(auth): SignUpController — 4-step state machine + createAccount + checkUsername**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `feat/ThienPDM/auth-signup-controller` |
+| Blocked by | T3, T4 |
+
+Files:
+- `lib/features/auth/application/sign_up_controller.dart` — full impl với `SignUpState` + `SignUpStep` enum
+- `test/features/auth/application/sign_up_controller_test.dart` — test cases: initial state step=email, nextStep progression, createAccount calls signUpWithEmail + createProfile, createAccount sets errorMessage on failure, checkUsername debounce 500ms, rollback deleteCurrentUser khi Firestore batch fail
+
+Acceptance criteria:
+- [ ] `SignUpStep` enum: email → password → name → username (sequential, no skip)
+- [ ] `checkUsername` debounce 500ms — không gọi repo khi user đang gõ
+- [ ] `createAccount()`: (1) `signUpWithEmail` → (2) `createProfile` — nếu step (2) fail → gọi `deleteCurrentUser()` rollback
+- [ ] `createAccountWithGoogle(uid, email)`: chỉ gọi `createProfile` (Auth user đã tạo qua Google)
+- [ ] `errorMessage` set khi bất kỳ step fail; `isLoading = false` trong mọi trường hợp (success + error)
+
+Cross-module imports: None
+
+---
+**T7 · feat(auth): LoginController + Google Sign-In (check /users/{uid})**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `feat/ThienPDM/auth-login-controller` |
+| Blocked by | T3, T4 |
+
+Files:
+- `lib/features/auth/application/login_controller.dart` — full impl với `LoginState`
+- `lib/features/auth/data/firebase_auth_repository.dart` — update: implement `signInWithGoogle()` (GoogleSignIn + credential)
+- `test/features/auth/application/login_controller_test.dart` — test cases: signIn success → isSuccess=true, signIn failure → errorMessage set, signInWithGoogle new user → needsProfile=true, signInWithGoogle returning user → isSuccess=true
+
+Acceptance criteria:
+- [ ] `signInWithGoogle()`: sau sign-in, query `/users/{uid}` (KHÔNG dùng `isNewUser` — unreliable)
+- [ ] New Google user (`profile == null`) → `LoginState.needsProfile = true` → router sends to `/signup/name`
+- [ ] Returning Google user (`profile != null`) → `LoginState.isSuccess = true` → router sends to `/home`
+- [ ] Google Sign-In user cancel → silent dismiss, `errorMessage = null` (không toast)
+- [ ] `sendPasswordReset(email)` → Firebase sends email; nếu email không tồn tại → Firebase vẫn return success (security) → toast message neutral
+
+Cross-module imports: None
+
+---
+**T8 · feat(auth): IntroPage + router wiring**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `feat/ThienPDM/auth-intro-page` |
+| Blocked by | T6, T7 |
+
+Files:
+- `lib/features/auth/presentation/intro_page.dart` — (Figma `556:2136`)
+- `test/features/auth/presentation/intro_page_test.dart` — widget tests: render 2 CTA buttons, tap "Tạo tài khoản mới" → push `/signup/email`, tap "Đăng nhập" → push `/login/email`
+
+Acceptance criteria:
+- [ ] Hiện logo Meep + tagline + 2 CTA buttons theo đúng Figma `556:2136`
+- [ ] Tap "Tạo tài khoản mới" → `context.push('/signup/email')`
+- [ ] Tap "Đăng nhập" → `context.push('/login/email')`
+- [ ] Background tối, design tokens từ `app_colors.dart`
+
+Cross-module imports: None
+
+---
+**T9 · feat(auth): Signup flow — 4 màn hình (email/password/name/username)**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | L (2 ngày) |
+| Branch | `feat/ThienPDM/auth-signup-screens` |
+| Blocked by | T8 |
+
+Files:
+- `lib/features/auth/presentation/signup/signup_email_page.dart` — (Figma `269:1441`): field + Google button
+- `lib/features/auth/presentation/signup/signup_password_page.dart` — (Figma `269:1487`): password ≥8 ký tự
+- `lib/features/auth/presentation/signup/signup_name_page.dart` — (Figma `269:1530`): 1 field "Họ và tên", min 2 ký tự
+- `lib/features/auth/presentation/signup/signup_username_page.dart` — (Figma `269:1501/1515`): debounce check, available indicator
+- `test/features/auth/presentation/signup_username_page_test.dart` — widget tests: hint pill khi empty, debounce indicator, available state "Tuyệt vời! ✓", taken state error text, nút disabled khi chưa available
+
+Acceptance criteria:
+- [ ] Email screen: dùng `app_text_input.dart` inputType=email + `app_google_button.dart` → shared widgets
+- [ ] Password screen: eye toggle, enforce ≥8 ký tự, nút disabled khi < 8
+- [ ] Name screen: 1 field duy nhất "Họ và tên", min 2 ký tự, nút disabled khi < 2
+- [ ] Username: debounce 500ms, 4 states: empty (hint pill) → checking (spinner) → available (border xanh + "Tuyệt vời!") → taken (border đỏ + error text)
+- [ ] Input tự động lowercase khi user gõ username
+- [ ] Google Sign-In từ email screen: nếu new user → navigate `/signup/name` với `displayName` pre-filled (editable), skip email+password screens
+
+Cross-module imports: None
+
+---
+**T10 · feat(auth): Login flow + forgot password + success screen**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `feat/ThienPDM/auth-login-screens` |
+| Blocked by | T8 |
+
+Files:
+- `lib/features/auth/presentation/login/login_email_page.dart` — (Figma `269:1424`)
+- `lib/features/auth/presentation/login/login_password_page.dart` — (Figma `269:1473`): forgot password pill + success state
+- `test/features/auth/presentation/login_password_page_test.dart` — widget tests: wrong creds → inline error tiếng Việt, forgot password link visible, success state "Bạn đã sẵn sàng"
+
+Acceptance criteria:
+- [ ] Login email screen: layout giống signup email (same title "Email của bạn là gì?", Google button)
+- [ ] Login password screen: title "Điền mật khẩu của bạn", forgot password pill trên button
+- [ ] Sai creds → inline error tiếng Việt (từ `_mapFirebaseError` trong repository) — không navigate
+- [ ] Forgot password: tap → `sendPasswordReset()` → toast "Đã gửi email khôi phục nếu tài khoản tồn tại"
+- [ ] Login thành công: nút hiện "Bạn đã sẵn sàng ✓" → **auto-navigate `/home` sau ~1.5s** (không cần user tap lại)
+
+Cross-module imports: None
+
+---
+**T11 · feat(auth): Shared UI components + design tokens**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `feat/ThienPDM/auth-shared-widgets` |
+| Blocked by | T1 |
+
+Files:
+- `lib/core/theme/app_colors.dart` — tất cả color constants từ spec §Shared components
+- `lib/shared/widgets/app_primary_button.dart` — 3 states: Active/Disabled/Loading
+- `lib/shared/widgets/app_back_button.dart` — 40×40, radius 22.5
+- `lib/shared/widgets/app_google_button.dart` — Android only
+- `lib/shared/widgets/app_text_input.dart` — email/username/name types + password variant + 3 states
+- `test/shared/widgets/app_primary_button_test.dart` — widget tests: Active state render, Disabled state render, Loading state shows indicator
+
+Acceptance criteria:
+- [ ] `AppPrimaryButton`: bg `#c7f7fb` + text `#004b54` (Active); bg `#394041` + text `#ced9da` (Disabled); `CircularProgressIndicator(color: #004b54)` (Loading)
+- [ ] `AppTextInput` state Error: border `#FF3D00`, label đỏ
+- [ ] `AppTextInput` password variant: eye icon toggle obscureText
+- [ ] Tất cả widgets dùng design tokens từ `app_colors.dart` — không hardcode color string
+- [ ] `AppGoogleButton`: disabled trên non-Android (guard `Platform.isAndroid`)
+
+Cross-module imports: None
+
+> **Note:** T11 có thể chạy song song với T2-T10 vì shared widgets không depend vào data/application layer. Thực tế nên implement T11 trước khi T9/T10 (screens cần widgets).
 
 ---
 
-### Task 3: AuthRepository contract update + FirebaseAuthRepository
-
-**Files:**
-- Modify: `apps/mobile/lib/features/auth/data/auth_repository.dart`
-- Create: `apps/mobile/lib/features/auth/data/firebase_auth_repository.dart`
-- Create: `apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart`
-
-**Dependencies:** Task 2
-
-- [ ] **Step 1: Cập nhật AuthRepository abstract (thêm signUp + resetPassword)**
-
-```dart
-// apps/mobile/lib/features/auth/data/auth_repository.dart
-import 'package:meep/core/error/app_error.dart';
-
-abstract class AuthRepository {
-  String? get currentUid;
-  Stream<String?> watchUid();
-
-  Future<void> signInWithEmail({
-    required String email,
-    required String password,
-  });
-
-  Future<void> signUpWithEmail({
-    required String email,
-    required String password,
-  });
-
-  Future<void> signInWithGoogle();
-
-  Future<void> sendPasswordResetEmail({required String email});
-
-  Future<void> signOut();
-}
-```
-
-- [ ] **Step 2: Viết test cho FirebaseAuthRepository**
-
-```dart
-// apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart
-import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:meep/core/error/app_error.dart';
-import 'package:meep/features/auth/data/firebase_auth_repository.dart';
-
-void main() {
-  group('FirebaseAuthRepository', () {
-    late MockFirebaseAuth mockAuth;
-    late FirebaseAuthRepository repo;
-
-    setUp(() {
-      mockAuth = MockFirebaseAuth();
-      repo = FirebaseAuthRepository(auth: mockAuth);
-    });
-
-    test('watchUid emits null when signed out', () {
-      expect(repo.watchUid(), emits(null));
-    });
-
-    test('signInWithEmail — wrong password throws UnauthenticatedError', () async {
-      final failAuth = MockFirebaseAuth(authExceptions: AuthExceptions(
-        signInWithEmailAndPassword: Exception('wrong-password'),
-      ));
-      final failRepo = FirebaseAuthRepository(auth: failAuth);
-      expect(
-        () => failRepo.signInWithEmail(email: 'a@b.com', password: 'bad'),
-        throwsA(isA<UnauthenticatedError>()),
-      );
-    });
-
-    test('signOut clears currentUid', () async {
-      final authedAuth = MockFirebaseAuth(signedIn: true);
-      final authedRepo = FirebaseAuthRepository(auth: authedAuth);
-      await authedRepo.signOut();
-      expect(authedRepo.currentUid, isNull);
-    });
-  });
-}
-```
-
-- [ ] **Step 3: Run test → FAIL**
-
-```pwsh
-flutter test test/features/auth/data/firebase_auth_repository_test.dart
-```
-
-Expected: FAIL — `FirebaseAuthRepository` not defined.
-
-- [ ] **Step 4: Implement FirebaseAuthRepository**
-
-```dart
-// apps/mobile/lib/features/auth/data/firebase_auth_repository.dart
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:meep/core/error/app_error.dart';
-import 'package:meep/features/auth/data/auth_repository.dart';
-
-class FirebaseAuthRepository implements AuthRepository {
-  FirebaseAuthRepository({required FirebaseAuth auth}) : _auth = auth;
-  final FirebaseAuth _auth;
-
-  @override
-  String? get currentUid => _auth.currentUser?.uid;
-
-  @override
-  Stream<String?> watchUid() =>
-      _auth.authStateChanges().map((user) => user?.uid);
-
-  @override
-  Future<void> signInWithEmail({
-    required String email,
-    required String password,
-  }) async {
-    try {
-      await _auth.signInWithEmailAndPassword(
-        email: email,
-        password: password,
-      );
-    } on FirebaseAuthException catch (e) {
-      throw UnauthenticatedError(message: _mapFirebaseError(e.code));
-    } catch (e) {
-      throw UnexpectedError(cause: e);
-    }
-  }
-
-  @override
-  Future<void> signUpWithEmail({
-    required String email,
-    required String password,
-  }) async {
-    try {
-      await _auth.createUserWithEmailAndPassword(
-        email: email,
-        password: password,
-      );
-    } on FirebaseAuthException catch (e) {
-      throw UnauthenticatedError(message: _mapFirebaseError(e.code));
-    } catch (e) {
-      throw UnexpectedError(cause: e);
-    }
-  }
-
-  @override
-  Future<void> signInWithGoogle() async {
-    throw UnimplementedError('Google Sign-In wired in Task 6');
-  }
-
-  @override
-  Future<void> sendPasswordResetEmail({required String email}) async {
-    try {
-      await _auth.sendPasswordResetEmail(email: email);
-    } on FirebaseAuthException catch (e) {
-      throw UnauthenticatedError(message: _mapFirebaseError(e.code));
-    }
-  }
-
-  @override
-  Future<void> signOut() async {
-    await _auth.signOut();
-  }
-
-  String _mapFirebaseError(String code) => switch (code) {
-        'user-not-found' => 'Không tìm thấy tài khoản với email này.',
-        'wrong-password' || 'invalid-credential' =>
-          'Mật khẩu không đúng. Vui lòng thử lại.',
-        'email-already-in-use' => 'Email này đã được sử dụng.',
-        'weak-password' => 'Mật khẩu phải dài tối thiểu 8 ký tự.',
-        'invalid-email' => 'Địa chỉ email không hợp lệ.',
-        'too-many-requests' => 'Quá nhiều lần thử. Vui lòng thử lại sau.',
-        _ => 'Đã có lỗi xảy ra. Vui lòng thử lại.',
-      };
-}
-```
-
-- [ ] **Step 5: Run test → PASS**
-
-```pwsh
-flutter test test/features/auth/data/firebase_auth_repository_test.dart
-```
-
-Expected: PASS 3/3.
-
-- [ ] **Step 6: Wire repository vào authRepositoryProvider (main.dart)**
-
-Thêm vào `main.dart` sau `Firebase.initializeApp`:
-
-```dart
-// Trong main() sau Firebase.initializeApp():
-runApp(
-  ProviderScope(
-    overrides: [
-      authRepositoryProvider.overrideWithValue(
-        FirebaseAuthRepository(auth: FirebaseAuth.instance),
-      ),
-    ],
-    child: const MeepApp(),
-  ),
-);
-```
-
-- [ ] **Step 7: Commit**
+## PART 3 — Dependency graph
 
 ```
-git add apps/mobile/lib/features/auth/data/ apps/mobile/test/features/auth/
-git commit -m "feat(auth): thêm FirebaseAuthRepository với error mapping tiếng Việt"
+contracts Part 1 → T1 → T2 → T3 → T6 → T9
+                              ↘
+                         T3 → T4 → T6 (parallel)
+                         T4 → T7 → T10
+                    T1 → T11 (parallel T2-T10)
+                    T6 → T8 → T9
+                    T7 → T8 → T10
+                    T4 → T5
 ```
+
+Thứ tự implement thực tế (recommended):
+1. T1 (Firebase init) → T11 (shared widgets) → T2 (model) → T3 (AuthRepo) → T4 (UserRepo) → T5 (rules) → T6 (SignUpController) → T7 (LoginController) → T8 (IntroPage) → T9 (signup screens) → T10 (login screens)
 
 ---
 
-### Task 4: UserRepository + FirebaseUserRepository
+## PART 4 — Open questions
 
-**Files:**
-- Create: `apps/mobile/lib/features/auth/data/user_repository.dart`
-- Create: `apps/mobile/lib/features/auth/data/firebase_user_repository.dart`
-- Create: `apps/mobile/test/features/auth/data/firebase_user_repository_test.dart`
+Tất cả đã resolved trong spec (`docs/specs/2026-05-04-auth.md`). None blocking.
 
-**Dependencies:** Task 2, 3
-
-- [ ] **Step 1: Viết test**
-
-```dart
-// apps/mobile/test/features/auth/data/firebase_user_repository_test.dart
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:meep/features/auth/data/firebase_user_repository.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
-
-void main() {
-  late FakeFirebaseFirestore fakeFirestore;
-  late FirebaseUserRepository repo;
-
-  setUp(() {
-    fakeFirestore = FakeFirebaseFirestore();
-    repo = FirebaseUserRepository(firestore: fakeFirestore);
-  });
-
-  group('FirebaseUserRepository', () {
-    test('createProfile writes /users/{uid} + /usernames/{username}', () async {
-      const profile = UserProfile(
-        uid: 'u1',
-        email: 'a@b.com',
-        displayName: 'Khoa Lê',
-        username: 'khoa123',
-        createdAt: null,
-        updatedAt: null,
-      );
-      await repo.createProfile(profile);
-
-      final userDoc = await fakeFirestore.doc('users/u1').get();
-      expect(userDoc.exists, isTrue);
-      expect(userDoc.data()?['username'], 'khoa123');
-
-      final usernameDoc =
-          await fakeFirestore.doc('usernames/khoa123').get();
-      expect(usernameDoc.exists, isTrue);
-      expect(usernameDoc.data()?['uid'], 'u1');
-    });
-
-    test('isUsernameAvailable returns true when not taken', () async {
-      final available = await repo.isUsernameAvailable('newuser');
-      expect(available, isTrue);
-    });
-
-    test('isUsernameAvailable returns false when taken', () async {
-      await fakeFirestore
-          .doc('usernames/taken')
-          .set({'uid': 'someone'});
-      final available = await repo.isUsernameAvailable('taken');
-      expect(available, isFalse);
-    });
-
-    test('getProfile returns null when not found', () async {
-      final profile = await repo.getProfile('nonexistent');
-      expect(profile, isNull);
-    });
-
-    test('getProfile returns UserProfile when exists', () async {
-      await fakeFirestore.doc('users/u1').set({
-        'uid': 'u1',
-        'email': 'a@b.com',
-        'displayName': 'Khoa Lê',
-        'username': 'khoa123',
-        'createdAt': Timestamp.now(),
-      });
-      final profile = await repo.getProfile('u1');
-      expect(profile?.username, 'khoa123');
-    });
-  });
-}
-```
-
-- [ ] **Step 2: Run test → FAIL**
-
-```pwsh
-flutter test test/features/auth/data/firebase_user_repository_test.dart
-```
-
-Expected: FAIL — `FirebaseUserRepository` not defined.
-
-- [ ] **Step 3: Tạo abstract UserRepository**
-
-```dart
-// apps/mobile/lib/features/auth/data/user_repository.dart
-import 'package:meep/features/auth/data/user_profile.dart';
-
-abstract class UserRepository {
-  Future<void> createProfile(UserProfile profile);
-  Future<UserProfile?> getProfile(String uid);
-  Future<bool> isUsernameAvailable(String username);
-}
-```
-
-- [ ] **Step 4: Implement FirebaseUserRepository**
-
-```dart
-// apps/mobile/lib/features/auth/data/firebase_user_repository.dart
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:meep/core/error/app_error.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
-import 'package:meep/features/auth/data/user_repository.dart';
-
-class FirebaseUserRepository implements UserRepository {
-  FirebaseUserRepository({required FirebaseFirestore firestore})
-      : _firestore = firestore;
-  final FirebaseFirestore _firestore;
-
-  @override
-  Future<void> createProfile(UserProfile profile) async {
-    try {
-      final batch = _firestore.batch();
-      final userRef = _firestore.doc('users/${profile.uid}');
-      final usernameRef =
-          _firestore.doc('usernames/${profile.username}');
-
-      final data = profile.toJson();
-      data['createdAt'] = FieldValue.serverTimestamp();
-      batch.set(userRef, data);
-      batch.set(usernameRef, {'uid': profile.uid});
-
-      await batch.commit();
-    } catch (e) {
-      throw UnexpectedError(cause: e);
-    }
-  }
-
-  @override
-  Future<UserProfile?> getProfile(String uid) async {
-    try {
-      final doc = await _firestore.doc('users/$uid').get();
-      if (!doc.exists || doc.data() == null) return null;
-      return UserProfile.fromJson(doc.data()!);
-    } catch (e) {
-      throw UnexpectedError(cause: e);
-    }
-  }
-
-  @override
-  Future<bool> isUsernameAvailable(String username) async {
-    final doc = await _firestore.doc('usernames/$username').get();
-    return !doc.exists;
-  }
-}
-```
-
-- [ ] **Step 5: Run test → PASS**
-
-```pwsh
-flutter test test/features/auth/data/firebase_user_repository_test.dart
-```
-
-Expected: PASS 5/5.
-
-- [ ] **Step 6: Wire userRepositoryProvider vào auth_controller.dart**
-
-```dart
-// Thêm vào apps/mobile/lib/features/auth/application/auth_controller.dart
-
-import 'package:meep/features/auth/data/user_repository.dart';
-
-final userRepositoryProvider = Provider<UserRepository>((ref) {
-  throw UnimplementedError(
-    'userRepositoryProvider must be overridden — wire FirebaseUserRepository in main.dart',
-  );
-});
-```
-
-Và trong `main.dart`, thêm override:
-
-```dart
-userRepositoryProvider.overrideWithValue(
-  FirebaseUserRepository(firestore: FirebaseFirestore.instance),
-),
-```
-
-- [ ] **Step 7: Commit**
-
-```
-git add apps/mobile/lib/features/auth/data/ apps/mobile/test/features/auth/
-git commit -m "feat(auth): thêm UserRepository + FirebaseUserRepository (batch write users+usernames)"
-```
+> **Username format:** `^[a-z0-9_]{3,20}$` — cho phép `_`, KHÔNG cho dấu chấm, max 20 ký tự. Input auto-lowercase khi user gõ.  
+> **`deleteCurrentUser()` fail sau batch fail:** router guard self-healing — `uid != null && profile == null` → redirect `/signup/name`, user tự hoàn tất. Không cần retry logic phức tạp.  
+> **SHA-1 Firebase console:** release build cần SHA-1 khác debug — xử lý trước khi demo.
 
 ---
 
-### Task 5: Firestore security rules
-
-**Files:**
-- Modify: `firebase/firestore.rules`
-- Create: `firebase/functions/test/auth-rules.test.ts` (rules test)
-
-**Dependencies:** Task 4
-
-- [ ] **Step 1: Cập nhật firestore.rules**
-
-Mở `firebase/firestore.rules`, thêm vào sau các helper functions hiện có:
-
-```javascript
-// Thêm vào trong service cloud.firestore { ... }
-
-match /users/{uid} {
-  // Auth sprint: owner-only read.
-  // TODO(Friend module): mở rộng thêm || isFriend(uid) sau khi Friend rules được deploy
-  allow read: if isAuthed() && request.auth.uid == uid;
-  allow create: if isAuthed()
-                && request.auth.uid == uid
-                && request.resource.data.keys().hasAll([
-                     'uid', 'email', 'displayName',
-                     'username', 'createdAt', 'updatedAt'
-                   ])
-                // Server-side username validation — lowercase alphanumeric, 3-20 chars
-                && request.resource.data.username.matches('^[a-z0-9]{3,20}$');
-  allow update: if isOwner(uid)
-                && !request.resource.data.diff(resource.data)
-                      .affectedKeys()
-                      .hasAny(['uid', 'createdAt', 'email']);
-  allow delete: if false;
-}
-
-match /usernames/{username} {
-  allow read: if isAuthed();
-  allow create: if isAuthed()
-                && request.resource.data.uid == request.auth.uid
-                // username key phải match document name (tránh key/value mismatch)
-                && request.resource.data.keys().hasOnly(['uid']);
-  allow delete: if isAuthed()
-                && resource.data.uid == request.auth.uid;
-  allow update: if false;
-}
-```
-
-- [ ] **Step 2: Deploy rules lên staging**
-
-```pwsh
-firebase deploy --only firestore:rules --project meep-staging
-```
-
-Expected: `+ firestore: released rules firestore.rules`
-
-- [ ] **Step 3: Commit**
-
-```
-git add firebase/firestore.rules
-git commit -m "feat(auth): thêm Firestore rules cho users + usernames collections"
-```
-
----
-
-## Checkpoint: Data layer complete
-
-**Verify trước khi tiếp:**
-- [ ] `flutter test test/features/auth/` — all tests PASS
-- [ ] `flutter analyze` — no issues
-- [ ] `firebase deploy --only firestore:rules --project meep-staging` — deployed OK
-
----
-
-## Phase 2: Application Layer (Controllers)
-
-### Task 6: SignUpController
-
-**Files:**
-- Create: `apps/mobile/lib/features/auth/application/sign_up_controller.dart`
-- Create: `apps/mobile/lib/features/auth/application/sign_up_state.dart`
-- Create: `apps/mobile/test/features/auth/application/sign_up_controller_test.dart`
-
-**Dependencies:** Task 3, 4
-
-- [ ] **Step 1: Viết test**
-
-```dart
-// apps/mobile/test/features/auth/application/sign_up_controller_test.dart
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:meep/core/error/app_error.dart';
-import 'package:meep/features/auth/application/auth_controller.dart';
-import 'package:meep/features/auth/application/sign_up_controller.dart';
-import 'package:meep/features/auth/data/auth_repository.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
-import 'package:meep/features/auth/data/user_repository.dart';
-import 'package:mocktail/mocktail.dart';
-
-class MockAuthRepository extends Mock implements AuthRepository {}
-class MockUserRepository extends Mock implements UserRepository {}
-
-void main() {
-  late MockAuthRepository mockAuth;
-  late MockUserRepository mockUser;
-  late ProviderContainer container;
-
-  setUp(() {
-    mockAuth = MockAuthRepository();
-    mockUser = MockUserRepository();
-    container = ProviderContainer(overrides: [
-      authRepositoryProvider.overrideWithValue(mockAuth),
-      userRepositoryProvider.overrideWithValue(mockUser),
-    ]);
-  });
-
-  tearDown(() => container.dispose());
-
-  group('SignUpController', () {
-    test('initial state is step=email, all empty', () {
-      final state = container.read(signUpControllerProvider);
-      expect(state.step, SignUpStep.email);
-      expect(state.email, '');
-      expect(state.isLoading, false);
-    });
-
-    test('nextStep from email stores email and moves to password', () {
-      final notifier = container.read(signUpControllerProvider.notifier);
-      notifier.setEmail('test@meep.app');
-      notifier.nextStep();
-      final state = container.read(signUpControllerProvider);
-      expect(state.step, SignUpStep.password);
-      expect(state.email, 'test@meep.app');
-    });
-
-    test('createAccount calls signUpWithEmail + createProfile', () async {
-      when(() => mockAuth.signUpWithEmail(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-          )).thenAnswer((_) async {});
-      when(() => mockAuth.currentUid).thenReturn('uid-123');
-      when(() => mockUser.createProfile(any()))
-          .thenAnswer((_) async {});
-
-      final notifier = container.read(signUpControllerProvider.notifier);
-      notifier.setEmail('a@b.com');
-      notifier.setPassword('password123');
-      notifier.setDisplayName('Khoa Lê');
-      notifier.setUsername('khoa123');
-
-      await notifier.createAccount();
-
-      verify(() => mockAuth.signUpWithEmail(
-            email: 'a@b.com',
-            password: 'password123',
-          )).called(1);
-      verify(() => mockUser.createProfile(any())).called(1);
-    });
-
-    test('createAccount sets errorMessage on failure', () async {
-      when(() => mockAuth.signUpWithEmail(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-          )).thenThrow(
-        const UnauthenticatedError(message: 'Email đã được sử dụng.'),
-      );
-
-      final notifier = container.read(signUpControllerProvider.notifier);
-      notifier.setEmail('a@b.com');
-      notifier.setPassword('password123');
-      notifier.setDisplayName('K L');
-      notifier.setUsername('klnd');
-
-      await notifier.createAccount();
-
-      final state = container.read(signUpControllerProvider);
-      expect(state.errorMessage, isNotNull);
-      expect(state.isLoading, false);
-    });
-  });
-}
-```
-
-- [ ] **Step 2: Run test → FAIL**
-
-```pwsh
-flutter test test/features/auth/application/sign_up_controller_test.dart
-```
-
-Expected: FAIL — `SignUpController` not defined.
-
-- [ ] **Step 3: Tạo SignUpState**
-
-```dart
-// apps/mobile/lib/features/auth/application/sign_up_state.dart
-import 'package:freezed_annotation/freezed_annotation.dart';
-
-part 'sign_up_state.freezed.dart';
-
-enum SignUpStep { email, password, name, username }
-
-@freezed
-class SignUpState with _$SignUpState {
-  const factory SignUpState({
-    @Default(SignUpStep.email) SignUpStep step,
-    @Default('') String email,
-    @Default('') String password,
-    @Default('') String displayName,
-    @Default(false) bool isGoogleSignIn,
-    @Default('') String username,
-    @Default(false) bool isCheckingUsername,
-    @Default(false) bool isUsernameAvailable,
-    @Default(false) bool isLoading,
-    String? errorMessage,
-  }) = _SignUpState;
-}
-```
-
-- [ ] **Step 4: Implement SignUpController**
-
-```dart
-// apps/mobile/lib/features/auth/application/sign_up_controller.dart
-import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import 'package:meep/features/auth/application/auth_controller.dart';
-import 'package:meep/features/auth/application/sign_up_state.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
-
-export 'sign_up_state.dart';
-
-part 'sign_up_controller.g.dart';
-
-@riverpod
-class SignUpController extends _$SignUpController {
-  @override
-  SignUpState build() => const SignUpState();
-
-  void setEmail(String email) => state = state.copyWith(email: email);
-  void setPassword(String password) =>
-      state = state.copyWith(password: password);
-  void setDisplayName(String displayName) =>
-      state = state.copyWith(displayName: displayName);
-  void setUsername(String username) =>
-      state = state.copyWith(username: username.toLowerCase());
-
-  /// Gọi từ LoginController sau khi Google Sign-In thành công nhưng chưa có profile.
-  /// Pre-fill displayName từ Google account để user chỉnh lại trên SignUpNamePage.
-  void prefillFromGoogle({
-    required String uid,
-    required String email,
-    required String displayName,
-  }) {
-    state = state.copyWith(
-      isGoogleSignIn: true,
-      displayName: displayName,
-    );
-  }
-
-  void nextStep() {
-    final next = switch (state.step) {
-      SignUpStep.email => SignUpStep.password,
-      SignUpStep.password => SignUpStep.name,
-      SignUpStep.name => SignUpStep.username,
-      SignUpStep.username => SignUpStep.username,
-    };
-    state = state.copyWith(step: next, errorMessage: null);
-  }
-
-  void prevStep() {
-    final prev = switch (state.step) {
-      SignUpStep.email => SignUpStep.email,
-      SignUpStep.password => SignUpStep.email,
-      SignUpStep.name => SignUpStep.password,
-      SignUpStep.username => SignUpStep.name,
-    };
-    state = state.copyWith(step: prev, errorMessage: null);
-  }
-
-  Future<void> checkUsername(String username) async {
-    if (username.length < 3) {
-      state = state.copyWith(isUsernameAvailable: false);
-      return;
-    }
-    state = state.copyWith(isCheckingUsername: true);
-    try {
-      final userRepo = ref.read(userRepositoryProvider);
-      final available = await userRepo.isUsernameAvailable(username);
-      state = state.copyWith(
-        isCheckingUsername: false,
-        isUsernameAvailable: available,
-      );
-    } catch (_) {
-      state = state.copyWith(isCheckingUsername: false);
-    }
-  }
-
-  Future<void> createAccount() async {
-    state = state.copyWith(isLoading: true, errorMessage: null);
-    try {
-      final authRepo = ref.read(authRepositoryProvider);
-      final userRepo = ref.read(userRepositoryProvider);
-
-      await authRepo.signUpWithEmail(
-        email: state.email,
-        password: state.password,
-      );
-
-      final uid = authRepo.currentUid!;
-      final profile = UserProfile(
-        uid: uid,
-        email: state.email,
-        displayName: state.displayName,
-        username: state.username,
-        createdAt: null,
-        updatedAt: null,
-      );
-
-      try {
-        await userRepo.createProfile(profile);
-      } catch (firestoreError) {
-        // Rollback: xóa Firebase Auth user vừa tạo để tránh orphan account
-        await authRepo.deleteCurrentUser();
-        rethrow;
-      }
-
-      state = state.copyWith(isLoading: false);
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        errorMessage: e.toString().replaceFirst(RegExp(r'^.*?: '), ''),
-      );
-    }
-  }
-
-  Future<void> createAccountWithGoogle({required String uid, required String email}) async {
-    state = state.copyWith(isLoading: true, errorMessage: null);
-    try {
-      final userRepo = ref.read(userRepositoryProvider);
-      final profile = UserProfile(
-        uid: uid,
-        email: email,
-        displayName: state.displayName,
-        username: state.username,
-        createdAt: null,
-        updatedAt: null,
-      );
-      await userRepo.createProfile(profile);
-      state = state.copyWith(isLoading: false);
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        errorMessage: e.toString().replaceFirst(RegExp(r'^.*?: '), ''),
-      );
-    }
-  }
-}
-```
-
-- [ ] **Step 5: Run build_runner**
-
-```pwsh
-flutter pub run build_runner build --delete-conflicting-outputs
-```
-
-- [ ] **Step 6: Run test → PASS**
-
-```pwsh
-flutter test test/features/auth/application/sign_up_controller_test.dart
-```
-
-Expected: PASS 4/4.
-
-- [ ] **Step 7: Commit**
-
-```
-git add apps/mobile/lib/features/auth/application/ apps/mobile/test/features/auth/application/
-git commit -m "feat(auth): thêm SignUpController với 4-step state machine"
-```
-
----
-
-### Task 7: LoginController + Google Sign-In
-
-**Files:**
-- Create: `apps/mobile/lib/features/auth/application/login_controller.dart`
-- Modify: `apps/mobile/lib/features/auth/data/firebase_auth_repository.dart`
-- Create: `apps/mobile/test/features/auth/application/login_controller_test.dart`
-
-**Dependencies:** Task 3, 4, 6
-
-- [ ] **Step 1: Viết test LoginController**
-
-```dart
-// apps/mobile/test/features/auth/application/login_controller_test.dart
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:meep/core/error/app_error.dart';
-import 'package:meep/features/auth/application/auth_controller.dart';
-import 'package:meep/features/auth/application/login_controller.dart';
-import 'package:meep/features/auth/data/auth_repository.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
-import 'package:meep/features/auth/data/user_repository.dart';
-import 'package:mocktail/mocktail.dart';
-
-class MockAuthRepository extends Mock implements AuthRepository {}
-class MockUserRepository extends Mock implements UserRepository {}
-
-void main() {
-  late MockAuthRepository mockAuth;
-  late MockUserRepository mockUser;
-  late ProviderContainer container;
-
-  setUp(() {
-    mockAuth = MockAuthRepository();
-    mockUser = MockUserRepository();
-    container = ProviderContainer(overrides: [
-      authRepositoryProvider.overrideWithValue(mockAuth),
-      userRepositoryProvider.overrideWithValue(mockUser),
-    ]);
-  });
-
-  tearDown(() => container.dispose());
-
-  group('LoginController', () {
-    test('signIn success sets isSuccess=true', () async {
-      when(() => mockAuth.signInWithEmail(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-          )).thenAnswer((_) async {});
-
-      final notifier = container.read(loginControllerProvider.notifier);
-      await notifier.signIn(email: 'a@b.com', password: 'pass1234');
-
-      final state = container.read(loginControllerProvider);
-      expect(state.isSuccess, isTrue);
-      expect(state.errorMessage, isNull);
-    });
-
-    test('signIn failure sets errorMessage', () async {
-      when(() => mockAuth.signInWithEmail(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-          )).thenThrow(
-        const UnauthenticatedError(message: 'Mật khẩu không đúng.'),
-      );
-
-      final notifier = container.read(loginControllerProvider.notifier);
-      await notifier.signIn(email: 'a@b.com', password: 'wrong');
-
-      final state = container.read(loginControllerProvider);
-      expect(state.errorMessage, isNotNull);
-      expect(state.isSuccess, isFalse);
-    });
-
-    test('signInWithGoogle — new user returns needsProfile=true', () async {
-      when(() => mockAuth.signInWithGoogle()).thenAnswer((_) async {});
-      when(() => mockAuth.currentUid).thenReturn('uid-google');
-      when(() => mockUser.getProfile('uid-google')).thenAnswer((_) async => null);
-
-      final notifier = container.read(loginControllerProvider.notifier);
-      await notifier.signInWithGoogle();
-
-      final state = container.read(loginControllerProvider);
-      expect(state.needsProfile, isTrue);
-    });
-
-    test('signInWithGoogle — returning user returns needsProfile=false', () async {
-      when(() => mockAuth.signInWithGoogle()).thenAnswer((_) async {});
-      when(() => mockAuth.currentUid).thenReturn('uid-google');
-      when(() => mockUser.getProfile('uid-google')).thenAnswer(
-        (_) async => const UserProfile(
-          uid: 'uid-google',
-          email: 'g@google.com',
-          displayName: 'G U',
-          username: 'gu',
-          createdAt: null,
-          updatedAt: null,
-        ),
-      );
-
-      final notifier = container.read(loginControllerProvider.notifier);
-      await notifier.signInWithGoogle();
-
-      final state = container.read(loginControllerProvider);
-      expect(state.needsProfile, isFalse);
-      expect(state.isSuccess, isTrue);
-    });
-  });
-}
-```
-
-- [ ] **Step 2: Run test → FAIL**
-
-```pwsh
-flutter test test/features/auth/application/login_controller_test.dart
-```
-
-- [ ] **Step 3: Implement LoginController**
-
-```dart
-// apps/mobile/lib/features/auth/application/login_controller.dart
-import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import 'package:meep/features/auth/application/auth_controller.dart';
-import 'package:meep/features/auth/data/auth_repository.dart';
-
-part 'login_controller.freezed.dart';
-part 'login_controller.g.dart';
-
-@freezed
-class LoginState with _$LoginState {
-  const factory LoginState({
-    @Default(false) bool isLoading,
-    @Default(false) bool isSuccess,
-    @Default(false) bool needsProfile,
-    String? googleUid,
-    String? googleEmail,
-    String? errorMessage,
-  }) = _LoginState;
-}
-
-@riverpod
-class LoginController extends _$LoginController {
-  @override
-  LoginState build() => const LoginState();
-
-  Future<void> signIn({
-    required String email,
-    required String password,
-  }) async {
-    state = state.copyWith(isLoading: true, errorMessage: null);
-    try {
-      await ref.read(authRepositoryProvider).signInWithEmail(
-            email: email,
-            password: password,
-          );
-      state = state.copyWith(isLoading: false, isSuccess: true);
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        errorMessage: e.toString().replaceFirst(RegExp(r'^.*?: '), ''),
-      );
-    }
-  }
-
-  Future<void> signInWithGoogle() async {
-    state = state.copyWith(isLoading: true, errorMessage: null);
-    try {
-      final authRepo = ref.read(authRepositoryProvider);
-      final userRepo = ref.read(userRepositoryProvider);
-
-      await authRepo.signInWithGoogle();
-      final uid = authRepo.currentUid!;
-      final profile = await userRepo.getProfile(uid);
-
-      if (profile == null) {
-        final user = authRepo.currentGoogleUser;
-        state = state.copyWith(
-          isLoading: false,
-          needsProfile: true,
-          googleUid: uid,
-          googleEmail: user?.email ?? '',
-        );
-      } else {
-        state = state.copyWith(isLoading: false, isSuccess: true);
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        errorMessage: e.toString().replaceFirst(RegExp(r'^.*?: '), ''),
-      );
-    }
-  }
-
-  Future<void> sendPasswordReset({required String email}) async {
-    state = state.copyWith(isLoading: true, errorMessage: null);
-    try {
-      await ref
-          .read(authRepositoryProvider)
-          .sendPasswordResetEmail(email: email);
-      state = state.copyWith(isLoading: false, isSuccess: true);
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        errorMessage: e.toString().replaceFirst(RegExp(r'^.*?: '), ''),
-      );
-    }
-  }
-}
-```
-
-Thêm `currentGoogleUser` vào `AuthRepository` abstract + `FirebaseAuthRepository`:
-
-```dart
-// AuthRepository — thêm:
-User? get currentGoogleUser;
-
-// FirebaseAuthRepository — thêm:
-@override
-User? get currentGoogleUser => _auth.currentUser;
-
-// signInWithGoogle() — implement thực:
-@override
-Future<void> signInWithGoogle() async {
-  try {
-    final googleUser = await GoogleSignIn().signIn();
-    if (googleUser == null) throw const UnauthenticatedError(message: 'Đã huỷ đăng nhập Google.');
-    final googleAuth = await googleUser.authentication;
-    final credential = GoogleAuthProvider.credential(
-      accessToken: googleAuth.accessToken,
-      idToken: googleAuth.idToken,
-    );
-    await _auth.signInWithCredential(credential);
-  } on FirebaseAuthException catch (e) {
-    throw UnauthenticatedError(message: _mapFirebaseError(e.code));
-  }
-}
-```
-
-- [ ] **Step 4: Run build_runner**
-
-```pwsh
-flutter pub run build_runner build --delete-conflicting-outputs
-```
-
-- [ ] **Step 5: Run test → PASS**
-
-```pwsh
-flutter test test/features/auth/application/login_controller_test.dart
-```
-
-Expected: PASS 4/4.
-
-- [ ] **Step 6: Run all auth tests**
-
-```pwsh
-flutter test test/features/auth/
-```
-
-Expected: All PASS.
-
-- [ ] **Step 7: Commit**
-
-```
-git add apps/mobile/lib/features/auth/ apps/mobile/test/features/auth/
-git commit -m "feat(auth): thêm LoginController + Google Sign-In với profile check"
-```
-
----
-
-## Checkpoint: Application layer complete
-
-**Verify:**
-- [ ] `flutter test test/features/auth/` — all PASS
-- [ ] `flutter analyze` — no issues
-
----
-
-## Phase 3: UI Screens
-
-### Task 8: IntroPage + router wiring
-
-**Files:**
-- Create: `apps/mobile/lib/features/auth/presentation/intro_page.dart`
-- Modify: `apps/mobile/lib/core/router/app_router.dart` (thêm đủ routes)
-- Create: `apps/mobile/test/features/auth/presentation/intro_page_test.dart`
-
-**Dependencies:** Task 7
-
-- [ ] **Step 1: Viết widget test**
-
-```dart
-// apps/mobile/test/features/auth/presentation/intro_page_test.dart
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:go_router/go_router.dart';
-import 'package:meep/features/auth/presentation/intro_page.dart';
-
-void main() {
-  testWidgets('IntroPage hiển thị 2 CTA button', (tester) async {
-    await tester.pumpWidget(
-      ProviderScope(
-        child: MaterialApp(
-          home: const IntroPage(),
-        ),
-      ),
-    );
-
-    expect(find.text('Tạo tài khoản mới'), findsOneWidget);
-    expect(find.text('Đăng nhập'), findsOneWidget);
-  });
-}
-```
-
-- [ ] **Step 2: Run test → FAIL**
-
-```pwsh
-flutter test test/features/auth/presentation/intro_page_test.dart
-```
-
-- [ ] **Step 3: Implement IntroPage**
-
-```dart
-// apps/mobile/lib/features/auth/presentation/intro_page.dart
-import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-
-class IntroPage extends StatelessWidget {
-  const IntroPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            children: [
-              const Spacer(flex: 3),
-              const Text(
-                'LogoMeep',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 28,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 16),
-              const Text(
-                'Bắt trọn từng khoảnh khắc,\nlưu giữ ký ức cùng những người thân yêu',
-                textAlign: TextAlign.center,
-                style: TextStyle(color: Colors.white70, fontSize: 15),
-              ),
-              const Spacer(flex: 2),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton.icon(
-                  onPressed: () => context.push('/signup/email'),
-                  icon: const Icon(Icons.photo_camera_outlined),
-                  label: const Text('Tạo tài khoản mới'),
-                  style: FilledButton.styleFrom(
-                    backgroundColor: Colors.white24,
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(vertical: 16),
-                    shape: const StadiumBorder(),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              TextButton(
-                onPressed: () => context.push('/login/email'),
-                child: const Text(
-                  'Đăng nhập',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ),
-              const SizedBox(height: 32),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-```
-
-- [ ] **Step 4: Run test → PASS**
-
-```pwsh
-flutter test test/features/auth/presentation/intro_page_test.dart
-```
-
-- [ ] **Step 5: Commit**
-
-```
-git add apps/mobile/lib/features/auth/presentation/intro_page.dart apps/mobile/test/
-git commit -m "feat(auth): thêm IntroPage với 2 CTA theo Figma"
-```
-
----
-
-### Task 9: Signup screens (email + password)
-
-**Files:**
-- Create: `apps/mobile/lib/features/auth/presentation/signup/signup_email_page.dart`
-- Create: `apps/mobile/lib/features/auth/presentation/signup/signup_password_page.dart`
-- Create: `apps/mobile/lib/features/auth/presentation/shared/auth_text_field.dart`
-
-**Dependencies:** Task 6, 8
-
-- [ ] **Step 1: Tạo shared AuthTextField widget**
-
-```dart
-// apps/mobile/lib/features/auth/presentation/shared/auth_text_field.dart
-import 'package:flutter/material.dart';
-
-class AuthTextField extends StatelessWidget {
-  const AuthTextField({
-    super.key,
-    required this.hint,
-    this.keyboardType,
-    this.obscureText = false,
-    this.onChanged,
-    this.controller,
-  });
-
-  final String hint;
-  final TextInputType? keyboardType;
-  final bool obscureText;
-  final ValueChanged<String>? onChanged;
-  final TextEditingController? controller;
-
-  @override
-  Widget build(BuildContext context) {
-    return TextField(
-      controller: controller,
-      obscureText: obscureText,
-      keyboardType: keyboardType,
-      onChanged: onChanged,
-      style: const TextStyle(color: Colors.white),
-      decoration: InputDecoration(
-        hintText: hint,
-        hintStyle: const TextStyle(color: Colors.white54),
-        filled: true,
-        fillColor: Colors.white12,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(30),
-          borderSide: BorderSide.none,
-        ),
-        contentPadding:
-            const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-      ),
-    );
-  }
-}
-```
-
-- [ ] **Step 2: Implement SignUpEmailPage**
-
-```dart
-// apps/mobile/lib/features/auth/presentation/signup/signup_email_page.dart
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-
-import 'package:meep/features/auth/application/login_controller.dart';
-import 'package:meep/features/auth/application/sign_up_controller.dart';
-import 'package:meep/features/auth/presentation/shared/auth_text_field.dart';
-
-class SignUpEmailPage extends ConsumerStatefulWidget {
-  const SignUpEmailPage({super.key});
-
-  @override
-  ConsumerState<SignUpEmailPage> createState() => _SignUpEmailPageState();
-}
-
-class _SignUpEmailPageState extends ConsumerState<SignUpEmailPage> {
-  final _emailController = TextEditingController();
-
-  @override
-  void dispose() {
-    _emailController.dispose();
-    super.dispose();
-  }
-
-  bool _isValidEmail(String email) =>
-      RegExp(r'^[^@]+@[^@]+\.[^@]+').hasMatch(email);
-
-  @override
-  Widget build(BuildContext context) {
-    final email = _emailController.text;
-
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(height: 16),
-              _BackButton(onTap: () => context.pop()),
-              const Spacer(flex: 2),
-              const Text(
-                'Email của bạn là gì?',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 22,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 16),
-              AuthTextField(
-                hint: 'Địa chỉ email',
-                keyboardType: TextInputType.emailAddress,
-                controller: _emailController,
-                onChanged: (_) => setState(() {}),
-              ),
-              const SizedBox(height: 16),
-              _OrDivider(),
-              const SizedBox(height: 16),
-              _GoogleButton(
-                onPressed: () async {
-                  final notifier = ref.read(loginControllerProvider.notifier);
-                  await notifier.signInWithGoogle();
-                  if (!mounted) return;
-                  final state = ref.read(loginControllerProvider);
-                  if (state.needsProfile) {
-                    context.go('/signup/name');
-                  } else if (state.isSuccess) {
-                    context.go('/home');
-                  }
-                },
-              ),
-              const Spacer(flex: 3),
-              _ContinueButton(
-                enabled: _isValidEmail(email),
-                onPressed: () {
-                  ref
-                      .read(signUpControllerProvider.notifier)
-                      .setEmail(_emailController.text);
-                  context.push('/signup/password');
-                },
-              ),
-              const SizedBox(height: 32),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-```
-
-- [ ] **Step 3: Implement SignUpPasswordPage**
-
-```dart
-// apps/mobile/lib/features/auth/presentation/signup/signup_password_page.dart
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-
-import 'package:meep/features/auth/application/sign_up_controller.dart';
-import 'package:meep/features/auth/presentation/shared/auth_text_field.dart';
-
-class SignUpPasswordPage extends ConsumerStatefulWidget {
-  const SignUpPasswordPage({super.key});
-
-  @override
-  ConsumerState<SignUpPasswordPage> createState() =>
-      _SignUpPasswordPageState();
-}
-
-class _SignUpPasswordPageState extends ConsumerState<SignUpPasswordPage> {
-  final _pwController = TextEditingController();
-
-  @override
-  void dispose() {
-    _pwController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final pw = _pwController.text;
-
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            children: [
-              const SizedBox(height: 16),
-              _BackButton(onTap: () => context.pop()),
-              const Spacer(flex: 2),
-              const Text(
-                'Chọn một mật khẩu',
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 22,
-                    fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 16),
-              AuthTextField(
-                hint: 'Mật khẩu',
-                obscureText: true,
-                controller: _pwController,
-                onChanged: (_) => setState(() {}),
-              ),
-              const SizedBox(height: 12),
-              _HintPill(text: 'Mật khẩu của bạn phải dài tối thiểu 8 ký tự'),
-              const Spacer(flex: 3),
-              _ContinueButton(
-                enabled: pw.length >= 8,
-                onPressed: () {
-                  ref
-                      .read(signUpControllerProvider.notifier)
-                      .setPassword(_pwController.text);
-                  context.push('/signup/name');
-                },
-              ),
-              const SizedBox(height: 32),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-```
-
-> **Chú ý:** `_BackButton`, `_OrDivider`, `_GoogleButton`, `_ContinueButton`, `_HintPill` là private shared widgets — đặt trong `apps/mobile/lib/features/auth/presentation/shared/auth_widgets.dart` (tạo ở step sau).
-
-- [ ] **Step 4: Tạo shared auth widgets**
-
-```dart
-// apps/mobile/lib/features/auth/presentation/shared/auth_widgets.dart
-import 'package:flutter/material.dart';
-
-class _BackButton extends StatelessWidget {
-  const _BackButton({required this.onTap});
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) => GestureDetector(
-        onTap: onTap,
-        child: Container(
-          padding: const EdgeInsets.all(10),
-          decoration: const BoxDecoration(
-            color: Colors.white12,
-            shape: BoxShape.circle,
-          ),
-          child: const Icon(Icons.arrow_back_ios_new,
-              color: Colors.white, size: 16),
-        ),
-      );
-}
-
-class _OrDivider extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) => Row(children: [
-        const Expanded(child: Divider(color: Colors.white24)),
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 12),
-          child: Text('Hoặc', style: TextStyle(color: Colors.white54)),
-        ),
-        const Expanded(child: Divider(color: Colors.white24)),
-      ]);
-}
-
-class _GoogleButton extends StatelessWidget {
-  const _GoogleButton({required this.onPressed});
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) => SizedBox(
-        width: double.infinity,
-        child: OutlinedButton.icon(
-          onPressed: onPressed,
-          icon: const FlutterLogo(size: 20),
-          label: const Text(
-            'Tiếp tục với Google',
-            style: TextStyle(color: Colors.white),
-          ),
-          style: OutlinedButton.styleFrom(
-            side: const BorderSide(color: Colors.white24),
-            padding: const EdgeInsets.symmetric(vertical: 14),
-            shape: const StadiumBorder(),
-          ),
-        ),
-      );
-}
-
-class _ContinueButton extends StatelessWidget {
-  const _ContinueButton({required this.enabled, required this.onPressed});
-  final bool enabled;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) => SizedBox(
-        width: double.infinity,
-        child: FilledButton.icon(
-          onPressed: enabled ? onPressed : null,
-          icon: const Icon(Icons.arrow_forward),
-          label: const Text('Tiếp tục'),
-          style: FilledButton.styleFrom(
-            backgroundColor: Colors.white,
-            foregroundColor: Colors.black,
-            disabledBackgroundColor: Colors.white12,
-            padding: const EdgeInsets.symmetric(vertical: 16),
-            shape: const StadiumBorder(),
-          ),
-        ),
-      );
-}
-
-class _HintPill extends StatelessWidget {
-  const _HintPill({required this.text, this.color});
-  final String text;
-  final Color? color;
-
-  @override
-  Widget build(BuildContext context) => Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        decoration: BoxDecoration(
-          color: color ?? Colors.white12,
-          borderRadius: BorderRadius.circular(20),
-        ),
-        child: Text(text,
-            style: TextStyle(color: color != null ? Colors.white : Colors.white70, fontSize: 13)),
-      );
-}
-```
-
-- [ ] **Step 5: flutter analyze**
-
-```pwsh
-flutter analyze
-```
-
-- [ ] **Step 6: Commit**
-
-```
-git add apps/mobile/lib/features/auth/presentation/
-git commit -m "feat(auth): thêm SignUpEmailPage + SignUpPasswordPage theo Figma"
-```
-
----
-
-### Task 10: Signup screens (name + username)
-
-**Files:**
-- Create: `apps/mobile/lib/features/auth/presentation/signup/signup_name_page.dart`
-- Create: `apps/mobile/lib/features/auth/presentation/signup/signup_username_page.dart`
-- Create: `apps/mobile/test/features/auth/presentation/signup_username_page_test.dart`
-
-**Dependencies:** Task 9
-
-- [ ] **Step 1: Implement SignUpNamePage**
-
-```dart
-// apps/mobile/lib/features/auth/presentation/signup/signup_name_page.dart
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-
-import 'package:meep/features/auth/application/sign_up_controller.dart';
-import 'package:meep/features/auth/presentation/shared/auth_text_field.dart';
-import 'package:meep/features/auth/presentation/shared/auth_widgets.dart';
-
-class SignUpNamePage extends ConsumerStatefulWidget {
-  const SignUpNamePage({super.key});
-
-  @override
-  ConsumerState<SignUpNamePage> createState() => _SignUpNamePageState();
-}
-
-class _SignUpNamePageState extends ConsumerState<SignUpNamePage> {
-  final _displayNameController = TextEditingController();
-
-  @override
-  void dispose() {
-    _displayNameController.dispose();
-    super.dispose();
-  }
-
-  bool get _isValid => _displayNameController.text.trim().length >= 2;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            children: [
-              const SizedBox(height: 16),
-              _BackButton(onTap: () => context.pop()),
-              const Spacer(flex: 2),
-              const Text(
-                'Tên bạn là gì?',
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 22,
-                    fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 16),
-              AuthTextField(
-                hint: 'Họ và tên',
-                controller: _displayNameController,
-                onChanged: (_) => setState(() {}),
-              ),
-              const Spacer(flex: 3),
-              _ContinueButton(
-                enabled: _isValid,
-                onPressed: () {
-                  ref.read(signUpControllerProvider.notifier)
-                      .setDisplayName(_displayNameController.text.trim());
-                  context.push('/signup/username');
-                },
-              ),
-              const SizedBox(height: 32),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-```
-
-- [ ] **Step 2: Viết widget test cho SignUpUsernamePage (username availability indicator)**
-
-```dart
-// apps/mobile/test/features/auth/presentation/signup_username_page_test.dart
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:meep/features/auth/application/auth_controller.dart';
-import 'package:meep/features/auth/application/sign_up_controller.dart';
-import 'package:meep/features/auth/data/user_repository.dart';
-import 'package:meep/features/auth/presentation/signup/signup_username_page.dart';
-import 'package:mocktail/mocktail.dart';
-
-class MockUserRepository extends Mock implements UserRepository {}
-
-void main() {
-  testWidgets('shows hint pill when username empty', (tester) async {
-    await tester.pumpWidget(
-      ProviderScope(
-        child: MaterialApp(home: const SignUpUsernamePage()),
-      ),
-    );
-    await tester.pump();
-    expect(
-      find.text('Việc này sẽ giúp bạn kết nối bạn bè nhanh chóng.'),
-      findsOneWidget,
-    );
-  });
-}
-```
-
-- [ ] **Step 3: Implement SignUpUsernamePage**
-
-```dart
-// apps/mobile/lib/features/auth/presentation/signup/signup_username_page.dart
-import 'dart:async';
-
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-
-import 'package:meep/features/auth/application/sign_up_controller.dart';
-import 'package:meep/features/auth/presentation/shared/auth_text_field.dart';
-import 'package:meep/features/auth/presentation/shared/auth_widgets.dart';
-
-class SignUpUsernamePage extends ConsumerStatefulWidget {
-  const SignUpUsernamePage({super.key});
-
-  @override
-  ConsumerState<SignUpUsernamePage> createState() =>
-      _SignUpUsernamePageState();
-}
-
-class _SignUpUsernamePageState extends ConsumerState<SignUpUsernamePage> {
-  final _controller = TextEditingController();
-  Timer? _debounce;
-
-  static final _usernameRegex = RegExp(r'^[a-zA-Z0-9]{3,20}$'); // auto-lowercased on input
-
-  @override
-  void dispose() {
-    _debounce?.cancel();
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _onUsernameChanged(String value) {
-    _debounce?.cancel();
-    if (!_usernameRegex.hasMatch(value)) {
-      ref
-          .read(signUpControllerProvider.notifier)
-          .setUsername(value);
-      return;
-    }
-    _debounce = Timer(const Duration(milliseconds: 500), () {
-      ref.read(signUpControllerProvider.notifier)
-        ..setUsername(value)
-        ..checkUsername(value);
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final state = ref.watch(signUpControllerProvider);
-    final username = _controller.text;
-    final hasValidFormat = _usernameRegex.hasMatch(username);
-
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            children: [
-              const SizedBox(height: 16),
-              _BackButton(onTap: () => context.pop()),
-              const Spacer(flex: 2),
-              const Text(
-                'Chọn tên người dùng của bạn',
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 22,
-                    fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 16),
-              AuthTextField(
-                hint: 'Tên người dùng',
-                controller: _controller,
-                onChanged: _onUsernameChanged,
-              ),
-              const SizedBox(height: 12),
-              _buildStatusPill(state, hasValidFormat, username),
-              const Spacer(flex: 3),
-              _ContinueButton(
-                enabled: state.isUsernameAvailable && !state.isCheckingUsername,
-                onPressed: () async {
-                  await ref
-                      .read(signUpControllerProvider.notifier)
-                      .createAccount();
-                  if (!mounted) return;
-                  final s = ref.read(signUpControllerProvider);
-                  if (s.errorMessage == null) context.go('/home');
-                },
-              ),
-              const SizedBox(height: 32),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildStatusPill(
-      SignUpState state, bool hasValidFormat, String username) {
-    if (username.isEmpty || !hasValidFormat) {
-      return _HintPill(text: 'Việc này sẽ giúp bạn kết nối bạn bè nhanh chóng.');
-    }
-    if (state.isCheckingUsername) {
-      return const CircularProgressIndicator(color: Colors.white54, strokeWidth: 2);
-    }
-    if (state.isUsernameAvailable) {
-      return Row(mainAxisSize: MainAxisSize.min, children: const [
-        Icon(Icons.check_circle_outline, color: Colors.greenAccent, size: 18),
-        SizedBox(width: 8),
-        Text('Tuyệt vời!', style: TextStyle(color: Colors.greenAccent)),
-      ]);
-    }
-    return _HintPill(
-      text: 'Tên này đã được dùng',
-      color: Colors.redAccent,
-    );
-  }
-}
-```
-
-- [ ] **Step 4: Run widget test**
-
-```pwsh
-flutter test test/features/auth/presentation/signup_username_page_test.dart
-```
-
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```
-git add apps/mobile/lib/features/auth/presentation/signup/ apps/mobile/test/
-git commit -m "feat(auth): thêm SignUpNamePage + SignUpUsernamePage với username availability check"
-```
-
----
-
-### Task 11: Login screens + forgot password
-
-**Files:**
-- Create: `apps/mobile/lib/features/auth/presentation/login/login_email_page.dart`
-- Create: `apps/mobile/lib/features/auth/presentation/login/login_password_page.dart`
-
-**Dependencies:** Task 7, 8
-
-- [ ] **Step 1: Implement LoginEmailPage**
-
-```dart
-// apps/mobile/lib/features/auth/presentation/login/login_email_page.dart
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-
-import 'package:meep/features/auth/application/login_controller.dart';
-import 'package:meep/features/auth/presentation/shared/auth_text_field.dart';
-import 'package:meep/features/auth/presentation/shared/auth_widgets.dart';
-
-class LoginEmailPage extends ConsumerStatefulWidget {
-  const LoginEmailPage({super.key});
-
-  @override
-  ConsumerState<LoginEmailPage> createState() => _LoginEmailPageState();
-}
-
-class _LoginEmailPageState extends ConsumerState<LoginEmailPage> {
-  final _emailController = TextEditingController();
-
-  @override
-  void dispose() {
-    _emailController.dispose();
-    super.dispose();
-  }
-
-  bool _isValidEmail(String email) =>
-      RegExp(r'^[^@]+@[^@]+\.[^@]+').hasMatch(email);
-
-  @override
-  Widget build(BuildContext context) {
-    final email = _emailController.text;
-
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            children: [
-              const SizedBox(height: 16),
-              _BackButton(onTap: () => context.pop()),
-              const Spacer(flex: 2),
-              const Text(
-                'Email của bạn là gì?',
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 22,
-                    fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 16),
-              AuthTextField(
-                hint: 'Địa chỉ email',
-                keyboardType: TextInputType.emailAddress,
-                controller: _emailController,
-                onChanged: (_) => setState(() {}),
-              ),
-              const SizedBox(height: 16),
-              _OrDivider(),
-              const SizedBox(height: 16),
-              _GoogleButton(
-                onPressed: () async {
-                  final notifier = ref.read(loginControllerProvider.notifier);
-                  await notifier.signInWithGoogle();
-                  if (!mounted) return;
-                  final state = ref.read(loginControllerProvider);
-                  if (state.needsProfile) {
-                    context.go('/signup/name');
-                  } else if (state.isSuccess) {
-                    context.go('/home');
-                  }
-                },
-              ),
-              const Spacer(flex: 3),
-              _ContinueButton(
-                enabled: _isValidEmail(email),
-                onPressed: () {
-                  context.push(
-                    '/login/password',
-                    extra: _emailController.text,
-                  );
-                },
-              ),
-              const SizedBox(height: 32),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-```
-
-- [ ] **Step 2: Implement LoginPasswordPage**
-
-```dart
-// apps/mobile/lib/features/auth/presentation/login/login_password_page.dart
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-
-import 'package:meep/features/auth/application/login_controller.dart';
-import 'package:meep/features/auth/presentation/shared/auth_text_field.dart';
-import 'package:meep/features/auth/presentation/shared/auth_widgets.dart';
-
-class LoginPasswordPage extends ConsumerStatefulWidget {
-  const LoginPasswordPage({super.key, required this.email});
-  final String email;
-
-  @override
-  ConsumerState<LoginPasswordPage> createState() =>
-      _LoginPasswordPageState();
-}
-
-class _LoginPasswordPageState extends ConsumerState<LoginPasswordPage> {
-  final _pwController = TextEditingController();
-
-  @override
-  void dispose() {
-    _pwController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final state = ref.watch(loginControllerProvider);
-    final pw = _pwController.text;
-
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            children: [
-              const SizedBox(height: 16),
-              _BackButton(onTap: () => context.pop()),
-              const Spacer(flex: 2),
-              const Text(
-                'Điền mật khẩu của bạn',
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 22,
-                    fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 16),
-              AuthTextField(
-                hint: 'Mật khẩu',
-                obscureText: true,
-                controller: _pwController,
-                onChanged: (_) => setState(() {}),
-              ),
-              const SizedBox(height: 12),
-              if (state.errorMessage != null)
-                _HintPill(
-                  text: state.errorMessage!,
-                  color: Colors.redAccent,
-                ),
-              GestureDetector(
-                onTap: () async {
-                  await ref
-                      .read(loginControllerProvider.notifier)
-                      .sendPasswordReset(email: widget.email);
-                  if (!mounted) return;
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Email đặt lại mật khẩu đã được gửi.'),
-                    ),
-                  );
-                },
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 16, vertical: 8),
-                  decoration: BoxDecoration(
-                    color: Colors.white12,
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: const Text(
-                    'Bạn đã quên mật khẩu?',
-                    style: TextStyle(color: Colors.white70, fontSize: 13),
-                  ),
-                ),
-              ),
-              const Spacer(flex: 3),
-              _LoginButton(
-                pw: pw,
-                isLoading: state.isLoading,
-                isSuccess: state.isSuccess,
-                onPressed: () async {
-                  await ref.read(loginControllerProvider.notifier).signIn(
-                        email: widget.email,
-                        password: pw,
-                      );
-                  if (!mounted) return;
-                  if (ref.read(loginControllerProvider).isSuccess) {
-                    await Future.delayed(const Duration(milliseconds: 800));
-                    if (!mounted) return;
-                    context.go('/home');
-                  }
-                },
-              ),
-              const SizedBox(height: 32),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _LoginButton extends StatelessWidget {
-  const _LoginButton({
-    required this.pw,
-    required this.isLoading,
-    required this.isSuccess,
-    required this.onPressed,
-  });
-  final String pw;
-  final bool isLoading;
-  final bool isSuccess;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: double.infinity,
-      child: FilledButton.icon(
-        onPressed: (pw.isNotEmpty && !isLoading) ? onPressed : null,
-        icon: isLoading
-            ? const SizedBox.square(
-                dimension: 18,
-                child: CircularProgressIndicator(
-                    strokeWidth: 2, color: Colors.black),
-              )
-            : Icon(isSuccess ? Icons.check_circle_outline : Icons.arrow_forward),
-        label: Text(isSuccess ? 'Bạn đã sẵn sàng' : 'Tiếp tục'),
-        style: FilledButton.styleFrom(
-          backgroundColor: Colors.white,
-          foregroundColor: Colors.black,
-          disabledBackgroundColor: Colors.white12,
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          shape: const StadiumBorder(),
-        ),
-      ),
-    );
-  }
-}
-```
-
-- [ ] **Step 3: Cập nhật app_router.dart — thêm đủ routes và pass email extra**
-
-```dart
-GoRoute(
-  path: '/login/password',
-  builder: (context, state) {
-    final email = state.extra as String? ?? '';
-    return LoginPasswordPage(email: email);
-  },
-),
-```
-
-- [ ] **Step 4: flutter analyze**
-
-```pwsh
-flutter analyze
-```
-
-- [ ] **Step 5: Commit**
-
-```
-git add apps/mobile/lib/features/auth/presentation/login/ apps/mobile/lib/core/router/
-git commit -m "feat(auth): thêm LoginEmailPage + LoginPasswordPage với forgot password + success state"
-```
-
----
-
-## Checkpoint: Auth flow complete
-
-**Verify toàn bộ:**
-- [ ] `flutter test test/features/auth/` — ALL PASS
-- [ ] `flutter analyze` — clean
-- [ ] Manual test trên emulator:
-  - [ ] Signup email/password → 4 screens → tạo tài khoản OK
-  - [ ] Login email/password → "Bạn đã sẵn sàng ✓" → navigate /home
-  - [ ] App restart → auto-login vào /home (không về /intro)
-  - [ ] Logout → về /intro
-  - [ ] Google Sign-In (new user) → vào name + username screen
-  - [ ] Forgot password → email nhận được
+> **Reference:** File `docs/plans/2026-05-04-auth.md` (original, archived below) chứa detailed code snippets cho từng task. Khi implement với `/build`, executor có thể tham khảo code đã viết sẵn trong phần gốc của file này. Format mới (Part 1-4 trên) là source of truth cho planning.

--- a/docs/plans/2026-05-23-chat.md
+++ b/docs/plans/2026-05-23-chat.md
@@ -1,0 +1,212 @@
+# Plan: Chat Module
+
+> **Phụ thuộc vào:** Friend — `Friendship` model, `FriendController.unfriend()`; Settings — `BlockRepository` (canonical owner, import interface này)
+> **Được phụ thuộc bởi:** Space (Group Chat), Notification (conversation data)
+> **Spec:** `docs/specs/2026-05-23-chat.md`
+> **Tier:** T1 Stretch (1-1) + T0+ exception (Group Chat trong Space ship cùng Space M3)
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/chat/data/conversation.dart` | freezed model | `conversationId String`, `type ConversationType` (direct/space), `participantIds List<String>`, `spaceId String?`, `quotedPostId String?`, `lastMessage String`, `lastMessageAt DateTime`, `lastSenderId String`, `status ConversationStatus` (active/blocked/unfriended), `createdAt DateTime` |
+| `lib/features/chat/data/message.dart` | freezed model | `messageId String`, `senderId String`, `text String` (≤500 chars), `createdAt DateTime` |
+| `lib/features/chat/data/conversation_repository.dart` | abstract class | `Stream<List<Conversation>> watchConversations()`, `Future<Conversation> getOrCreateConversation(String peerUid)`, `Future<void> sendMessage(String conversationId, String text)`, `Stream<List<Message>> watchMessages(String conversationId)` |
+| `lib/features/chat/application/chat_controller.dart` | Riverpod stub | `ChatState`, methods throw `UnimplementedError` |
+| `lib/features/chat/presentation/inbox_screen.dart` | widget stub | |
+| `lib/features/chat/presentation/chat_screen.dart` | widget stub | |
+| `lib/features/chat/presentation/group_chat_screen.dart` | widget stub | |
+| `lib/features/chat/presentation/widgets/space_members_sheet.dart` | widget stub | |
+| `lib/core/router/app_router.dart` | router update | Routes `/inbox`, `/chat/:conversationId` |
+
+> `BlockRepository` import từ **settings** module: `lib/features/settings/data/block_repository.dart` — KHÔNG define riêng trong chat.
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(chat): FirebaseConversationRepository — watch + getOrCreate + sendMessage + watchMessages**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/chat-repository` |
+| Blocked by | contracts Part 1, Friend T5 (CF tạo conversation) |
+
+Files:
+- `lib/features/chat/data/firebase_conversation_repository.dart` — impl `ConversationRepository`
+- `test/features/chat/firebase_conversation_repository_test.dart` — test: watchConversations filter active, getOrCreateConversation idempotent, sendMessage tạo doc, sendMessage >500 chars → throw, watchMessages stream đúng thứ tự
+
+Acceptance criteria:
+- [ ] `watchConversations()` filter `status != 'blocked'` cho Inbox display — blocked conversations ẩn hoàn toàn khỏi Inbox (conversation doc vẫn tồn tại trong Firestore, nhưng không hiện trong list)
+- [ ] `getOrCreateConversation(peerUid)` idempotent — tạo mới nếu không tồn tại, trả existing nếu đã có (không duplicate)
+- [ ] `sendMessage` với `text.length > 500` → throw `AppError` trước khi write Firestore
+- [ ] `sendMessage` với `text.isEmpty` → throw `AppError`
+- [ ] `watchMessages` stream sort `createdAt ASC` (chronological)
+- [ ] `getOrCreateConversation` chỉ là fallback — conversation 1-1 bình thường đã được tạo bởi CF `acceptFriendRequest`
+
+Cross-module imports: `BlockRepository` từ **settings** (`lib/features/settings/data/block_repository.dart`)
+
+---
+**T2 · feat(chat): ChatController — loadMessages + sendMessage + sendMessageFromFeed**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/chat-controller` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/chat/application/chat_controller.dart` — `ChatState` (conversations, messages, isLoading, errorMessage), impl: `loadMessages`, `sendMessage`, `sendMessageFromFeed(postId, authorId, text)`
+- `test/features/chat/chat_controller_test.dart` — test: sendMessage success → message appears, sendMessage rỗng → error, getConversations sort by lastMessageAt DESC
+
+Acceptance criteria:
+- [ ] `sendMessage` KHÔNG optimistic — chỉ append vào bubbles sau Firestore confirm
+- [ ] `sendMessageFromFeed(postId, authorId, text)` gọi `getOrCreateConversation(authorId)` trước khi send (idempotent)
+- [ ] `getConversations()` sort `lastMessageAt DESC`
+- [ ] Error network → `ChatState.errorMessage = "Gửi thất bại — thử lại"`, message KHÔNG xuất hiện trong list
+- [ ] Send button disabled khi `text.isEmpty`
+
+Cross-module imports: None
+
+---
+**T3 · feat(chat): InboxScreen — list conversations + conversation tile**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/chat-inbox-ui` |
+| Blocked by | T2 |
+
+Files:
+- `lib/features/chat/presentation/inbox_screen.dart` — full impl (Figma `269:942`)
+- `lib/features/chat/presentation/widgets/conversation_tile.dart` — 1-1: avatar + displayName + lastMessage; group: Space icon + name + lastMessage
+
+Acceptance criteria:
+- [ ] List sort by `lastMessageAt DESC`
+- [ ] Empty state: "Chưa có tin nhắn nào — reply một ảnh để bắt đầu"
+- [ ] Skeleton loading khi fetch
+- [ ] Conversations với `status == 'blocked'` KHÔNG hiện trong Inbox (filter `watchConversations()`)
+- [ ] Tap conversation → navigate `ChatScreen` hoặc `GroupChatScreen` tuỳ `type`
+
+Cross-module imports: `UserProfile` từ **auth**
+
+---
+**T4 · feat(chat): ChatScreen 1-1 — quoted photo + message bubbles + input bar**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2 ngày) |
+| Branch | `feat/TBD/chat-screen-ui` |
+| Blocked by | T3 |
+
+Files:
+- `lib/features/chat/presentation/chat_screen.dart` — full impl (Figma `564:6934`)
+- `lib/features/chat/presentation/widgets/quoted_photo_block.dart` — thumbnail 301×301 + Note/caption pill + timestamp
+- `lib/features/chat/presentation/widgets/message_bubble.dart` — trái (đối phương) + phải (mình)
+- `lib/features/chat/presentation/widgets/chat_input_bar.dart` — TextField + send button
+- `test/features/chat/chat_screen_test.dart` — widget tests: bubble trái/phải đúng side, send disabled khi empty, quoted photo render
+
+Acceptance criteria:
+- [ ] Bubble trái = đối phương: `[avatar] [text bubble]`. Bubble phải = mình: `[text bubble]` (Figma `564:6934`)
+- [ ] Quoted photo block ở đầu thread: thumbnail + caption pill + timestamp (`DD thg M HH:mm`)
+- [ ] Send button disabled khi input rỗng
+- [ ] Conversation `status == 'unfriended'`: input bar ẩn, banner "Hãy thêm bạn lại để nhắn tin"
+- [ ] Conversation `status == 'blocked'`: input bar ẩn, message không gửi được (Firestore rule enforce)
+- [ ] `limit(50)` messages + load-more khi scroll lên trên
+
+Cross-module imports: `Post` từ **home-camera-feed** (fetch quoted post thumbnail)
+
+---
+**T5 · feat(chat): GroupChatScreen + SpaceMembersSheet**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/chat-group-screen` |
+| Blocked by | T4 |
+
+Files:
+- `lib/features/chat/presentation/group_chat_screen.dart` — full impl (Figma `564:8603`)
+- `lib/features/chat/presentation/widgets/group_message_bubble.dart` — avatar + displayName above bubble
+- `lib/features/chat/presentation/widgets/space_members_sheet.dart` — "Mọi người (N)" + list members + creator badge (Figma `564:8896`)
+
+Acceptance criteria:
+- [ ] Topbar: `[←] [Space icon + Space name] [⋯ menu]`
+- [ ] ⋯ menu: Chỉnh sửa theme (→ Space settings) / Xem thành viên (→ SpaceMembersSheet) / Rời khỏi Space (→ dialog confirm)
+- [ ] SpaceMembersSheet: header "Mọi người (N)", list `[avatar] [displayName] [role badge nếu creator]`
+- [ ] Rời Space từ chat → reuse `SpaceController.leaveSpace()` (Space module)
+- [ ] Non-member: Firestore rule deny → navigate back + toast "Bạn không còn là thành viên"
+
+Cross-module imports: `SpaceController.leaveSpace()` từ **space**, `Space` model từ **space**
+
+---
+**T6 · feat(chat): Block + unfriend từ chat menu**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/chat-block-unfriend` |
+| Blocked by | T4 |
+
+Files:
+- `lib/features/chat/presentation/widgets/chat_menu_dropdown.dart` — dropdown (Figma `564:6965`): [Xóa bạn] / [Chặn]
+- (reuse) `lib/features/settings/presentation/block_confirm_dialog.dart` — từ Settings module
+- (reuse) unfriend confirm dialog pattern từ Friend module
+
+Acceptance criteria:
+- [ ] ⋯ menu trong ChatScreen: [Xóa bạn] + [Chặn] (Figma `564:6965`)
+- [ ] Tap [Chặn] → `BlockConfirmDialog` (từ Settings) → confirm → `BlockRepository.blockUser()` → đóng chat → về Inbox
+- [ ] Tap [Xóa bạn] → unfriend popup (Figma `564:7131`) → confirm → `FriendController.unfriend()` → về Inbox
+- [ ] Sau block/unfriend: conversation vẫn readable (lịch sử giữ), input ẩn
+
+Cross-module imports: `BlockRepository` từ **settings**, `FriendController.unfriend()` từ **friend**
+
+---
+**T7 · test(chat): Firestore rules tests — /conversations + /messages**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/chat-rules` |
+| Blocked by | T1 |
+
+Files:
+- `firebase/functions/test/rules/chat.rules.test.ts`
+
+Acceptance criteria:
+- [ ] `/conversations/{id}`: participant read ✓, non-participant read ✗, unauthenticated ✗
+- [ ] `/conversations/{id}/messages/{id}`: participant create với `text ≤ 500` ✓
+- [ ] `/conversations/{id}/messages/{id}`: participant create với `text > 500` ✗
+- [ ] `/conversations/{id}/messages/{id}`: message khi `conversation.status == 'blocked'` → ✗ (rule check status == 'active')
+- [ ] `/conversations/{id}/messages/{id}`: edit message → ✗; delete message → ✗
+
+Cross-module imports: None
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T2 → T3 → T4 → T6 → T7
+                                      ↘
+                                   T4 → T5 (parallel T6)
+```
+
+---
+
+## PART 4 — Open questions
+
+Tất cả đã resolved trong spec (`docs/specs/2026-05-23-chat.md`). None blocking.
+
+> **Note T1 stretch:** Group Chat (T5) là T0+ — phải ship cùng Space module M3. Tasks T1–T4 (InboxScreen + ChatScreen 1-1) là T1 stretch — có thể defer sau M3 nếu cần.

--- a/docs/plans/2026-05-23-diary.md
+++ b/docs/plans/2026-05-23-diary.md
@@ -1,0 +1,250 @@
+# Plan: Diary Module
+
+> **Phụ thuộc vào:** Auth — `UserProfile` (authorUid = currentUid)
+> **Được phụ thuộc bởi:** Profile — `DiaryRepository.getPublicEntries(authorUid)` (Profile tab diary section)
+> **Spec:** `docs/specs/2026-05-23-diary.md`
+> **Tier:** T0+ — Milestone M3
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/diary/data/diary_entry.dart` | freezed model | `entryId String`, `authorUid String`, `moodTemplate MoodTemplate` enum (happy/bored/tired/shy/sad), `coverImageUrl String`, `moodCaption String` (≤50), `content List<DiaryContentBlock>` (≤20), `privacy DiaryPrivacy` enum (private/public), `createdAt DateTime`, `updatedAt DateTime` |
+| `lib/features/diary/data/diary_content_block.dart` | freezed model | `type ContentBlockType` enum (text/image), `value String?` (text content), `style TextBlockStyle?` enum (normal/heading/subheading/quote), `imageUrl String?` |
+| `lib/features/diary/data/diary_repository.dart` | abstract class — **phải có `getPublicEntries`** | `Future<String> createEntry(DiaryEntry entry)`, `Stream<List<DiaryEntry>> watchEntries(String uid)`, `Future<List<DiaryEntry>> getPublicEntries(String authorUid)`, `Future<DiaryEntry?> getEntry(String entryId)`, `Future<void> updateEntry(String entryId, DiaryEntry entry)`, `Future<void> deleteEntry(String entryId)`, `Future<List<DiaryEntry>> searchEntries(String uid, String query)` |
+| `lib/features/diary/application/diary_controller.dart` | Riverpod stub | `DiaryState`, methods throw `UnimplementedError` |
+| `lib/features/diary/presentation/diary_list_screen.dart` | widget stub | |
+| `lib/features/diary/presentation/diary_create_screen.dart` | widget stub | |
+| `lib/features/diary/presentation/diary_canvas_screen.dart` | widget stub | `DiaryCanvasMode` enum (create/read/edit) — cùng file |
+| `lib/features/diary/presentation/diary_search_screen.dart` | widget stub | |
+| `lib/features/diary/presentation/discard_changes_dialog.dart` | widget stub | |
+| `lib/features/diary/presentation/privacy_sheet.dart` | widget stub | |
+| `lib/core/router/app_router.dart` | update | Route `/diary`, `/diary/create`, `/diary/:entryId` |
+
+> `getPublicEntries(authorUid)` **phải tồn tại** trong interface — Profile module dùng. Thiếu → Profile module không implement được.
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(diary): FirebaseDiaryRepository — CRUD + getPublicEntries + searchEntries**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/diary-repository` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/diary/data/firebase_diary_repository.dart` — impl `DiaryRepository`
+- `test/features/diary/firebase_diary_repository_test.dart` — test: createEntry tạo doc, watchEntries stream, getPublicEntries filter privacy=public, searchEntries in-memory, deleteEntry xóa
+
+Acceptance criteria:
+- [ ] `createEntry` dùng Firestore auto-ID, trả `entryId`
+- [ ] `watchEntries(uid)` ORDER BY `createdAt DESC` — chỉ entries của owner
+- [ ] `getPublicEntries(authorUid)` filter `privacy == 'public'` — dùng bởi Profile module, trả list không stream
+- [ ] `searchEntries(uid, query)` load tất cả entries rồi filter in-memory (client-side, MVP đủ cho <100 entries)
+- [ ] `updateEntry` không cho đổi `authorUid` (check trong repository)
+
+Cross-module imports: None
+
+---
+**T2 · feat(diary): DiaryController — saveEntry (create/update) + deleteEntry + searchEntries + updatePrivacy**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/diary-controller` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/diary/application/diary_controller.dart` — `DiaryState` (entries, currentEntry, isLoading, mode, searchResults), full impl
+- `test/features/diary/diary_controller_test.dart` — test: saveEntry create mode → tạo, saveEntry edit mode → update, upload sequence đúng thứ tự, upload fail → không tạo Firestore doc
+
+Acceptance criteria:
+- [ ] `saveEntry()` trong `DiaryCanvasMode.create` → `createEntry()`; trong `edit` → `updateEntry()`
+- [ ] Upload sequence: (1) cover image → lấy coverUrl, (2) inline images tuần tự, (3) TẤT CẢ URLs sẵn sàng → Firestore write
+- [ ] Upload fail bất kỳ bước → toast error, KHÔNG tạo/update Firestore doc
+- [ ] `saveEntry` validate: phải có ít nhất 1 ảnh cover + 1 ký tự text
+- [ ] `updatePrivacy(entryId, privacy)` → Firestore update chỉ field `privacy` + `updatedAt`
+
+Cross-module imports: None
+
+---
+**T3 · feat(diary): mood assets + MoodZoneBlock widget**
+
+| | |
+|---|---|
+| Assignee | TBD (HanDHG export assets) |
+| Estimate | M (~8h) — blocked trên designer export |
+| Branch | `feat/TBD/diary-mood-assets` |
+| Blocked by | contracts Part 1, designer export |
+
+Files:
+- `assets/moods/icon_happy.svg`, `icon_bored.svg`, `icon_tired.svg`, `icon_shy.svg`, `icon_sad.svg` — SVG mood icons (HanDHG export)
+- `assets/moods/bg_happy.png` ... `bg_sad.png` — background shape PNGs (HanDHG export)
+- `assets/frames/frame_polaroid.png` — Polaroid frame cho inline image (HanDHG export)
+- `lib/features/diary/presentation/widgets/mood_zone_block.dart` — Stack: bg shape + ClipPath cover + caption text
+- `lib/features/diary/presentation/widgets/mood_clipper.dart` — `CustomClipper` per mood template
+- `pubspec.yaml` — update: add `flutter_svg` + asset declarations
+
+Acceptance criteria:
+- [ ] `happy`: `BorderRadius.circular(~38.5)` (circle) — không cần SVG clipper
+- [ ] `bored`: `BorderRadius.circular(10)` (rounded rect)
+- [ ] `tired`, `shy`, `sad`: `CustomClipper` extract path từ SVG (HanDHG export SVG path data)
+- [ ] `MoodZoneBlock` render đúng: bg shape layer + clipped cover photo + moodCaption với turquoise underline
+- [ ] Canvas background: `Scaffold(backgroundColor: Color(0xFFF9FCFC))` — KHÔNG dùng `Theme.of(context)` (canvas intentionally light)
+
+Cross-module imports: None
+
+> **Designer dependency:** HanDHG phải export 11 assets trước khi T3 implement: 5 SVG icon + 5 bg PNG + 1 polaroid PNG. Xem bảng mapping trong spec §Technical approach.
+
+---
+**T4 · feat(diary): DiaryCreateScreen — mood picker overlay**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/diary-create-screen` |
+| Blocked by | T3 |
+
+Files:
+- `lib/features/diary/presentation/diary_create_screen.dart` — overlay "Hôm nay bạn thế nào?" (Figma `656:1953`)
+- `test/features/diary/diary_create_screen_test.dart` — widget tests: 5 mood frames hiển thị, tap mood → mở canvas, [X] đóng overlay
+
+Acceptance criteria:
+- [ ] Overlay slide up trên DiaryListScreen
+- [ ] 5 mood frames horizontal scroll: lấy ảnh gần nhất từ gallery (`image_picker.pickImage(source: gallery)`) làm preview
+- [ ] Tap mood → moodTemplate + ảnh được chọn làm cover → mở `DiaryCanvasScreen(mode: create)`
+- [ ] [X] button → đóng overlay, về DiaryListScreen
+- [ ] Fallback nếu gallery trống: hiện placeholder image, vẫn cho chọn mood
+
+Cross-module imports: None
+
+---
+**T5 · feat(diary): DiaryCanvasScreen — block editor + TextStylePicker + PrivacySheet + DiscardDialog**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2 ngày) |
+| Branch | `feat/TBD/diary-canvas-screen` |
+| Blocked by | T2, T3, T4 |
+
+Files:
+- `lib/features/diary/presentation/diary_canvas_screen.dart` — `DiaryCanvasMode` enum (create/read/edit), `SingleChildScrollView` Column layout
+- `lib/features/diary/presentation/widgets/text_block_widget.dart` — `TextField` (edit mode) / `Text` (read mode), 4 styles
+- `lib/features/diary/presentation/widgets/inline_image_block_widget.dart` — Stack: Polaroid frame + user image
+- `lib/features/diary/presentation/widgets/text_style_picker.dart` — bottom sheet: Normal/Heading/Sub-heading/Quote
+- `lib/features/diary/presentation/privacy_sheet.dart` — [Riêng tư / Công khai] + [Xong]
+- `lib/features/diary/presentation/discard_changes_dialog.dart` — [Bỏ] / [Tiếp tục viết]
+- `test/features/diary/diary_canvas_screen_test.dart` — widget tests: create mode → discard dialog on back, read mode → về list không dialog, privacy toggle, max 20 blocks disable
+
+Acceptance criteria:
+- [ ] Canvas layout: `MoodZoneBlock` (header cố định) → content blocks (text + inline images)
+- [ ] `TextBlock` edit mode: `TextField` với cursor; read mode: `Text` widget
+- [ ] 4 text styles: Normal (body), Heading (H1 bold), Sub-heading (H2 semibold), Quote (italic + left border)
+- [ ] Tap [←] trong `create` mode → `DiscardChangesDialog`; trong `read/edit` mode → về list trực tiếp
+- [ ] Max 20 content blocks → nút thêm block bị disable
+- [ ] Max 5 images (cover + 4 inline) → nút chèn ảnh disable khi đạt giới hạn
+- [ ] `PrivacySheet`: [Riêng tư] / [Công khai] → tap [Xong] → topbar icon đổi lock/unlock
+
+Cross-module imports: None
+
+---
+**T6 · feat(diary): DiaryListScreen — grid cards + search trigger + FAB**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/diary-list-screen` |
+| Blocked by | T5 |
+
+Files:
+- `lib/features/diary/presentation/diary_list_screen.dart` — grid 2 columns (Figma `656:1831`)
+- `lib/features/diary/presentation/widgets/diary_mood_card.dart` — circular clip + date label (Figma "Diary Mood" component, 150.5px wide)
+
+Acceptance criteria:
+- [ ] Grid 2 columns, gap 32px horizontal + 32px vertical, content 333px wide (padding-x 39px)
+- [ ] `DiaryMoodCard`: 120×120px image vùng, clip theo mood shape, date label Nunito SemiBold 14px `#656c6d`
+- [ ] Empty state: "Bạn chưa có nhật ký nào" + [+] FAB (Figma `656:1945`)
+- [ ] FAB (60×60, Turquoise/500) → `DiaryCreateScreen` overlay
+- [ ] Tap card → `DiaryCanvasScreen(mode: read, entryId: id)`
+- [ ] Topbar: search icon + "Nhật ký" + avatar
+
+Cross-module imports: None
+
+---
+**T7 · feat(diary): DiarySearchScreen — in-memory filter**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/diary-search-screen` |
+| Blocked by | T6 |
+
+Files:
+- `lib/features/diary/presentation/diary_search_screen.dart` — (Figma `712:4356`)
+- `test/features/diary/diary_search_screen_test.dart` — widget tests: gõ keyword → filter results, 0 results → empty state
+
+Acceptance criteria:
+- [ ] `DiaryController.searchEntries(uid, query)` load all entries → filter in-memory (case-insensitive)
+- [ ] Kết quả: `[keyword highlight] + [date: "22 tháng 5 năm 2026"]`
+- [ ] "N kết quả" label
+- [ ] 0 kết quả → empty state "0 kết quả"
+- [ ] Tap result → `DiaryCanvasScreen(mode: read)`
+
+Cross-module imports: None
+
+---
+**T8 · test(diary): Firestore rules + Storage rules tests**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/diary-rules` |
+| Blocked by | T1 |
+
+Files:
+- `firebase/functions/test/rules/diary.rules.test.ts`
+
+Acceptance criteria:
+- [ ] `/diary/{id}`: owner read ✓ (cả private + public); friend read public ✓; friend read private ✗; stranger ✗
+- [ ] `/diary/{id}`: create chỉ owner ✓; `moodCaption.size() > 50` ✗; `content.size() > 20` ✗
+- [ ] `/diary/{id}`: update chỉ owner ✓; không được đổi `authorUid` ✗
+- [ ] `/diary/{id}`: delete chỉ owner ✓, stranger ✗
+- [ ] Storage `diary/{uid}/...`: owner write ✓, >10MB ✗, non-image ✗
+
+Cross-module imports: `isFriend()` helper từ **friend** module (dùng trong diary read rule)
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T2 ─────────────────────────────→ T5
+                       ↘                                  ↗
+contracts Part 1 → T3 → T4 ──────────────────────────────
+T5 → T6 → T7
+T1 → T8
+```
+
+T2 (controller) và T3 (assets) có thể chạy song song sau contracts.  
+T5 blocked by T2, T3, T4 (cả 3 phải xong).
+
+---
+
+## PART 4 — Open questions
+
+Tất cả đã resolved trong spec (`docs/specs/2026-05-23-diary.md`). None blocking.
+
+> **Designer gate:** T3 bị blocked trên HanDHG export 11 assets (5 SVG + 5 bg PNG + 1 polaroid). Leader cần confirm timeline với HanDHG trước khi assign T3.

--- a/docs/plans/2026-05-23-friend.md
+++ b/docs/plans/2026-05-23-friend.md
@@ -1,0 +1,218 @@
+# Plan: Friend Module
+
+> **Phụ thuộc vào:** Auth — `UserProfile` (`lib/features/auth/data/user_profile.dart`), `currentUidProvider`
+> **Được phụ thuộc bởi:** Settings, Chat, Home/Camera/Feed, Notification, Profile, Space, Widget
+> **Spec:** `docs/specs/2026-05-22-friend.md`
+> **Tier:** T0 — Milestone M2
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/friend/data/friendship.dart` | freezed model | `uid1 String`, `uid2 String`, `members List<String>`, `createdAt DateTime` |
+| `lib/features/friend/data/friend_request.dart` | freezed model | `requestId String`, `senderId String`, `receiverId String`, `status FriendRequestStatus` (enum pending/accepted/declined/cancelled), `createdAt DateTime`, `updatedAt DateTime` |
+| `lib/features/friend/data/friend_repository.dart` | abstract class | `Future<UserProfile?> searchUser(String username)`, `Stream<List<Friendship>> watchFriends(String uid)`, `Future<List<String>> getFriendUids(String uid)`, `Future<void> unfriend(String pairId)` |
+| `lib/features/friend/data/friend_request_repository.dart` | abstract class | `Stream<List<FriendRequest>> watchPendingRequests(String uid)`, `Future<void> sendFriendRequest(String receiverId)`, `Future<void> cancelFriendRequest(String requestId)`, `Future<void> declineFriendRequest(String requestId)` |
+| `lib/features/friend/application/friend_controller.dart` | Riverpod stub | `FriendState`, tất cả methods throw `UnimplementedError('// TODO(T<N>/TBD): ...')` |
+| `lib/features/friend/presentation/friend_sheet.dart` | widget stub | Bottom sheet skeleton, TODO markers |
+| `lib/features/friend/presentation/friend_filter_dropdown.dart` | widget stub | Dropdown skeleton |
+| `lib/core/utils/pair_id.dart` | pure util | `String pairIdOf(String a, String b)` — sorted deterministic |
+| `firebase/functions/src/index.ts` | CF stubs | `acceptFriendRequest` (HTTPS Callable), `onFriendshipDeleted` (Firestore onDelete) — stub throws unimplemented |
+| `lib/core/router/app_router.dart` | router update | Route `/invite/:uid` deep link |
+| `firestore.rules` | rule helper | `function isFriend(uid)` — xem spec §Security |
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(friend): data layer — FirebaseFriendRepository + FirebaseFriendRequestRepository**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/friend-data-layer` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/friend/data/firebase_friend_repository.dart` — impl `FriendRepository`: `searchUser` (direct query `/users.where('username', isEqualTo, query.toLowerCase()).limit(1)` — KHÔNG qua `/usernames` lookup), `watchFriends` (arrayContains stream), `getFriendUids`, `unfriend` (client delete `/friendships/{pairId}`)
+- `lib/features/friend/data/firebase_friend_request_repository.dart` — impl `FriendRequestRepository`
+- `lib/core/utils/pair_id.dart` — pure function
+- `test/features/friend/firebase_friend_repository_test.dart` — test cases: searchUser hit, searchUser miss, searchUser self-filter, getFriendUids query đúng, unfriend deletes doc, pairIdOf symmetry
+
+Acceptance criteria:
+- [ ] `searchUser("ThienPDM")` tự lowercase → query `/users.where('username', isEqualTo, "thienpdm").limit(1)` → trả 1 result (KHÔNG query `/usernames` collection)
+- [ ] `searchUser("notexist")` → trả `null`
+- [ ] `getFriendUids` dùng `where('members', arrayContains, uid)` — không full-scan collection
+- [ ] `unfriend(pairId)` xóa `/friendships/{pairId}` — không tự xóa conversation hay feed
+- [ ] `pairIdOf(a, b) == pairIdOf(b, a)` — đối xứng (test cả 2 chiều)
+- [ ] `sendFriendRequest` với `receiverId == currentUid` → throw `AppError` trước khi write
+
+Cross-module imports: `UserProfile` từ **auth** (`lib/features/auth/data/user_profile.dart`)
+
+---
+**T2 · feat(friend): FriendController — search + loadFriends + pending requests + send/accept/decline/cancel/unfriend**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/friend-controller` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/friend/application/friend_controller.dart` — `FriendState` (friends, pendingRequests, searchResult, searchQuery, isLoading, errorMessage?), full impl 8 methods
+- `test/features/friend/friend_controller_test.dart` — test cases: debounce không double-fire, accept → state updates, decline → card biến mất, unfriend → optimistic remove, error CF max-20 → errorMessage set
+
+Acceptance criteria:
+- [ ] `searchUser` debounce 500ms — chỉ gọi repo sau 500ms im lặng
+- [ ] `acceptFriendRequest` gọi CF callable, KHÔNG write Firestore trực tiếp
+- [ ] Error CF "max 20 friends" → `FriendState.errorMessage = "Bạn đã có 20 bạn bè..."` — card không biến mất
+- [ ] `unfriend` optimistic-remove bạn khỏi `FriendState.friends` trước khi server confirm
+- [ ] `sendFriendRequest` success → search result card đổi sang state "Đã gửi"
+
+Cross-module imports: None
+
+---
+**T3 · feat(friend): FriendSheet UI — search + pending requests + friend list + unfriend dialog**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2 ngày) |
+| Branch | `feat/TBD/friend-sheet-ui` |
+| Blocked by | T2 |
+
+Files:
+- `lib/features/friend/presentation/friend_sheet.dart` — full impl 3 sections: search, pending requests, friend list
+- `lib/features/friend/presentation/widgets/friend_search_result_card.dart` — 2 states: chưa bạn (nút "Gửi kết bạn") / đã bạn (nút "Trang cá nhân" → navigate FriendProfileScreen)
+- `lib/features/friend/presentation/widgets/pending_request_card.dart` — "Chấp nhận" + ✕ (Figma `710:3999`)
+- `lib/features/friend/presentation/widgets/friend_list_item.dart` — avatar + displayName + ✕ (Figma `501:2054`)
+- `test/features/friend/friend_sheet_test.dart` — widget tests: tap search → ẩn sections, không tìm thấy → empty state, tap ✕ → confirm dialog
+
+Acceptance criteria:
+- [ ] Tap search bar → ẩn sections (Bạn bè + Chia sẻ liên kết + Yêu cầu kết bạn), chỉ hiện search (Figma `710:2522`)
+- [ ] Tap "Hủy" → collapse search bar, restore all sections
+- [ ] Section "Yêu cầu kết bạn" ẩn khi `pendingRequests.isEmpty`
+- [ ] Tap ✕ unfriend → confirm dialog title "Xóa {displayName} khỏi Meep của bạn?" với đúng body text (spec §Luồng xoá bạn)
+- [ ] Search result: nếu `result.uid == currentUid` → không hiển thị (filter bản thân)
+
+Cross-module imports: `FriendProfileScreen` từ **profile** (navigate khi tap "Trang cá nhân")
+
+---
+**T4 · feat(friend): FriendFilterDropdown + invite link section**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/friend-filter-invite` |
+| Blocked by | T2 |
+
+Files:
+- `lib/features/friend/presentation/friend_filter_dropdown.dart` — full impl: "Mọi người" / "Bạn" / từng friend (Figma `472:2142`)
+- `lib/features/friend/presentation/widgets/invite_section.dart` — copy link + Messenger + Instagram + Tin nhắn (mock toast)
+- `lib/core/router/app_router.dart` — update: handle `/invite/:uid` + `pendingInviteUid` ephemeral state khi chưa đăng nhập
+- `test/features/friend/friend_filter_dropdown_test.dart` — widget tests: chọn friend → title đổi, tap ngoài → đóng, "Mọi người" default
+
+Acceptance criteria:
+- [ ] Chọn friend → dropdown đóng, FriendsButton title = `[avatar] [tên] ∧`
+- [ ] "Mọi người" selected by default khi mở
+- [ ] Tap ngoài dropdown → đóng, không thay đổi filter
+- [ ] Copy link → toast "Đã sao chép liên kết", icon đổi link → check (Figma `710:4189`)
+- [ ] `/invite/:uid` khi chưa login → lưu `pendingInviteUid` → redirect `/intro` → sau auth navigate profile
+
+Cross-module imports: `FeedFilter` từ **home-camera-feed**
+
+---
+**T5 · feat(friend): CF `acceptFriendRequest` — validate + batch friendship + conversation + friendCount**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/friend-cf-accept` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `firebase/functions/src/friend/acceptFriendRequest.ts` — HTTPS Callable
+- `firebase/functions/test/friend/acceptFriendRequest.test.ts` — test: success flow, sender ≥ 20 friends, receiver ≥ 20 friends, duplicate request, request not found, unauthorized
+
+Acceptance criteria:
+- [ ] Check `sender.friendCount < 20` VÀ `receiver.friendCount < 20` — cả 2 phải < 20, thiếu 1 → throw `FAILED_PRECONDITION`
+- [ ] Firestore batch (1 commit): create `/friendships/{pairId}` + create `/conversations/{pairId}` (type=direct, participantIds=[uid1,uid2]) + set `friend_requests.status = accepted` + FieldValue.increment friendCount cả 2 user
+- [ ] `conversationId == pairId` (sorted uid1\_uid2) — đồng bộ với friendship docId
+- [ ] Nếu A→B và B→A gửi request đồng thời → detect, tạo 1 friendship duy nhất (idempotent)
+- [ ] Return `{ success: true, pairId: string }` khi thành công
+
+Cross-module imports: None (CF dùng Firebase Admin SDK)
+
+---
+**T6 · feat(friend): CF `onFriendshipDeleted` — friendCount + conversation status + cross-feed cleanup**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/friend-cf-deleted` |
+| Blocked by | T5 |
+
+Files:
+- `firebase/functions/src/friend/onFriendshipDeleted.ts` — Firestore onDelete `/friendships/{pairId}`
+- `firebase/functions/test/friend/onFriendshipDeleted.test.ts` — test: friendCount decrement, conversation updated, cross-feed cleanup, Space posts preserved
+
+Acceptance criteria:
+- [ ] Decrement `friendCount` cho `uid1` và `uid2` bằng transaction (idempotent — dùng FieldValue.increment(-1))
+- [ ] Update `/conversations/{pairId}.status = 'unfriended'` nếu conversation tồn tại (không crash nếu không tồn tại)
+- [ ] Batch delete: `/users/{uid1}/feed/{postId}` WHERE `authorId == uid2 AND spaceId == null` — và ngược lại
+- [ ] Space posts (`spaceId != null`) KHÔNG bị xóa khỏi feed
+- [ ] CF idempotent: chạy lại sau partial fail không crash, kết quả cuối cùng như nhau
+
+> **Lưu ý:** CF này owns cả feed cleanup (Home/Camera/Feed module concern). Home/Camera/Feed module KHÔNG tạo CF riêng cho cleanup này.
+
+Cross-module imports: None
+
+---
+**T7 · test(friend): Firestore rules tests — /friendships + /friend_requests**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/friend-rules` |
+| Blocked by | T1 |
+
+Files:
+- `firebase/functions/test/rules/friend.rules.test.ts`
+
+Acceptance criteria:
+- [ ] `/friendships/{id}`: uid1 read ✓, uid2 read ✓, stranger read ✗, unauthenticated read ✗
+- [ ] `/friendships/{id}`: client create → ✗ (CF Admin SDK only)
+- [ ] `/friendships/{id}`: uid1 delete ✓, stranger delete ✗
+- [ ] `/friend_requests/{id}`: sender create với `senderId != receiverId` ✓; self-request ✗
+- [ ] `/friend_requests/{id}`: receiver update pending→accepted ✓; receiver update pending→cancelled ✗ (chỉ sender cancel)
+- [ ] `/friend_requests/{id}`: sender update pending→cancelled ✓; sender update pending→accepted ✗ (chỉ receiver accept)
+
+Cross-module imports: None
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T2 → T3
+                              ↘
+                         T2 → T4   (parallel T3, T4)
+contracts Part 1 → T5 → T6 → T7
+```
+
+T5 (CF) có thể bắt đầu song song với T1 ngay sau khi contracts merge.
+
+---
+
+## PART 4 — Open questions
+
+Tất cả đã resolved trong spec (`docs/specs/2026-05-22-friend.md`). None blocking.

--- a/docs/plans/2026-05-23-home-camera-feed.md
+++ b/docs/plans/2026-05-23-home-camera-feed.md
@@ -1,0 +1,326 @@
+# Plan: Home / Camera / Feed / Post Module
+
+> **Phụ thuộc vào:** Friend — `isFriend()` rule helper, `FriendRepository`; Settings — `BlockRepository` (feed filter loại bỏ blocked users)
+> **Được phụ thuộc bởi:** Notification (Post model, `onPostCreated` CF), Reaction (Post model, reactions subcollection), Profile (PhotoGrid), Space (FeedScreen + Post model + spaceId field), Streak (PostRepository), Widget (feed subcollection)
+> **Spec:** `docs/specs/2026-05-22-home-camera-feed.md`
+> **Tier:** T0 — Milestone M2
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/feed/data/post.dart` | freezed model | `postId String`, `authorId String`, `authorName String`, `authorAvatarUrl String?`, `imageUrl String`, `caption String?` (≤200), `captionType CaptionType?` enum, `audienceType AudienceType` (all/select), `audienceUids List<String>`, `spaceId String?`, `createdAt DateTime` |
+| `lib/features/feed/data/post_repository.dart` | abstract class | `Future<void> createPost(Post post)`, `Stream<List<Post>> watchFeed(FeedFilter filter)`, `Future<void> deletePost(String postId)`, `Future<List<Post>> getPostsByAuthor(String uid, {DocumentSnapshot? cursor})` |
+| `lib/features/feed/data/storage_repository.dart` | abstract class | `Future<String> uploadImage(String uid, String postId, File file)`, `Future<void> deleteImage(String imageUrl)` |
+| `lib/features/feed/application/caption_service.dart` | abstract class | `Future<String> resolve(CaptionType type)` |
+| `lib/features/feed/application/feed_controller.dart` | Riverpod stub | `FeedState` (posts, filter, isLoading, isLoadingMore, cursor), `FeedFilter` enum (all/person/space) |
+| `lib/features/feed/application/app_camera_controller.dart` | Riverpod stub | `CameraState` (isInitialized, isCapturing, flashMode, zoomLevel) |
+| `lib/features/feed/application/post_controller.dart` | Riverpod stub | `PostState` (isUploading, progress, error?) |
+| `lib/shared/widgets/app_camera_button.dart` | shared widget | 82×82, inner white 70×70, outer Turquoise/500 ring |
+| `lib/shared/widgets/app_note_pill.dart` | shared widget | `cornerRadius 30`, bg `#39404166`, editable |
+| `lib/shared/widgets/app_act_text_bar.dart` | shared widget | M2: render disabled. M3: inject `ReactionController` |
+| `lib/shared/widgets/post_card.dart` | shared widget | 400×400, cornerRadius 50, Note overlay |
+| `lib/shared/widgets/share_modal.dart` | shared widget | Bottom sheet: share targets + actions |
+| `lib/features/feed/presentation/home_screen.dart` | widget stub | `CustomScrollView` với Camera + Feed sections |
+| `lib/features/home/presentation/photo_action_sheet.dart` | **shared widget** — owned by Feed, used by Settings | "Chia sẻ đến..." overlay: Row 1 (Chia sẻ/Messenger/Instagram/Tin nhắn-disabled) + Row 2 (Báo cáo-stub/Chặn/Lưu/Xoá-if-author). Xoá chỉ hiện khi `isAuthor`. [Báo cáo] → toast "Tính năng sắp có". [Chặn] → `BlockConfirmDialog` từ Settings |
+| `firebase/functions/src/index.ts` | CF stubs | `onPostCreated`, `onPostDeleted` |
+
+> `FeedFilter.space(spaceId)` được thêm khi Space module implement — field đã reserve trong enum.
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(feed): data layer — FirebasePostRepository + FirebaseStorageRepository**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/feed-data-layer` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/feed/data/firebase_post_repository.dart` — impl `PostRepository`: `createPost` (Firestore set), `watchFeed` (query `/users/{uid}/feed` subcollection, fetch `/posts/{postId}`), `deletePost`, `getPostsByAuthor` (cursor pagination)
+- `lib/features/feed/data/firebase_storage_repository.dart` — impl `StorageRepository`
+- `test/features/feed/firebase_post_repository_test.dart` — test: createPost doc tạo đúng fields, watchFeed trả đúng filter, deletePost xóa doc, upload >5MB → reject
+
+Acceptance criteria:
+- [ ] `watchFeed` query `/users/{uid}/feed` ORDER BY `createdAt DESC` — không query `/posts` trực tiếp (fan-out architecture)
+- [ ] `FeedFilter.person(specificUid)` → thêm `.where('authorId', isEqualTo, specificUid)` vào feed query
+- [ ] `createPost` với `audienceType == 'select'` và `audienceUids.isEmpty` → throw `AppError`
+- [ ] `uploadImage` nhận file đã compressed (compress là trách nhiệm của `PostController`, không phải repository) — repository chỉ validate size ≤5MB rồi upload
+- [ ] Upload file > 5MB → throw `AppError` trước khi gọi Firebase Storage
+- [ ] `deletePost` không cascade xóa Storage (CF `onPostDeleted` làm việc này)
+
+Cross-module imports: None
+
+---
+**T2 · feat(feed): CaptionService — Text + Location + Weather + Time + Mock**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/feed-caption-service` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/feed/application/caption_service_impl.dart` — impl 7 types
+- `lib/features/feed/application/weather_code_mapper.dart` — WMO → emoji + text mapping
+- `test/features/feed/caption_service_test.dart` — test: Text passthrough, Time format HH:mm, Location Nominatim mock, Weather OpenMeteo mock + WMO mapping, GPS denied → fallback
+
+Acceptance criteria:
+- [ ] `CaptionType.text`: passthrough `TextEditingController.text`
+- [ ] `CaptionType.location`: GPS → Nominatim `GET /reverse?lat&lon&format=json&accept-language=vi` → trim thành "Quận X, TP.HCM"
+- [ ] `CaptionType.weather`: GPS → Open-Meteo `GET /v1/forecast?latitude&longitude&current_weather=true` → WMO code + temp → "☀️ Nắng 32°C"
+- [ ] `CaptionType.time`: `DateTime.now()` local timezone → `DateFormat('HH:mm').format(now)`
+- [ ] GPS `permission-denied` → tự động fallback sang `CaptionType.text`, không crash
+- [ ] Nominatim/Open-Meteo timeout >5s → hiện fallback text `"📍 ..."` / `"🌤️ ..."`, không block
+
+Cross-module imports: None
+
+---
+**T3 · feat(feed): AppCameraController + CameraSection UI**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2 ngày) |
+| Branch | `feat/TBD/feed-camera-section` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/feed/application/app_camera_controller.dart` — full impl: initialize, capture, flip, flash, zoom, dispose
+- `lib/features/feed/presentation/widgets/camera_section.dart` — viewfinder 400×400 + controls (Figma `440:1767`)
+- `lib/features/feed/presentation/home_screen.dart` — `CustomScrollView`: `SliverToBoxAdapter` (CameraSection) + `SliverList` (FeedSection)
+- `test/features/feed/app_camera_controller_test.dart` — test: double-tap capture → disabled until navigate, GPS fallback
+
+Acceptance criteria:
+- [ ] `AppCameraController` (không phải `CameraController` — tránh conflict với `camera` package)
+- [ ] Tap capture → disable button ngay lập tức cho đến khi navigate xong (tránh double submission)
+- [ ] Swipe TRÁI trên viewfinder → Dual Camera mode
+- [ ] Camera stop preview khi scroll xuống feed (`ScrollController` listener)
+- [ ] Camera không khởi động được (quyền) → `CameraPermissionScreen`, không crash
+- [ ] Tap "Lịch sử" → `scrollController.animateTo(cameraHeight)` xuống feed
+
+Cross-module imports: None (camera section không import từ Friend module trực tiếp; friend data được FeedController inject qua FriendRepository ở T4/T6)
+
+---
+**T4 · feat(feed): CapturePreviewScreen — caption cycle + audience selector + send + save local**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2 ngày) |
+| Branch | `feat/TBD/feed-capture-preview` |
+| Blocked by | T2, T3 |
+
+Files:
+- `lib/features/feed/presentation/capture_preview_screen.dart` — full impl (Figma `442:2319`)
+- `lib/features/feed/presentation/caption_preset_modal.dart` — 7 caption types grid (Figma `269:1747`)
+- `test/features/feed/capture_preview_screen_test.dart` — widget tests: swipe caption → cycle 7 types, audience "Tất cả" default, tap download → icon changes in-place
+
+Acceptance criteria:
+- [ ] Swipe trái/phải trên Note pill → cycle qua 7 caption types theo thứ tự
+- [ ] Tap `sparkles+` → `CaptionPresetModal` bottom sheet hiện 7 types (Figma `269:1747`)
+- [ ] "Tất cả" button selected by default, avatar circles từng friend có thể toggle select/deselect
+- [ ] `audienceType == 'select'` và 0 friend chọn → nút "Đăng" disabled
+- [ ] Tap download → icon đổi in-place (download → ✔), ảnh lưu gallery, ở lại preview (Figma `579:1575`)
+- [ ] Tap X → về Camera, không upload gì
+
+Cross-module imports: `FriendRepository.getFriendUids()` từ **friend** (hiển thị audience avatars)
+
+---
+**T5 · feat(feed): PostController.createPost — compress + upload Storage + Firestore**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/feed-post-controller` |
+| Blocked by | T1, T4 |
+
+Files:
+- `lib/features/feed/application/post_controller.dart` — full impl: `createPost(File photo, PostDraft draft)`
+- `test/features/feed/post_controller_test.dart` — test: compress → upload → Firestore, Storage fail → không tạo Firestore doc, OOM compress → toast error
+
+Acceptance criteria:
+- [ ] Compress ảnh ≤ 1MB, maxWidth 1080px bằng `flutter_image_compress` trước khi upload
+- [ ] Upload fail → toast "Tải ảnh thất bại — thử lại", KHÔNG tạo Firestore doc
+- [ ] Compress fail (OOM) → toast "Không thể xử lý ảnh", về Camera
+- [ ] `audienceType == 'all'` → `audienceUids = []` (không lưu empty với all)
+- [ ] Post tạo xong → navigate về Camera (không hiện post ngay lập tức — chờ CF fan-out feed)
+
+Cross-module imports: None
+
+---
+**T6 · feat(feed): FeedController — fan-out query + cursor pagination + FeedFilter**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/feed-controller` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/feed/application/feed_controller.dart` — full impl: `loadFeed(FeedFilter)`, `loadNextPage()`, `onItemVisible(int index)` (prefetch tại index `length - 4`)
+- `test/features/feed/feed_controller_test.dart` — test: loadFeed trả đúng 10 posts, loadNextPage append, filter person → đúng authorId, prefetch trigger đúng index
+
+Acceptance criteria:
+- [ ] Query `/users/{uid}/feed` ORDER BY `createdAt DESC` LIMIT 10, `startAfterDocument` cho cursor
+- [ ] Prefetch: `onItemVisible(index)` khi `index == currentItems.length - 4` → `loadNextPage()`
+- [ ] `FeedFilter.all` → không filter thêm; `FeedFilter.person(uid)` → `.where('authorId', isEqualTo, uid)`
+- [ ] Feed load fail (offline) → hiện cached posts từ `cached_network_image`; error banner
+- [ ] Hết list → "Đã hiển thị tất cả", không call thêm
+
+Cross-module imports: `BlockRepository` từ **settings** (filter blocked user posts khỏi feed)
+
+---
+**T7 · feat(feed): FeedSection UI — PostCard (friend + own) + ActText bar M2**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/feed-section-ui` |
+| Blocked by | T6 |
+
+Files:
+- `lib/features/feed/presentation/widgets/feed_section.dart` — `SliverList` của PostCards
+- `lib/features/feed/presentation/widgets/friend_post_card.dart` — ảnh + caption + `[Tên bạn] [time ago]` + `ActTextBar` (disabled M2)
+- `lib/features/feed/presentation/widgets/own_post_card.dart` — ảnh + caption + `"Bạn [ngày]"` + "✨ Chưa có hoạt động nào!" pill
+- `lib/shared/widgets/app_act_text_bar.dart` — M2: render "Gửi tin nhắn..." + 3 emoji + smile-plus, **disabled** no-op
+- `test/features/feed/feed_section_test.dart` — widget tests: OwnPostCard "Chưa có HĐ" pill, FriendPostCard hiện đúng label, tap post của người unfriend → ẩn (permission-denied)
+
+Acceptance criteria:
+- [ ] `FriendPostCard`: ảnh 400×400, `Note` overlay, label `"[Tên bạn] [time ago]"`, ActText bar disabled
+- [ ] `OwnPostCard`: ảnh 400×400, `"Bạn [ngày]"`, pill "✨ Chưa có hoạt động nào!" (M2)
+- [ ] Tap post của người unfriend → Firestore `permission-denied` → ẩn card, không crash
+- [ ] `ActTextBar` M2: render UI nhưng mọi interaction là no-op (disabled)
+- [ ] `FriendsButton` dropdown kết hợp với `FeedController.setFilter()` → title đổi
+
+Cross-module imports: None
+
+---
+**T8 · feat(feed): GridViewScreen + ShareModal**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/feed-grid-share` |
+| Blocked by | T7 |
+
+Files:
+- `lib/features/feed/presentation/grid_view_screen.dart` — 3-column grid (Figma `580:2883`), tap → FriendPostCard full-screen
+- `lib/shared/widgets/share_modal.dart` — basic share (Figma `580:2813`): Chia sẻ + Messenger + Instagram + Tin nhắn (disabled) + [Lưu] + [Xoá] (chỉ khi `isAuthor`)
+- `lib/features/home/presentation/photo_action_sheet.dart` — full action sheet (Figma `605:1769`): share row + [Báo cáo(stub)] + [Chặn → BlockConfirmDialog] + [Lưu] + [Xoá if author]. Trigger: tap ↑ icon khi đang xem ảnh bạn
+- `test/features/feed/grid_view_screen_test.dart` — widget tests: grid 3 columns, tap → detail view
+
+Acceptance criteria:
+- [ ] Grid: 3-column layout, `cached_network_image`, FriendsButton filter giữ nguyên
+- [ ] Tap ảnh → Xem ảnh bạn bè full-screen (nếu filter = bản thân → TODO Profile module)
+- [ ] ShareModal: [Xoá] chỉ hiện khi `post.authorId == currentUid`
+- [ ] "Tin nhắn" trong ShareModal → disabled M2 (Chat module T1 stretch)
+- [ ] `PhotoActionSheet` (tab ↑ trên ảnh bạn): [Báo cáo] → toast "Tính năng sắp có" (stub); [Chặn] → `BlockConfirmDialog` từ **Settings module** + gọi `BlockRepository.blockUser()`
+
+Cross-module imports: `BlockConfirmDialog` từ **settings**
+
+---
+**T9 · feat(feed): CF `onPostCreated` — feed fan-out + postCount increment + FCM to friends**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2 ngày) |
+| Branch | `feat/TBD/feed-cf-post-created` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `firebase/functions/src/feed/onPostCreated.ts` — Firestore onCreate trigger `/posts/{postId}`
+- `firebase/functions/test/feed/onPostCreated.test.ts` — test: fan-out đúng recipients, audienceType all vs select, spaceId field preserved, postCount increment, FCM gọi đúng số tokens
+
+Acceptance criteria:
+- [ ] `audienceType == 'all'`: đọc `/friendships` arrayContains `authorId` → fan-out feed cho tất cả friends — **chỉ khi `post.spaceId == null`**
+- [ ] `audienceType == 'select'`: fan-out chỉ cho `audienceUids` list — **chỉ khi `post.spaceId == null`**
+- [ ] **Guard Space posts:** nếu `post.spaceId != null` → skip friend fan-out (Space module CF `onSpacePostCreated` owns fan-out cho Space posts); vẫn increment `postCount`
+- [ ] Feed doc: `{ postId, authorId, spaceId?, createdAt }` — phải include `spaceId` field (Space filter dùng)
+- [ ] Increment `postCount` trên `/users/{authorId}` (FieldValue.increment(1)) — cho CẢ all-friends VÀ Space posts
+- [ ] FCM fan-out: gửi notification cho friends có FCM token — **chỉ khi `post.spaceId == null`** (Space FCM handled by `onSpacePostCreated`)
+- [ ] **1 function duy nhất** — không tạo function riêng trong notification.md (xem [H10] trong spec)
+
+Cross-module imports: None (Admin SDK, nhưng đọc `/users/{uid}/fcmTokens` schema từ Notification module)
+
+---
+**T10 · feat(feed): CF `onPostDeleted` — feed cleanup + Storage delete + postCount decrement**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/feed-cf-post-deleted` |
+| Blocked by | T9 |
+
+Files:
+- `firebase/functions/src/feed/onPostDeleted.ts` — Firestore onDelete trigger `/posts/{postId}`
+- `firebase/functions/test/feed/onPostDeleted.test.ts` — test: feed docs xóa, Storage file xóa, postCount decrement
+
+Acceptance criteria:
+- [ ] Batch delete tất cả `/users/{uid}/feed/{postId}` docs (tất cả recipients)
+- [ ] Decrement `postCount` trên `/users/{authorId}`
+- [ ] Xóa Storage file: parse path từ `post.imageUrl` → `posts/{uid}/{postId}/photo.jpg`
+- [ ] Xóa reactions subcollection `/posts/{postId}/reactions/*` (batch)
+
+Cross-module imports: None
+
+---
+**T11 · test(feed): Firestore rules + Storage rules tests**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/feed-rules` |
+| Blocked by | T1, T9 |
+
+Files:
+- `firebase/functions/test/rules/feed.rules.test.ts`
+
+Acceptance criteria:
+- [ ] `/posts/{id}`: author read ✓, recipient (có feed doc) read ✓, user không trong feed ✗
+- [ ] `/posts/{id}`: create với `caption > 200 chars` ✗; create by author ✓
+- [ ] `/posts/{id}`: update → ✗ (posts bất biến sau khi tạo)
+- [ ] `/users/{uid}/feed/{postId}`: owner read ✓, stranger read ✗, client write → ✗ (CF only)
+- [ ] Storage `/posts/{uid}/...`: owner write ✓, >5MB ✗, non-image ✗
+- [ ] Storage `/posts/{uid}/...`: read bởi author ✓, read bởi user có feed doc ✓, stranger ✗
+
+Cross-module imports: None
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T5 → (check T4 done) → navigate Post → Camera
+contracts Part 1 → T2 → (parallel T3)
+T1, T2, T3 → T4
+T1 → T6 → T7 → T8
+contracts Part 1 → T9 → T10 → T11
+```
+
+T2 (CaptionService) và T3 (Camera) có thể chạy song song sau contracts.
+T9, T10 (Cloud Functions) có thể chạy song song với T1-T8 (Flutter).
+
+---
+
+## PART 4 — Open questions
+
+Tất cả đã resolved trong spec. 
+
+> **Note cross-module:** `onFriendshipDeleted` CF (cross-feed cleanup) được implement tại **Friend module T6** — Feed module KHÔNG tạo CF riêng.
+> **Note Space:** Khi Space module bắt đầu, cần leader gate thêm `spaceId` param vào `FeedScreen` và `FeedFilter.space(spaceId)` — xem Space spec §Cross-module contract.

--- a/docs/plans/2026-05-23-leader.md
+++ b/docs/plans/2026-05-23-leader.md
@@ -1,0 +1,494 @@
+# Plan: Leader Tasks — Contract Creation + Shared Infrastructure
+
+> **Owner:** ThienPDM
+> **Tier:** Foundation — phải xong TRƯỚC khi giao module cho dev
+> **Rule:** Mỗi LX task commit thẳng vào `develop`. App phải compile sau mỗi commit (Skeleton rule).
+
+---
+
+## Tổng quan
+
+Leader làm 3 loại việc:
+1. **Contract stubs** — tạo freezed models, abstract interfaces, Riverpod stubs, widget stubs, CF stubs cho từng module (theo dependency order). Dev không được start khi chưa có contracts.
+2. **Shared infrastructure** — `firestore.rules`, `storage.rules`, `pubspec.yaml`, `app_router.dart` đầy đủ.
+3. **Gate changes** — approve và merge cross-module changes (ví dụ Space cần sửa Post model của Feed).
+
+---
+
+## PART 2 — Tasks
+
+---
+**LX0 · chore(core): khởi tạo core infrastructure trước tất cả modules**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `chore/ThienPDM/core-infrastructure` |
+| Blocked by | None |
+
+Files to create:
+- `lib/core/error/app_error.dart` — `AppError` sealed class hierarchy: `UnauthenticatedError`, `UnexpectedError`, `ValidationError`, `PermissionDeniedError`
+- `lib/core/theme/app_colors.dart` — tất cả color constants từ auth spec §Shared components (Turquoise 300/500/800, BW 100-900, semantic success700/error700)
+- `lib/core/utils/pair_id.dart` — `String pairIdOf(String a, String b)` sorted deterministic (dùng bởi Friend + Chat)
+- `lib/core/config/app_config.dart` — `static const shareBaseUrl = 'meep://profile'` (không hardcode elsewhere)
+- `lib/main.dart` — Firebase.initializeApp + ProviderScope skeleton (chưa override providers)
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] App launch không crash
+
+---
+**LX1 · chore(contracts): auth module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `chore/ThienPDM/auth-contracts` |
+| Blocked by | LX0 |
+
+> Xem chi tiết: `docs/plans/2026-05-04-auth.md` §PART 1
+
+Files to create:
+- `lib/features/auth/data/user_profile.dart` — @freezed, full schema (incl. Profile fields), TimestampConverter
+- `lib/features/auth/data/auth_repository.dart` — abstract (9 methods incl. deleteCurrentUser, reauthenticateWithCredential, updateEmail)
+- `lib/features/auth/data/user_repository.dart` — abstract (createProfile, getProfile, isUsernameAvailable)
+- `lib/features/auth/application/auth_controller.dart` — `currentUidProvider` (StreamProvider), `currentUserProfileProvider` (StreamProvider), `isSignedInProvider`, `authRepositoryProvider` (throw UnimplementedError), `userRepositoryProvider` (throw UnimplementedError)
+- `lib/features/auth/application/sign_up_controller.dart` — stub + `SignUpState` + `SignUpStep` enum
+- `lib/features/auth/application/login_controller.dart` — stub + `LoginState`
+- `lib/core/router/app_router.dart` — GoRouter với redirect guard + tất cả auth routes (`/intro`, `/signup/*`, `/login/*`) + stub `/home`
+- `lib/features/home/presentation/home_page.dart` — placeholder "Home — TODO"
+- `lib/shared/widgets/app_primary_button.dart` — stub
+- `lib/shared/widgets/app_back_button.dart` — stub
+- `lib/shared/widgets/app_google_button.dart` — stub
+- `lib/shared/widgets/app_text_input.dart` — stub
+- `lib/features/auth/presentation/intro_page.dart` — stub
+- `lib/features/auth/presentation/signup/signup_email_page.dart` — stub
+- `lib/features/auth/presentation/signup/signup_password_page.dart` — stub
+- `lib/features/auth/presentation/signup/signup_name_page.dart` — stub
+- `lib/features/auth/presentation/signup/signup_username_page.dart` — stub
+- `lib/features/auth/presentation/login/login_email_page.dart` — stub
+- `lib/features/auth/presentation/login/login_password_page.dart` — stub
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean — không có undefined class errors
+- [ ] `authRepositoryProvider` throw `UnimplementedError('wire FirebaseAuthRepository in main.dart')`
+- [ ] Router redirect guard compile + đúng 3-state logic (không cần test UI, chỉ cần compile)
+- [ ] TODO markers format: `// TODO(A/T<N>/TBD): implement <artifact> — see docs/plans/2026-05-04-auth.md`
+
+---
+**LX2 · chore(contracts): friend module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `chore/ThienPDM/friend-contracts` |
+| Blocked by | LX1 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-friend.md` §PART 1
+
+Files to create:
+- `lib/features/friend/data/friendship.dart` — @freezed (uid1, uid2, members List<String>, createdAt)
+- `lib/features/friend/data/friend_request.dart` — @freezed (requestId, senderId, receiverId, status enum, createdAt, updatedAt)
+- `lib/features/friend/data/friend_repository.dart` — abstract (searchUser, watchFriends, getFriendUids, unfriend)
+- `lib/features/friend/data/friend_request_repository.dart` — abstract (watchPendingRequests, sendFriendRequest, cancelFriendRequest, declineFriendRequest)
+- `lib/features/friend/application/friend_controller.dart` — stub (8 methods throw UnimplementedError)
+- `lib/features/friend/presentation/friend_sheet.dart` — stub
+- `lib/features/friend/presentation/friend_filter_dropdown.dart` — stub
+- `lib/core/router/app_router.dart` — **update:** thêm route `/invite/:uid`
+- `firestore.rules` — **update:** thêm `function isFriend(uid)` helper
+
+Files to stub trong `firebase/functions/src/index.ts`:
+- `acceptFriendRequest` HTTPS Callable stub
+- `onFriendshipDeleted` Firestore trigger stub
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] `pairIdOf` từ LX0 được dùng trong `friendship.dart` (import path đúng)
+- [ ] `isFriend(uid)` helper đúng format spec (không deploy rules — chỉ local)
+- [ ] TODO markers: `// TODO(F/T<N>/TBD): ...`
+
+---
+**LX3 · chore(contracts): settings module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `chore/ThienPDM/settings-contracts` |
+| Blocked by | LX2 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-settings.md` §PART 1
+
+Files to create:
+- `lib/features/settings/data/block.dart` — @freezed (blockId NOT sorted, blockerUid, blockedUid, createdAt)
+- `lib/features/settings/data/block_repository.dart` — **canonical owner** abstract (blockUser, unblockUser, watchBlockedUsers, isBlocked)
+- `lib/features/settings/application/settings_controller.dart` — stub
+- `lib/features/settings/presentation/settings_sheet.dart` — stub
+- `lib/features/settings/presentation/blocked_accounts_page.dart` — stub
+- `lib/features/settings/presentation/block_confirm_dialog.dart` — stub
+- `lib/features/settings/presentation/logout_confirm_dialog.dart` — stub
+- `lib/features/settings/presentation/widget_confirm_sheet.dart` — stub
+- `lib/features/settings/presentation/delete_account_dialog.dart` — stub
+- `lib/shared/widgets/share_profile_sheet.dart` — **leader own** stub (shared Profile + Settings)
+- `firestore.rules` — **update:** thêm `function isBlocked(uid)` helper + `/blocks` match block
+
+Files to stub trong `firebase/functions/src/index.ts`:
+- `blockUser` HTTPS Callable stub
+- `deleteAccount` HTTPS Callable stub
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] `BlockRepository` ở đúng path `lib/features/settings/data/block_repository.dart` — Chat và Feed sẽ import từ đây
+- [ ] `isBlocked(uid)` helper check cả 2 chiều
+- [ ] TODO markers: `// TODO(SE/T<N>/TBD): ...`
+
+---
+**LX4 · chore(contracts): chat module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `chore/ThienPDM/chat-contracts` |
+| Blocked by | LX3 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-chat.md` §PART 1
+
+Files to create:
+- `lib/features/chat/data/conversation.dart` — @freezed (conversationId, type enum, participantIds, spaceId?, quotedPostId?, lastMessage, lastMessageAt, lastSenderId, status enum, createdAt)
+- `lib/features/chat/data/message.dart` — @freezed (messageId, senderId, text ≤500, createdAt)
+- `lib/features/chat/data/conversation_repository.dart` — abstract (watchConversations, getOrCreateConversation, sendMessage, watchMessages)
+- `lib/features/chat/application/chat_controller.dart` — stub
+- `lib/features/chat/presentation/inbox_screen.dart` — stub
+- `lib/features/chat/presentation/chat_screen.dart` — stub
+- `lib/features/chat/presentation/group_chat_screen.dart` — stub
+- `lib/features/chat/presentation/widgets/space_members_sheet.dart` — stub
+- `lib/core/router/app_router.dart` — **update:** thêm routes `/inbox`, `/chat/:conversationId`
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] `Conversation` model import đúng `ConversationStatus` enum
+- [ ] Chat module KHÔNG define `BlockRepository` riêng — import từ settings
+- [ ] TODO markers: `// TODO(C/T<N>/TBD): ...`
+
+---
+**LX5 · chore(contracts): home/camera/feed module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `chore/ThienPDM/feed-contracts` |
+| Blocked by | LX3 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-home-camera-feed.md` §PART 1
+
+Files to create:
+- `lib/features/feed/data/post.dart` — @freezed (postId, authorId, authorName, authorAvatarUrl?, imageUrl, caption?, captionType? enum, audienceType enum, audienceUids List<String>, **spaceId String?**, createdAt)
+- `lib/features/feed/data/post_repository.dart` — abstract (createPost, watchFeed, deletePost, getPostsByAuthor)
+- `lib/features/feed/data/storage_repository.dart` — abstract (uploadImage, deleteImage)
+- `lib/features/feed/application/caption_service.dart` — abstract (resolve(CaptionType) → Future<String>) + `CaptionType` enum (text/location/weather/music/star/time/streak)
+- `lib/features/feed/application/feed_controller.dart` — stub + `FeedState` + `FeedFilter` enum (all/person/space — space reserved)
+- `lib/features/feed/application/app_camera_controller.dart` — stub + `CameraState`
+- `lib/features/feed/application/post_controller.dart` — stub + `PostState`
+- `lib/features/feed/presentation/home_screen.dart` — **replace** placeholder HomePage, CustomScrollView skeleton
+- `lib/features/home/presentation/photo_action_sheet.dart` — stub (owned by Feed)
+- `lib/shared/widgets/app_camera_button.dart` — stub
+- `lib/shared/widgets/app_note_pill.dart` — stub
+- `lib/shared/widgets/app_act_text_bar.dart` — M2 stub (disabled, no-op)
+- `lib/shared/widgets/post_card.dart` — stub
+- `lib/shared/widgets/share_modal.dart` — stub
+- `lib/core/router/app_router.dart` — **update:** thêm routes `/home`, `/capture-preview`, `/caption-modal`, `/grid-view`
+
+Files to stub trong `firebase/functions/src/index.ts`:
+- `onPostCreated` Firestore trigger stub
+- `onPostDeleted` Firestore trigger stub
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] `Post` model có field `spaceId String?` (Space module dùng sau)
+- [ ] `FeedFilter` enum có `space` case dù chưa implement
+- [ ] `AppCameraController` — KHÔNG phải `CameraController` (conflict với camera package)
+- [ ] TODO markers: `// TODO(FE/T<N>/TBD): ...`
+
+---
+**LX6 · chore(contracts): notification module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `chore/ThienPDM/notification-contracts` |
+| Blocked by | LX5 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-notification.md` §PART 1
+
+Files to create:
+- `lib/features/notification/data/app_notification.dart` — @freezed (notifId, type enum, title, body, data Map<String,String>, read bool, createdAt)
+- `lib/features/notification/data/notification_repository.dart` — abstract (saveFcmToken, deleteFcmToken, getNotifications, markAsRead)
+- `lib/features/notification/application/notification_controller.dart` — stub
+- `lib/main.dart` — **update:** FCM init comment + NotificationController stub call
+- `lib/core/router/app_router.dart` — **update:** thêm deep link handler slots cho notification tap
+
+Files to stub trong `firebase/functions/src/index.ts`:
+- `onFriendRequestCreated` Firestore trigger stub
+- `onFriendRequestAccepted` Firestore trigger stub
+- `onReactionCreated` Firestore trigger stub
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] `NotificationType` enum có: friend_request, friend_accepted, reaction (KHÔNG có new_post — không lưu doc)
+- [ ] TODO markers: `// TODO(N/T<N>/TBD): ...`
+
+---
+**LX7 · chore(contracts): reaction module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | XS (~2h) |
+| Branch | `chore/ThienPDM/reaction-contracts` |
+| Blocked by | LX5 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-reaction.md` §PART 1
+
+Files to create:
+- `lib/features/reaction/data/reaction.dart` — @freezed (reactorUid = docId, reactorName, emoji, createdAt)
+- `lib/features/reaction/data/reaction_repository.dart` — abstract (watchReactions, upsertReaction, deleteReaction, **getMyReaction** — bắt buộc [H2-FIX])
+- `lib/features/reaction/application/reaction_controller.dart` — stub + `ReactionState`
+- `lib/features/reaction/presentation/emoji_picker_sheet.dart` — stub
+- `lib/features/reaction/presentation/reaction_list_sheet.dart` — stub
+- `lib/shared/widgets/app_act_text_bar.dart` — **update stub:** thêm optional `ReactionController?` param (M2: null → no-op; M3: inject)
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] `getMyReaction` có trong abstract interface (thiếu → `toggleReact` không implement được)
+- [ ] `ActTextBar` vẫn backward compat khi controller null
+- [ ] TODO markers: `// TODO(R/T<N>/TBD): ...`
+
+---
+**LX8 · chore(contracts): diary module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `chore/ThienPDM/diary-contracts` |
+| Blocked by | LX1 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-diary.md` §PART 1
+
+Files to create:
+- `lib/features/diary/data/diary_entry.dart` — @freezed (entryId, authorUid, moodTemplate enum, coverImageUrl, moodCaption ≤50, content List<DiaryContentBlock> ≤20, privacy enum, createdAt, updatedAt)
+- `lib/features/diary/data/diary_content_block.dart` — @freezed (type enum text/image, value?, style? enum, imageUrl?)
+- `lib/features/diary/data/diary_repository.dart` — abstract (**phải có `getPublicEntries(authorUid)`** — Profile module dùng)
+- `lib/features/diary/application/diary_controller.dart` — stub + `DiaryState`
+- `lib/features/diary/presentation/diary_canvas_screen.dart` — stub + `DiaryCanvasMode` enum (create/read/edit) trong cùng file
+- `lib/features/diary/presentation/diary_list_screen.dart` — stub
+- `lib/features/diary/presentation/diary_create_screen.dart` — stub
+- `lib/features/diary/presentation/diary_search_screen.dart` — stub
+- `lib/features/diary/presentation/discard_changes_dialog.dart` — stub
+- `lib/features/diary/presentation/privacy_sheet.dart` — stub
+- `lib/core/router/app_router.dart` — **update:** `/diary`, `/diary/create`, `/diary/:entryId`
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] `getPublicEntries(String authorUid)` là `Future<List<DiaryEntry>>` — không phải Stream
+- [ ] `DiaryCanvasMode` enum cùng file với `DiaryCanvasScreen`
+- [ ] TODO markers: `// TODO(D/T<N>/TBD): ...`
+
+---
+**LX9 · chore(contracts): profile module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `chore/ThienPDM/profile-contracts` |
+| Blocked by | LX2, LX8 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-profile.md` §PART 1
+
+Files to create / update:
+- `lib/features/auth/data/user_profile.dart` — **verify** đủ fields (đã tạo đủ ở LX1 — chỉ cần verify, không tạo lại)
+- `lib/features/profile/data/profile_repository.dart` — abstract (getUserProfile, watchUserProfile, updateProfile, updateAvatar, removeAvatar)
+- `lib/features/profile/application/profile_controller.dart` — stub + `ProfileState`
+- `lib/features/profile/presentation/profile_screen.dart` — stub
+- `lib/features/profile/presentation/edit_profile_screen.dart` — stub
+- `lib/features/profile/presentation/photo_detail_screen.dart` — stub
+- `lib/features/profile/presentation/avatar_picker_sheet.dart` — stub
+- `lib/core/router/app_router.dart` — **update:** `/profile`, `/profile/edit`, `/profile/photo/:postId`, `/friend-profile/:uid`
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] `isUsernameAvailable` KHÔNG có trong `ProfileRepository` — ProfileController inject `UserRepository` từ auth
+- [ ] `ShareProfileSheet` đã tạo ở LX3 — không tạo lại
+- [ ] TODO markers: `// TODO(P/T<N>/TBD): ...`
+
+---
+**LX10 · chore(contracts): space module contracts + gate changes**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `chore/ThienPDM/space-contracts` |
+| Blocked by | LX5, LX4 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-space.md` §PART 1
+
+Files to create:
+- `lib/features/space/data/space.dart` — @freezed (spaceId, name ≤30, iconEmoji, colorHex 7 chars, creatorId, memberCount, memberIds List<String> ≤10, createdAt, deletedAt?)
+- `lib/features/space/data/space_member.dart` — @freezed (uid, role SpaceRole enum, joinedAt)
+- `lib/features/space/data/space_repository.dart` — abstract (watchMySpaces, getSpace, deleteSpace)
+- `lib/features/space/application/space_controller.dart` — stub + `SpaceState`
+- `lib/features/space/presentation/space_create_sheet.dart` — stub
+- `lib/features/space/presentation/space_context_bottom_sheet.dart` — stub
+- `lib/features/space/presentation/widgets/space_list_tile.dart` — stub
+- `lib/features/space/presentation/widgets/space_context_badge.dart` — stub
+- `lib/core/router/app_router.dart` — **update:** `/space/create`, `/space/:spaceId`
+
+**Gate changes (leader merge):**
+- `lib/features/feed/data/post.dart` — verify `spaceId String?` field đã có (đã add ở LX5)
+- `lib/features/feed/presentation/home_screen.dart` — **update:** thêm optional `spaceId` param + `FeedFilter.space` support
+
+Files to stub trong `firebase/functions/src/index.ts`:
+- `createSpace`, `leaveSpace`, `kickMember`, `transferOwnership` HTTPS Callable stubs
+- `onSpaceMemberAdded`, `onSpaceMemberRemoved`, `onSpacePostCreated`, `onSpaceDeleted` trigger stubs
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] `Post.spaceId` đã reserve từ LX5 — confirm field tồn tại
+- [ ] `FeedFilter.space(spaceId)` case compile
+- [ ] `emoji_picker_flutter` được confirm trong pubspec (LX-SHARED)
+- [ ] TODO markers: `// TODO(SP/T<N>/TBD): ...`
+
+---
+**LX11 · chore(contracts): widget android contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `chore/ThienPDM/widget-contracts` |
+| Blocked by | LX5 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-widget-android.md` §PART 1
+
+Files to create:
+- `android/app/src/main/kotlin/.../MeepWidget.kt` — AppWidgetProvider skeleton (`onUpdate` returns immediately)
+- `android/app/src/main/kotlin/.../WidgetSyncWorker.kt` — Worker skeleton (`doWork` returns `Result.success()`)
+- `android/app/src/main/res/layout/meep_widget.xml` — RemoteViews layout với placeholder text
+- `android/app/src/main/res/xml/meep_widget_info.xml` — metadata (minWidth 250dp, minHeight 250dp, updatePeriodMillis 1800000)
+- `android/app/src/main/AndroidManifest.xml` — **update:** khai báo widget receiver + intent filter
+- `lib/features/widget/application/widget_data_service.dart` — stub (throws UnimplementedError)
+- `lib/core/router/app_router.dart` — **update:** handle intent extras `action: OPEN_POST`
+
+Acceptance criteria:
+- [ ] Android build clean (Kotlin compile)
+- [ ] Flutter build clean
+- [ ] Widget visible trong Android widget picker sau khi install
+- [ ] TODO markers: `// TODO(W/T<N>/TBD): ...`
+
+---
+**LX12 · chore(contracts): streak module contracts**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | XS (~2h) |
+| Branch | `chore/ThienPDM/streak-contracts` |
+| Blocked by | LX5 |
+
+> Xem chi tiết: `docs/plans/2026-05-23-streak.md` §PART 1
+
+Files to create:
+- `lib/features/streak/application/streak_controller.dart` — stub + `StreakState` (monthPosts, allPostDates, viewingMonth, currentStreak, totalMoments, isLoading)
+- `lib/features/streak/presentation/streak_screen.dart` — stub
+- `lib/features/streak/presentation/streak_photo_detail_screen.dart` — stub
+- `lib/core/router/app_router.dart` — **update:** `/streak`, `/streak/photo/:postId`
+
+Acceptance criteria:
+- [ ] `flutter analyze` clean
+- [ ] Reuse `Post` và `PostRepository` từ Feed module — KHÔNG tạo model mới
+- [ ] TODO markers: `// TODO(ST/T<N>/TBD): ...`
+
+---
+**LX-RULES · chore(rules): viết firestore.rules + storage.rules hoàn chỉnh**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | M (~8h) |
+| Branch | `chore/ThienPDM/firestore-rules` |
+| Blocked by | LX1–LX12 (tất cả helper functions phải đã define) |
+
+Files:
+- `firebase/firestore.rules` — merge theo thứ tự:
+  1. Helper functions: `isAuthed()`, `isOwner(uid)`, `isFriend(uid)` (từ LX2), `isBlocked(uid)` (từ LX3), `isMember(spaceId)`, `isCreator(spaceId)` (từ LX10), `isParticipant(conversationId)` (từ LX4)
+  2. Match blocks từng collection (theo spec §Security của từng module)
+  3. Merged `/posts` rule (feed + space + reaction — 3 specs contribute)
+- `firebase/storage.rules` — `avatars/{uid}/`, `posts/{uid}/`, `diary/{uid}/`
+
+Acceptance criteria:
+- [ ] `firebase emulators:exec --only firestore "npm run test:rules"` pass tất cả rules tests đã viết
+- [ ] KHÔNG có `allow read, write: if true` ở bất kỳ đâu
+- [ ] `/posts/{postId}` rule là 1 block duy nhất (không duplicate)
+- [ ] Mọi collection có user data đều có `isOwner()` hoặc `isFriend()` check
+
+---
+**LX-PUBSPEC · chore(deps): cập nhật pubspec.yaml + build.gradle**
+
+| | |
+|---|---|
+| Assignee | ThienPDM |
+| Estimate | S (~4h) |
+| Branch | `chore/ThienPDM/pubspec-packages` |
+| Blocked by | LX0 (sau khi biết đủ packages cần) |
+
+Files:
+- `apps/mobile/pubspec.yaml` — thêm packages: `share_plus`, `camera`, `flutter_image_compress`, `gal`, `geolocator`, `cached_network_image`, `http`, `intl`, `image_picker`, `firebase_messaging`, `flutter_local_notifications`, `emoji_picker_flutter`, `flutter_svg`, `shared_preferences`
+- `android/app/build.gradle` — thêm: `androidx.work:work-runtime-ktx`, `com.github.bumptech.glide:glide` (hoặc Coil nếu đã có)
+
+Acceptance criteria:
+- [ ] `flutter pub get` thành công, không conflict
+- [ ] `flutter build apk --debug` thành công
+- [ ] `emoji_picker_flutter` chỉ add 1 lần (dùng bởi cả Reaction và Space)
+- [ ] `shared_preferences` chỉ add 1 lần (dùng bởi Profile + Widget)
+
+---
+
+## PART 3 — Dependency graph
+
+```
+LX0 (core) → LX1 (auth) → LX2 (friend) → LX3 (settings) → LX4 (chat)
+                                       ↘
+                         LX2 → LX3 → LX5 (feed) → LX6 (notification)
+                                                 → LX7 (reaction)
+                                                 → LX11 (widget)
+                                                 → LX12 (streak)
+             LX1 → LX8 (diary) → LX9 (profile) ← LX2
+             LX5 + LX4 → LX10 (space)
+
+LX-PUBSPEC: parallel với LX0+ (thêm packages dần theo nhu cầu)
+LX-RULES: sau khi LX1–LX12 complete
+```
+
+**Nhóm theo milestone:**
+- M1: LX0 → LX1 → LX-PUBSPEC (partial)
+- M2: LX2 → LX3 → LX5 → LX8 → LX9
+- M3: LX4 → LX6 → LX7 → LX10 → LX11 → LX12 → LX-RULES
+
+---
+
+## PART 4 — Checklist trước khi giao dev từng module
+
+Trước khi nói "contracts ready — start implementing":
+- [ ] `flutter analyze` clean
+- [ ] App launch được (placeholder screens)
+- [ ] Tất cả providers trong module throw `UnimplementedError` với hint text
+- [ ] TODO markers đúng format `// TODO(<module-prefix>/T<N>/TBD): ...`
+- [ ] Commit message: `chore(contracts): thêm contracts module <name>` — merge PR vào `develop`

--- a/docs/plans/2026-05-23-notification.md
+++ b/docs/plans/2026-05-23-notification.md
@@ -1,0 +1,226 @@
+# Plan: Push Notification Module
+
+> **Phụ thuộc vào:** Home/Camera/Feed — `Post` model, `onPostCreated` CF (FCM logic embedded [H10]); Friend — `Friendship` model (fan-out recipients); Chat — `Conversation` model (token cleanup khi block/delete)
+> **Được phụ thuộc bởi:** Settings (deleteFcmToken khi logout), Widget Android (đọc `/users/{uid}/fcmTokens` schema)
+> **Spec:** `docs/specs/2026-05-23-notification.md`
+> **Tier:** T0 — Milestone M3
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/notification/data/app_notification.dart` | freezed model | `notifId String`, `type NotificationType` enum (friend_request/friend_accepted/reaction), `title String`, `body String`, `data Map<String,String>`, `read bool`, `createdAt DateTime` |
+| `lib/features/notification/data/notification_repository.dart` | abstract class | `Future<void> saveFcmToken(String uid, String token)`, `Future<void> deleteFcmToken(String uid)`, `Future<List<AppNotification>> getNotifications(String uid)`, `Future<void> markAsRead(String notifId)` |
+| `lib/features/notification/application/notification_controller.dart` | Riverpod stub | `NotificationState`, methods: `initFCM`, `handleForeground`, `handleBackground`, `markAsRead` — throw `UnimplementedError` |
+| `apps/mobile/lib/main.dart` | update | FCM init call, `NotificationController.initFCM()` trong `ProviderScope` setup |
+| `lib/core/router/app_router.dart` | update | Deep link handler từ notification tap: `getInitialMessage()` + `onMessageOpenedApp` stream |
+| `firebase/functions/src/index.ts` | CF stubs | `onFriendRequestCreated`, `onFriendRequestAccepted`, `onReactionCreated` |
+
+> `new_post` FCM không có notification doc, và FCM fan-out logic được gọi TRONG `onPostCreated` của Feed module ([H10]) — Notification module KHÔNG tạo CF riêng cho new_post.
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(notification): NotificationRepository — FCM token lifecycle + notifications CRUD**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/notification-repository` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/notification/data/firebase_notification_repository.dart` — impl `NotificationRepository`
+- `test/features/notification/firebase_notification_repository_test.dart` — test: saveFcmToken creates doc, deleteFcmToken deletes all docs, getNotifications sort DESC, markAsRead updates field
+
+Acceptance criteria:
+- [ ] `saveFcmToken(uid, token)`: (1) xóa tất cả docs hiện có trong `/users/{uid}/fcmTokens/*` (1 token/user policy), (2) tạo doc mới với `tokenId = SHA-256(token)` (hex), `platform = 'android'`
+- [ ] `deleteFcmToken(uid)`: xóa tất cả docs trong `/users/{uid}/fcmTokens/*` (logout cleanup)
+- [ ] `getNotifications(uid)`: query ORDER BY `createdAt DESC`, không bao gồm `new_post` type (không lưu)
+- [ ] `markAsRead(notifId)`: update `read = true` — chỉ field này, không đổi field khác
+
+Cross-module imports: None
+
+---
+**T2 · feat(notification): NotificationController — initFCM + permission + token lifecycle + background/terminated handlers**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/notification-controller` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/notification/application/notification_controller.dart` — full impl
+- `lib/main.dart` — update: `FirebaseMessaging.instance.requestPermission()`, `NotificationController.initFCM()` gọi trong init
+- `test/features/notification/notification_controller_test.dart` — test: token save on init, permission denied → không crash, markAsRead updates state
+
+Acceptance criteria:
+- [ ] `initFCM()`: `requestPermission()` → lấy token → `saveFcmToken()` → lắng nghe `onTokenRefresh` → tự động update
+- [ ] Android 13+ `POST_NOTIFICATIONS` bị denied → không crash, không push, hiện banner nhắc enable
+- [ ] App terminated: `getInitialMessage()` → parse notification data → navigate đúng route sau app open
+- [ ] App background: `onMessageOpenedApp` stream → navigate khi user tap notification
+- [ ] `FirebaseMessaging.onTokenRefresh` → tự động gọi `saveFcmToken()` (cleanup + replace token cũ)
+
+Cross-module imports: `NotificationRepository` từ Part 1
+
+---
+**T3 · feat(notification): Foreground notification banner component**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/notification-banner` |
+| Blocked by | T2 |
+
+Files:
+- `lib/features/notification/presentation/widgets/notification_banner.dart` — overlay component (Figma `765:4766` expanded / `765:4981` collapsed)
+- `lib/features/notification/application/notification_controller.dart` — update: `handleForeground()` trigger banner
+- `test/features/notification/notification_banner_test.dart` — widget tests: collapsed state render, tap expand, "Tắt thông báo" toggle
+
+Acceptance criteria:
+- [ ] Collapsed (h=65): Logo + senderName + timestamp + chevron-down + message preview (Figma `765:4981`)
+- [ ] Tap → Expanded (h=112): thêm [Trả lời] + [Tắt thông báo] (Figma `765:4766`)
+- [ ] "Tắt thông báo": local preference (suppress foreground banner) — KHÔNG unsubscribe FCM
+- [ ] Banner tự dismiss sau 4s nếu không interact
+- [ ] Foreground notification (`onMessage` stream) → `flutter_local_notifications` hiện local notification
+
+Cross-module imports: None
+
+---
+**T4 · feat(notification): Deep link routing từ notification tap**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/notification-deep-link` |
+| Blocked by | T2 |
+
+Files:
+- `lib/core/router/app_router.dart` — update: đọc `notification.data.type` → navigate đúng route
+
+Acceptance criteria:
+- [ ] `type == 'friend_request'` → navigate `FriendSheet`
+- [ ] `type == 'friend_accepted'` → navigate `FriendSheet`
+- [ ] `type == 'reaction'` → navigate Feed, scroll đến `postId` (highlight)
+- [ ] `type == 'new_post'` → navigate Feed (top)
+- [ ] Post đã bị xóa khi user tap notification → navigate Home + toast "Bài viết không còn tồn tại"
+- [ ] Double-tap notification → navigate idempotent (không push duplicate routes)
+
+Cross-module imports: `FriendSheet` từ **friend**, `FeedController` từ **home-camera-feed**
+
+---
+**T5 · feat(notification): CF `onFriendRequestCreated` — FCM + notification doc**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/notification-cf-friend-request` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `firebase/functions/src/notification/onFriendRequestCreated.ts` — Firestore onCreate `/friend_requests/{id}`
+- `firebase/functions/test/notification/onFriendRequestCreated.test.ts` — test: FCM gửi, notification doc tạo, receiver không có token → skip không crash
+
+Acceptance criteria:
+- [ ] Đọc FCM token của `receiverId` từ `/users/{receiverId}/fcmTokens/*`
+- [ ] Gửi FCM: `title = "{senderName} muốn kết bạn với bạn"`, `body = "Tap để xem và chấp nhận"`, `data = { type: 'friend_request', requestId }`
+- [ ] Tạo `/users/{receiverId}/notifications/{id}` với đúng fields
+- [ ] Receiver không có FCM token → skip gracefully, không crash
+- [ ] Receiver FCM token stale (invalid-argument) → xóa token khỏi Firestore, không retry
+
+Cross-module imports: None (Admin SDK)
+
+---
+**T6 · feat(notification): CF `onFriendRequestAccepted` — FCM cho sender**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/notification-cf-friend-accepted` |
+| Blocked by | T5 |
+
+Files:
+- `firebase/functions/src/notification/onFriendRequestAccepted.ts` — Firestore onUpdate `/friend_requests/{id}` (status → accepted)
+- `firebase/functions/test/notification/onFriendRequestAccepted.test.ts`
+
+Acceptance criteria:
+- [ ] Trigger chỉ khi `status == 'accepted'` (onUpdate guard: `change.before.data().status != 'accepted' && change.after.data().status == 'accepted'`)
+- [ ] Gửi FCM cho `senderId`: `title = "{receiverName} đã chấp nhận lời mời kết bạn"`, `body = "Các bạn giờ là bạn bè trên Meep!"`
+- [ ] Tạo notification doc cho `senderId`
+
+Cross-module imports: None
+
+---
+**T7 · feat(notification): CF `onReactionCreated` — FCM + notification doc cho post author**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/notification-cf-reaction` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `firebase/functions/src/notification/onReactionCreated.ts` — Firestore onCreate `/posts/{postId}/reactions/{reactorUid}`
+- `firebase/functions/test/notification/onReactionCreated.test.ts` — test: FCM gửi, self-react guard, notification doc tạo
+
+Acceptance criteria:
+- [ ] Guard: `reactorId == post.authorId` → skip (không tự notify mình)
+- [ ] Gửi FCM cho `post.authorId`: `title = "{reactorName} đã react vào ảnh của bạn"`, `body = "{emoji}"`, `data = { type: 'reaction', postId }`
+- [ ] Tạo `/users/{authorId}/notifications/{id}`
+
+Cross-module imports: None
+
+---
+**T8 · test(notification): Firestore rules + CF tests**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/notification-rules` |
+| Blocked by | T1 |
+
+Files:
+- `firebase/functions/test/rules/notification.rules.test.ts`
+
+Acceptance criteria:
+- [ ] `/users/{uid}/notifications/{id}` read by owner ✓, stranger ✗
+- [ ] `/users/{uid}/notifications/{id}` update `read` field by owner ✓, update other field ✗
+- [ ] `/users/{uid}/notifications/{id}` create by client ✗ (CF Admin SDK only)
+- [ ] `/users/{uid}/fcmTokens/{id}` read by owner ✓, write by owner ✓, stranger ✗
+
+Cross-module imports: None
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T2 → T3
+                          ↘
+                     T2 → T4 (parallel T3)
+contracts Part 1 → T5 → T6 → T8
+contracts Part 1 → T7 → T8
+```
+
+T5, T7 (Cloud Functions) có thể chạy song song với T1-T4 (Flutter).
+
+---
+
+## PART 4 — Open questions
+
+| # | Câu hỏi | Status |
+|---|---|---|
+| OQ1 | In-app notification list screen | Foreground banner đã có. Full list screen: **Nice-to-have M3** — implement nếu còn thời gian sau T1-T8 |

--- a/docs/plans/2026-05-23-profile.md
+++ b/docs/plans/2026-05-23-profile.md
@@ -1,0 +1,259 @@
+# Plan: Profile Module
+
+> **Phụ thuộc vào:** Auth — `UserProfile` model (source of truth), `AuthRepository.reauthenticateWithCredential()`, `UserRepository.isUsernameAvailable()`; Friend — `FriendRepository` (friend count, FriendSheet access); Diary — `DiaryRepository.getPublicEntries(authorUid)` (Profile Diary tab)
+> **Được phụ thuộc bởi:** Chat (FriendProfileScreen navigate từ chat search), Reaction (tap avatar → FriendProfileScreen)
+> **Spec:** `docs/specs/2026-05-22-profile.md`
+> **Tier:** T0+ — Milestone M2
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/auth/data/user_profile.dart` | **update** freezed model | Thêm fields: `bio String?` (≤150), `dateOfBirth String?` (DD/MM/YYYY), `phoneNumber String?`, `gender String?` (male/female/other), `postCount int` default 0, `friendCount int` default 0, `spaceCount int` default 0 |
+| `lib/features/profile/data/profile_repository.dart` | abstract class | `Future<UserProfile?> getUserProfile(String uid)`, `Stream<UserProfile?> watchUserProfile(String uid)`, `Future<void> updateProfile(String uid, Map<String,dynamic> fields)`, `Future<void> updateAvatar(String uid, File imageFile)`, `Future<void> removeAvatar(String uid)` |
+| `lib/features/profile/application/profile_controller.dart` | Riverpod stub | `ProfileState` (profile, isLoading, errorMessage), methods throw `UnimplementedError` |
+| `lib/features/profile/presentation/profile_screen.dart` | widget stub | |
+| `lib/features/profile/presentation/edit_profile_screen.dart` | widget stub | |
+| `lib/features/profile/presentation/photo_detail_screen.dart` | widget stub | |
+| `lib/features/profile/presentation/avatar_picker_sheet.dart` | widget stub | |
+| `lib/shared/widgets/share_profile_sheet.dart` | **shared widget** — leader own | Dùng chung Profile + Settings |
+| `lib/core/router/app_router.dart` | update | Routes `/profile`, `/profile/edit`, `/profile/photo/:postId`, `/friend-profile/:uid` |
+| `firebase/storage.rules` | update | Rules cho `avatars/{uid}/` — read: authed; write: owner + ≤5MB + image/* |
+
+> `UserProfile` model: Profile spec là source of truth cho full schema. Auth module khi tạo user phải khởi tạo tất cả new fields với default values (null/0).  
+> `isUsernameAvailable` KHÔNG có trong `ProfileRepository` — inject `UserRepository` (từ auth) vào `ProfileController`.
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(profile): FirebaseProfileRepository — getUserProfile + watchUserProfile + updateProfile + avatar ops**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/profile-repository` |
+| Blocked by | contracts Part 1 (UserProfile model update) |
+
+Files:
+- `lib/features/profile/data/firebase_profile_repository.dart` — impl `ProfileRepository`
+- `test/features/profile/firebase_profile_repository_test.dart` — test: getUserProfile đúng, updateProfile chỉ update allowed fields, removeAvatar set null, updateAvatar compress + upload + update URL
+
+Acceptance criteria:
+- [ ] `updateProfile(uid, fields)` chỉ cho phép update: `displayName, username, avatarUrl, bio, dateOfBirth, phoneNumber, gender, updatedAt` — bất kỳ field khác → throw `AppError`
+- [ ] `updateAvatar(uid, file)`: compress → upload `avatars/{uid}/avatar.jpg` (overwrite) → update `avatarUrl` field
+- [ ] `removeAvatar(uid)`: update `avatarUrl = null` (không xóa Storage file ngay — orphan acceptable)
+- [ ] Avatar upload > 5MB → throw `AppError` trước khi upload
+- [ ] `watchUserProfile(uid)` — realtime stream, không one-time get
+
+Cross-module imports: `UserProfile` từ **auth** (`lib/features/auth/data/user_profile.dart`)
+
+---
+**T2 · feat(profile): ProfileController — loadProfile + updateField + avatar ops + shareProfile**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/profile-controller` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/profile/application/profile_controller.dart` — `ProfileState`, full impl
+- `test/features/profile/profile_controller_test.dart` — test: updateField displayName, avatar upload → state updated, isUsernameAvailable check, shareProfile URL đúng
+
+Acceptance criteria:
+- [ ] `isUsernameAvailable` delegate sang `UserRepository.isUsernameAvailable()` (từ auth) — KHÔNG call Firestore trực tiếp trong ProfileController
+- [ ] Avatar upload fail → rollback `ProfileState.profile.avatarUrl` về giá trị cũ
+- [ ] `shareProfile(username)` → `AppConfig.shareBaseUrl/username` (không hardcode)
+- [ ] `updateField('bio', value)` validate `value.length <= 150` trước khi gọi repository
+
+Cross-module imports: `UserRepository` từ **auth** (isUsernameAvailable)
+
+---
+**T3 · feat(profile): ProfileScreen — header + stats + tab bar**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/profile-screen` |
+| Blocked by | T2 |
+
+Files:
+- `lib/features/profile/presentation/profile_screen.dart` — (Figma `269:1941`)
+- `lib/features/profile/presentation/widgets/profile_header.dart` — avatar + username + bio
+- `lib/features/profile/presentation/widgets/profile_stats.dart` — [N Khoảnh khắc] [N Bạn bè] [N Space]
+
+Acceptance criteria:
+- [ ] Stats: Khoảnh khắc = `postCount`, Bạn bè = `friendCount`, Space = `spaceCount` (hiện `0` M2)
+- [ ] Tap "N Bạn bè" → mở `FriendSheet` bottom sheet
+- [ ] Avatar: avatar url → `CachedNetworkImage`; null → initials placeholder
+- [ ] 2 action buttons: [Chỉnh sửa] → `EditProfileScreen`, [Chia sẻ trang cá nhân] → `ShareProfileSheet`
+- [ ] Tab bar: Photos (active) + Diary (empty state M2)
+
+Cross-module imports: `FriendSheet` từ **friend**
+
+---
+**T4 · feat(profile): PhotoGrid tab + PhotoDetailScreen (swipe)**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/profile-photo-grid` |
+| Blocked by | T3 |
+
+Files:
+- `lib/features/profile/presentation/widgets/photo_grid.dart` — 3-column grid, lazy load, cursor-paginated 9/batch, `PostRepository.getPostsByAuthor(currentUid)`
+- `lib/features/profile/presentation/photo_detail_screen.dart` — full impl (Figma `660:1940`): swipe carousel + Note + Tag + thumbnail strip
+- `test/features/profile/photo_detail_screen_test.dart` — widget tests: swipe trái → ảnh cũ hơn, swipe phải → ảnh mới hơn, swipe quá giới hạn → bounce
+
+Acceptance criteria:
+- [ ] PhotoGrid: 3-column, lazy load, 9 posts/batch cursor-paginated (createdAt DESC)
+- [ ] Tap ảnh → `PhotoDetailScreen` với `initialIndex`
+- [ ] Swipe trái = ảnh cũ hơn (createdAt nhỏ hơn); swipe phải = ảnh mới hơn
+- [ ] Swipe đến ảnh đầu/cuối → bounce animation, không crash
+- [ ] Thumbnail strip: ảnh đang xem = enlarged + outline turquoise `#00DEEE`
+- [ ] Share icon trong PhotoDetail topbar → `ShareModal` (từ Feed module)
+
+Cross-module imports: `PostRepository` từ **home-camera-feed**, `ShareModal` từ **home-camera-feed**
+
+---
+**T5 · feat(profile): EditProfileScreen — tất cả fields + email re-auth + username uniqueness**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2 ngày) |
+| Branch | `feat/TBD/profile-edit-screen` |
+| Blocked by | T2 |
+
+Files:
+- `lib/features/profile/presentation/edit_profile_screen.dart` — list settings options (Figma `573:2968`)
+- `lib/features/profile/presentation/widgets/date_picker_sheet.dart` — DD/MM/YYYY date picker
+- `lib/features/profile/presentation/widgets/gender_picker_sheet.dart` — Nam / Nữ / Khác
+- `lib/features/profile/presentation/widgets/bio_input_sheet.dart` — multiline, max 150 chars, hint text
+- `lib/features/profile/presentation/widgets/email_update_dialog.dart` — re-auth dialog step
+- `lib/features/profile/presentation/widgets/notification_toggle.dart` — toggle switch lưu vào `SharedPreferences`
+
+Acceptance criteria:
+- [ ] `displayName` change: validate không rỗng, min 2 ký tự → update
+- [ ] `username` change: `isUsernameAvailable()` check → inline error nếu taken; dùng Firestore transaction (race condition)
+- [ ] `bio`: max 150 chars, optional (trống OK), hint "Tiểu sử của bạn hiển thị với bạn bè của bạn."
+- [ ] Email update: `reauthenticateWithCredential()` required → nếu Google user → dùng GoogleAuthProvider (không hiện password field)
+- [ ] `requires-recent-login` error → re-auth dialog inline, KHÔNG show generic error
+- [ ] Tất cả optional fields (`dateOfBirth`, `phoneNumber`, `gender`) có thể bỏ trống, không lỗi
+- [ ] Notification toggle: lưu boolean vào `SharedPreferences` (key: `notification_enabled`) — KHÔNG lưu Firestore; toggle off không unsubscribe FCM nhưng `NotificationController` đọc pref này để suppress foreground banner
+
+Cross-module imports: `AuthRepository.reauthenticateWithCredential()`, `updateEmail()` từ **auth**
+
+---
+**T6 · feat(profile): AvatarPickerSheet + ShareProfileSheet integration**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/profile-avatar-share` |
+| Blocked by | T5 |
+
+Files:
+- `lib/features/profile/presentation/avatar_picker_sheet.dart` — (Figma `573:3561`): Chọn từ thư viện / Chụp ảnh / Gỡ ảnh hiện tại
+
+Acceptance criteria:
+- [ ] "Chọn từ thư viện" → `image_picker.pickImage(source: gallery)` → compress → `updateAvatar()`
+- [ ] "Chụp ảnh" → `image_picker.pickImage(source: camera)` → compress → `updateAvatar()`
+- [ ] "Gỡ ảnh hiện tại" → `removeAvatar()` → avatar hiện initials placeholder; nút ẩn/disabled khi `avatarUrl == null`
+- [ ] `ShareProfileSheet` (shared) hiện từ [Chia sẻ trang cá nhân] + từ Settings — cùng component
+
+Cross-module imports: `ShareProfileSheet` từ **shared widgets** (leader own)
+
+---
+**T7 · feat(profile): FriendProfileScreen — bạn bè xem profile người khác**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/profile-friend-screen` |
+| Blocked by | T3 |
+
+Files:
+- `lib/features/profile/presentation/friend_profile_screen.dart` — view-only profile (stats K.khắc + Bạn bè chung; Space ẩn)
+
+Acceptance criteria:
+- [ ] Chỉ accessible khi đã là bạn bè (`isFriend` check ở tầng routing hoặc controller)
+- [ ] Hiện: avatar + stats (postCount + friendCount, KHÔNG hiện Space) + bio + grid ảnh (read-only)
+- [ ] KHÔNG có nút Edit / Chia sẻ — chỉ có nút "Xoá bạn" (mở FriendSheet)
+- [ ] Grid ảnh của người đó: dùng `PostRepository.getPostsByAuthor(friendUid)` — chỉ posts có trong feed của mình
+
+Cross-module imports: `FriendSheet` từ **friend**, `PostRepository` từ **home-camera-feed**
+
+---
+**T8 · feat(profile): Diary tab integration**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/profile-diary-tab` |
+| Blocked by | T3 |
+
+Files:
+- `lib/features/profile/presentation/widgets/diary_tab_content.dart` — M2: empty state "Tính năng sắp ra mắt"; M3: gọi `DiaryRepository.getPublicEntries(uid)` → `DiaryMoodCard` grid
+
+Acceptance criteria:
+- [ ] M2: Diary tab hiển thị empty state, tab icon vẫn tappable (không grayed out)
+- [ ] M3: Diary tab hiện `DiaryMoodCard` grid (reuse component từ Diary module) chỉ public entries
+- [ ] Tap card → `DiaryCanvasScreen(mode: read)` (view-only, không edit người khác)
+- [ ] Viewer không phải bạn bè của profile owner → ẩn diary section
+
+Cross-module imports: `DiaryRepository.getPublicEntries()` từ **diary**, `DiaryMoodCard` từ **diary**
+
+---
+**T9 · test(profile): Firestore rules + Storage rules tests**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/profile-rules` |
+| Blocked by | T1 |
+
+Files:
+- `firebase/functions/test/rules/profile.rules.test.ts`
+
+Acceptance criteria:
+- [ ] `/users/{uid}` read by any authed user ✓ (CANONICAL — cần cho username search)
+- [ ] `/users/{uid}` update với `uid` field thay đổi ✗; `email` field thay đổi ✗
+- [ ] `/users/{uid}` update chỉ allowed fields (`displayName, username, avatarUrl, bio, dateOfBirth, phoneNumber, gender, updatedAt`) ✓; field ngoài allowlist ✗
+- [ ] Storage `avatars/{uid}/`: owner write ✓, >5MB ✗, non-image ✗; read by any authed ✓
+- [ ] Storage `avatars/{uid}/`: stranger write ✗
+
+Cross-module imports: None
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T2 → T3 → T4
+                               ↘
+                          T2 → T5 → T6 (parallel T4)
+                          T3 → T7 (parallel T5)
+                          T3 → T8 (parallel T5, T7)
+contracts Part 1 → T1 → T9 (chạy sớm sau T1 done)
+```
+
+---
+
+## PART 4 — Open questions
+
+Tất cả đã resolved trong spec (`docs/specs/2026-05-22-profile.md`). None blocking.
+
+> **Note M2 vs M3:** T8 (Diary tab) bao gồm cả M2 stub và M3 implementation. M2 deploy trước (empty state), M3 update sau khi Diary module implement xong.

--- a/docs/plans/2026-05-23-reaction.md
+++ b/docs/plans/2026-05-23-reaction.md
@@ -1,0 +1,157 @@
+# Plan: Reaction Module
+
+> **Phụ thuộc vào:** Home/Camera/Feed — `Post` model, `ActTextBar` widget (update từ M2 stub → M3 active), `PostRepository` (feed read check)
+> **Được phụ thuộc bởi:** Notification (CF `onReactionCreated` trigger)
+> **Spec:** `docs/specs/2026-05-23-reaction.md`
+> **Tier:** T0 — Milestone M3
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/reaction/data/reaction.dart` | freezed model | `reactorUid String` (= documentId — enforce 1/user/post), `reactorName String`, `emoji String`, `createdAt DateTime` |
+| `lib/features/reaction/data/reaction_repository.dart` | abstract class | `Stream<List<Reaction>> watchReactions(String postId)`, `Future<void> upsertReaction(String postId, String uid, String emoji)`, `Future<void> deleteReaction(String postId, String uid)`, `Future<Reaction?> getMyReaction(String postId, String uid)` |
+| `lib/features/reaction/application/reaction_controller.dart` | Riverpod stub | `ReactionState` (reactions, myReaction, isLoading), methods throw `UnimplementedError` |
+| `lib/features/reaction/presentation/emoji_picker_sheet.dart` | widget stub | |
+| `lib/features/reaction/presentation/reaction_list_sheet.dart` | widget stub | |
+| `lib/shared/widgets/app_act_text_bar.dart` | update stub | M3: inject `ReactionController` parameter, M2 stub remains no-op until controller provided |
+
+> **`getMyReaction` là bắt buộc** — thiếu method này thì `toggleReact` không implement được đúng ([H2-FIX] trong spec).
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(reaction): FirebaseReactionRepository — upsert + delete + watch + getMyReaction**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/reaction-repository` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/reaction/data/firebase_reaction_repository.dart` — impl `ReactionRepository`
+- `test/features/reaction/firebase_reaction_repository_test.dart` — test: upsert creates doc với docId=reactorUid, upsert overwrite emoji, delete removes doc, getMyReaction returns null khi chưa react, watchReactions stream
+
+Acceptance criteria:
+- [ ] `upsertReaction(postId, uid, emoji)` dùng `Firestore.set()` với `docId = uid` (KHÔNG `add()`) — đảm bảo 1 reaction/user/post
+- [ ] Overwrite emoji: gọi `upsertReaction` lần 2 với emoji khác → field `emoji` cập nhật, `createdAt` cập nhật
+- [ ] `getMyReaction(postId, uid)` → query doc `/posts/{postId}/reactions/{uid}` — trả `null` nếu không tồn tại
+- [ ] `watchReactions(postId)` → realtime stream của toàn subcollection
+- [ ] `loadReactors(postId)` → list sort by `createdAt DESC` (controller method gọi `watchReactions` rồi sort — KHÔNG thêm method riêng vào abstract interface)
+
+Cross-module imports: None
+
+---
+**T2 · feat(reaction): ReactionController — toggleReact logic (react / un-react / change)**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/reaction-controller` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/reaction/application/reaction_controller.dart` — `ReactionState`, `toggleReact(postId, emoji)`, `watchReactions(postId)`, `loadReactors(postId)`
+- `test/features/reaction/reaction_controller_test.dart` — test: chưa react → tạo doc, react cùng emoji → xóa, react emoji khác → overwrite, double-tap lock, optimistic rollback khi fail
+
+Acceptance criteria:
+- [ ] `toggleReact`: `existing == null` → `upsertReaction`; `existing.emoji == emoji` → `deleteReaction` (un-react); `existing.emoji != emoji` → `upsertReaction` (change)
+- [ ] Optimistic update: count tăng/giảm ngay, emoji highlight ngay — rollback nếu Firestore fail
+- [ ] In-flight lock: tap thứ 2 bị bỏ qua khi request thứ 1 chưa resolve (tránh race condition)
+- [ ] Upsert fail → rollback optimistic + toast "Thả cảm xúc thất bại — thử lại"
+- [ ] Reaction count không hiển thị số âm: `max(0, count)`
+
+Cross-module imports: None
+
+---
+**T3 · feat(reaction): ActTextBar M3 — 3 preset emoji + count + optimistic update**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/reaction-act-text-bar` |
+| Blocked by | T2 |
+
+Files:
+- `lib/shared/widgets/app_act_text_bar.dart` — update M2 stub → M3: inject `ReactionController`, enable interactions
+- `lib/features/reaction/presentation/widgets/emoji_button.dart` — active/inactive states
+- `test/features/reaction/act_text_bar_test.dart` — widget tests: tap emoji → active state, tap active → inactive (un-react), count display đúng, EmojiPickerSheet mở khi tap smile-plus
+
+Acceptance criteria:
+- [ ] 3 quick emoji: light-blue-heart / 🤣 / 🥰 (Figma `472:2252`, nodes 501:1008/1009/1010)
+- [ ] Tap emoji → highlight active state + count tăng (optimistic)
+- [ ] Tap active emoji → un-highlight + count giảm (optimistic)
+- [ ] Tap smile-plus → `EmojiPickerSheet` bottom sheet
+- [ ] M2 behavior vẫn đúng khi `ReactionController` là null (no-op — backward compat)
+
+Cross-module imports: None (ActTextBar là shared widget, được dùng bởi `FriendPostCard` từ **home-camera-feed**)
+
+---
+**T4 · feat(reaction): EmojiPickerSheet + ReactionListSheet**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/reaction-sheets` |
+| Blocked by | T3 |
+
+Files:
+- `lib/features/reaction/presentation/emoji_picker_sheet.dart` — dùng `emoji_picker_flutter` package (MIT), no search MVP
+- `lib/features/reaction/presentation/reaction_list_sheet.dart` — list `[avatar] [displayName] [emoji]`, sort newest first. Tap avatar → `FriendProfileScreen` nếu là bạn bè
+- `test/features/reaction/reaction_list_sheet_test.dart` — widget tests: hiện đúng list, tap avatar → navigate
+
+Acceptance criteria:
+- [ ] `EmojiPickerSheet`: grid scroll, không có search (MVP), tap emoji → `toggleReact()` + sheet đóng
+- [ ] `ReactionListSheet`: trigger từ tap vùng count, list sort `createdAt DESC`
+- [ ] `emoji_picker_flutter` — package này cũng được dùng bởi **Space module** (không add 2 lần vào pubspec)
+- [ ] Tap avatar trong ReactionListSheet → navigate `FriendProfileScreen` (Profile module)
+
+Cross-module imports: `FriendProfileScreen` từ **profile**
+
+---
+**T5 · test(reaction): Firestore rules tests — reactions subcollection**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/reaction-rules` |
+| Blocked by | T1 |
+
+Files:
+- `firebase/functions/test/rules/reaction.rules.test.ts`
+
+Acceptance criteria:
+- [ ] `/posts/{postId}/reactions/{uid}`: create by owner (là author hoặc có feed doc) ✓, stranger ✗, uid mismatch ✗
+- [ ] `/posts/{postId}/reactions/{uid}`: update `emoji` + `createdAt` by owner ✓, update `reactorUid` field ✗
+- [ ] `/posts/{postId}/reactions/{uid}`: delete by owner ✓, stranger ✗
+- [ ] Read chỉ khi có quyền đọc post đó (author hoặc feed doc exists)
+
+Cross-module imports: None
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T2 → T3 → T4
+                              ↘
+                         T1 → T5 (parallel T2-T4)
+```
+
+---
+
+## PART 4 — Open questions
+
+| # | Câu hỏi | Status |
+|---|---|---|
+| OQ1 | Reaction count hiển thị ở đâu trong ActText bar? | ⏳ Pending Figma M3 frame — implement khi designer cung cấp; tạm thời count hiện bên cạnh emoji |

--- a/docs/plans/2026-05-23-settings.md
+++ b/docs/plans/2026-05-23-settings.md
@@ -1,0 +1,242 @@
+# Plan: Settings Module
+
+> **Phụ thuộc vào:** Auth — `AuthRepository.signOut()`, `reauthenticateWithCredential()`; Friend — `FriendRepository.unfriend()`, `Friendship` model; Notification — `NotificationRepository.deleteFcmToken()` (gọi khi logout)
+> **Được phụ thuộc bởi:** Chat (import `BlockRepository`), Home/Camera/Feed (import `BlockRepository` cho feed filter)
+> **Spec:** `docs/specs/2026-05-23-settings.md`
+> **Tier:** T0 (block/logout/delete) + T1 (widget setup) — Milestone M2/M3
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/settings/data/block.dart` | freezed model | `blockId String` (`{blockerUid}_{blockedUid}` — NOT sorted), `blockerUid String`, `blockedUid String`, `createdAt DateTime` |
+| `lib/features/settings/data/block_repository.dart` | abstract class — **canonical owner** | `Future<void> blockUser(String targetUid)` (gọi CF), `Future<void> unblockUser(String targetUid)` (client delete), `Stream<List<Block>> watchBlockedUsers()`, `Future<bool> isBlocked(String uid)` |
+| `lib/features/settings/application/settings_controller.dart` | Riverpod stub | `SettingsState`, methods: `copyProfileLink`, `shareProfile`, `logout`, `deleteAccount`, `getBlockedUsers` — throw `UnimplementedError` |
+| `lib/features/settings/presentation/settings_sheet.dart` | widget stub | SettingsSheet skeleton |
+| `lib/features/settings/presentation/blocked_accounts_page.dart` | widget stub | |
+| `lib/features/settings/presentation/block_confirm_dialog.dart` | widget stub | |
+| `lib/features/settings/presentation/logout_confirm_dialog.dart` | widget stub | |
+| `lib/features/settings/presentation/widget_confirm_sheet.dart` | widget stub | |
+| `lib/features/settings/presentation/delete_account_dialog.dart` | widget stub | |
+| `lib/shared/widgets/share_profile_sheet.dart` | **shared widget** — leader own | Title "Kết bạn với tôi trên Meep nhé!", URL `meep://profile/{username}`, copy + Messenger |
+| `firebase/functions/src/index.ts` | CF stubs | `blockUser` (HTTPS Callable), `deleteAccount` (HTTPS Callable) |
+| `firestore.rules` | rule helper | `function isBlocked(uid)` — check cả 2 chiều `blockId1` + `blockId2` |
+
+> `BlockRepository` là **canonical owner** của block logic. Chat module và Home/Camera/Feed module đều import interface này — KHÔNG tự define.
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(settings): FirebaseBlockRepository — blockUser + unblockUser + watchBlockedUsers + isBlocked**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/settings-block-repository` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/settings/data/firebase_block_repository.dart` — impl `BlockRepository`
+- `test/features/settings/firebase_block_repository_test.dart` — test cases: blockUser creates doc, unblockUser deletes doc, watchBlockedUsers stream, isBlocked cả 2 chiều
+
+Acceptance criteria:
+- [ ] `blockUser(targetUid)` gọi CF callable `blockUser` — KHÔNG write Firestore trực tiếp (CF Admin SDK bypass rules)
+- [ ] `unblockUser(targetUid)` xóa `/blocks/{currentUid}_{targetUid}` trực tiếp (client delete OK)
+- [ ] `isBlocked(uid)` check cả 2 chiều: tồn tại `/blocks/{me}_{uid}` OR `/blocks/{uid}_{me}` → true
+- [ ] `watchBlockedUsers()` query `where('blockerUid', isEqualTo, currentUid)` — chỉ list người mình block
+
+Cross-module imports: None
+
+---
+**T2 · feat(settings): SettingsSheet UI — header + quick actions + Space row + menu sections**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/settings-sheet-ui` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/settings/presentation/settings_sheet.dart` — full layout per spec (Figma `572:4183`)
+- `lib/features/settings/presentation/widgets/settings_header.dart` — avatar + username + copy link
+- `lib/features/settings/presentation/widgets/space_quick_row.dart` — horizontal scroll Space cards + "Tạo" button (mock pre-M3)
+- `lib/features/settings/presentation/terms_page.dart` — long-scroll static text
+- `lib/features/settings/presentation/privacy_policy_page.dart` — long-scroll static text
+- `lib/features/settings/presentation/privacy_data_page.dart` — static sub-page
+- `test/features/settings/settings_sheet_test.dart` — widget tests: tap avatar → sheet opens, tap Bạn bè → FriendSheet opens, tap Chia sẻ → ShareProfileSheet opens
+
+Acceptance criteria:
+- [ ] Settings sheet trigger: tap avatar góc phải topbar → SettingsSheet slide up
+- [ ] Tap "👥 N người bạn" → đóng SettingsSheet → mở FriendSheet
+- [ ] Tap "↗ Chia sẻ" → ShareProfileSheet với URL `meep://profile/{username}`
+- [ ] SpaceQuickRow pre-M3: mock card placeholder + tap "Tạo" → toast "Tính năng đang phát triển"
+- [ ] Tap "Thêm tiện ích" → mở WidgetConfirmSheet
+- [ ] Copy link → clipboard + toast "Đã sao chép liên kết" + AppConfig.shareBaseUrl không hardcode
+
+Cross-module imports: `FriendSheet` từ **friend** module
+
+---
+**T3 · feat(settings): SettingsController — logout + copy link + share**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/settings-controller` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/settings/application/settings_controller.dart` — `SettingsState`, impl: `logout()`, `copyProfileLink()`, `shareProfile()`
+- `test/features/settings/settings_controller_test.dart` — test: logout clears auth + navigates /intro, copyProfileLink đúng URL
+
+Acceptance criteria:
+- [ ] `logout()`: gọi `deleteFcmToken()` (Notification module) → `AuthRepository.signOut()` → clear SharedPreferences → `GoRouter.go('/intro')`
+- [ ] `copyProfileLink(username)` → clipboard = `meep://profile/{username}` (dùng `AppConfig.shareBaseUrl`)
+- [ ] `logout()` offline vẫn hoạt động (Firebase clears local session locally)
+
+Cross-module imports: `AuthRepository` từ **auth**, `NotificationRepository` từ **notification** (deleteFcmToken)
+
+---
+**T4 · feat(settings): BlockedAccountsPage + BlockConfirmDialog + block/unblock flow**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/settings-block-ui` |
+| Blocked by | T1, T2 |
+
+Files:
+- `lib/features/settings/presentation/blocked_accounts_page.dart` — list blocked users (Figma `572:4490`, `572:4839`)
+- `lib/features/settings/presentation/block_confirm_dialog.dart` — overlay (Figma `605:1991`) dùng từ `PhotoActionSheet` trong feed module
+- `lib/features/settings/presentation/widget_confirm_sheet.dart` — bottom sheet (Figma `662:3341`) + `requestPinAppWidget()` Android intent
+- `test/features/settings/blocked_accounts_page_test.dart` — widget tests: list hiện đúng, tap "Bỏ chặn" → confirm dialog
+
+Acceptance criteria:
+- [ ] `BlockedAccountsPage` load stream `watchBlockedUsers()` — list avatar + username + "Bỏ chặn" button
+- [ ] Tap "Bỏ chặn" → confirm dialog "Bỏ chặn {username}?" → [Xác nhận] → `unblockUser()` → user removed from list
+- [ ] `BlockConfirmDialog` (shared với Feed): hiện đúng title/body/note từ spec §Luồng Block user
+- [ ] Block success → button đổi sang "[Đã chặn!]" state (Figma `624:1906`)
+- [ ] Widget confirm sheet: tap [Thêm] → `requestPinAppWidget()` Android API → không có success callback → hiện instructional screen (Figma `693:2617`)
+
+Cross-module imports: Được dùng bởi **home-camera-feed** (`PhotoActionSheet` gọi `BlockConfirmDialog`)
+
+---
+**T5 · feat(settings): CF `blockUser` — atomic block + unfriend + conversation status**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/settings-cf-block` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `firebase/functions/src/settings/blockUser.ts` — HTTPS Callable
+- `firebase/functions/test/settings/blockUser.test.ts` — test: success, self-block guard, already blocked idempotent, unfriend side-effect, conversation status update
+
+Acceptance criteria:
+- [ ] Guard: `blockerUid != targetUid` (no self-block) → throw `INVALID_ARGUMENT` nếu same uid
+- [ ] Firestore batch (Admin SDK): create `/blocks/{blockerUid}_{targetUid}` + delete `/friendships/{pairId}` nếu tồn tại + update `/conversations/{pairId}.status = 'blocked'` nếu tồn tại
+- [ ] Deletion của friendship triggers `onFriendshipDeleted` CF (cross-feed cleanup handled there)
+- [ ] Idempotent: nếu block doc đã tồn tại → không throw, return success
+- [ ] Return `{ success: true }`
+
+Cross-module imports: None (Admin SDK)
+
+---
+**T6 · feat(settings): DeleteAccountDialog — step 1 + re-auth step 2**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/settings-delete-dialog` |
+| Blocked by | T3 |
+
+Files:
+- `lib/features/settings/presentation/delete_account_dialog.dart` — 2-step flow (Figma `572:4605` → re-auth inline)
+- `lib/features/settings/presentation/logout_confirm_dialog.dart` — single confirm dialog
+- `lib/features/settings/application/settings_controller.dart` — **update:** thêm `deleteAccount()` implementation gọi CF callable `deleteAccount`
+
+Acceptance criteria:
+- [ ] Step 1: confirm intent → [Xoá] → step 2
+- [ ] Step 2 email user: hiện password field inline
+- [ ] Step 2 Google user: trigger `reauthenticateWithCredential(GoogleAuthProvider)` (không hiện password field)
+- [ ] `FirebaseAuthException(code: 'requires-recent-login')` → hiện error inline, KHÔNG auto-dismiss dialog
+- [ ] Re-auth thành công → gọi `SettingsController.deleteAccount()` → navigate `/intro`
+
+Cross-module imports: `AuthRepository.reauthenticateWithCredential()` từ **auth**
+
+---
+**T7 · feat(settings): CF `deleteAccount` — cascade delete Storage + Firestore + Auth**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2-3 ngày) |
+| Branch | `feat/TBD/settings-cf-delete-account` |
+| Blocked by | T5 |
+
+Files:
+- `firebase/functions/src/settings/deleteAccount.ts` — HTTPS Callable
+- `firebase/functions/test/settings/deleteAccount.test.ts` — test: order đúng (subcollection trước document), idempotent gọi lần 2, Storage cleanup, Auth delete cuối cùng
+
+Acceptance criteria:
+- [ ] Thứ tự: Storage buckets → Firestore subcollections → Firestore documents → `admin.auth().deleteUser(uid)` (Auth xóa CUỐI CÙNG)
+- [ ] Storage (pagination 1000 files/batch): `posts/{uid}/**`, `avatars/{uid}/**`, `diary/{uid}/**`
+- [ ] Firestore (subcollection TRƯỚC document): `users/{uid}/feed/*` → `users/{uid}/notifications/*` → `users/{uid}/fcmTokens/*` → diary entries → posts → friendships → friend_requests → blocks → conversations (set status=deleted) → `/users/{uid}` → `/usernames/{username}`
+- [ ] Idempotent: check existence trước mỗi bước, skip nếu đã xóa (không crash khi gọi lần 2)
+- [ ] Nếu CF fail giữa chừng: Auth account vẫn còn → user có thể retry từ app (không throw trước khi deleteUser)
+
+Cross-module imports: None (Admin SDK)
+
+---
+**T8 · test(settings): Firestore rules tests + CF tests**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/settings-rules` |
+| Blocked by | T1, T5 |
+
+Files:
+- `firebase/functions/test/rules/settings.rules.test.ts`
+
+Acceptance criteria:
+- [ ] `/blocks/{id}`: blocker read ✓, blocked read ✓, stranger read ✗
+- [ ] `/blocks/{id}`: client create → ✗ (CF only, Admin SDK bypasses)
+- [ ] `/blocks/{id}`: blocker delete ✓, stranger delete ✗
+- [ ] `/blocks/{id}`: update → ✗
+- [ ] CF `blockUser`: self-block guard ✗, success flow ✓, already blocked idempotent ✓
+- [ ] CF `deleteAccount`: no re-auth → reject; cascade order đúng ✓; idempotent ✓
+
+Cross-module imports: None
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T3
+                ↘
+                  T2 → T4 (parallel T3)
+contracts Part 1 → T5 → T8
+                     ↘
+                  T3 → T6 → T7
+```
+
+T5 (CF blockUser) có thể start song song với T1 ngay sau contracts merge.
+
+---
+
+## PART 4 — Open questions
+
+Tất cả đã resolved trong spec (`docs/specs/2026-05-23-settings.md`). None blocking.

--- a/docs/plans/2026-05-23-space.md
+++ b/docs/plans/2026-05-23-space.md
@@ -1,0 +1,332 @@
+# Plan: Space Module
+
+> **Phụ thuộc vào:** Friend — `FriendRepository` (invite members từ friend list), `Friendship` model; Home/Camera/Feed — `PostRepository.createPost()` (thêm `spaceId` param), `FeedScreen` (thêm `spaceId` filter param), `Post` model (thêm `spaceId` field); Chat — `ConversationRepository` (group conversation tạo bởi CF `createSpace`)
+> **Được phụ thuộc bởi:** (Space là module cuối cùng trong dependency chain T0+)
+> **Spec:** `docs/specs/2026-05-23-space.md`
+> **Tier:** T0+ — Milestone M3
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/space/data/space.dart` | freezed model | `spaceId String`, `name String` (≤30), `iconEmoji String`, `colorHex String` (hex 7 chars), `creatorId String`, `memberCount int`, `memberIds List<String>` (≤10), `createdAt DateTime`, `deletedAt DateTime?` |
+| `lib/features/space/data/space_member.dart` | freezed model | `uid String`, `role SpaceRole` enum (creator/member), `joinedAt DateTime` |
+| `lib/features/space/data/space_repository.dart` | abstract class | `Stream<List<Space>> watchMySpaces(String uid)`, `Future<Space?> getSpace(String spaceId)`, `Future<void> deleteSpace(String spaceId)` |
+| `lib/features/space/application/space_controller.dart` | Riverpod stub | `SpaceState` (mySpaces, currentSpace, isLoading), methods throw `UnimplementedError` |
+| `lib/features/space/presentation/space_create_sheet.dart` | widget stub | 3-step bottom sheet |
+| `lib/features/space/presentation/space_context_bottom_sheet.dart` | widget stub | |
+| `lib/features/space/presentation/widgets/space_list_tile.dart` | widget stub | |
+| `lib/features/space/presentation/widgets/space_context_badge.dart` | widget stub | |
+| `lib/features/feed/data/post.dart` | **gate change** — leader only | Thêm `spaceId String?` field (nếu chưa có) |
+| `lib/features/feed/presentation/home_screen.dart` | **gate change** — leader only | `FeedScreen` nhận `spaceId` param |
+| `firebase/functions/src/index.ts` | CF stubs | `createSpace`, `leaveSpace`, `kickMember`, `transferOwnership`, `onSpaceMemberAdded`, `onSpaceMemberRemoved`, `onSpacePostCreated`, `onSpaceDeleted` |
+| `lib/core/router/app_router.dart` | update | Routes `/space/create`, `/space/:spaceId` |
+| `pubspec.yaml` | update | Thêm `emoji_picker_flutter` (MIT) |
+
+> **Gate change cảnh báo:** `Post` model và `FeedScreen` thuộc Feed module. Leader phải gate change này (merge to develop) trước khi Space dev start — không để Space dev tự sửa.
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(space): FirebaseSpaceRepository — watchMySpaces + getSpace + deleteSpace**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/space-repository` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `lib/features/space/data/firebase_space_repository.dart` — impl `SpaceRepository`
+- `test/features/space/firebase_space_repository_test.dart` — test: watchMySpaces arrayContains, getSpace, deleteSpace soft delete
+
+Acceptance criteria:
+- [ ] `watchMySpaces(uid)` query `/spaces` `.where('memberIds', arrayContains, uid)` filter `deletedAt == null` — 1 query duy nhất (denormalized memberIds)
+- [ ] `deleteSpace(spaceId)` soft delete: update `deletedAt = serverTimestamp()` — KHÔNG hard delete document
+- [ ] Client KHÔNG create `/spaces` trực tiếp (rule `create: if false`) — chỉ CF Admin SDK
+
+Cross-module imports: None
+
+---
+**T2 · feat(space): SpaceController — createSpace + loadMySpaces + leaveSpace + deleteSpace**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/space-controller` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/space/application/space_controller.dart` — `SpaceState`, full impl
+- `test/features/space/space_controller_test.dart` — test: createSpace validation, createSpace > 9 friends → error, leaveSpace creator without transfer → error, deleteSpace non-creator → error
+
+Acceptance criteria:
+- [ ] `createSpace(name, emoji, color, friendUids)`: validate `name.isNotEmpty`, `friendUids.isNotEmpty`, `friendUids.length ≤ 9` (creator + 9 = max 10) → gọi CF `createSpace`
+- [ ] `leaveSpace(spaceId)`: nếu là creator → throw `AppError("Chọn người quản trị mới trước")` — UI phải xử lý
+- [ ] `deleteSpace(spaceId)`: chỉ creator → update `spaces/{spaceId}.deletedAt = serverTimestamp()` (soft delete) → `onSpaceDeleted` CF tự trigger — non-creator → throw `AppError`
+- [ ] `loadMySpaces()` watch stream từ repository, filter soft-deleted
+
+Cross-module imports: None
+
+---
+**T3 · feat(space): SpaceCreateSheet — 3-step flow (FriendSelect + SpaceConfig + IconBuilder)**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2 ngày) |
+| Branch | `feat/TBD/space-create-sheet` |
+| Blocked by | T2 |
+
+Files:
+- `lib/features/space/presentation/space_create_sheet.dart` — 3-step bottom sheet flow
+- `lib/features/space/presentation/widgets/friend_select_step.dart` — search + checkbox list (Figma `269:1193`)
+- `lib/features/space/presentation/widgets/space_config_step.dart` — tên + 3×3 emoji preset grid (Figma `269:1257`)
+- `lib/features/space/presentation/widgets/icon_builder_step.dart` — `emoji_picker_flutter` + color preset (Figma `269:1334`, `596:1601`, `600:3498`)
+- `test/features/space/space_create_sheet_test.dart` — widget tests: "Tiếp tục" disabled khi 0 friend, "Hoàn tất" disabled khi name rỗng, emoji preset tap → selected, back gesture về step trước
+
+Acceptance criteria:
+- [ ] Step 1: search friends, checkbox select, "Tiếp tục" disabled khi 0 chọn; tối đa 9 friends (10 bao gồm creator)
+- [ ] Step 2: preset 8 emoji + 1 "+" button (Figma `269:1257`); "Hoàn tất" disabled khi name rỗng; loading spinner thay button khi tạo
+- [ ] Step 3 (từ "+"): `emoji_picker_flutter` tab + color preset grid (KHÔNG custom hex) → "Xong" → về Step 2 với icon mới
+- [ ] Back gesture Step 2 → Step 1 giữ friends đã chọn
+- [ ] Back gesture Step 3 → Step 2 bỏ thay đổi icon
+- [ ] Create success → đóng sheet, navigate Feed per Space mới tạo
+
+Cross-module imports: `FriendRepository.watchFriends()` từ **friend**
+
+---
+**T4 · feat(space): SpaceContextBottomSheet + Camera context switch + SpaceContextBadge**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/space-camera-context` |
+| Blocked by | T2, T3 |
+
+Files:
+- `lib/features/space/presentation/space_context_bottom_sheet.dart` — list Spaces + "All friends" option
+- `lib/features/space/presentation/widgets/space_context_badge.dart` — "Đang gửi: [SpaceName]" badge topbar
+- `lib/features/feed/presentation/widgets/camera_section.dart` — update: long-press FriendsButton → SpaceContextBottomSheet; viền viewfinder + nút chụp đổi màu theo `colorHex`
+
+Acceptance criteria:
+- [ ] Long-press FriendsButton camera topbar → `SpaceContextBottomSheet` (khác với tap FriendsButton = FriendSheet)
+- [ ] Chọn Space → Camera UI: viền viewfinder = `colorHex`, nút chụp = `colorHex`, badge "Đang gửi: [SpaceName]" hiện
+- [ ] Chọn "All friends" → reset Camera về mặc định, badge ẩn
+- [ ] Badge luôn visible khi đang trong Space context (nhắc nhở user tránh gửi nhầm)
+
+Cross-module imports: `AppCameraController` từ **home-camera-feed** (update selectedSpaceId state)
+
+---
+**T5 · feat(space): Feed per Space (FeedFilter.space + FeedScreen spaceId param)**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/space-feed` |
+| Blocked by | T4 |
+
+Files:
+- `lib/features/feed/application/feed_controller.dart` — update: `FeedFilter.space(spaceId)` → `.where('spaceId', isEqualTo, spaceId)` trên feed subcollection
+- `lib/features/feed/presentation/home_screen.dart` — update: nhận optional `spaceId` param
+
+Acceptance criteria:
+- [ ] `FeedFilter.space(spaceId)` query `/users/{uid}/feed WHERE spaceId == spaceId` ORDER BY `createdAt DESC`
+- [ ] Feed subcollection docs phải có `spaceId` field (xem Feed module T9 — CF `onPostCreated`)
+- [ ] Navigate từ Space context → `FeedScreen(spaceId: spaceId)` hiện đúng Space posts
+- [ ] **Leader gate change** — file thuộc Feed module, Space dev KHÔNG tự sửa mà phải qua leader
+
+Cross-module imports: `FeedController` từ **home-camera-feed**
+
+---
+**T6 · feat(space): CF `createSpace` — batch create /spaces + /space_members + group conversation**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/space-cf-create` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `firebase/functions/src/space/createSpace.ts` — HTTPS Callable
+- `firebase/functions/test/space/createSpace.test.ts` — test: success flow, > 9 members → error, empty name → error, batch atomic
+
+Acceptance criteria:
+- [ ] Validate: `name.isNotEmpty`, `memberUids.length + 1 ≤ 10` (creator + members)
+- [ ] Firestore batch (Admin SDK): create `/spaces/{spaceId}` + create `/space_members/{spaceId}/members/{uid}` cho tất cả members (kể cả creator) + create `/conversations/{spaceId}` (type=space, participantIds=memberIds)
+- [ ] `memberIds` array và `space_members` subcollection được sync (cả 2 trong cùng batch)
+- [ ] `memberCount` = `memberUids.length + 1` (creator included)
+- [ ] Return `{ success: true, spaceId: string }`
+
+Cross-module imports: None (Admin SDK)
+
+---
+**T7 · feat(space): CF `leaveSpace` + `kickMember` + `transferOwnership`**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/space-cf-member-management` |
+| Blocked by | T6 |
+
+Files:
+- `firebase/functions/src/space/leaveSpace.ts` — HTTPS Callable
+- `firebase/functions/src/space/kickMember.ts` — HTTPS Callable (creator only)
+- `firebase/functions/src/space/transferOwnership.ts` — HTTPS Callable (creator only)
+- `firebase/functions/test/space/memberManagement.test.ts` — test: leaveSpace removes member, creator leave without transfer → error, kickMember non-creator → error, transferOwnership updates roles
+
+Acceptance criteria:
+- [ ] `leaveSpace`: xóa `/space_members/{spaceId}/members/{uid}` + update `spaces/{spaceId}.memberIds` (atomic batch); creator với `role == 'creator'` → throw error (phải transfer trước)
+- [ ] `kickMember`: chỉ `creatorId == caller.uid`; xóa member tương tự leaveSpace
+- [ ] `transferOwnership`: update `space_members/{spaceId}/members/{newUid}.role = 'creator'` + `{oldUid}.role = 'member'` + `spaces/{spaceId}.creatorId = newUid` (atomic batch)
+- [ ] Không cho phép kick creator (guard: `targetUid != space.creatorId`)
+
+Cross-module imports: None
+
+---
+**T8 · feat(space): CF `onSpaceMemberAdded` + `onSpaceMemberRemoved`**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/space-cf-member-triggers` |
+| Blocked by | T7 |
+
+Files:
+- `firebase/functions/src/space/onSpaceMemberAdded.ts` — Firestore onCreate `/space_members/{spaceId}/members/{uid}`
+- `firebase/functions/src/space/onSpaceMemberRemoved.ts` — Firestore onDelete
+
+Acceptance criteria:
+- [ ] `onSpaceMemberAdded`: increment `memberCount` trên `/spaces/{spaceId}` + increment `spaceCount` trên `/users/{uid}`
+- [ ] `onSpaceMemberRemoved`: decrement `memberCount` + decrement `spaceCount`
+- [ ] Idempotent: dùng transaction để tránh double-count
+
+Cross-module imports: None
+
+---
+**T9 · feat(space): CF `onSpacePostCreated` — FCM fan-out to Space members**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/space-cf-post-created` |
+| Blocked by | T6 |
+
+Files:
+- `firebase/functions/src/space/onSpacePostCreated.ts` — Firestore onCreate `/posts/{postId}` WHERE `spaceId != null`
+
+Acceptance criteria:
+- [ ] Trigger chỉ khi `post.spaceId != null` (guard ở đầu function)
+- [ ] Đọc `/space_members/{spaceId}/members/*` → lấy tất cả member uids
+- [ ] Gửi FCM cho tất cả members (đọc `/users/{uid}/fcmTokens`) — KHÔNG bao gồm author (guard: `uid != authorId`)
+- [ ] Fan-out feed: ghi `/users/{uid}/feed/{postId}` cho tất cả Space members (kể cả author) với `spaceId` field — **đây là nguồn duy nhất fan-out cho Space posts** (Feed module `onPostCreated` skip khi `spaceId != null`)
+
+> **Note:** FCM token schema (`/users/{uid}/fcmTokens`) được owned bởi **Notification module** — Space CF chỉ đọc, không write.  
+> **Phân chia rõ ràng với Feed `onPostCreated`:** `onPostCreated` skip khi `spaceId != null`; `onSpacePostCreated` xử lý toàn bộ fan-out (feed + FCM) cho Space posts.
+
+Cross-module imports: None (Admin SDK, đọc schema từ Notification module)
+
+---
+**T10 · feat(space): CF `onSpaceDeleted` — cleanup space_members + conversation + posts**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/space-cf-deleted` |
+| Blocked by | T9 |
+
+Files:
+- `firebase/functions/src/space/onSpaceDeleted.ts` — Firestore onUpdate `/spaces/{spaceId}` WHERE `deletedAt != null`
+
+Acceptance criteria:
+- [ ] Trigger khi `deletedAt` chuyển từ null → timestamp (guard: `before.deletedAt == null && after.deletedAt != null`)
+- [ ] Xóa tất cả `/space_members/{spaceId}/members/*`
+- [ ] Update `/conversations/{spaceId}.status = 'deleted'` (không xóa — giữ lịch sử)
+- [ ] Posts của Space vẫn tồn tại trong `/posts` (không xóa) — chỉ ẩn khỏi feed vì `spaceId` không còn accessible
+
+Cross-module imports: None
+
+---
+**T10b · feat(space): SpaceManagementSheet — Leave / Delete / Kick / Transfer UI**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/space-management-ui` |
+| Blocked by | T7 (CFs đã có), T5 (FeedScreen với spaceId context) |
+
+Files:
+- `lib/features/space/presentation/space_management_sheet.dart` — bottom sheet trigger từ `...` icon khi trong Space context (FeedScreen + spaceId)
+- `lib/features/space/presentation/widgets/leave_space_dialog.dart` — dialog confirm (member thường) + dialog chọn creator mới (nếu là creator)
+- `lib/features/space/presentation/widgets/kick_member_dialog.dart` — list members + confirm kick (chỉ creator thấy)
+- `lib/features/space/presentation/widgets/delete_space_dialog.dart` — confirm xóa Space (chỉ creator)
+
+Acceptance criteria:
+- [ ] `...` icon hiện trên FeedScreen khi `spaceId != null` → mở `SpaceManagementSheet`
+- [ ] Member thường: chỉ thấy [Rời khỏi Space] → `LeaveSpaceDialog` → confirm → `SpaceController.leaveSpace()`
+- [ ] Creator: thấy [Rời khỏi Space] + [Xóa Space] + [Kick thành viên]
+- [ ] Creator leave: dialog yêu cầu chọn creator mới trước → `SpaceController.transferOwnership()` → rồi mới `leaveSpace()`
+- [ ] Creator delete: confirm dialog → `SpaceController.deleteSpace()` (soft delete) → navigate về Camera
+- [ ] Kick member: list members (trừ bản thân) → chọn → confirm → CF `kickMember(spaceId, targetUid)`
+
+Cross-module imports: None
+
+---
+**T11 · test(space): Firestore rules tests**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/space-rules` |
+| Blocked by | T1 |
+
+Files:
+- `firebase/functions/test/rules/space.rules.test.ts`
+
+Acceptance criteria:
+- [ ] `/spaces/{id}`: member read ✓, non-member read ✗, unauthenticated ✗
+- [ ] `/spaces/{id}`: client create → ✗ (CF only); creator update ✓; member update ✗
+- [ ] `/space_members/{id}/members/{uid}`: member read ✓; client create/delete → ✗ (CF only)
+- [ ] `/posts/{id}` với spaceId: Space member read ✓, non-member ✗
+
+Cross-module imports: `isMember(spaceId)` helper, `isCreator(spaceId)` helper từ spec §Security
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T2 → T3 → T4 → T5 → T10b
+contracts Part 1 → T6 → T7 → T8
+                        ↘
+                   T6 → T9 → T10 → T10b → T11
+```
+
+T6 (CF createSpace) có thể chạy song song với T1-T2 (Flutter data layer) ngay sau contracts.  
+T10b (management UI) cần T7 (CFs) và T5 (FeedScreen Space context) xong trước.
+
+---
+
+## PART 4 — Open questions
+
+Tất cả đã resolved trong spec (`docs/specs/2026-05-23-space.md`). None blocking.
+
+> **Gate changes trước khi Space dev start:**  
+> 1. Leader thêm `spaceId String?` vào `Post` model (`lib/features/feed/data/post.dart`)  
+> 2. Leader thêm `spaceId` param vào `FeedScreen` và update `FeedController` để hỗ trợ `FeedFilter.space(spaceId)`  
+> 3. Leader confirm `emoji_picker_flutter` package đã có trong `pubspec.yaml` (cũng dùng bởi Reaction module)

--- a/docs/plans/2026-05-23-streak.md
+++ b/docs/plans/2026-05-23-streak.md
@@ -1,0 +1,148 @@
+# Plan: Streak / Kỷ niệm Module
+
+> **Phụ thuộc vào:** Home/Camera/Feed — `Post` model, `PostRepository` abstract interface (reuse), `ShareModal` widget (reuse)
+> **Được phụ thuộc bởi:** (không có module nào phụ thuộc Streak)
+> **Spec:** `docs/specs/2026-05-22-streak.md`
+> **Tier:** T1 Stretch — unlock sau retro 13/5 + 27/5
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `lib/features/streak/application/streak_controller.dart` | Riverpod stub | `StreakState` (monthPosts, allPostDates, viewingMonth, currentStreak, totalMoments, isLoading), methods throw `UnimplementedError` |
+| `lib/features/streak/presentation/streak_screen.dart` | widget stub | Calendar screen skeleton |
+| `lib/features/streak/presentation/streak_photo_detail_screen.dart` | widget stub | Photo detail skeleton |
+| `lib/core/router/app_router.dart` | update | Routes `/streak`, `/streak/photo/:postId` |
+
+> **Reuse** (không tạo lại): `PostRepository` từ `lib/features/feed/data/post_repository.dart`, `Post` model từ `lib/features/feed/data/post.dart`, `ShareModal` từ `lib/shared/widgets/share_modal.dart`.
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(streak): StreakController — loadMonth + loadAllPostDates + calculateStreak (timezone-aware)**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/streak-controller` |
+| Blocked by | contracts Part 1, Feed module T1 (PostRepository) |
+
+Files:
+- `lib/features/streak/application/streak_controller.dart` — full impl
+- `test/features/streak/streak_controller_test.dart` — test cases: calculateStreak 3 consecutive days → 3, gap → reset to 1, empty → 0, timezone UTC→UTC+7 không drift, loadMonth trả đúng posts, loadAllPostDates cache
+
+Acceptance criteria:
+- [ ] `loadMonth(month)` query `/posts WHERE authorId == currentUid AND createdAt >= startOfMonth AND createdAt < startOfNextMonth ORDER BY createdAt ASC`
+- [ ] `loadAllPostDates()` cache kết quả trong controller, chỉ re-fetch khi mở màn (không watch realtime)
+- [ ] **Timezone contract:** convert `createdAt.toDate().toLocal()` trước khi tính `dayKey = DateTime(y, m, d)` — không dùng UTC trực tiếp
+- [ ] `calculateStreak(List<DateTime> allPostDates)`: đếm ngày liên tiếp từ hôm nay trở về; 1 ngày miss → streak = 0; tính theo local timezone
+- [ ] `calculateStreak([today, yesterday, 2d ago])` → 3; `calculateStreak([today, 3d ago])` → 1; `calculateStreak([])` → 0
+- [ ] Pill stats: `totalMoments = allPosts.length` (toàn bộ lịch sử, không reset khi swipe tháng)
+- [ ] Swipe tháng → chỉ `viewingMonth` thay đổi, `currentStreak` + `totalMoments` giữ nguyên
+
+Cross-module imports: `PostRepository` từ **home-camera-feed** (`lib/features/feed/data/post_repository.dart`)
+
+---
+**T2 · feat(streak): StreakScreen — custom calendar grid + StreakStatsPill**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | L (2 ngày) |
+| Branch | `feat/TBD/streak-calendar-ui` |
+| Blocked by | T1 |
+
+Files:
+- `lib/features/streak/presentation/streak_screen.dart` — full impl (Figma `269:1983`)
+- `lib/features/streak/presentation/widgets/streak_calendar.dart` — custom `GridView` 7 columns (CN-T7), glassmorphism ô sáng
+- `lib/features/streak/presentation/widgets/calendar_day_cell.dart` — sáng (blur glassmorphism) / tối (mờ) / hôm nay (outlined)
+- `lib/features/streak/presentation/widgets/streak_stats_pill.dart` — `"[N] Khoảnh khắc | [Xd] chuỗi"`
+- `test/features/streak/streak_calendar_test.dart` — widget tests: ngày có post → ô sáng, ngày không có → ô tối, swipe phải → tháng cũ, swipe trái capped tại tháng hiện tại, tap ngày → navigate PhotoDetail
+
+Acceptance criteria:
+- [ ] Custom `GridView` — KHÔNG dùng `table_calendar` package (spec chỉ định custom)
+- [ ] Header: `"tháng MM YYYY"` (center) + avatar (góc phải)
+- [ ] Ngày có post → ô sáng (blur glassmorphism); ngày không có → ô tối (mờ); hôm nay → outline highlight
+- [ ] Swipe phải→trái = tháng cũ hơn (không giới hạn); swipe trái→phải = tháng mới hơn (capped tại tháng hiện tại, bounce animation)
+- [ ] Empty state (tháng không có post): toàn ô tối + subtitle "Chưa có khoảnh khắc nào trong tháng này"
+- [ ] Empty state (chưa bao giờ post): subtitle "Gửi khoảnh khắc đầu tiên của bạn tại Meep !"
+- [ ] Tap ô sáng → navigate `StreakPhotoDetailScreen`
+
+Cross-module imports: None
+
+---
+**T3 · feat(streak): StreakPhotoDetailScreen — carousel + thumbnail strip + share modal reuse**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/streak-photo-detail` |
+| Blocked by | T2 |
+
+Files:
+- `lib/features/streak/presentation/streak_photo_detail_screen.dart` — full impl (Figma `630:1923`)
+- `lib/features/streak/presentation/widgets/streak_photo_carousel.dart` — swipe carousel trong tháng đang xem
+- `lib/features/streak/presentation/widgets/streak_thumbnail_strip.dart` — horizontal scroll, active = 60×60 + outline turquoise
+- `test/features/streak/streak_photo_detail_test.dart` — widget tests: swipe cuối tháng → bounce, thumbnail active = enlarged, share modal mở, nút Xoá chỉ hiện khi isAuthor
+
+Acceptance criteria:
+- [ ] Topbar: `[X close] [Ngày M tháng D] [share icon]`
+- [ ] Carousel 350×350, cornerRadius 50: swipe phải→trái = ngày cũ hơn; swipe trái→phải = ngày mới hơn (trong tháng đang xem)
+- [ ] Swipe quá ngày đầu/cuối tháng → bounce nhẹ, KHÔNG jump sang tháng khác
+- [ ] Note pill (caption nếu có) + Tag (giờ đăng "HH:mm")
+- [ ] Thumbnail strip: ảnh của tháng hiện tại, thứ tự trái = cũ nhất; active = 60×60 + outline `#00DEEE`; inactive = 50×50
+- [ ] Tap share icon → `ShareModal` (reuse từ Feed module); [Xoá] chỉ hiện khi `post.authorId == currentUid`
+- [ ] Xoá thành công → pop modal + pop PhotoDetail → Calendar (ô ngày đó tắt sáng)
+
+Cross-module imports: `ShareModal` từ **home-camera-feed** (`lib/shared/widgets/share_modal.dart`), `PostController.deletePost()` từ **home-camera-feed**
+
+---
+**T4 · test(streak): StreakController unit tests — edge cases bổ sung**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/streak-tests` |
+| Blocked by | T1 |
+
+Files:
+- `test/features/streak/streak_controller_test.dart` — **extend** file đã tạo ở T1, thêm edge cases
+
+Acceptance criteria:
+- [ ] `calculateStreak([today])` → 1
+- [ ] `calculateStreak([today, yesterday, 2d ago])` → 3
+- [ ] `calculateStreak([today, 3d ago])` → 1 (gap ở 2d ago, 1d ago → streak đứt)
+- [ ] `calculateStreak([])` → 0
+- [ ] Timezone: post lúc 23:00 UTC = `2026-05-22T23:00Z` → UTC+7 = `2026-05-23T06:00+07:00` → ngày local là 23/5 (không drift)
+- [ ] `loadMonth` tháng không có post → trả `[]`, không crash
+- [ ] Pill stats không thay đổi khi swipe tháng
+
+Cross-module imports: `PostRepository` từ **home-camera-feed**
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T2 → T3
+                   ↘
+              T1 → T4 (parallel T2)
+```
+
+T4 (tests) có thể chạy song song với T2 ngay sau T1 xong.
+
+---
+
+## PART 4 — Open questions
+
+Tất cả đã resolved trong spec (`docs/specs/2026-05-22-streak.md`). None blocking.
+
+> **T1 Stretch note:** Streak bắt đầu sau khi team confirm unlock (retro 13/5 đã qua, retro 27/5 upcoming). Contacts Part 1 chỉ cần merge sau retro 27/5 confirm.  
+> Streak KHÔNG có Firestore collection riêng — hoàn toàn read-only từ `/posts`. Không cần Firestore rules mới.

--- a/docs/plans/2026-05-23-widget-android.md
+++ b/docs/plans/2026-05-23-widget-android.md
@@ -1,0 +1,186 @@
+# Plan: Widget Android Module
+
+> **Phụ thuộc vào:** Home/Camera/Feed — `/users/{uid}/feed` subcollection schema (fan-out, query từ Kotlin WorkManager); Auth — `FirebaseAuth` (token check trong Worker, không lưu vào SharedPreferences)
+> **Được phụ thuộc bởi:** Settings (WidgetConfirmSheet trigger → `requestPinAppWidget()`)
+> **Spec:** `docs/specs/2026-05-23-widget-android.md`
+> **Tier:** T0 — Milestone M3 · Android only
+
+---
+
+## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
+
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| `android/app/src/main/kotlin/.../MeepWidget.kt` | AppWidgetProvider stub | Skeleton class, `onUpdate()` throws unimplemented |
+| `android/app/src/main/kotlin/.../WidgetSyncWorker.kt` | Worker stub | `doWork()` returns `Result.success()` immediately |
+| `android/app/src/main/res/layout/meep_widget.xml` | RemoteViews layout stub | Placeholder text only |
+| `android/app/src/main/res/xml/meep_widget_info.xml` | AppWidget metadata | `minWidth/minHeight = 2×2`, `updatePeriodMillis = 1800000` (30 phút — Android thực ra cap ở 30 phút, không 15 phút) |
+| `android/app/src/main/AndroidManifest.xml` | update | Khai báo widget receiver + WorkManager |
+| `lib/features/widget/application/widget_data_service.dart` | Flutter service stub | `updateWidgetData({postId, imageUrl, authorName})` → throws unimplemented |
+| `lib/core/router/app_router.dart` | update | Handle intent extras `action: OPEN_POST, postId: ...` từ widget tap |
+
+> **Lưu ý Android WorkManager:** Minimum interval = 15 phút nhưng Android thường defer. Widget có thể stale tối đa 30+ phút trên devices tiết kiệm pin (Doze mode). Đây là known limitation, document trong README.
+
+---
+
+## PART 2 — Tasks
+
+---
+**T1 · feat(widget): Android widget layout + AppWidget metadata + AndroidManifest**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/widget-android-layout` |
+| Blocked by | contracts Part 1 |
+
+Files:
+- `android/app/src/main/res/layout/meep_widget.xml` — RemoteViews layout: `RelativeLayout` → `ImageView` (ảnh 2×2) + `TextView` (authorName) + placeholder state
+- `android/app/src/main/res/xml/meep_widget_info.xml` — metadata: minWidth 250dp, minHeight 250dp, `previewImage`, `updatePeriodMillis`
+- `android/app/src/main/AndroidManifest.xml` — update: `<receiver android:name=".MeepWidget">` với intent filter + `<meta-data android:name="android.appwidget.provider">`
+
+Acceptance criteria:
+- [ ] Widget 2×2 cells → khai báo đúng `minWidth/minHeight` trong `appwidget-provider` XML
+- [ ] `meep_widget.xml` có 2 states: normal (ImageView + TextView) + placeholder (Meep logo + "Mở Meep để bắt đầu")
+- [ ] Widget khai báo trong `AndroidManifest.xml` với đúng `ACTION_APPWIDGET_UPDATE` intent filter
+- [ ] WorkManager dependency trong `android/app/build.gradle`: `androidx.work:work-runtime-ktx`
+- [ ] Glide dependency trong `build.gradle`: `com.github.bumptech.glide:glide` (hoặc Coil nếu đã có)
+
+Cross-module imports: None
+
+---
+**T2 · feat(widget): MeepWidget.kt — AppWidgetProvider + RemoteViews render + placeholder**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/widget-android-provider` |
+| Blocked by | T1 |
+
+Files:
+- `android/app/src/main/kotlin/.../MeepWidget.kt` — full `AppWidgetProvider`
+- `android/app/src/main/kotlin/.../WidgetDataStore.kt` — helper đọc `SharedPreferences` (widget_post_id, widget_image_url, widget_author_name)
+
+Acceptance criteria:
+- [ ] `onUpdate()`: đọc `SharedPreferences` → nếu có data → render ảnh + authorName; nếu không có → render placeholder
+- [ ] `updateWidget(context, postId, imageUrl, authorName)` static method: Glide load `imageUrl` → Bitmap → `RemoteViews.setImageViewBitmap()` → `AppWidgetManager.updateAppWidget()`
+- [ ] Placeholder state: Meep logo + "Mở Meep để bắt đầu" text (khi `imageUrl == null` hoặc chưa login)
+- [ ] `AppWidgetManager.updateAppWidget(appWidgetIds, views)` — update tất cả instances đồng thời (nhiều widget trên home screen)
+
+Cross-module imports: None (Kotlin native)
+
+---
+**T3 · feat(widget): WidgetSyncWorker.kt — auth check + Firestore query + Glide + RemoteViews update**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | M (~8h) |
+| Branch | `feat/TBD/widget-sync-worker` |
+| Blocked by | T2 |
+
+Files:
+- `android/app/src/main/kotlin/.../WidgetSyncWorker.kt` — `CoroutineWorker`, `PeriodicWorkRequest`
+- Cần register WorkManager trong `Application.onCreate()` hoặc Flutter plugin initialization
+
+Acceptance criteria:
+- [ ] **[H7] Auth token KHÔNG lưu SharedPreferences** — Worker gọi `FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()` mỗi lần chạy; nếu `currentUser == null` → update placeholder, return `Result.success()`
+- [ ] Query Firestore (Kotlin): `/users/{currentUid}/feed` ORDER BY `createdAt DESC` LIMIT 1 → lấy `postId` → fetch `/posts/{postId}` → lấy `imageUrl`
+- [ ] Glide download `imageUrl` → cache vào app's files directory → `MeepWidget.updateWidget()` với Bitmap
+- [ ] Network fail → giữ Glide cached image cũ (không crash, không clear widget)
+- [ ] `WorkManager.enqueueUniquePeriodicWork("widget_sync", KEEP, PeriodicWorkRequest)` — không duplicate worker
+
+Cross-module imports: None (Kotlin native + Firebase SDK cho Android)
+
+---
+**T4 · feat(widget): Deep link tap — PendingIntent + MainActivity + MethodChannel + GoRouter**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/widget-deep-link` |
+| Blocked by | T2 |
+
+Files:
+- `android/app/src/main/kotlin/.../MeepWidget.kt` — update: `setOnClickPendingIntent()` với extras `action=OPEN_POST, postId=...`
+- `android/app/src/main/kotlin/.../MainActivity.kt` — update: handle `intent.action == "OPEN_POST"` → call `MethodChannel` với `postId`
+- `lib/core/router/app_router.dart` — update: handle method channel call → `GoRouter.go('/feed?highlight=$postId')`
+
+Acceptance criteria:
+- [ ] Tap widget → `PendingIntent` với `Intent(context, MainActivity::class.java).putExtra("action", "OPEN_POST").putExtra("postId", postId)`
+- [ ] `MainActivity.onNewIntent()` override: xử lý cả foreground + background app resume
+- [ ] `MethodChannel("meep/widget")` Flutter side nhận `postId` → `GoRouter.go('/feed?highlight=$postId')`
+- [ ] Post đã xóa → navigate Home + toast "Khoảnh khắc này không còn tồn tại"
+- [ ] Widget tap khi `postId == null` (placeholder state) → mở app tại Home
+
+Cross-module imports: `FeedController` từ **home-camera-feed** (scroll đến postId)
+
+---
+**T5 · feat(widget): WidgetDataService (Flutter) — SharedPreferences write + trigger update**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `feat/TBD/widget-data-service` |
+| Blocked by | T4 |
+
+Files:
+- `lib/features/widget/application/widget_data_service.dart` — full impl
+- Gọi `updateWidgetData()` từ `FeedController` sau mỗi lần fetch feed mới
+
+Acceptance criteria:
+- [ ] `updateWidgetData({latestPostId, latestImageUrl, authorName})`: lưu 3 keys vào `SharedPreferences` + gọi `MethodChannel("meep/widget").invokeMethod("updateWidget")`
+- [ ] `MethodChannel` trigger Kotlin side → `MeepWidget.onUpdate()` → re-render
+- [ ] User logout → `WidgetDataService.clearWidgetData()` → SharedPreferences xóa tất cả widget keys → widget hiện placeholder
+- [ ] `shared_preferences` package đã có (cũng dùng bởi Profile notification toggle — không add 2 lần)
+
+Cross-module imports: `FeedController` từ **home-camera-feed** (gọi `updateWidgetData` sau fetch)
+
+---
+**T6 · test(widget): Kotlin unit tests + manual smoke test checklist**
+
+| | |
+|---|---|
+| Assignee | TBD |
+| Estimate | S (~4h) |
+| Branch | `test/TBD/widget-tests` |
+| Blocked by | T3 |
+
+Files:
+- `android/app/src/test/kotlin/.../WidgetSyncWorkerTest.kt` — JUnit + Robolectric (hoặc mock)
+- `docs/plans/widget-smoke-tests.md` — manual test checklist
+
+Acceptance criteria:
+- [ ] `WidgetSyncWorker` không có token → return `Result.success()`, không crash, không throw
+- [ ] `WidgetSyncWorker` có token → mock Firestore → `MeepWidget.updateWidget()` được gọi với đúng data
+- [ ] Manual smoke: widget thêm được vào home screen từ Android widget picker ✓
+- [ ] Manual smoke: widget hiện ảnh mới nhất sau khi đăng ảnh từ app ✓
+- [ ] Manual smoke: tap widget → app mở đúng post ✓
+- [ ] Manual smoke: widget hiện placeholder khi logout ✓
+
+Cross-module imports: None
+
+---
+
+## PART 3 — Dependency graph
+
+```
+contracts Part 1 → T1 → T2 → T3 → T6
+                      ↘
+                   T2 → T4 (parallel T3) → T5
+```
+
+T3 (Worker) và T4 (Deep link) có thể chạy song song sau T2 (AppWidgetProvider) xong.
+
+---
+
+## PART 4 — Open questions
+
+| # | Câu hỏi | Status |
+|---|---|---|
+| OQ1 | `workmanager` Flutter plugin hay native WorkManager? | ✅ **Native WorkManager** (Kotlin) — tránh thêm plugin, logic đơn giản |
+| OQ2 | Glide hay Coil? | Nếu project đã có Coil trong Android deps → dùng Coil để tránh duplicate. Kiểm tra `build.gradle` trước khi add Glide |

--- a/docs/specs/2026-05-04-auth.md
+++ b/docs/specs/2026-05-04-auth.md
@@ -1,8 +1,9 @@
 # Spec: Auth — Đăng ký + Đăng nhập + Auto-login
 
-**Date:** 2026-05-04
-**Status:** Draft
-**Owner:** ThienPDM
+**Date:** 2026-05-04  
+**Cập nhật:** 2026-05-22 (chốt sau review Figma thực tế)  
+**Status:** Chốt v22/05  
+**Owner:** ThienPDM  
 **Epic:** [T0] Auth — Issue #1 · Milestone M1 (2026-05-13)
 
 ---
@@ -27,15 +28,15 @@ Cho phép user tạo tài khoản, đăng nhập (email/password hoặc Google),
 
 ### In-scope (MVP)
 
-1. **Intro screen** — 2 CTA: "Tạo tài khoản mới" / "Đăng nhập". Acceptance: navigate đúng route.
+1. **Intro screen** (Figma `556:2136`) — tagline + logo + 2 CTA: "Tạo tài khoản mới" / "Đăng nhập". Acceptance: navigate đúng route.
 2. **Signup email/password — 4 screens:**
-   - Screen 1: Nhập email — title "Email của bạn là gì?", field "Địa chỉ email", divider "Hoặc", button "Tiếp tục với Google"
-   - Screen 2: Nhập password — title "Chọn một mật khẩu", hint pill "Mật khẩu của bạn phải dài tối thiểu 8 ký tự" (≥8 ký tự)
-   - Screen 3: Họ + Tên — title "Tên bạn là gì?", 2 field "Họ" / "Tên", không empty
-   - Screen 4: Username — title "Chọn tên người dùng của bạn", hint pill "Việc này sẽ giúp bạn kết nối bạn bè nhanh chóng.", available indicator "Tuyệt vời! ✓", nút "Tiếp tục" disabled khi chưa available
+   - Screen 1: Nhập email (`269:1441`) — title "Email của bạn là gì?", field "Địa chỉ email", divider "hoặc", button "Tiếp tục với Google"
+   - Screen 2: Nhập password (`269:1487`) — title "Chọn một mật khẩu", ≥8 ký tự
+   - Screen 3: Họ và tên (`269:1530`) — title "Nhập họ và tên của bạn", **1 field duy nhất** "Họ và tên" → lưu vào `displayName`, không empty, min 2 ký tự
+   - Screen 4: Username (`269:1501` empty / `269:1515` valid) — title "Chọn tên người dùng của bạn", hint pill, available indicator "Tuyệt vời! ✓", nút disabled khi chưa available
    - Firebase `createUserWithEmailAndPassword` + tạo Firestore `/users/{uid}` sau screen 4
-3. **Google Sign-In** — button "Tiếp tục với Google" nằm trên email screen (cả signup lẫn login). User mới → tiếp tục vào screen 3 (Họ Tên) + screen 4 (Username). User cũ → navigate `/home`.
-4. **Login flow** — Email → Password → home. Title password screen: "Điền mật khẩu của bạn". Button đổi sang "Bạn đã sẵn sàng ✓" (~800ms) rồi auto-navigate `/home`. Inline error tiếng Việt khi sai creds.
+3. **Google Sign-In** — button "Tiếp tục với Google" trên email screen (cả signup lẫn login). User mới → vào screen 3 (Họ tên — **pre-filled từ Google displayName, editable**) + screen 4 (Username). User cũ → navigate `/home`.
+4. **Login flow** — Email (`269:1424`) → Password (`269:1473`) → Success (`269:1544`). Title password screen: "Điền mật khẩu của bạn". Sau khi nhập MK + bấm "Tiếp tục" → trigger animation screen "Bạn đã sẵn sàng" → **auto-navigate `/home` sau ~1.5s**. Màn này dùng chung cho cả login và register. Inline error tiếng Việt khi sai creds.
 5. **Forgot password** — link "Bạn đã quên mật khẩu?" nằm trên **login password screen** (pill/tag style). Tap → gửi Firebase reset email → success toast. KHÔNG gating login.
 6. **Auto-login** — `authStateChanges()` stream, redirect `/home` nếu có session khi khởi động.
 7. **Logout** — gọi `signOut()` từ Settings (UI của Settings thuộc Tier 1; auth chỉ expose method).
@@ -58,19 +59,26 @@ Cho phép user tạo tài khoản, đăng nhập (email/password hoặc Google),
 Presentation          Application              Data
 ─────────────────     ────────────────────     ──────────────────────
 IntroPage             SignUpController          AuthRepository (abstract)
-SignUpEmailPage        ├─ SignUpState           FirebaseAuthRepository (impl)
-SignUpPasswordPage     └─ SignUpStep enum       UserRepository (abstract)
-SignUpNamePage                                  FirebaseUserRepository (impl)
-SignUpUsernamePage     LoginController
-LoginPage               └─ LoginState
+SignUpEmailPage        ├─ SignUpState               ├─ signUpWithEmail()
+SignUpPasswordPage     └─ SignUpStep enum           ├─ signInWithGoogle()
+SignUpNamePage                                      ├─ deleteCurrentUser()  ← Fix5
+SignUpUsernamePage     LoginController             └─ authStateChanges
+LoginPage               └─ LoginState           FirebaseAuthRepository (impl)
 ForgotPasswordPage
-                      currentUidProvider
+  (/login/forgot-password  UserRepository (abstract)
+   ?email=... query param)  ├─ createProfile()
+                            ├─ getProfile()
+                      currentUidProvider      └─ isUsernameAvailable()
+                      currentUserProfileProvider  ← Fix1
                       isSignedInProvider
 ```
 
 **Shared UI pattern:** Email screen layout giống nhau cho cả signup và login (cùng title "Email của bạn là gì?", Google button). Tách thành 2 route riêng (`/signup/email`, `/login/email`) để controller đúng.
 
-**Router guard:** `main.dart` watches `currentUidProvider` → redirect `/home` nếu uid != null, `/intro` nếu null.
+**Router guard:** Watch cả `currentUidProvider` và `currentUserProfileProvider`:
+- `uid == null` → `/intro`
+- `uid != null && profile == null` → `/signup/name` (resume incomplete Google signup)
+- `uid != null && profile != null` → `/home`
 
 ### Data model
 
@@ -79,12 +87,12 @@ ForgotPasswordPage
 {
   uid: string,
   email: string,
-  firstName: string,
-  lastName: string,
-  username: string,       // lowercase, unique
-  photoUrl: string?,      // null — user upload thủ công qua Settings (Tier 1)
-  createdAt: Timestamp,   // serverTimestamp()
+  displayName: string,    // "Họ và tên" từ screen 3 — KHÔNG tách firstName/lastName
+  username: string,       // stored lowercase always; input validates ^[a-zA-Z0-9]{3,20}$ then auto-lowercased
+  avatarUrl: string?,     // null — user upload qua Profile/Settings (Tier 1)
   bio: string?,
+  createdAt: Timestamp,   // serverTimestamp()
+  updatedAt: Timestamp,   // serverTimestamp()
 }
 ```
 
@@ -108,9 +116,9 @@ class SignUpState with _$SignUpState {
     @Default(SignUpStep.email) SignUpStep step,
     @Default('') String email,
     @Default('') String password,
-    @Default('') String firstName,
-    @Default('') String lastName,
+    @Default('') String displayName,  // single field, not firstName+lastName
     @Default('') String username,
+    @Default(false) bool isGoogleSignIn,
     @Default(false) bool isCheckingUsername,
     @Default(false) bool isUsernameAvailable,
     @Default(false) bool isLoading,
@@ -128,19 +136,19 @@ class SignUpState with _$SignUpState {
 - Button "Tiếp tục với Google" trên email screen → gọi `signInWithGoogle()`
 - Sau sign-in: **luôn query `/users/{uid}`** (không dùng `isNewUser` — không reliable)
   - Tồn tại → navigate `/home` (returning user)
-  - Không tồn tại → navigate `SignUpNamePage` (new user hoặc incomplete signup lần trước)
+  - Không tồn tại → navigate `SignUpNamePage` với `displayName` **pre-filled từ Google account** (editable), skip email + password screens
 - `SignUpController` nhận `isGoogleSignIn = true` → skip bước tạo Auth user (đã tạo qua Google), chỉ cần batch write Firestore
-- `photoUrl` để `null` — không lưu Google avatar URL
+- `avatarUrl` để `null` — không lưu Google avatar URL tự động
 
 ### Username uniqueness check
 
 - Debounce 500ms sau mỗi keystroke
 - Query `/usernames/{username}` — document tồn tại → taken
-- UI states:
-  - Đang kiểm tra: spinner (isCheckingUsername = true)
-  - Available: badge pill "Tuyệt vời! ✓", nút "Tiếp tục" enabled
-  - Taken: badge pill "Tên này đã được dùng" (đỏ), nút disabled
-  - Empty: hint pill "Việc này sẽ giúp bạn kết nối bạn bè nhanh chóng.", nút disabled
+- UI states (Design System `323:1896`, `349:972–983`):
+  - Empty: hint pill "Việc này sẽ giúp bạn kết nối bạn bè nhanh chóng.", nút disabled (`inputType=Username, type=Default`)
+  - Đang kiểm tra: spinner (isCheckingUsername = true) — loading indicator thay thế checkmark
+  - Available: input border xanh + checkmark (`inputType=Username, type=Success`), badge pill "Tuyệt vời!", nút enabled
+  - Taken: input border đỏ (`inputType=Username, type=Error`), error text "Tên người dùng này đã tồn tại. Vui lòng chọn tên khác.", nút disabled
 
 ### Dependencies
 
@@ -164,11 +172,11 @@ Không thêm package mới.
 ```javascript
 // users collection
 match /users/{uid} {
-  allow read: if isAuthed() && (request.auth.uid == uid || isFriend(uid));
+  // Auth sprint: owner-only. TODO(Friend module): thêm || isFriend(uid)
+  allow read: if isAuthed() && request.auth.uid == uid;
   allow create: if isAuthed() && request.auth.uid == uid
-                && request.resource.data.keys().hasAll(['uid','email','firstName','lastName','username','createdAt'])
-                && request.resource.data.username.size() >= 3
-                && request.resource.data.username.size() <= 20;
+                && request.resource.data.keys().hasAll(['uid','email','displayName','username','createdAt','updatedAt'])
+                && request.resource.data.username.matches('^[a-z0-9]{3,20}$');
   allow update: if isOwner(uid)
                 && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['uid','createdAt','email']);
   allow delete: if false;
@@ -177,7 +185,9 @@ match /users/{uid} {
 // usernames lookup
 match /usernames/{username} {
   allow read: if isAuthed();
-  allow create: if isAuthed() && request.resource.data.uid == request.auth.uid;
+  allow create: if isAuthed()
+                && request.resource.data.uid == request.auth.uid
+                && request.resource.data.keys().hasOnly(['uid']);
   allow delete: if isAuthed() && resource.data.uid == request.auth.uid;
   allow update: if false;
 }
@@ -234,12 +244,14 @@ match /usernames/{username} {
 
 - `serverTimestamp()` cho `createdAt` — không dùng client time.
 - Convert `FirebaseAuthException` → `AppError` tại repository boundary.
-- Validate username format client-side (regex `^[a-z0-9_]{3,20}$`) trước khi query Firestore.
+- Validate username format client-side (regex `^[a-zA-Z0-9]{3,20}$`, **không cho ký tự đặc biệt**) trước khi query Firestore. Input tự động lowercase khi user nhập.
 - Batch write `users` + `usernames` atomically.
+- Nếu Firestore batch fail sau khi Firebase Auth đã tạo user → gọi `deleteCurrentUser()` rollback trước khi throw error.
 
 ### Ask first
 
 - Username tồn tại khi Google Sign-In (race condition): hỏi anh trước khi implement tiebreaker logic.
+- `deleteCurrentUser()` fail sau batch fail: user còn kẹt trong Firebase Auth mà không có Firestore doc. Hiếm nhưng có thể xảy ra — hỏi leader nếu gặp.
 
 ### Never do
 
@@ -249,9 +261,39 @@ match /usernames/{username} {
 
 ---
 
+## Shared components (leader code trước khi giao module)
+
+File path: `apps/mobile/lib/shared/widgets/`
+
+| Widget | Spec |
+|---|---|
+| `app_primary_button.dart` | 338×57, radius=30. `state=Active`: bg=`#c7f7fb`, text=`#004b54`. `state=Disabled`: bg=`#394041`, text=`#ced9da`. `state=Loading`: bg=`#c7f7fb`, `CircularProgressIndicator(color=#004b54)`. Font: Nunito Bold 16. |
+| `app_back_button.dart` | 40×40, radius=22.5, bg=`#656c6d`, chevron-left 24×24 stroke=`#ced9da` |
+| `app_google_button.dart` | 357×60, radius=30, bg=`#ffffff`, border=`#eff0f6`. Google icon 18×18 + "Tiếp tục với Google" Nunito Bold 16 `#1a1c1e`. Android only. |
+| `app_text_input.dart` | Bọc `TextButton` component set. `inputType`: email / username / name. States: Default/Active/Error. Password variant có eye toggle. |
+
+Design tokens → `apps/mobile/lib/core/theme/app_colors.dart`:
+```dart
+// Turquoise
+static const turquoise300 = Color(0xFFC7F7FB);
+static const turquoise500 = Color(0xFF00DEEE);
+static const turquoise800 = Color(0xFF004B54);
+// Black & White
+static const bw100 = Color(0xFFF9FCFC); static const bw200 = Color(0xFFEEF2F3);
+static const bw300 = Color(0xFFDEE5E6); static const bw400 = Color(0xFFCED9DA);
+static const bw500 = Color(0xFF8D999B); static const bw600 = Color(0xFF656C6D);
+static const bw700 = Color(0xFF394041); static const bw800 = Color(0xFF252627);
+static const bw900 = Color(0xFF050F10);
+// Semantic
+static const success700 = Color(0xFF0EC760);
+static const error700   = Color(0xFFFF3D00);
+```
+
+---
+
 ## Open questions
 
-_Không còn open question._
+_Không còn open question — tất cả đã chốt ngày 22/05._
 
 ---
 

--- a/docs/specs/2026-05-04-auth.md
+++ b/docs/specs/2026-05-04-auth.md
@@ -61,12 +61,14 @@ Presentation          Application              Data
 IntroPage             SignUpController          AuthRepository (abstract)
 SignUpEmailPage        ├─ SignUpState               ├─ signUpWithEmail()
 SignUpPasswordPage     └─ SignUpStep enum           ├─ signInWithGoogle()
-SignUpNamePage                                      ├─ deleteCurrentUser()  ← Fix5
-SignUpUsernamePage     LoginController             └─ authStateChanges
-LoginPage               └─ LoginState           FirebaseAuthRepository (impl)
-ForgotPasswordPage
-  (/login/forgot-password  UserRepository (abstract)
-   ?email=... query param)  ├─ createProfile()
+SignUpNamePage                                      ├─ deleteCurrentUser()
+SignUpUsernamePage     LoginController             ├─ authStateChanges
+LoginPage               └─ LoginState             ├─ reauthenticateWithCredential()  ← [H3] Profile
+ForgotPasswordPage                                └─ updateEmail()                   ← [H3] Profile
+  (/login/forgot-password                         FirebaseAuthRepository (impl)
+   ?email=... query param)
+                            UserRepository (abstract)
+                             ├─ createProfile()
                             ├─ getProfile()
                       currentUidProvider      └─ isUsernameAvailable()
                       currentUserProfileProvider  ← Fix1
@@ -88,9 +90,12 @@ ForgotPasswordPage
   uid: string,
   email: string,
   displayName: string,    // "Họ và tên" từ screen 3 — KHÔNG tách firstName/lastName
-  username: string,       // stored lowercase always; input validates ^[a-zA-Z0-9]{3,20}$ then auto-lowercased
+  username: string,       // stored lowercase always; input validates ^[a-z0-9_]{3,20}$ then auto-lowercased; ký tự _ cho phép, dấu chấm không
   avatarUrl: string?,     // null — user upload qua Profile/Settings (Tier 1)
-  bio: string?,
+  bio: string?,           // null khi tạo
+  postCount: number,      // 0 khi tạo — CF onPostCreated/onPostDeleted
+  friendCount: number,    // 0 khi tạo — CF acceptFriendRequest/onFriendshipDeleted
+  spaceCount: number,     // 0 khi tạo — CF onSpaceMemberAdded/onSpaceMemberRemoved
   createdAt: Timestamp,   // serverTimestamp()
   updatedAt: Timestamp,   // serverTimestamp()
 }
@@ -172,11 +177,13 @@ Không thêm package mới.
 ```javascript
 // users collection
 match /users/{uid} {
-  // Auth sprint: owner-only. TODO(Friend module): thêm || isFriend(uid)
+  // [C7-NOTE] Đây là rule auth-sprint chỉ dùng khi chưa có Friend module.
+  // CANONICAL rule (sau khi Friend module deploy): allow read: if isAuthed()
+  // (xém profile.md §Security — cần cho username search, MVP tradeoff)
   allow read: if isAuthed() && request.auth.uid == uid;
   allow create: if isAuthed() && request.auth.uid == uid
                 && request.resource.data.keys().hasAll(['uid','email','displayName','username','createdAt','updatedAt'])
-                && request.resource.data.username.matches('^[a-z0-9]{3,20}$');
+                && request.resource.data.username.matches('^[a-z0-9_]{3,20}$');
   allow update: if isOwner(uid)
                 && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['uid','createdAt','email']);
   allow delete: if false;
@@ -233,7 +240,7 @@ match /usernames/{username} {
 
 ### Firestore rules tests (`firebase/functions/test/`)
 
-- `users/{uid}`: owner read/write ✓, stranger read ✗, unauthenticated ✗
+- `users/{uid}`: owner read ✓; **auth-sprint rule: stranger read ✗** (sau khi Friend module deploy, canonical rule đổi sang `allow read: if isAuthed()` — xem friend.md §Security); unauthenticated ✗
 - `usernames/{x}`: authed read ✓, create by owner ✓, update ✗
 
 ---
@@ -244,14 +251,14 @@ match /usernames/{username} {
 
 - `serverTimestamp()` cho `createdAt` — không dùng client time.
 - Convert `FirebaseAuthException` → `AppError` tại repository boundary.
-- Validate username format client-side (regex `^[a-zA-Z0-9]{3,20}$`, **không cho ký tự đặc biệt**) trước khi query Firestore. Input tự động lowercase khi user nhập.
+- Validate username format client-side (regex `^[a-z0-9_]{3,20}$`, cho phép `_`, **không cho dấu chấm và ký tự đặc biệt khác**) trước khi query Firestore. Input tự động lowercase khi user nhập.
 - Batch write `users` + `usernames` atomically.
 - Nếu Firestore batch fail sau khi Firebase Auth đã tạo user → gọi `deleteCurrentUser()` rollback trước khi throw error.
 
 ### Ask first
 
 - Username tồn tại khi Google Sign-In (race condition): hỏi anh trước khi implement tiebreaker logic.
-- `deleteCurrentUser()` fail sau batch fail: user còn kẹt trong Firebase Auth mà không có Firestore doc. Hiếm nhưng có thể xảy ra — hỏi leader nếu gặp.
+- `deleteCurrentUser()` fail sau batch fail: ✅ **Resolved** — router guard self-healing (`uid != null && profile == null` → redirect `/signup/name`). Xem Worst path.
 
 ### Never do
 
@@ -296,6 +303,23 @@ static const error700   = Color(0xFFFF3D00);
 _Không còn open question — tất cả đã chốt ngày 22/05._
 
 ---
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| Signup: email đã tồn tại | Toast "Email này đã được sử dụng", ở lại `SignUpEmailScreen` |
+| Signup: Firestore batch write fail sau Firebase Auth createUser | Auth account tạo nhưng không có Firestore doc → gọi `deleteCurrentUser()` cleanup → toast "Tạo tài khoản thất bại, thử lại” |
+| `deleteCurrentUser()` fail sau batch write fail | Orphan Firebase Auth user — lần mở tiếp theo router guard `uid != null && profile == null` → resume tại `/signup/name`, user tự hoàn tất (self-healing) |
+| App crash giữa các bước signup (sau Auth, trước Firestore) | Router guard xử lý: `uid != null && profile == null` → redirect `/signup/name` tự động |
+| Signup: upload avatar fail (optional step) | Bỏ qua, dùng avatar null (hiển thị placeholder), không block signup |
+| Login: sai email/password | Toast "Email hoặc mật khẩu không đúng", ở lại `LoginScreen` |
+| Login: quá nhiều lần sai (Firebase throttle) | Toast "Quá nhiều lần thử — đợi vài phút rồi thử lại" |
+| Google Sign-In: người dùng huỷ dialog | Silent dismiss, không toast, ở lại màn hình |
+| Google Sign-In: Play Services không có | Toast "Thiết bị không hỗ trợ Google Sign-In", ở lại màn hình |
+| Auto-login: token hết hạn / bị revoke | Redirect về `LoginScreen`, xóa cached state |
+| Forgot password: email không tồn tại | Firebase vẫn trả success (security) → toast "Đã gửi email khôi phục nếu tài khoản tồn tại" |
+| Username đã tồn tại khi đăng ký | Toast "Username đã được dùng", ở lại step chọn username |
 
 ## Risks
 

--- a/docs/specs/2026-05-22-friend.md
+++ b/docs/specs/2026-05-22-friend.md
@@ -1,7 +1,7 @@
 # Spec: Friend Module
 
 **Date:** 2026-05-22  
-**Status:** Locked (partial — OQ3 pending Figma)  
+**Status:** Locked  
 **Owner:** ThienPDM  
 **Epic:** [T0] Friends — Milestone M2
 
@@ -35,8 +35,8 @@ Cho phép user thêm bạn bè (tìm theo username / share invite link), xem dan
 
 ### Out-of-scope
 
-- "Màn hình xem profile + kết bạn sau search" — **TODO: anh đang thiết kế**
-- Accept/decline friend request — **TODO: linked to screen trên**
+- "Màn hình xem profile của bạn bè" — navigate từ Friend sheet, thuộc Profile module
+- Accept/decline (UI đã có trong Friend sheet — xem luồng bên dưới)
 - "Tin nhắn" internal trong invite section — mock only M2
 - Notification khi nhận friend request (M3 — FCM)
 - Block / report user (Tier 2 — cut)
@@ -57,11 +57,26 @@ Camera screen → tap FriendsButton "15 người bạn" (440:1790)
 
 ---
 
+### Luồng accept/decline friend request
+
+```
+Bottom sheet → Section "Yêu cầu kết bạn" (hiện khi có ≥ 1 pending request)
+    → Card: [avatar] [displayName]
+        ├─ Nút "Chấp nhận" (turquoise) → gọi acceptFriendRequest Cloud Function
+        │       └─ thành công → card biến mất, friendCount tăng, cả 2 users có friendship
+        │       └─ thất bại (max 20) → toast "Bạn đã có 20 bạn bè, không thể chấp nhận"
+        └─ Icon ✕ (decline) → cập nhật friend_requests.status = 'declined'
+                └─ card biến mất khỏi list
+```
+
+---
+
 ### Luồng tìm bạn theo username
 
 ```
 Bottom sheet → tap Search bar "Thêm một người bạn mới"
-    → Ẩn tất cả sections (Bạn bè của bạn + Chia sẻ liên kết)
+    → Search bar mở rộng, hiện nút "Hủy" bên phải
+    → Ẩn tất cả sections (Bạn bè của bạn + Chia sẻ liên kết + Yêu cầu kết bạn)
     → Chỉ hiện search bar + kết quả
     │
     ├─ User đang nhập → debounce 500ms
@@ -69,7 +84,8 @@ Bottom sheet → tap Search bar "Thêm một người bạn mới"
     │
     ├─ Tìm thấy (exact match username):
     │   └─ Hiện 1 user card: [avatar] [displayName] [@username]
-    │       └─ Tap card → TODO: màn hình xem profile + kết bạn (anh đang thiết kế)
+    │       ├─ Chưa kết bạn → hiện nút "Gửi kết bạn"; tap card = không navigate
+    │       └─ Đã là bạn → hiện nút "Trang cá nhân"; tap → FriendProfileScreen
     │
     └─ Không tìm thấy:
         └─ "Không có người dùng với username này"
@@ -137,9 +153,12 @@ Feed screen → tap "Mọi người ▾" (FriendsButton)
 
 | Màn hình | Figma ID | Ghi chú |
 |---|---|---|
-| "Bạn bè" bottom sheet | `501:2054` | Trigger: FriendsButton camera topbar |
+| "Bạn bè" bottom sheet (default) | `501:2054` | Trigger: FriendsButton camera topbar |
+| Bottom sheet + Yêu cầu kết bạn | `710:3999` | State khi có pending requests |
+| Tìm kiếm — có kết quả | `710:2522` | Nhập username, hiện card + nút "+ Thêm" |
+| Tìm kiếm — không có kết quả | `709:2484` | Hiện empty state |
+| Sao chép liên kết (state after copy) | `710:4189` | Icon link → icon check sau khi copy |
 | FriendsButton dropdown (feed) | `472:2142` | Trigger: FriendsButton feed topbar |
-| Xem profile + kết bạn | ❓ TODO | Anh đang thiết kế |
 
 ---
 
@@ -385,9 +404,9 @@ match /users/{uid} {
 
 | # | Câu hỏi | Quyết định |
 |---|---|---|
-| OQ1 | Màn hình xem profile + kết bạn sau khi search | **Out of scope** — thuộc Profile module. Friend module chỉ search + hiển thị kết quả; tap → navigate sang Profile (xử lý ở Profile spec). |
+| OQ1 | Màn hình xem profile + kết bạn sau khi search | **✅ Resolved** — Search card có 2 state: (A) chưa bạn → hiện nút "Gửi kết bạn", tap card = không navigate; (B) đã bạn → nút "Trang cá nhân", tap → navigate → FriendProfileScreen (thuộc Profile module). |
 | OQ2 | Confirm unfriend: có cần dialog không? | **Có** — confirm dialog từ Figma (`564:7178`). Title: "Xóa {displayName} khỏi Meep của bạn?". Body: giải thích hậu quả + lịch sử phục hồi được. Nút: "Lưu" (hủy) / "Xoá" (đỏ `Error/800`). |
-| OQ3 | Accept/decline request UI ở đâu? | **⏳ Pending** — anh đang design Figma. Note: likely nằm trong Friend sheet (tab "Lời mời") hoặc Notification. Lock khi Figma xong. |
+| OQ3 | Accept/decline request UI ở đâu? | **✅ Resolved** — Nằm trong Friend sheet chính (`501:2054`), section **"Yêu cầu kết bạn"** (`710:4142`). Card hiện: [avatar] [displayName] + nút **"Chấp nhận"** (turquoise `#00DEEE`) + icon **✕** (decline). Figma ID: `710:3999`. |
 | OQ4 | Username format constraint | **Theo Auth spec:** `[a-z0-9_.]`, max 30 ký tự, stored lowercase. Search input sanitize `.toLowerCase()` trước khi query Firestore. |
 | OQ5 | Invite deep link technology | **Custom URI scheme `meep://invite/{uid}`** — Firebase Dynamic Links deprecated Aug 2025. Android intent filter trong `AndroidManifest.xml`. Dùng `share_plus` để share URL dạng `meep://invite/{uid}`. |
 

--- a/docs/specs/2026-05-22-friend.md
+++ b/docs/specs/2026-05-22-friend.md
@@ -36,10 +36,11 @@ Cho phép user thêm bạn bè (tìm theo username / share invite link), xem dan
 ### Out-of-scope
 
 - "Màn hình xem profile của bạn bè" — navigate từ Friend sheet, thuộc Profile module
-- Accept/decline (UI đã có trong Friend sheet — xem luồng bên dưới)
 - "Tin nhắn" internal trong invite section — mock only M2
-- Notification khi nhận friend request (M3 — FCM)
+- Notification khi nhận friend request (M3 — FCM, thuộc Notification module)
 - Block / report user (Tier 2 — cut)
+
+> **Accept/decline (đã là In-scope):** UI có trong Friend sheet — luồng được mô tả bên dưới. Đây KHÔNG phải out-of-scope.
 
 ---
 
@@ -172,11 +173,14 @@ Presentation                  Application               Data
 FriendSheet (bottom sheet)    FriendController          FriendRepository (abstract)
  ├─ SearchBar                  ├─ FriendState            FirebaseFriendRepository
  ├─ SearchResult               ├─ searchUser()
- ├─ FriendList                 ├─ unfriend()             FriendRequestRepository (abstract)
- │   └─ FriendItem             ├─ sendInviteLink()       FirebaseFriendRequestRepository
- └─ InviteSection              └─ loadFriends()
-FriendFilterDropdown
- └─ FriendFilterItem
+ ├─ FriendList                 ├─ loadFriends()          FriendRequestRepository (abstract)
+ │   └─ FriendItem             ├─ loadPendingRequests()  FirebaseFriendRequestRepository
+ ├─ PendingRequestSection      ├─ sendFriendRequest()
+ └─ InviteSection              ├─ acceptFriendRequest()  ← gọi CF
+FriendFilterDropdown           ├─ declineFriendRequest()
+ └─ FriendFilterItem           ├─ cancelFriendRequest()
+                               ├─ unfriend()
+                               └─ sendInviteLink()
 ```
 
 ### Data model
@@ -256,10 +260,11 @@ Enforce tại Cloud Function `onUserCreated`:
 
 | Function | Trigger | Việc làm |
 |---|---|---|
-| `acceptFriendRequest` | HTTPS Callable | Validate receiver, check max 20 friends, tạo `/friendships/{pairId}`, update `friendCount` cả 2 user, set `friend_requests.status = accepted` |
-| `onFriendshipDeleted` | Firestore onDelete `/friendships/{pairId}` | Decrement `friendCount` cho `uid1` và `uid2` |
+| `acceptFriendRequest` | HTTPS Callable | Validate receiver, **[H1-FIX] check cả sender.friendCount < 20 và receiver.friendCount < 20** (cả 2 phải < 20), tạo `/friendships/{pairId}`, update `friendCount` cả 2 user, set `friend_requests.status = accepted`, **tạo `/conversations/{pairId}`** (Chat module dùng luôn) |
+| `onFriendshipDeleted` | Firestore onDelete `/friendships/{pairId}` | Decrement `friendCount` cho `uid1` và `uid2`; **[C4] update `/conversations/{pairId}.status = 'unfriended'`** nếu conversation tồn tại |
 
-> Client KHÔNG tự tạo friendship. Chỉ `acceptFriendRequest` tạo.
+> Client KHÔNG tự tạo friendship hay conversation. Chỉ `acceptFriendRequest` tạo cả hai.  
+> `conversationId` của 1-1 chat = `pairId` (sorted uid1_uid2) — consistent với friendship doc ID.
 
 ---
 
@@ -335,11 +340,16 @@ match /friend_requests/{requestId} {
   allow delete: if false;
 }
 
+// [C7-CANONICAL] Rule này là CANONICAL cho /users/{uid} trong MVP:
+// allow read: if isAuthed() — bắt buộc cho username search hoạt động.
+// Auth spec (auth-sprint) và Profile spec có rule khác nhưng đều phải align với rule này khi deploy.
+// MVP tradeoff: email/phoneNumber exposed to all authed users (documented).
 match /users/{uid} {
-  // username field: readable by all authed (cần cho search)
-  allow read: if isAuthed();
-  // write: chỉ owner
-  allow write: if isAuthed() && request.auth.uid == uid;
+  allow read: if isAuthed();   // [CANONICAL] needed for username search
+  // update: chỉ owner, dùng affectedKeys() (xem profile.md §Security — có full update rule)
+  allow update: if isAuthed() && request.auth.uid == uid;
+  allow create: if isAuthed() && request.auth.uid == uid;
+  allow delete: if false;
 }
 ```
 
@@ -389,7 +399,8 @@ match /users/{uid} {
 | `Friendship` freezed model | `lib/features/friend/data/friendship.dart` | ❌ |
 | `FriendRequest` freezed model | `lib/features/friend/data/friend_request.dart` | ❌ |
 | `FriendRepository` abstract | `lib/features/friend/data/friend_repository.dart` | ❌ |
-| `FriendController` stub | `lib/features/friend/application/friend_controller.dart` | ❌ |
+| `FriendRequestRepository` abstract | `lib/features/friend/data/friend_request_repository.dart` | ❌ |
+| `FriendController` stub (có đủ 8 methods theo architecture) | `lib/features/friend/application/friend_controller.dart` | ❌ |
 | `FriendSheet` widget stub | `lib/features/friend/presentation/friend_sheet.dart` | ❌ |
 | `FriendFilterDropdown` widget stub | `lib/features/friend/presentation/friend_filter_dropdown.dart` | ❌ |
 | Routes: `/invite/:uid` deep link | `lib/core/router/app_router.dart` | ❌ |
@@ -407,10 +418,25 @@ match /users/{uid} {
 | OQ1 | Màn hình xem profile + kết bạn sau khi search | **✅ Resolved** — Search card có 2 state: (A) chưa bạn → hiện nút "Gửi kết bạn", tap card = không navigate; (B) đã bạn → nút "Trang cá nhân", tap → navigate → FriendProfileScreen (thuộc Profile module). |
 | OQ2 | Confirm unfriend: có cần dialog không? | **Có** — confirm dialog từ Figma (`564:7178`). Title: "Xóa {displayName} khỏi Meep của bạn?". Body: giải thích hậu quả + lịch sử phục hồi được. Nút: "Lưu" (hủy) / "Xoá" (đỏ `Error/800`). |
 | OQ3 | Accept/decline request UI ở đâu? | **✅ Resolved** — Nằm trong Friend sheet chính (`501:2054`), section **"Yêu cầu kết bạn"** (`710:4142`). Card hiện: [avatar] [displayName] + nút **"Chấp nhận"** (turquoise `#00DEEE`) + icon **✕** (decline). Figma ID: `710:3999`. |
-| OQ4 | Username format constraint | **Theo Auth spec:** `[a-z0-9_.]`, max 30 ký tự, stored lowercase. Search input sanitize `.toLowerCase()` trước khi query Firestore. |
+| OQ4 | Username format constraint | **Chốt:** `^[a-z0-9_]{3,20}$` — cho phép `_`, **không cho dấu chấm**, max 20 ký tự, stored lowercase. Search input sanitize `.toLowerCase()` trước khi query Firestore. Đồng bộ với Auth spec. |
 | OQ5 | Invite deep link technology | **Custom URI scheme `meep://invite/{uid}`** — Firebase Dynamic Links deprecated Aug 2025. Android intent filter trong `AndroidManifest.xml`. Dùng `share_plus` để share URL dạng `meep://invite/{uid}`. |
 
 ---
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| `acceptFriendRequest` CF fail (network/timeout) | Toast "Không thể chấp nhận lúc này — thử lại", friendship + conversation KHÔNG được tạo (atomic) |
+| `acceptFriendRequest` fail vì đã đạt max 20 bạn | Toast "Bạn đã có 20 bạn bè, không thể chấp nhận thêm", card không biến mất |
+| A→B và B→A gửi request đồng thời | CF `acceptFriendRequest` check cả 2 hướng → auto-convert thành friendship, không duplicate |
+| `acceptFriendRequest` tạo friendship OK nhưng conversation fail | Phải dùng **Firestore batch** cho cả 2 — nếu batch fail, cả 2 không được tạo (atomic) |
+| Unfriend khi đang offline | Local optimistic update → sync khi online; nếu fail → revert + toast |
+| Unfriend với active conversation | Conversation doc giữ nguyên (history không xoá) nhưng gửi tin nhắn mới bị chặn (Chat rule: `isFriend` check) |
+| Deep link invite + chưa đăng nhập | Lưu `pendingInviteUid` → redirect Auth flow → sau login restore + navigate |
+| Deep link invite với uid không tồn tại | 404 state → toast "Không tìm thấy người dùng", về Home |
+| Search trả về người đã là bạn bè | Hiển thị card state B (nút "Trang cá nhân"), không hiện nút "Gửi kết bạn" lại |
+| `onFriendshipDeleted` fan-out fail (partial feed cleanup) | Một số posts cũ còn trong feed → Firestore rules revoke đọc; client nhận `permission-denied` → ẩn card |
 
 ## Risks
 

--- a/docs/specs/2026-05-22-friend.md
+++ b/docs/specs/2026-05-22-friend.md
@@ -1,0 +1,406 @@
+# Spec: Friend Module
+
+**Date:** 2026-05-22  
+**Status:** Locked (partial — OQ3 pending Figma)  
+**Owner:** ThienPDM  
+**Epic:** [T0] Friends — Milestone M2
+
+---
+
+## Goal
+
+Cho phép user thêm bạn bè (tìm theo username / share invite link), xem danh sách bạn bè, xoá bạn, và lọc feed theo từng người. Tối đa 20 bạn/user.
+
+---
+
+## User stories
+
+- Là user, tôi muốn tìm người quen theo username để gửi lời mời kết bạn.
+- Là user, tôi muốn chia sẻ link mời Meep qua Messenger / Instagram cho bạn bè ngoài app.
+- Là user, tôi muốn xem danh sách bạn bè hiện tại và xoá bạn khi cần.
+- Là user, tôi muốn lọc feed để chỉ xem ảnh của một người cụ thể.
+
+---
+
+## Scope
+
+### In-scope (M2)
+
+1. **"Bạn bè" bottom sheet** — tap FriendsButton "15 người bạn" trên Camera topbar
+2. **Search by username** — debounce 500ms, exact match, 1 kết quả hoặc "không tìm thấy"
+3. **Invite via link** — copy deep link / share Messenger / Instagram DM / Instagram post
+4. **Danh sách bạn bè** — hiển thị, scroll, "Xem thêm"
+5. **Unfriend** — tap ✕ trên từng bạn
+6. **FriendsButton dropdown** (feed) — lọc feed: "Mọi người" / "Bạn" / từng bạn
+
+### Out-of-scope
+
+- "Màn hình xem profile + kết bạn sau search" — **TODO: anh đang thiết kế**
+- Accept/decline friend request — **TODO: linked to screen trên**
+- "Tin nhắn" internal trong invite section — mock only M2
+- Notification khi nhận friend request (M3 — FCM)
+- Block / report user (Tier 2 — cut)
+
+---
+
+## Luồng đầy đủ
+
+### Trigger
+
+```
+Camera screen → tap FriendsButton "15 người bạn" (440:1790)
+    → "Bạn bè" bottom sheet slide up
+```
+
+> ⚠️ FriendsButton trên CAMERA topbar = mở Friend management sheet  
+> FriendsButton trên FEED = mở filter dropdown — 2 component khác nhau, cùng tên
+
+---
+
+### Luồng tìm bạn theo username
+
+```
+Bottom sheet → tap Search bar "Thêm một người bạn mới"
+    → Ẩn tất cả sections (Bạn bè của bạn + Chia sẻ liên kết)
+    → Chỉ hiện search bar + kết quả
+    │
+    ├─ User đang nhập → debounce 500ms
+    │   └─ [loading indicator nhỏ]
+    │
+    ├─ Tìm thấy (exact match username):
+    │   └─ Hiện 1 user card: [avatar] [displayName] [@username]
+    │       └─ Tap card → TODO: màn hình xem profile + kết bạn (anh đang thiết kế)
+    │
+    └─ Không tìm thấy:
+        └─ "Không có người dùng với username này"
+```
+
+**Search logic:** exact match, case-insensitive (ví dụ `"thienpdm"` matches `"ThienPDM"`), full string match (`== length`). Không tìm partial.
+
+> Filter bản thân: nếu `result.uid == currentUid` → bỏ qua (không hiện kết quả là chính mình).
+
+---
+
+### Luồng chia sẻ invite link
+
+```
+Bottom sheet → Section "Chia sẻ liên kết Meep của bạn"
+    ├─ "Liên kết của bạn" → copy deep link meep://invite/{currentUid}
+    ├─ "Messenger" → open Messenger share intent (Android) với link
+    ├─ "Tin nhắn Instagram" → open Instagram DM intent với link
+    ├─ "Tin Instagram" → open Instagram post intent
+    └─ "Tin nhắn" → MOCK chỉ hiện toast "Chức năng đang phát triển"
+```
+
+**Deep link receiver flow:**
+```
+User B nhận link → tap → app mở
+    ├─ B đã đăng nhập → hiện màn hình xem profile A + nút "Kết bạn"
+    │                    (TODO: linked to màn hình anh đang thiết kế)
+    └─ B chưa đăng nhập → Auth flow → sau auth → redirect về profile A
+```
+
+---
+
+### Luồng xoá bạn (unfriend)
+
+```
+Bottom sheet → Section "Bạn bè của bạn" → tap ✕ bên cạnh tên
+    → Confirm dialog (from Figma 564:7178):
+        Title:  "Xóa {displayName} khỏi Meep của bạn?"
+        Body:   "Các bạn sẽ không còn có thể gửi ảnh cho nhau trên Meep.
+                 Lịch sử của bạn sẽ có thể phục hồi nếu các bạn thêm lại nhau."
+        [Lưu]  → đóng dialog, không thay đổi
+        [Xoá]  → delete /friendships/{pairId} → Cloud Function onFriendshipDeleted
+                  giảm friendCount trên cả 2 user
+```
+
+---
+
+### Luồng FriendsButton dropdown (feed)
+
+```
+Feed screen → tap "Mọi người ▾" (FriendsButton)
+    → Dropdown panel slide down (dark rounded):
+        ├─ 👥 "Mọi người" → hiện tất cả bạn bè + bản thân (default)
+        ├─ "Bạn" → hiện chỉ posts của bản thân
+        ├─ [tên bạn 1] → filter feed by uid
+        ├─ [tên bạn 2] → filter feed by uid
+        └─ ...
+    → Chọn một người → dropdown đóng, title đổi "[avatar] [tên] ∧"
+    → Tap ngoài dropdown → đóng, không thay đổi filter
+```
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Ghi chú |
+|---|---|---|
+| "Bạn bè" bottom sheet | `501:2054` | Trigger: FriendsButton camera topbar |
+| FriendsButton dropdown (feed) | `472:2142` | Trigger: FriendsButton feed topbar |
+| Xem profile + kết bạn | ❓ TODO | Anh đang thiết kế |
+
+---
+
+## Technical approach
+
+### Architecture
+
+```
+Presentation                  Application               Data
+──────────────────────        ─────────────────         ─────────────────────
+FriendSheet (bottom sheet)    FriendController          FriendRepository (abstract)
+ ├─ SearchBar                  ├─ FriendState            FirebaseFriendRepository
+ ├─ SearchResult               ├─ searchUser()
+ ├─ FriendList                 ├─ unfriend()             FriendRequestRepository (abstract)
+ │   └─ FriendItem             ├─ sendInviteLink()       FirebaseFriendRequestRepository
+ └─ InviteSection              └─ loadFriends()
+FriendFilterDropdown
+ └─ FriendFilterItem
+```
+
+### Data model
+
+**Firestore `/friendships/{pairId}`:**
+```
+{
+  uid1:      string,           // min(uidA, uidB) — sorted
+  uid2:      string,           // max(uidA, uidB) — sorted
+  members:   string[],         // [uid1, uid2] — dùng arrayContains để query
+  createdAt: Timestamp,
+}
+```
+
+> `pairId = uid1 + "_" + uid2` (đã sorted — deterministic)  
+> `members` array cho phép query `where('members', arrayContains, currentUid)` hiệu quả.
+
+**Firestore `/friend_requests/{requestId}`:**
+```
+{
+  senderId:   string,
+  receiverId: string,
+  status:     'pending' | 'accepted' | 'declined' | 'cancelled',
+  createdAt:  Timestamp,
+  updatedAt:  Timestamp,   // cập nhật khi status thay đổi
+}
+```
+
+**Firestore `/users/{uid}` — thêm field:**
+```
+{
+  username:    string,   // unique, lowercase, dùng cho search
+  friendCount: number,   // denormalized, max 20
+}
+```
+
+> `username` là field duy nhất dùng cho search — phải unique enforce ở Cloud Function.
+
+### Friend query
+
+```dart
+// Lấy tất cả bạn bè của currentUid
+FirebaseFirestore.instance
+  .collection('friendships')
+  .where('members', arrayContains: currentUid)
+  .get()
+// → parse: friendUid = (uid1 == currentUid) ? uid2 : uid1
+```
+
+### Search by username
+
+```dart
+// Exact match, case-insensitive → store username lowercase
+FirebaseFirestore.instance
+  .collection('users')
+  .where('username', isEqualTo: query.toLowerCase())
+  .limit(1)
+  .get()
+```
+
+> Username phải được store lowercase khi tạo. Query exact match.
+
+### Username uniqueness
+
+Enforce tại Cloud Function `onUserCreated`:
+```typescript
+// Check username chưa tồn tại trước khi write
+// Dùng transaction để atomic check + write
+```
+
+### Invite deep link
+
+- Format: `meep://invite/{currentUid}` (Firebase Dynamic Links hoặc custom scheme)
+- Receiver click → app open → AppRouter handle `/invite/{uid}` → navigate đến profile screen của `uid`
+
+### Cloud Functions liên quan
+
+| Function | Trigger | Việc làm |
+|---|---|---|
+| `acceptFriendRequest` | HTTPS Callable | Validate receiver, check max 20 friends, tạo `/friendships/{pairId}`, update `friendCount` cả 2 user, set `friend_requests.status = accepted` |
+| `onFriendshipDeleted` | Firestore onDelete `/friendships/{pairId}` | Decrement `friendCount` cho `uid1` và `uid2` |
+
+> Client KHÔNG tự tạo friendship. Chỉ `acceptFriendRequest` tạo.
+
+---
+
+### `isFriend` helper cho Firestore rules
+
+```javascript
+function isFriend(uid) {
+  let pair1 = request.auth.uid < uid
+    ? request.auth.uid + '_' + uid
+    : uid + '_' + request.auth.uid;
+  return exists(/databases/$(database)/documents/friendships/$(pair1));
+}
+```
+
+Dùng trong rules của `/posts` và `/storage` khi Friend module done (TODO trong Camera/Feed module).
+
+### Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `cloud_firestore` | friendship + friend_request + user search | ✅ |
+| `go_router` | Deep link handle `/invite/{uid}` | ✅ |
+| `riverpod` | State management | ✅ |
+| `share_plus` | Share invite link natively (Android share intent) | ❌ cần thêm |
+
+---
+
+## Security
+
+### Firestore rules
+
+```javascript
+match /friendships/{pairId} {
+  // Chỉ 2 người trong friendship đọc được
+  allow read: if isAuthed() && (
+    resource.data.uid1 == request.auth.uid ||
+    resource.data.uid2 == request.auth.uid
+  );
+  // Chỉ hệ thống (Cloud Function) create — client KHÔNG tự tạo
+  allow create: if false; // TODO: mở khi có Cloud Function createFriendship
+  allow delete: if isAuthed() && (
+    resource.data.uid1 == request.auth.uid ||
+    resource.data.uid2 == request.auth.uid
+  );
+  allow update: if false;
+}
+
+match /friend_requests/{requestId} {
+  // Sender hoặc receiver đọc được
+  allow read: if isAuthed() && (
+    resource.data.senderId == request.auth.uid ||
+    resource.data.receiverId == request.auth.uid
+  );
+  // Chỉ sender tạo, chỉ gửi cho người khác
+  allow create: if isAuthed()
+                && request.auth.uid == request.resource.data.senderId
+                && request.auth.uid != request.resource.data.receiverId;
+  // Receiver chỉ accept hoặc decline (pending → accepted | declined)
+  // Sender chỉ cancel (pending → cancelled)
+  allow update: if isAuthed() && (
+    (
+      resource.data.receiverId == request.auth.uid &&
+      resource.data.status == 'pending' &&
+      request.resource.data.status in ['accepted', 'declined']
+    ) || (
+      resource.data.senderId == request.auth.uid &&
+      resource.data.status == 'pending' &&
+      request.resource.data.status == 'cancelled'
+    )
+  );
+  // Ngăn duplicate request: không tạo nếu đã có pending request cùng cặp
+  // (enforce ở Cloud Function — Firestore rule không check cross-doc efficiently)
+  allow delete: if false;
+}
+
+match /users/{uid} {
+  // username field: readable by all authed (cần cho search)
+  allow read: if isAuthed();
+  // write: chỉ owner
+  allow write: if isAuthed() && request.auth.uid == uid;
+}
+```
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+| Test | Target |
+|---|---|
+| `searchUser("thienpdm")` → 1 user | `FirebaseFriendRepository` |
+| `searchUser("notexist")` → empty | `FirebaseFriendRepository` |
+| `getFriendUids(uid)` → list uids | `FirebaseFriendRepository` |
+| `unfriend(uid)` → doc deleted | `FirebaseFriendRepository` |
+| `pairIdOf(a, b)` == `pairIdOf(b, a)` | pure util |
+
+### Widget tests
+
+| Test | Screen |
+|---|---|
+| Search: gõ username → debounce → hiện 1 kết quả | `FriendSheet` |
+| Search: không tìm thấy → hiện "Không có người dùng..." | `FriendSheet` |
+| Tap ✕ → confirm dialog hiện | `FriendList` |
+| FriendsButton dropdown: chọn friend → title đổi | `FriendFilterDropdown` |
+
+### Firestore rules tests
+
+- `/friendships/{id}`: uid1 read ✓, uid2 read ✓, stranger read ✗
+- `/friendships/{id}`: client create → rejected ✗
+- `/friendships/{id}`: uid1 delete ✓, stranger delete ✗
+- `/friend_requests/{id}`: sender read ✓, receiver read ✓, stranger read ✗
+- `/friend_requests/{id}`: sender create với receiverId != senderId ✓
+- `/friend_requests/{id}`: sender create với receiverId == senderId ✗ (tự kết bạn)
+- `/friend_requests/{id}`: receiver update pending → accepted ✓
+- `/friend_requests/{id}`: receiver update pending → declined ✓
+- `/friend_requests/{id}`: receiver update pending → cancelled ✗ (chỉ sender cancel)
+- `/friend_requests/{id}`: sender update pending → cancelled ✓
+- `/friend_requests/{id}`: sender update pending → accepted ✗ (chỉ receiver accept)
+
+---
+
+## Contract bàn giao (leader merge trước khi giao dev)
+
+| Artifact | File | Status |
+|---|---|---|
+| `Friendship` freezed model | `lib/features/friend/data/friendship.dart` | ❌ |
+| `FriendRequest` freezed model | `lib/features/friend/data/friend_request.dart` | ❌ |
+| `FriendRepository` abstract | `lib/features/friend/data/friend_repository.dart` | ❌ |
+| `FriendController` stub | `lib/features/friend/application/friend_controller.dart` | ❌ |
+| `FriendSheet` widget stub | `lib/features/friend/presentation/friend_sheet.dart` | ❌ |
+| `FriendFilterDropdown` widget stub | `lib/features/friend/presentation/friend_filter_dropdown.dart` | ❌ |
+| Routes: `/invite/:uid` deep link | `lib/core/router/app_router.dart` | ❌ |
+| `isFriend()` Firestore rule helper | `firestore.rules` | ❌ |
+| Cloud Function `acceptFriendRequest` stub | `firebase/functions/src/index.ts` | ❌ |
+| Cloud Function `onFriendshipDeleted` stub | `firebase/functions/src/index.ts` | ❌ |
+| TODO markers trên mọi stub | — | ⏳ |
+
+---
+
+## Open questions — đã resolved
+
+| # | Câu hỏi | Quyết định |
+|---|---|---|
+| OQ1 | Màn hình xem profile + kết bạn sau khi search | **Out of scope** — thuộc Profile module. Friend module chỉ search + hiển thị kết quả; tap → navigate sang Profile (xử lý ở Profile spec). |
+| OQ2 | Confirm unfriend: có cần dialog không? | **Có** — confirm dialog từ Figma (`564:7178`). Title: "Xóa {displayName} khỏi Meep của bạn?". Body: giải thích hậu quả + lịch sử phục hồi được. Nút: "Lưu" (hủy) / "Xoá" (đỏ `Error/800`). |
+| OQ3 | Accept/decline request UI ở đâu? | **⏳ Pending** — anh đang design Figma. Note: likely nằm trong Friend sheet (tab "Lời mời") hoặc Notification. Lock khi Figma xong. |
+| OQ4 | Username format constraint | **Theo Auth spec:** `[a-z0-9_.]`, max 30 ký tự, stored lowercase. Search input sanitize `.toLowerCase()` trước khi query Firestore. |
+| OQ5 | Invite deep link technology | **Custom URI scheme `meep://invite/{uid}`** — Firebase Dynamic Links deprecated Aug 2025. Android intent filter trong `AndroidManifest.xml`. Dùng `share_plus` để share URL dạng `meep://invite/{uid}`. |
+
+---
+
+## Risks
+
+- **Username uniqueness race condition:** 2 users tạo cùng username đồng thời → cần Cloud Function transaction check.
+- **`arrayContains` query performance:** với max 20 bạn bè, không vấn đề.
+- **Deep link Android intent:** `share_plus` cần test thực tế trên device — intent không guaranteed mở đúng app (Messenger/Instagram có thể ignore).
+- **Deep link + chưa đăng nhập:** GoRouter không tự preserve deep link intent qua Auth flow. Cần lưu `pendingInviteUid` vào ephemeral state (ví dụ `SharedPreferences` hoặc router `extra`) trước khi redirect sang Auth, sau đó restore sau login.
+- **Duplicate friend request:** Firestore rule không ngăn được cross-doc efficiently → enforce trong `acceptFriendRequest` Cloud Function (check không tồn tại pending request giữa cùng cặp).
+- **Max 20 friends enforcement:** Cloud Function `acceptFriendRequest` check `friendCount < 20` trước khi tạo friendship. Client side hiển thị error nếu nhận về lỗi.
+- **Empty state friend list:** khi `friendCount == 0`, FriendSheet hiện empty state + hướng dẫn chia sẻ invite link.
+- **Firestore rules `isFriend`:** mỗi call cần 1 extra `exists()` read → tính vào quota. Với feed 10 posts, thêm 10 reads/request.
+- **`friendCount` denormalization:** nếu Cloud Function fail giữa chừng → count không sync. Cần idempotent function. `onFriendshipDeleted` phải dùng transaction decrement.

--- a/docs/specs/2026-05-22-home-camera-feed.md
+++ b/docs/specs/2026-05-22-home-camera-feed.md
@@ -60,7 +60,7 @@ HomeScreen (CustomScrollView)
 │
 ├─ [Top / scroll UP] Camera Section
 │   ├─ FriendsButton "15 người bạn" [audience selector cho post sắp gửi]
-│   ├─ Avatar góc phải (Profile module — out of scope)
+│   ├─ Avatar góc phải → Settings sheet (tap → SettingsSheet slide up)
 │   ├─ Viewfinder 400×400, cornerRadius 50
 │   ├─ 2 pagination dots: [Single] [Dual]
 │   ├─ Swipe TRÁI trên viewfinder → Dual Camera mode
@@ -78,7 +78,7 @@ HomeScreen (CustomScrollView)
     │   ├─ Photo 400×400
     │   ├─ Caption overlay (Note pill)
     │   ├─ "[Tên bạn] [time ago]" label bên dưới ảnh
-    │   └─ ActText bar: "Gửi tin nhắn..." + �🤣🥰 + smile-plus [M3 — disabled]
+    │   └─ ActText bar: "Gửi tin nhắn..." + light-blue-heart/🤣/🥰 + smile-plus [M3 — disabled]
     │
     └─ Post card: ảnh bản thân
         ├─ Photo 400×400
@@ -159,17 +159,19 @@ HomeScreen (CustomScrollView)
 ```
 Presentation                  Application                Data
 ──────────────────────        ──────────────────         ──────────────────────
-HomeScreen                    CameraController            PostRepository (abstract)
+HomeScreen                    AppCameraController         PostRepository (abstract)
  ├─ CameraSection              └─ CameraState             FirebasePostRepository
  └─ FeedSection               FeedController              StorageRepository (abstract)
      ├─ FeedFilterBar           ├─ FeedState               FirebaseStorageRepository
-     └─ PostCard                └─ FeedFilter
+     └─ PostCard                └─ FeedFilter (all/person/space)
          ├─ FriendPostCard      PostController
          └─ OwnPostCard          └─ PostState
 CapturePreviewScreen
 CaptionPresetModal
 GridViewScreen
 ```
+
+> **[NAMING] `AppCameraController`** (không phải `CameraController`) — tránh trùng với `CameraController` export từ Flutter `camera` package. File: `lib/features/feed/application/app_camera_controller.dart`.
 
 **Scroll architecture:** `CustomScrollView` với 2 sliver:
 - `SliverToBoxAdapter` → `CameraSection` (fixed height)
@@ -189,7 +191,9 @@ GridViewScreen
   caption:          string?,       // ≤ 200 chars, null nếu không chọn
   captionType:      'text' | 'location' | 'weather' | 'music' | 'star' | 'time' | 'streak' | null,
   audienceType:     'all' | 'select',
-  audienceUids:     string[],      // [] khi audienceType='all'
+  audienceUids:     string[],      // [] khi audienceType='all'; ignored khi spaceId != null
+  spaceId:          string?,       // [Space module] null nếu All-friends post; spaceId nếu Space post
+                                   // khi spaceId != null: broadcast tới tất cả Space members, audienceType/audienceUids bị ignore
   createdAt:        Timestamp,     // serverTimestamp()
 }
 ```
@@ -199,34 +203,48 @@ GridViewScreen
 { reactorId, reactorName, emoji, createdAt }
 ```
 
+**Firestore `/users/{uid}/feed/{postId}`** — fan-out collection (ghi bởi CF `onPostCreated`):
+```
+{
+  postId:    string,     // = documentId
+  authorId:  string,     // dùng cho filter per-person
+  spaceId:   string?,    // [C6-FIX] null nếu All-friends post; spaceId nếu Space post
+                         // dùng cho Space feed filter: .where('spaceId', isEqualTo: spaceId)
+  createdAt: Timestamp,  // copy từ post — dùng cho sort
+}
+```
+
+> Mỗi user có feed collection riêng. CF `onPostCreated` ghi vào feed của từng người nhận dựa trên `audienceType`. Không giới hạn số bạn bè.
+
 **Firebase Storage path:** `posts/{uid}/{postId}/photo.jpg`
 
 ### Feed query + pagination
 
-**Giới hạn hệ thống:** tối đa 20 bạn bè/user → `whereIn` tối đa 21 UIDs (20 bạn + bản thân), an toàn với giới hạn 30 của Firestore.
+**Fan-out architecture — scalable, không giới hạn số bạn bè:**
 
 **M2 (Friend module chưa có) — owner-only:**
 ```dart
-Firestore.collection('posts')
-  .where('authorId', isEqualTo: currentUid)
-  .orderBy('createdAt', descending: true)
-  .limit(10)
-  .startAfterDocument(lastDoc)  // cursor pagination
-```
-
-**M2+ (sau khi Friend module done) — all friends + self:**
-```dart
-final friendUids = await friendRepository.getFriendUids(currentUid);
-Firestore.collection('posts')
-  .where('authorId', whereIn: [currentUid, ...friendUids])  // max 21 UIDs
+// Query feed của bản thân (chỉ post của mình hiện trong feed)
+Firestore.collection('users').doc(currentUid).collection('feed')
   .orderBy('createdAt', descending: true)
   .limit(10)
   .startAfterDocument(lastDoc)
 ```
 
+**M2+ (sau khi Friend module done) — all friends + self:**
+```dart
+// CF đã fan-out vào /users/{uid}/feed — chỉ cần query collection của mình
+Firestore.collection('users').doc(currentUid).collection('feed')
+  .orderBy('createdAt', descending: true)
+  .limit(10)
+  .startAfterDocument(lastDoc)
+// Rồi fetch từng post: .doc('posts').doc(feedDoc.postId).get()
+```
+
 **Feed filter (FriendsButton):**
-- `FeedFilter.all` → `whereIn [currentUid + friendUids]`
-- `FeedFilter.person(uid)` → `where authorId == uid` (xem feed của 1 người)
+- `FeedFilter.all` → query `/users/{uid}/feed` — không filter thêm
+- `FeedFilter.person(specificUid)` → query `/users/{uid}/feed` `.where('authorId', isEqualTo: specificUid)`
+- `FeedFilter.space(spaceId)` → query `/users/{uid}/feed` `.where('spaceId', isEqualTo: spaceId)` **[Space module]**
 
 **Pagination strategy — prefetch tại item thứ 6:**
 ```dart
@@ -296,7 +314,16 @@ Output: "14:30" (không cần API)
 4. Firestore batch:
    - Set /posts/{postId} với imageUrl + metadata
 // Không có notification khi đăng ảnh
+// CF onPostCreated trigger sau khi doc tạo → increment postCount trên /users/{uid}
 ```
+
+### Cloud Functions
+
+| Function | Trigger | Việc làm |
+|---|---|---|
+| `onPostCreated` | Firestore onCreate `/posts/{postId}` | **[H10: 1 function duy nhất — không tạo trùng trong notification.md]** (1) Fan-out feed: ghi `/users/{recipientUid}/feed/{postId}` (include `spaceId` field) cho từng recipient theo `audienceType` hoặc Space `memberIds`; (2) Increment `postCount` trên `/users/{authorId}`; (3) Fan-out FCM (dùng logic từ Notification module, gọi trong cùng function) |
+| `onPostDeleted` | Firestore onDelete `/posts/{postId}` | (1) Xoá tất cả `/users/{uid}/feed/{postId}` docs (batch); (2) Decrement `postCount`; (3) Xoá Storage file (parse path từ `post.imageUrl`) |
+| `onFriendshipDeleted` | Firestore onDelete `/friendships/{pairId}` | Xoá cross-feed: posts của A khỏi feed của B và ngược lại (batch delete where `authorId == removedFriendUid` **AND `spaceId == null`**) — Space posts được giữ nguyên |
 
 ### Dependencies
 
@@ -320,14 +347,38 @@ Output: "14:30" (không cần API)
 
 ## Security
 
+### Global Firestore rules helpers (define trong `firestore.rules` trước tất cả rules)
+
+```javascript
+// ⚠️ PHẢI define trong firestore.rules trước khi dùng trong bất kỳ rule nào
+// isAuthed() được dùng khắp tất cả specs — define 1 lần ở đầu file
+
+function isAuthed() {
+  return request.auth != null;
+}
+
+function isOwner(uid) {
+  return isAuthed() && request.auth.uid == uid;
+}
+
+// isFriend(uid) — defined trong friend.md §Security
+// isMember(spaceId) — defined trong space.md §Security
+// isCreator(spaceId) — defined trong space.md §Security
+// isBlocked(uid) — defined trong settings.md §Security
+```
+
+> Khi viết `firestore.rules` file thật: copy-paste tất cả helper functions từ các spec vào đầu file, SAU đó copy-paste từng `match` block theo module.
+
 ### Firestore rules
 
 ```javascript
 match /posts/{postId} {
-  // M2: owner-only — chỉ tác giả đọc được post của mình
-  // TODO(Friend module): mở rộng thêm || isFriend(authorId)
-  // để bạn bè đọc được sau khi Friend rules được deploy
-  allow read: if isAuthed() && request.auth.uid == resource.data.authorId;
+  // Author luôn đọc được post của mình
+  // Recipient đọc được nếu postId xuất hiện trong feed của họ (CF đã fan-out)
+  allow read: if isAuthed() && (
+    request.auth.uid == resource.data.authorId ||
+    exists(/databases/$(database)/documents/users/$(request.auth.uid)/feed/$(postId))
+  );
   allow create: if isAuthed()
                 && request.auth.uid == request.resource.data.authorId
                 && (request.resource.data.caption == null
@@ -335,15 +386,25 @@ match /posts/{postId} {
   allow delete: if isAuthed() && request.auth.uid == resource.data.authorId;
   allow update: if false; // posts bất biến sau khi tạo
 }
+
+match /users/{uid}/feed/{postId} {
+  // Chỉ owner của feed đọc được
+  allow read:   if isAuthed() && request.auth.uid == uid;
+  // CF Admin SDK ghi — client không tự ghi/xóa
+  allow write:  if false;
+}
 ```
 
 ### Storage rules
 
 ```javascript
 match /posts/{uid}/{postId}/{filename} {
-  // M2: owner-only — chỉ tác giả đọc được ảnh của mình
-  // TODO(Friend module): mở rộng thêm || isFriend(uid)
-  allow read:  if isAuthed() && request.auth.uid == uid;
+  // Đọc được nếu là author HOẶC có feed doc (CF đã fan-out)
+  // Không cần isFriend check — feed subcollection enforce access
+  allow read:  if isAuthed() && (
+    request.auth.uid == uid ||
+    exists(/databases/$(database)/documents/users/$(request.auth.uid)/feed/$(postId))
+  );
   allow write: if isAuthed()
                && request.auth.uid == uid
                && request.resource.size < 5 * 1024 * 1024
@@ -378,13 +439,15 @@ match /posts/{uid}/{postId}/{filename} {
 
 ### Firestore rules tests
 
-- `/posts/{id}` Firestore: author read ✓, other user read ✗
-- Storage `/posts/{uid}/...`: owner read ✓, other user read ✗
-- `/posts/{id}` Firestore: author read ✓
+- `/posts/{id}`: author read ✓
+- `/posts/{id}`: recipient (có feed doc) read ✓
+- `/posts/{id}`: user không trong feed (không phải friend/audience) read ✗
 - `/posts/{id}`: caption > 200 chars → create rejected ✗
 - `/posts/{id}`: update → rejected ✗
-- Storage: upload > 5MB → rejected ✗
-- Storage: non-image MIME → rejected ✗
+- `/users/{uid}/feed/{postId}`: owner read ✓
+- `/users/{uid}/feed/{postId}`: stranger read ✗
+- `/users/{uid}/feed/{postId}`: client write trực tiếp → rejected ✗ (CF only)
+- Storage `/posts/{uid}/...`: owner write ✓, > 5MB rejected ✗, non-image rejected ✗
 
 ---
 
@@ -394,7 +457,7 @@ match /posts/{uid}/{postId}/{filename} {
 |---|---|
 | `app_camera_button.dart` | 82×82, inner white 70×70 `Ellipse`, outer Turquoise/500 ring. Tap animate scale 0.9→1. |
 | `app_note_pill.dart` | `cornerRadius 30`, bg `#39404166`, Nunito Bold 14, white. `case-sensitive` icon bên trái. Editable via `TextEditingController`. |
-| `app_act_text_bar.dart` | M3 placeholder — render "Gửi tin nhắn..." + 3 emoji + smile-plus. Disabled (no-op tap) ở M2. |
+| `app_act_text_bar.dart` | M2: render "Gửi tin nhắn..." + 3 emoji + smile-plus, **disabled** (no-op). M3: (1) tap text area → inline `TextField` expand ngay trên Feed, user gõ + nhấn gửi → tin nhắn đến conversation 1-1 sẵn có của tác giả post (tạo lúc kết bạn); (2) tap emoji preset → react (Reaction module); (3) tap smile-plus → EmojiPickerSheet. Không navigate khỏi Feed. |
 | `post_card.dart` | 400×400 image, cornerRadius 50, `Note` overlay, label bên dưới. |
 | `caption_service.dart` | Abstract: `Future<String> resolve(CaptionType type)`. Impl: Text (passthrough), Location (Nominatim), Weather (Open-Meteo), Time (DateTime), Mock (Music/Star/Streak). |
 | `share_modal.dart` | Bottom sheet: title "Chia sẻ đến...", 4 share targets (Chia sẻ/Messenger/Instagram/Tin nhắn-disabled), 2 actions (Lưu/Xoá). Xoá chỉ hiển khi `isAuthor == true`. |
@@ -432,7 +495,7 @@ match /posts/{uid}/{postId}/{filename} {
 | `StorageRepository` abstract | `lib/features/feed/data/storage_repository.dart` | ❌ |
 | `CaptionService` abstract | `lib/features/feed/application/caption_service.dart` | ❌ |
 | `FeedController` stub | `lib/features/feed/application/feed_controller.dart` | ❌ |
-| `CameraController` stub | `lib/features/feed/application/camera_controller.dart` | ❌ |
+| `AppCameraController` stub | `lib/features/feed/application/app_camera_controller.dart` | ❌ |
 | `PostController` stub | `lib/features/feed/application/post_controller.dart` | ❌ |
 | Routes: `/home`, `/capture-preview`, `/caption-modal`, `/grid-view` | `lib/core/router/app_router.dart` | ❌ |
 | Shared widgets (6 items) | `lib/shared/widgets/` | ❌ |
@@ -455,9 +518,9 @@ match /posts/{uid}/{postId}/{filename} {
 |---|---|
 | 1 | Caption = 7 types (Text/Vị trí/Thời tiết/Nhạc-mock/Sao-mock/Giờ/Streak-TODO) |
 | 2 | Không có notification khi đăng ảnh |
-| 3 | Feed M2: owner-only. M2+: whereIn max 21 UIDs (giới hạn 20 bạn/user) |
+| 3 | Feed dùng **fan-out subcollection** `/users/{uid}/feed` — query owner's subcollection, không dùng whereIn. M2: chỉ post của bản thân. M2+: sau khi Friend module done, fan-out include cả friends' posts. [H8-FIX: removed stale whereIn reference] |
 | 4 | Vị trí: Nominatim. Thời tiết: Open-Meteo. Cả 2 free, no API key |
-| 5 | Firestore + Storage rules M2: owner-only read, TODO isFriend khi Friend module done |
+| 5 | Firestore rules dùng fan-out feed doc check (`exists(feed/{postId})`) — không cần `isFriend` check trực tiếp. M2: owner-only (feed chưa có data bạn bè). M2+: sau khi fan-out done, tự mở cho bạn bè. |
 | 6 | Dual camera: swipe trái trên viewfinder, không phải Tier 2 nữa |
 | 7 | Xem ảnh bản thân (3 states) — thuộc Profile module, out of scope |
 | 8 | Download tap = icon đổi in-place (download → ✔), không navigate |
@@ -468,6 +531,24 @@ match /posts/{uid}/{postId}/{filename} {
 | 13 | "Tin nhắn" trong Share Modal → disabled M2, TODO Chat module (Tier 1) |
 
 ---
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| Compress ảnh fail (OOM) | Toast "Không thể xử lý ảnh", ở lại Camera, không navigate |
+| Upload Storage fail (network) | Toast "Tải ảnh thất bại — thử lại", KHÔNG tạo Firestore doc |
+| Firestore createPost fail sau khi Storage đã upload | Orphan file trong Storage — CF `onPostDeleted` cleanup; toast retry |
+| App bị kill giữa chừng upload | Storage `UploadTask` bị huỷ, không resume — user phải chụp lại; không orphan Firestore doc |
+| Double-tap capture button | Disable button ngay sau tap đầu tiên cho đến khi navigate xong — tránh double submission |
+| `audienceType='select'` không chọn friend nào | Disable nút "Đăng" — phải chọn ít nhất 1 người |
+| GPS permission denied | Caption tự động switch về Text type, không crash |
+| Nominatim / Open-Meteo timeout (> 5s) | Hiển thị fallback text `"📍 ..."` / `"🌤️ ..."`, không block user |
+| CF `onPostCreated` fan-out fail (partial) | Một số feed không nhận post — acceptable, CF retry tự động (idempotent) |
+| Camera không khởi động được (thiếu permission) | Hiện `CameraPermissionScreen` yêu cầu cấp quyền, không crash |
+| Feed load fail (offline) | Hiện cached posts từ `cached_network_image`; error banner trên đầu |
+| Feed scroll hết danh sách | Hiện indicator "Đã hiển thị tất cả", không gọi thêm |
+| Tap post của người đã unfriend | Feed doc vẫn tồn tại nhưng `/posts/{id}` read → `permission-denied` → ẩn post card, không crash |
 
 ## Risks
 

--- a/docs/specs/2026-05-22-home-camera-feed.md
+++ b/docs/specs/2026-05-22-home-camera-feed.md
@@ -1,0 +1,479 @@
+# Spec: HomePage + Camera + Feed + Post
+
+**Date:** 2026-05-22  
+**Status:** 🔒 LOCKED  
+**Owner:** ThienPDM  
+**Epic:** [T0] Camera + Share + Feed — Milestone M2
+
+---
+
+## Goal
+
+Cho phép user chụp ảnh, thêm caption preset, chọn audience và gửi đến bạn bè. Feed hiển thị ảnh mới nhất của bạn bè (và bản thân) theo dạng full-screen card cuộn dọc. Reactions (M3) được thiết kế sẵn nhưng implement sau.
+
+---
+
+## User stories
+
+- Là user, tôi muốn chụp ảnh bằng camera và gửi cho bạn bè ngay từ màn hình chính.
+- Là user, tôi muốn chọn caption preset nhanh (hoặc tự gõ) để đính kèm ảnh.
+- Là user, tôi muốn chọn gửi cho tất cả bạn bè hoặc chọn từng người.
+- Là user, tôi muốn scroll xuống để xem ảnh mới nhất từ bạn bè.
+- Là user, tôi muốn lọc feed theo từng người bạn để chỉ xem ảnh của họ.
+- Là user, tôi muốn xem lại ảnh của mình cùng trạng thái hoạt động (reactions).
+
+---
+
+## Scope
+
+### In-scope (M2)
+
+1. **Camera screen** — viewfinder + flash + zoom 1x + flip + album picker + capture
+2. **Photo preview** — 7 caption types (swipe), audience selector, send/cancel/save-local
+3. **Caption type modal** (`sparkles+`) — hiển thị 7 loại caption, user chọn type
+4. **Post creation** — upload ảnh lên Storage + tạo Firestore doc (không có notification)
+5. **Feed** — scroll dọc dưới camera, mỗi card = 1 post full-width, newest first
+6. **Feed filter** (`FriendsButton`) — lọc theo người cụ thể, title đổi thành tên + avatar
+7. **View friend's photo** — full-screen card, caption, name + time, ActText (M3 placeholder)
+8. **View own photo** — full-screen card, 3 states: no-activity / has-activity / share-mode
+9. **Grid view** — 3-column grid ảnh đã post (từ grid icon trên Taskbar feed)
+10. **Save to local** — tap download trên preview → lưu vào gallery thiết bị (không upload)
+
+### Out-of-scope
+
+- Reactions / gửi tin nhắn trả lời ảnh (M3 — `ActText` render nhưng không functional)
+- Profile tap (avatar góc phải — thuộc Profile module)
+- **Xem ảnh bản thân** (3 states) — thuộc **Profile module**, TODO khi Profile done
+- Notification khi đăng ảnh (không cần)
+- Music detection thực sự (mock only ở M2)
+- Horoscope/ngôi sao thực sự (mock only ở M2)
+- Streak caption thực sự (TODO — link Streak module)
+
+---
+
+## Luồng đầy đủ
+
+### Luồng chính — Camera + Feed (một viewport)
+
+```
+HomeScreen (CustomScrollView)
+│
+├─ [Top / scroll UP] Camera Section
+│   ├─ FriendsButton "15 người bạn" [audience selector cho post sắp gửi]
+│   ├─ Avatar góc phải (Profile module — out of scope)
+│   ├─ Viewfinder 400×400, cornerRadius 50
+│   ├─ 2 pagination dots: [Single] [Dual]
+│   ├─ Swipe TRÁI trên viewfinder → Dual Camera mode
+│   ├─ Flash (zap), Zoom "1x" tag
+│   ├─ [ Album | Capture | Flip ]
+│   └─ "Lịch sử" combo → tap = scroll xuống feed (❓ còn chờ confirm)
+│
+└─ [Scroll DOWN] Feed Section (newest first)
+    ├─ FriendsButton filter [filter feed — khác với FriendsButton trên camera]:
+    │   ├─ Default: "Mọi người" → tất cả bạn bè + bản thân
+    │   ├─ Tap → dropdown list friends + "Bản thân"
+    │   └─ Chọn một người → filter feed + title = [avatar người đó] [tên] ▾
+    │
+    ├─ Post card: ảnh bạn bè
+    │   ├─ Photo 400×400
+    │   ├─ Caption overlay (Note pill)
+    │   ├─ "[Tên bạn] [time ago]" label bên dưới ảnh
+    │   └─ ActText bar: "Gửi tin nhắn..." + �🤣🥰 + smile-plus [M3 — disabled]
+    │
+    └─ Post card: ảnh bản thân
+        ├─ Photo 400×400
+        ├─ Caption overlay
+        └─ "Bạn [ngày]" label
+        └─ "\u2728 Chưa có hoạt động nào!" pill (M2 — reactions M3)
+        └─ [TODO Profile module: Xem ảnh bản thân các states]
+```
+
+### Luồng chụp + gửi ảnh
+
+```
+[Tap Capture] hoặc [Swipe trái viewfinder → Dual Camera mode]
+    → Xem trước ảnh chụp
+        ├─ Photo preview 400×400
+        ├─ Caption type overlay (Note pill, default = Text rỗng)
+        │   ├─ Swipe trái/phải trên pill → cycle 7 caption types
+        │   └─ Tap sparkles+ → Caption Type Modal (chọn type)
+        │
+        ├─ Audience selector (bottom):
+        │   ├─ "Tất cả" button (Turquoise) — default selected
+        │   └─ Avatar circles từng bạn → tap select/deselect
+        │
+        ├─ Tap Download (top-right):
+        │   → Icon đổi từ download → ✔ tick (in-place, không navigate)
+        │   → Ảnh lưu vào gallery, ở lại màn preview
+        ├─ Tap X → huỷ, về Camera
+        └─ Tap Send → [loading] → upload → post created → về Camera
+```
+
+### Luồng Grid View
+
+```
+[Tap layout-grid icon (góc trái Taskbar feed)] → Grid View
+    ├─ 3-column grid tất cả ảnh đã post (của filter hiện tại)
+    ├─ FriendsButton filter giữ nguyên
+    └─ Tap 1 ảnh → Xem ảnh bạn bè (full-screen, thông tin người đăng)
+         [nếu filter = bản thân → TODO Profile module]
+```
+
+### Luồng Share Modal
+
+```
+[Tap ↑ (share icon, ngoài pill Taskbar)] → Share Modal (bottom sheet)
+    ├─ Title: "Chia sẻ đến..."
+    ├─ Share targets (4 icon):
+    │   ├─ "Chia sẻ" → native OS share sheet
+    │   ├─ "Messenger" → deep link Messenger
+    │   ├─ "Instagram" → deep link Instagram
+    │   └─ "Tin nhắn" → TODO Tier 1 — Chat module (disabled M2)
+    └─ Actions:
+        ├─ [Lưu] → lưu ảnh xuống gallery
+        └─ [Xoá] → xóa post (chỉ hiển khi là bản thân là author)
+```
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Ghi chú |
+|---|---|---|
+| Trang chủ - Single Camera | `440:1767` | MVP |
+| Xem trước ảnh chụp | `442:2319` | |
+| Trang chủ - Dual Camera | `269:1402` | Swipe trái từ Single Camera |
+| Lưu ảnh thành công | `579:1575` | In-place icon download→✔ |
+| Chú thích ảnh (caption modal) | `269:1747` | Mở từ sparkles+ |
+| Xem ảnh bạn bè | `472:2241` | Feed card + Grid detail |
+| Xem ảnh dạng lưới | `580:2883` | Grid view |
+| Share Modal (bottom sheet) | `580:2813` | Tap ↑ trên Taskbar feed |
+| ~~Xem ảnh bản thân (3 states)~~ | ~~`472:1950`, `472:2041`, `579:2844`~~ | **Profile module** |
+
+---
+
+## Technical approach
+
+### Architecture
+
+```
+Presentation                  Application                Data
+──────────────────────        ──────────────────         ──────────────────────
+HomeScreen                    CameraController            PostRepository (abstract)
+ ├─ CameraSection              └─ CameraState             FirebasePostRepository
+ └─ FeedSection               FeedController              StorageRepository (abstract)
+     ├─ FeedFilterBar           ├─ FeedState               FirebaseStorageRepository
+     └─ PostCard                └─ FeedFilter
+         ├─ FriendPostCard      PostController
+         └─ OwnPostCard          └─ PostState
+CapturePreviewScreen
+CaptionPresetModal
+GridViewScreen
+```
+
+**Scroll architecture:** `CustomScrollView` với 2 sliver:
+- `SliverToBoxAdapter` → `CameraSection` (fixed height)
+- `SliverList` → `FeedSection` (danh sách `PostCard`)
+
+`CameraSection` scroll OUT khi user kéo xuống. Tap "Lịch sử" = `scrollController.animateTo(cameraHeight)`.
+
+### Data model
+
+**Firestore `/posts/{postId}`:**
+```
+{
+  authorId:         string,
+  authorName:       string,        // denormalized từ UserProfile
+  authorAvatarUrl:  string?,       // denormalized
+  imageUrl:         string,        // Firebase Storage URL
+  caption:          string?,       // ≤ 200 chars, null nếu không chọn
+  captionType:      'text' | 'location' | 'weather' | 'music' | 'star' | 'time' | 'streak' | null,
+  audienceType:     'all' | 'select',
+  audienceUids:     string[],      // [] khi audienceType='all'
+  createdAt:        Timestamp,     // serverTimestamp()
+}
+```
+
+**Firestore `/posts/{postId}/reactions/{reactionId}`** — M3:
+```
+{ reactorId, reactorName, emoji, createdAt }
+```
+
+**Firebase Storage path:** `posts/{uid}/{postId}/photo.jpg`
+
+### Feed query + pagination
+
+**Giới hạn hệ thống:** tối đa 20 bạn bè/user → `whereIn` tối đa 21 UIDs (20 bạn + bản thân), an toàn với giới hạn 30 của Firestore.
+
+**M2 (Friend module chưa có) — owner-only:**
+```dart
+Firestore.collection('posts')
+  .where('authorId', isEqualTo: currentUid)
+  .orderBy('createdAt', descending: true)
+  .limit(10)
+  .startAfterDocument(lastDoc)  // cursor pagination
+```
+
+**M2+ (sau khi Friend module done) — all friends + self:**
+```dart
+final friendUids = await friendRepository.getFriendUids(currentUid);
+Firestore.collection('posts')
+  .where('authorId', whereIn: [currentUid, ...friendUids])  // max 21 UIDs
+  .orderBy('createdAt', descending: true)
+  .limit(10)
+  .startAfterDocument(lastDoc)
+```
+
+**Feed filter (FriendsButton):**
+- `FeedFilter.all` → `whereIn [currentUid + friendUids]`
+- `FeedFilter.person(uid)` → `where authorId == uid` (xem feed của 1 người)
+
+**Pagination strategy — prefetch tại item thứ 6:**
+```dart
+// Trong FeedController — build từng PostCard:
+bool _shouldPrefetch(int index) => index == currentItems.length - 4;
+// 10 items loaded → prefetch khi render item index 6 (còn 4 item trước khi hết)
+
+void onItemVisible(int index) {
+  if (_shouldPrefetch(index) && !isLoadingMore) {
+    loadNextPage(); // .limit(10).startAfterDocument(lastDoc)
+  }
+}
+```
+
+### Caption types (7 loại)
+
+Swipe trái/phải trên preview = cycle qua 7 loại theo thứ tự. Tap `sparkles+` = modal hiển thị cả 7 để chọn nhanh. Tất cả resolve client-side (không cần Firestore).
+
+| # | Type | Data source | M2 status |
+|---|---|---|---|
+| 1 | **Text** | `TextEditingController` — user tự gõ | ✅ Full |
+| 2 | **Vị trí** | GPS (`geolocator`) → Nominatim reverse geocode | ✅ Full |
+| 3 | **Thời tiết** | GPS → Open-Meteo API | ✅ Full |
+| 4 | **Đang phát** | Hardcoded mock text `"♪ Đang phát nhạc"` | ⚙️ Mock |
+| 5 | **Ngôi sao** | Hardcoded mock text `"⭐ Ngôi sao"` | ⚙️ Mock |
+| 6 | **Giờ hiện tại** | `DateTime.now()` + `intl` timezone | ✅ Full |
+| 7 | **Streak** | TODO — link Streak module | 🔗 TODO |
+
+**API specs:**
+
+```
+// Vị trí — Nominatim (free, no key)
+GET https://nominatim.openstreetmap.org/reverse
+    ?lat={lat}&lon={lon}&format=json&accept-language=vi
+Output: display_name → trim thành "Quận X, TP.HCM"
+
+// Thời tiết — Open-Meteo (free, no key)
+GET https://api.open-meteo.com/v1/forecast
+    ?latitude={lat}&longitude={lon}&current_weather=true
+Output: weathercode + temperature_2m → map sang emoji + text
+        vd: "☀️ Nắng 32°C" / "🌧️ Mưa 25°C"
+
+// Giờ hiện tại — device timezone
+DateTime.now() → format "HH:mm" theo intl DateFormat
+Output: "14:30" (không cần API)
+```
+
+**Weather code mapping (cần implement):**
+
+| WMO code | Text | Emoji |
+|---|---|---|
+| 0 | Trời quang | ☀️ |
+| 1-3 | Có mây | ⛅ |
+| 45,48 | Sương mù | 🌫️ |
+| 51-67 | Mưa nhỏ/vừa | 🌧️ |
+| 71-77 | Tuyết | ❄️ |
+| 80-82 | Mưa rào | 🌦️ |
+| 95-99 | Dông | ⛈️ |
+
+### Post creation flow
+
+```dart
+// PostController.createPost()
+1. Compress ảnh (≤ 1MB, max 1080px) — dùng flutter_image_compress
+2. Upload Storage: posts/{uid}/{postId}/photo.jpg
+3. Lấy download URL
+4. Firestore batch:
+   - Set /posts/{postId} với imageUrl + metadata
+// Không có notification khi đăng ảnh
+```
+
+### Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `camera` | Camera capture, flash, zoom | ❌ cần thêm |
+| `flutter_image_compress` | Compress ảnh trước upload | ❌ cần thêm |
+| `gal` | Lưu ảnh vào gallery thiết bị | ❌ cần thêm |
+| `geolocator` | GPS lat/lng cho caption Vị trí + Thời tiết | ❌ cần thêm |
+| `cached_network_image` | Cache ảnh feed, tránh re-download | ❌ cần thêm |
+| `http` | Gọi Nominatim + Open-Meteo API | ❌ cần thêm |
+| `intl` | Format giờ hiện tại theo timezone | ❌ cần thêm |
+| `cloud_firestore` | Post docs, feed query | ✅ |
+| `firebase_storage` | Image upload | ✅ |
+| `go_router` | Navigation | ✅ |
+| `riverpod` | State | ✅ |
+
+> **Leader phải approve** trước khi add package mới. Tổng: 7 package cần thêm.
+
+---
+
+## Security
+
+### Firestore rules
+
+```javascript
+match /posts/{postId} {
+  // M2: owner-only — chỉ tác giả đọc được post của mình
+  // TODO(Friend module): mở rộng thêm || isFriend(authorId)
+  // để bạn bè đọc được sau khi Friend rules được deploy
+  allow read: if isAuthed() && request.auth.uid == resource.data.authorId;
+  allow create: if isAuthed()
+                && request.auth.uid == request.resource.data.authorId
+                && (request.resource.data.caption == null
+                    || request.resource.data.caption.size() <= 200);
+  allow delete: if isAuthed() && request.auth.uid == resource.data.authorId;
+  allow update: if false; // posts bất biến sau khi tạo
+}
+```
+
+### Storage rules
+
+```javascript
+match /posts/{uid}/{postId}/{filename} {
+  // M2: owner-only — chỉ tác giả đọc được ảnh của mình
+  // TODO(Friend module): mở rộng thêm || isFriend(uid)
+  allow read:  if isAuthed() && request.auth.uid == uid;
+  allow write: if isAuthed()
+               && request.auth.uid == uid
+               && request.resource.size < 5 * 1024 * 1024
+               && request.resource.contentType.matches('image/.*');
+}
+```
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+| Test | Target |
+|---|---|
+| `createPost` success → doc tạo + Storage URL | `FirebasePostRepository` |
+| `createPost` Storage fail → Firestore không tạo | `FirebasePostRepository` |
+| `getFeed` trả đúng posts theo filter | `FirebasePostRepository` |
+| `FeedController` pagination cursor | `FeedController` |
+| `PostController` compress + upload flow | `PostController` |
+| Caption preset cycle (7 presets) | `CaptionPresetService` |
+
+### Widget tests
+
+| Test | Screen |
+|---|---|
+| Camera screen render, tap capture → PreviewScreen | `HomeScreen` |
+| Preview: swipe caption → cycles 7 presets | `CapturePreviewScreen` |
+| Audience: "Tất cả" default selected, tap friend toggles | `CapturePreviewScreen` |
+| Feed filter: chọn friend → FriendsButton title đổi | `FeedFilterBar` |
+| Own photo "Chưa có HĐ" → đúng pill hiển thị | `OwnPostCard` |
+
+### Firestore rules tests
+
+- `/posts/{id}` Firestore: author read ✓, other user read ✗
+- Storage `/posts/{uid}/...`: owner read ✓, other user read ✗
+- `/posts/{id}` Firestore: author read ✓
+- `/posts/{id}`: caption > 200 chars → create rejected ✗
+- `/posts/{id}`: update → rejected ✗
+- Storage: upload > 5MB → rejected ✗
+- Storage: non-image MIME → rejected ✗
+
+---
+
+## Components (leader code trước)
+
+| Widget | Spec |
+|---|---|
+| `app_camera_button.dart` | 82×82, inner white 70×70 `Ellipse`, outer Turquoise/500 ring. Tap animate scale 0.9→1. |
+| `app_note_pill.dart` | `cornerRadius 30`, bg `#39404166`, Nunito Bold 14, white. `case-sensitive` icon bên trái. Editable via `TextEditingController`. |
+| `app_act_text_bar.dart` | M3 placeholder — render "Gửi tin nhắn..." + 3 emoji + smile-plus. Disabled (no-op tap) ở M2. |
+| `post_card.dart` | 400×400 image, cornerRadius 50, `Note` overlay, label bên dưới. |
+| `caption_service.dart` | Abstract: `Future<String> resolve(CaptionType type)`. Impl: Text (passthrough), Location (Nominatim), Weather (Open-Meteo), Time (DateTime), Mock (Music/Star/Streak). |
+| `share_modal.dart` | Bottom sheet: title "Chia sẻ đến...", 4 share targets (Chia sẻ/Messenger/Instagram/Tin nhắn-disabled), 2 actions (Lưu/Xoá). Xoá chỉ hiển khi `isAuthor == true`. |
+
+---
+
+## Boundaries
+
+### Always do
+
+- Compress ảnh xuống ≤ 1MB, maxWidth 1080px trước khi upload.
+- `serverTimestamp()` cho `createdAt`.
+- Không lưu local path vào Firestore — chỉ lưu Storage download URL.
+- Paginate feed bằng `startAfterDocument` — không dùng `limit+offset`.
+
+### Ask first
+
+- Cache strategy cho feed (offline support): hỏi anh trước khi implement.
+- Caption type 7 (Streak): hỏi anh khi Streak module bắt đầu implement.
+
+### Never do
+
+- Không upload ảnh > 5MB (enforce cả client + Storage rules).
+- Không query feed không có filter uid (full collection scan).
+- Không store `audienceUids` cho `audienceType='all'` (để mảng rỗng `[]`).
+
+---
+
+## Contract bàn giao (leader merge trước khi giao dev)
+
+| Artifact | File | Status |
+|---|---|---|
+| `Post` freezed model | `lib/features/feed/data/post.dart` | ❌ cần tạo |
+| `PostRepository` abstract | `lib/features/feed/data/post_repository.dart` | ❌ |
+| `StorageRepository` abstract | `lib/features/feed/data/storage_repository.dart` | ❌ |
+| `CaptionService` abstract | `lib/features/feed/application/caption_service.dart` | ❌ |
+| `FeedController` stub | `lib/features/feed/application/feed_controller.dart` | ❌ |
+| `CameraController` stub | `lib/features/feed/application/camera_controller.dart` | ❌ |
+| `PostController` stub | `lib/features/feed/application/post_controller.dart` | ❌ |
+| Routes: `/home`, `/capture-preview`, `/caption-modal`, `/grid-view` | `lib/core/router/app_router.dart` | ❌ |
+| Shared widgets (6 items) | `lib/shared/widgets/` | ❌ |
+| TODO markers trên mọi stub | — | ⏳ thêm khi commit |
+
+---
+
+## Open questions — đã chốt hết
+
+| # | Kết luận |
+|---|---|
+| OQ1 | Icon ↑ = **Share button** → mở bottom sheet "Chia sẻ đến..." |
+| OQ2 | "Lịch sử" tap = **chỉ scroll xuống feed** (Option A), không mở dropdown |
+
+---
+
+## Decisions đã chốt
+
+| # | Quyết định |
+|---|---|
+| 1 | Caption = 7 types (Text/Vị trí/Thời tiết/Nhạc-mock/Sao-mock/Giờ/Streak-TODO) |
+| 2 | Không có notification khi đăng ảnh |
+| 3 | Feed M2: owner-only. M2+: whereIn max 21 UIDs (giới hạn 20 bạn/user) |
+| 4 | Vị trí: Nominatim. Thời tiết: Open-Meteo. Cả 2 free, no API key |
+| 5 | Firestore + Storage rules M2: owner-only read, TODO isFriend khi Friend module done |
+| 6 | Dual camera: swipe trái trên viewfinder, không phải Tier 2 nữa |
+| 7 | Xem ảnh bản thân (3 states) — thuộc Profile module, out of scope |
+| 8 | Download tap = icon đổi in-place (download → ✔), không navigate |
+| 9 | Camera stop khi scroll xuống feed |
+| 10 | Grid tap ảnh → Xem ảnh bạn bè full-screen |
+| 11 | Icon ↑ Taskbar feed = Share button → bottom sheet "Chia sẻ đến..." |
+| 12 | "Lịch sử" tap = scroll xuống feed (không dropdown) |
+| 13 | "Tin nhắn" trong Share Modal → disabled M2, TODO Chat module (Tier 1) |
+
+---
+
+## Risks
+
+- **`camera` package cold start** trên Android low-end: preview lag khi khởi tạo. Mitigation: init camera trong `initState` với `loading` overlay.
+- **Storage upload fail mid-way:** Retry logic cần thiết. Mitigation: `UploadTask` với resume support.
+- **GPS permission cold start:** Lần đầu request permission → dialog → user deny → caption Vị trí + Thời tiết không hoạt động. Mitigation: graceful fallback về Text type, không crash.
+- **Nominatim rate limit:** 1 req/giây. Mitigation: cache kết quả geocode trong session (không gọi lại nếu vị trí chưa đổi đáng kể).
+- **Open-Meteo cold start:** API call mất 200-500ms. Mitigation: hiển thị loading spinner trong Note pill.
+- **Feed empty state (M2):** Vì owner-only, khi user chưa post gì → feed rỗng. Cần empty state widget.

--- a/docs/specs/2026-05-22-profile.md
+++ b/docs/specs/2026-05-22-profile.md
@@ -1,0 +1,398 @@
+# Spec: Profile Module
+
+**Date:** 2026-05-22  
+**Status:** Locked  
+**Owner:** ThienPDM (leader assign trước khi giao)  
+**Epic:** [T0+] Profile — Milestone M2
+
+---
+
+## Tóm tắt 5 câu hỏi đã chốt
+
+| # | Câu hỏi | Quyết định |
+|---|---|---|
+| Q1 | `dateOfBirth` + `phoneNumber` + `gender` có bắt buộc không? | **Optional** — user có thể bỏ qua |
+| Q2 | Email update có flow re-auth không? | **Có** — Firebase yêu cầu re-auth |
+| Q3 | `meep.cam` domain thật hay placeholder? | **Placeholder** — dùng deep link `meep://profile/{username}` |
+| Q4 | Diary tab trong Profile hiện M2 không? | **Chờ M3** — hiện tab icon nhưng empty state + disable |
+| Q5 | "user-round-plus" button làm gì? | **Bỏ** — xóa khỏi UI |
+
+---
+
+## Goal
+
+Cho phép user xem trang cá nhân của mình (stats + avatar + bio + grid ảnh), chỉnh sửa thông tin, chia sẻ profile, và xem ảnh đã đăng theo dạng lưới.
+
+---
+
+## User stories
+
+- Là user, tôi muốn xem trang cá nhân với số liệu (Khoảnh khắc, Bạn bè, Space), avatar, username và bio.
+- Là user, tôi muốn chỉnh sửa họ tên, username, ngày sinh, số điện thoại, email và giới tính.
+- Là user, tôi muốn thay đổi hoặc xoá ảnh đại diện.
+- Là user, tôi muốn chia sẻ trang cá nhân của mình qua link / Messenger / Instagram.
+- Là user, tôi muốn xem lại tất cả ảnh mình đã đăng theo dạng lưới, và tap vào để xem chi tiết.
+
+---
+
+## Màn hình & Figma IDs
+
+| Frame | Figma ID | Mô tả |
+|---|---|---|
+| Profile main | `269:1941` | Avatar + stats + username + bio + 2 action buttons + tab bar + grid ảnh |
+| Profile_Diary tab | `573:3213` | Cùng layout nhưng tab Diary active — M2: hiện empty state |
+| Edit profile (form) | `573:2968` | Danh sách settings options dạng list |
+| Avatar picker sheet | `573:3561` (bottom sheet) | Chọn thư viện / Chụp ảnh / Gỡ ảnh |
+| Share profile sheet | `573:3648` (overlay) | Link + Messenger + Instagram |
+| Photo detail | `660:1940` | Ảnh full + caption Note + Tag + thumbnail strip |
+
+---
+
+## Scope
+
+### In-scope (M2)
+
+1. **Profile main screen** — stats, avatar, username, bio, grid ảnh (tab Photos active)
+2. **Edit profile** — họ tên, username, ngày sinh, số điện thoại, email, giới tính, thông báo toggle
+3. **Avatar edit** — bottom sheet: Chọn từ thư viện / Chụp ảnh / Gỡ ảnh hiện tại
+4. **Share profile** — bottom sheet: deep link copy / Messenger / Instagram DM / Instagram post
+5. **Photo detail** — xem ảnh full, caption, timestamp, thumbnail strip (swipe)
+6. **Diary tab** — hiện icon + empty state "Tính năng sắp ra mắt" (disabled, chờ M3)
+7. **Friend profile screen** — xem profile của bạn bè (chỉ khi đã là friend); navigate từ Friend search result
+
+### Out-of-scope
+
+- Profile người khác khi **chưa kết bạn** — chỉ hiện search card + nút "Gửi kết bạn" (xử lý trong Friend module)
+- Diary content — **Diary module M3**
+- Space count click-through — **Space module M3**
+- Block/report — Tier 2 cut
+- Account deletion — Tier 2 cut
+
+---
+
+## Luồng đầy đủ
+
+### Profile main
+
+```
+Taskbar → tap icon User (active)
+    → Profile screen
+        ├─ Stats: [9 Khoảnh khắc] [15 Bạn bè] [2 Space]
+        │   (Bạn bè count tap → Friend sheet; Space count tap → out of scope M2)
+        ├─ [Chỉnh sửa] → Edit profile screen
+        ├─ [Chia sẻ trang cá nhân] → Share profile bottom sheet
+        ├─ Tab [grid-3x3] (default) → Photos grid
+        ├─ Tab [book-heart] → Diary tab (empty state M2)
+        └─ Tap ảnh trong grid → Photo detail
+```
+
+### Edit profile
+
+```
+Profile → [Chỉnh sửa]
+    → Edit profile screen (list settings)
+        ├─ Tap "Chỉnh sửa ảnh đại diện" → Avatar picker sheet
+        │   ├─ "Chọn từ thư viện" → image_picker → crop/upload
+        │   ├─ "Chụp ảnh" → camera → crop/upload
+        │   └─ "Gỡ ảnh hiện tại" → xoá avatarUrl → null
+        ├─ Tap "Chỉnh sửa họ tên" → inline edit / bottom input sheet
+        ├─ Tap "Chỉnh sửa tên người dùng" → inline edit, uniqueness check
+        ├─ Tap "Chỉnh sửa ngày sinh" → date picker sheet (DD/MM/YYYY)
+        ├─ Tap "Cập nhật số điện thoại" → phone input sheet
+        ├─ Tap "Cập nhật địa chỉ email" → email input + re-auth flow
+        ├─ Tap "Chỉnh sửa giới tính" → bottom sheet options (Nam / Nữ / Khác)
+        ├─ Tap "Tiểu sử" → text input sheet (multiline, max 150 chars, hint: "Tiểu sử của bạn hiển thị với bạn bè của bạn.")
+        └─ "Thông báo" toggle → bật/tắt FCM notifications (local preference)
+```
+
+> **Email update re-auth flow:**
+> ```
+> Nhập email mới → Firebase yêu cầu re-auth
+>     → Hiện dialog "Nhập mật khẩu hiện tại để xác nhận"
+>     → reauthenticateWithCredential() → updateEmail()
+>     → Toast "Đã cập nhật email"
+> ```
+
+### Share profile
+
+```
+Profile → [Chia sẻ trang cá nhân]
+    → Bottom sheet:
+        ├─ "Liên kết của bạn" (meep://profile/{username}) → copy to clipboard
+        ├─ "Messenger" → share intent Android
+        ├─ "Tin nhắn Instagram" → Instagram DM intent
+        └─ "Tin Instagram" → Instagram post intent
+```
+
+### Friend profile screen
+
+```
+Friend search result → user card (exact match)
+    ├─ Trường hợp A: chưa kết bạn
+    │   └─ Hiện card: [avatar] [displayName] [@username] [Nút "Gửi kết bạn"]
+    │       └─ Tap anywhere trên card (trừ nút) → không navigate (non-interactive)
+    │       └─ Tap "Gửi kết bạn" → gửi friend request → nút đổi "Đã gửi"
+    │
+    └─ Trường hợp B: đã là bạn bè
+        └─ Hiện card: [avatar] [displayName] [@username] [Nút "Trang cá nhân"]
+            └─ Tap card hoặc nút → navigate → FriendProfileScreen
+                ├─ Hiện: avatar + stats (chỉ K.khắc + Bạn bè chung; Space ẩn hoặc 0)
+                ├─ Bio (nếu có)
+                └─ Grid ảnh của người đó (chỉ read, không edit)
+```
+
+> **Không có** nút Edit / Chia sẻ trên FriendProfileScreen — chỉ hiện nút "Xoá bạn" (mở Friend sheet).
+
+---
+
+### Photo detail
+
+```
+Profile grid → tap ảnh
+    → Photo detail screen:
+        ├─ Topbar: [X close] [Date + Year] [share icon]
+        ├─ Ảnh full (swipe trái = ảnh cũ hơn, swipe phải = ảnh mới hơn)
+        │   Tất cả ảnh của bản thân, sắp xếp createdAt desc
+        ├─ Note caption (nếu có)
+        ├─ Tag (tên + thời gian)
+        └─ Thumbnail strip (cuộn ngang, ảnh đang xem = active/enlarged)
+```
+
+---
+
+## Data model
+
+### Firestore `/users/{uid}` — update từ Auth spec
+
+```
+{
+  uid:          string,
+  email:        string,
+  displayName:  string,
+  username:     string,       // unique, lowercase
+  avatarUrl:    string?,
+  bio:          string?,       // ≤ 150 chars — "Tiểu sử" trong Edit profile, optional
+  dateOfBirth:  string?,       // "DD/MM/YYYY" — optional
+  phoneNumber:  string?,       // optional
+  gender:       'male' | 'female' | 'other' | null,
+  createdAt:    Timestamp,
+  updatedAt:    Timestamp,
+}
+```
+
+> **Field mới so với Auth spec:** `dateOfBirth`, `phoneNumber`, `gender`  
+> **Không thêm vào Auth model** — extend ở đây và update Auth spec sau khi leader confirm.
+
+### Notification preference
+
+Lưu **local** (SharedPreferences / flutter_local_notifications config) — KHÔNG lưu Firestore.  
+Khi toggle off: unsubscribe FCM topic hoặc local flag → notification module đọc.
+
+---
+
+## Freezed model
+
+```dart
+@freezed
+class UserProfile with _$UserProfile {
+  const factory UserProfile({
+    required String uid,
+    required String email,
+    required String displayName,
+    required String username,
+    String? avatarUrl,
+    String? bio,
+    String? dateOfBirth,    // "DD/MM/YYYY"
+    String? phoneNumber,
+    String? gender,         // 'male' | 'female' | 'other'
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _UserProfile;
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) =>
+      _$UserProfileFromJson(json);
+}
+```
+
+> ⚠️ **Leader cần update Auth spec** để `UserProfile` model trong Auth plan đồng bộ với 3 field mới này. Auth plan hiện chưa có `dateOfBirth`, `phoneNumber`, `gender`.
+
+---
+
+## Repository interface
+
+```dart
+abstract class ProfileRepository {
+  Future<UserProfile?> getUserProfile(String uid);
+  Stream<UserProfile?> watchUserProfile(String uid);
+  Future<void> updateProfile(String uid, Map<String, dynamic> fields);
+  Future<void> updateAvatar(String uid, File imageFile);
+  Future<void> removeAvatar(String uid);
+  Future<bool> isUsernameAvailable(String username); // reuse từ AuthRepository
+}
+```
+
+---
+
+## Architecture
+
+```
+Presentation                    Application                   Data
+─────────────────────────       ──────────────────────        ────────────────────────
+ProfileScreen                   ProfileController             ProfileRepository (abstract)
+ ├─ ProfileHeader                ├─ ProfileState               FirebaseProfileRepository
+ ├─ ProfileStats                 ├─ loadProfile()
+ ├─ ProfileActionButtons         ├─ updateField()
+ ├─ ProfileTabBar                ├─ updateAvatar()
+ ├─ PhotoGrid (tab 1)            ├─ removeAvatar()
+ └─ DiaryTabEmpty (tab 2)        └─ shareProfile()
+EditProfileScreen
+ ├─ AvatarEditSection
+ └─ ProfileSettingsList
+AvatarPickerSheet
+ShareProfileSheet
+PhotoDetailScreen
+```
+
+---
+
+## Security
+
+### Firestore rules (update `/users/{uid}`)
+
+```javascript
+match /users/{uid} {
+  // Chính chủ đọc full profile; bạn bè đọc được public fields
+  allow read: if isAuthed() && (
+    request.auth.uid == uid ||
+    isFriend(uid)           // từ Friend module — exists(/friendships/{pairId})
+  );
+
+  // Chỉ owner update — restrict allowed fields
+  allow update: if isAuthed()
+    && request.auth.uid == uid
+    && request.resource.data.uid == uid          // uid không đổi
+    && request.resource.data.email == resource.data.email  // email chỉ đổi qua Firebase Auth
+    && request.resource.data.keys().hasOnly([
+        'displayName', 'username', 'avatarUrl', 'bio',
+        'dateOfBirth', 'phoneNumber', 'gender', 'updatedAt'
+       ]);
+}
+```
+
+### Storage rules (avatar)
+
+```javascript
+match /avatars/{uid}/{filename} {
+  allow read: if isAuthed();
+  allow write: if isAuthed()
+    && request.auth.uid == uid
+    && request.resource.size < 5 * 1024 * 1024   // 5MB max
+    && request.resource.contentType.matches('image/.*');
+}
+```
+
+> Storage path: `avatars/{uid}/avatar.jpg` — overwrite cùng tên, không tích lũy file cũ.
+
+---
+
+## Contract bàn giao (leader merge trước khi giao dev)
+
+| Artifact | File | Status |
+|---|---|---|
+| `UserProfile` freezed model (update: thêm 3 fields) | `lib/features/auth/data/user_profile.dart` | ❌ update needed |
+| `ProfileRepository` abstract | `lib/features/profile/data/profile_repository.dart` | ❌ |
+| `ProfileController` stub + `ProfileState` | `lib/features/profile/application/profile_controller.dart` | ❌ |
+| `ProfileScreen` stub | `lib/features/profile/presentation/profile_screen.dart` | ❌ |
+| `EditProfileScreen` stub | `lib/features/profile/presentation/edit_profile_screen.dart` | ❌ |
+| `PhotoDetailScreen` stub | `lib/features/profile/presentation/photo_detail_screen.dart` | ❌ |
+| `AvatarPickerSheet` stub | `lib/features/profile/presentation/avatar_picker_sheet.dart` | ❌ |
+| `ShareProfileSheet` stub | `lib/features/profile/presentation/share_profile_sheet.dart` | ❌ |
+| Routes: `/profile`, `/profile/edit`, `/profile/photo/:postId` | `lib/core/router/app_router.dart` | ❌ |
+| Storage rules: `avatars/{uid}/` | `firebase/storage.rules` | ❌ |
+| TODO markers | — | ⏳ |
+
+---
+
+## Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `image_picker` | Chọn ảnh từ gallery hoặc camera | ❌ cần thêm |
+| `firebase_storage` | Upload avatar | ❌ cần thêm |
+| `share_plus` | Share profile link (reuse từ Friend module) | ❌ cần thêm |
+| `shared_preferences` | Lưu notification toggle local | ❌ cần thêm |
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+| Test | Target |
+|---|---|
+| `getUserProfile(uid)` → returns model đúng | `FirebaseProfileRepository` |
+| `updateProfile(uid, {'displayName': 'X'})` → field updated | `FirebaseProfileRepository` |
+| `removeAvatar(uid)` → `avatarUrl = null` | `FirebaseProfileRepository` |
+| `isUsernameAvailable('taken')` → false | `ProfileRepository` / `AuthRepository` |
+
+### Widget tests
+
+| Test | Screen |
+|---|---|
+| Stats hiển thị đúng số (Khoảnh khắc, Bạn bè, Space=0) | `ProfileScreen` |
+| Tap [Chỉnh sửa] → navigate to Edit | `ProfileScreen` |
+| Tap ảnh trong grid → PhotoDetail | `PhotoGrid` |
+| PhotoDetail swipe trái → ảnh cũ hơn, swipe phải → ảnh mới hơn | `PhotoDetailScreen` |
+| AvatarPickerSheet hiện 3 options | `AvatarPickerSheet` |
+| Bio field trong Edit: nhập > 150 chars → inline error | `EditProfileScreen` |
+| Diary tab → hiện empty state | `ProfileTabBar` |
+
+### Firestore rules tests
+
+- `/users/{uid}` read by owner ✓
+- `/users/{uid}` read by stranger ✗ (M2 — mở rộng khi Friend module done)
+- `/users/{uid}` update với `uid` field thay đổi ✗
+- `/users/{uid}` update với `email` field thay đổi ✗
+- `/users/{uid}` update với fields ngoài allowlist ✗
+- `/avatars/{uid}/` write by owner, đúng MIME + size ✓
+- `/avatars/{uid}/` write by stranger ✗
+
+---
+
+## Acceptance criteria
+
+- [ ] Profile screen hiển thị đúng stats (Khoảnh khắc = số posts, Bạn bè = friendCount, Space = spaceCount)
+- [ ] Grid ảnh load lazy, cursor-paginated 9 ảnh/batch (sắp xếp createdAt desc)
+- [ ] Edit profile: save thành công → Firestore updated + UI reflected
+- [ ] Avatar upload: chọn từ gallery → compress < 5MB → upload → avatarUrl updated
+- [ ] Avatar remove: tap "Gỡ ảnh" → avatarUrl = null → avatar hiện initials placeholder
+- [ ] Username change: uniqueness check + inline error nếu đã bị lấy
+- [ ] Email change: re-auth dialog → thành công → Firebase Auth email updated
+- [ ] Share profile: copy link → clipboard toast; share Messenger/Instagram → intent fired
+- [ ] Photo detail: swipe trái → ảnh cũ hơn, swipe phải → ảnh mới hơn (tất cả ảnh bản thân, mới → cũ)
+- [ ] Diary tab: hiện empty state, không crash
+- [ ] Bio: nhập ≤ 150 chars, hint text hiển thị đúng, empty OK
+- [ ] Space stats hiện `0` M2, không crash
+- [ ] Tất cả optional fields có thể bỏ trống mà không lỗi
+
+---
+
+## Risks
+
+- **Avatar compression:** ảnh RAW từ camera có thể > 20MB → compress trong isolate trước khi upload. Nếu không → OOM hoặc timeout.
+- **Username change race condition:** 2 user đổi sang cùng username → cần transaction. Reuse logic từ Auth module (`/usernames/{username}` doc).
+- **Email re-auth UX:** Firebase `requires-recent-login` error phải được handle gracefully — nếu session cũ > 5 phút → hiện dialog re-auth.
+- **Stats count denormalization:** `friendCount` từ Friend module, `spaceCount` chưa có (Space module M3) → **hiện `0`** cho Space count M2, cập nhật khi Space module xong.
+- **Diary tab M2:** hiện empty state nhưng tab icon phải vẫn tap được (không bị disabled/grayed out hoàn toàn) để không confuse user.
+- **`user-round-plus` button:** đã confirm xoá khỏi UI — designer cần update Figma.
+
+---
+
+## Open questions
+
+| # | Câu hỏi | Status |
+|---|---|---|
+| OQ1 | Friend profile screen (xem profile người khác + kết bạn) — thiết kế xong chưa? | **✅ Resolved** — Chỉ xem được profile người khác khi đã là bạn bè. Chưa kết bạn → chỉ hiện search result card + nút "Gửi kết bạn", không navigate vào profile. |
+| OQ2 | Bio field có trong Profile screen không? Figma không thấy field bio riêng trong Edit | **✅ Resolved** — Anh đã thêm "Tiểu sử" vào Edit profile (node `719:2722`). Field `bio` optional, hint: *"Tiểu sử của bạn hiển thị với bạn bè của bạn."* |
+| OQ3 | `spaceCount` M2 hiện 0 hay ẩn hẳn? | **✅ Resolved** — Hiện số `0` cho đến khi Space module (M3) đi vào hoạt động |
+| OQ4 | Photo detail swipe đi qua ảnh nào? | **✅ Resolved** — Tất cả ảnh bản thân, swipe trái = cũ hơn (mới → cũ, sắp theo `createdAt` desc) |

--- a/docs/specs/2026-05-22-profile.md
+++ b/docs/specs/2026-05-22-profile.md
@@ -116,13 +116,15 @@ Profile → [Chỉnh sửa]
 ### Share profile
 
 ```
-Profile → [Chia sẻ trang cá nhân]
-    → Bottom sheet:
-        ├─ "Liên kết của bạn" (meep://profile/{username}) → copy to clipboard
-        ├─ "Messenger" → share intent Android
-        ├─ "Tin nhắn Instagram" → Instagram DM intent
-        └─ "Tin Instagram" → Instagram post intent
+Profile → tap [Chia sẻ trang cá nhân]
+    → ShareProfileSheet (shared component — `lib/shared/widgets/share_profile_sheet.dart`):
+        Title: "Kết bạn với tôi trên Meep nhé!"
+        URL:   meep://profile/{username}  ← [Q3 resolved: deep link scheme, không phải meep.cam domain]
+        ├─ [Gửi qua Messenger] → Android share intent
+        └─ [Sao chép liên kết] → copy to clipboard + toast
 ```
+
+> Figma `573:3648`. Sheet này được dùng chung với Settings module — **không tạo riêng**.
 
 ### Friend profile screen
 
@@ -175,13 +177,17 @@ Profile grid → tap ảnh
   dateOfBirth:  string?,       // "DD/MM/YYYY" — optional
   phoneNumber:  string?,       // optional
   gender:       'male' | 'female' | 'other' | null,
+  postCount:    number,        // denormalized — tăng/giảm bởi CF onPostCreated/onPostDeleted
+  friendCount:  number,        // denormalized — tăng/giảm bởi CF acceptFriendRequest/onFriendshipDeleted
+  spaceCount:   number,        // denormalized — tăng/giảm bởi CF onSpaceMemberAdded/onSpaceMemberRemoved
   createdAt:    Timestamp,
   updatedAt:    Timestamp,
 }
 ```
 
-> **Field mới so với Auth spec:** `dateOfBirth`, `phoneNumber`, `gender`  
-> **Không thêm vào Auth model** — extend ở đây và update Auth spec sau khi leader confirm.
+> **Field mới so với Auth spec:** `dateOfBirth`, `phoneNumber`, `gender`, `postCount`, `friendCount`, `spaceCount`  
+> **Không thêm vào Auth model** — Auth chỉ tạo doc với giá trị khởi tạo; Profile spec là source of truth cho full schema.  
+> **Giá trị khởi tạo khi tạo user:** `postCount: 0`, `friendCount: 0`, `spaceCount: 0`.
 
 ### Notification preference
 
@@ -202,9 +208,12 @@ class UserProfile with _$UserProfile {
     required String username,
     String? avatarUrl,
     String? bio,
-    String? dateOfBirth,    // "DD/MM/YYYY"
+    String? dateOfBirth,          // "DD/MM/YYYY"
     String? phoneNumber,
-    String? gender,         // 'male' | 'female' | 'other'
+    String? gender,               // 'male' | 'female' | 'other'
+    @Default(0) int postCount,    // denormalized — CF onPostCreated/onPostDeleted
+    @Default(0) int friendCount,  // denormalized — CF acceptFriendRequest/onFriendshipDeleted
+    @Default(0) int spaceCount,   // denormalized — CF onSpaceMemberAdded/onSpaceMemberRemoved
     required DateTime createdAt,
     required DateTime updatedAt,
   }) = _UserProfile;
@@ -214,7 +223,7 @@ class UserProfile with _$UserProfile {
 }
 ```
 
-> ⚠️ **Leader cần update Auth spec** để `UserProfile` model trong Auth plan đồng bộ với 3 field mới này. Auth plan hiện chưa có `dateOfBirth`, `phoneNumber`, `gender`.
+> ✅ **Auth spec đã được đồng bộ** — `UserProfile` model này là source of truth. Auth module khi tạo user khởi tạo: `postCount: 0`, `friendCount: 0`, `spaceCount: 0`, `bio: null`, `avatarUrl: null`, `dateOfBirth: null`, `phoneNumber: null`, `gender: null`.
 
 ---
 
@@ -227,9 +236,21 @@ abstract class ProfileRepository {
   Future<void> updateProfile(String uid, Map<String, dynamic> fields);
   Future<void> updateAvatar(String uid, File imageFile);
   Future<void> removeAvatar(String uid);
-  Future<bool> isUsernameAvailable(String username); // reuse từ AuthRepository
+  // [H4] Delegate sang AuthRepository.isUsernameAvailable() — KHÔNG implement riêng.
+  // ProfileController inject AuthRepository để gọi method này, không gọi qua ProfileRepository.
+  // Future<bool> isUsernameAvailable(String username); // REMOVED — dùng AuthRepository
 }
 ```
+
+> **[H3] Email update:** `reauthenticateWithCredential()` và `updateEmail()` là Firebase Auth operations, không phải Firestore. Chúng phải được thêm vào `AuthRepository`:
+> ```dart
+> abstract class AuthRepository {
+>   // ... (các method hiện có) ...
+>   Future<void> reauthenticateWithCredential(AuthCredential credential);
+>   Future<void> updateEmail(String newEmail);
+> }
+> ```
+> Profile module inject `AuthRepository` để thực hiện email update flow.
 
 ---
 
@@ -261,18 +282,19 @@ PhotoDetailScreen
 
 ```javascript
 match /users/{uid} {
-  // Chính chủ đọc full profile; bạn bè đọc được public fields
-  allow read: if isAuthed() && (
-    request.auth.uid == uid ||
-    isFriend(uid)           // từ Friend module — exists(/friendships/{pairId})
-  );
+  // [CANONICAL] MVP tradeoff: readable by any authed user — bắt buộc cho username search (Friend module).
+  // Consequence: email/phoneNumber visible với mọi user đã đăng nhập.
+  // TODO post-MVP: tạo /users/{uid}/private subcollection chứa sensitive fields.
+  allow read: if isAuthed();
 
-  // Chỉ owner update — restrict allowed fields
+  // Chỉ owner update — chỉ các field trong allowlist
+  // [FIX] Dùng affectedKeys() thay vì keys() để chỉ check các field ĐƯỢC THAY ĐỔI,
+  // không phải toàn bộ document (keys() sẽ DENY vì document còn có uid, email, postCount...)
   allow update: if isAuthed()
     && request.auth.uid == uid
     && request.resource.data.uid == uid          // uid không đổi
     && request.resource.data.email == resource.data.email  // email chỉ đổi qua Firebase Auth
-    && request.resource.data.keys().hasOnly([
+    && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
         'displayName', 'username', 'avatarUrl', 'bio',
         'dateOfBirth', 'phoneNumber', 'gender', 'updatedAt'
        ]);
@@ -306,7 +328,7 @@ match /avatars/{uid}/{filename} {
 | `EditProfileScreen` stub | `lib/features/profile/presentation/edit_profile_screen.dart` | ❌ |
 | `PhotoDetailScreen` stub | `lib/features/profile/presentation/photo_detail_screen.dart` | ❌ |
 | `AvatarPickerSheet` stub | `lib/features/profile/presentation/avatar_picker_sheet.dart` | ❌ |
-| `ShareProfileSheet` stub | `lib/features/profile/presentation/share_profile_sheet.dart` | ❌ |
+| `ShareProfileSheet` stub | `lib/shared/widgets/share_profile_sheet.dart` — **shared**, leader own (Profile + Settings dùng chung) | ❌ |
 | Routes: `/profile`, `/profile/edit`, `/profile/photo/:postId` | `lib/core/router/app_router.dart` | ❌ |
 | Storage rules: `avatars/{uid}/` | `firebase/storage.rules` | ❌ |
 | TODO markers | — | ⏳ |
@@ -350,7 +372,7 @@ match /avatars/{uid}/{filename} {
 ### Firestore rules tests
 
 - `/users/{uid}` read by owner ✓
-- `/users/{uid}` read by stranger ✗ (M2 — mở rộng khi Friend module done)
+- `/users/{uid}` read by any authed user ✓ (canonical rule — needed for search, xem profile.md §Security)
 - `/users/{uid}` update với `uid` field thay đổi ✗
 - `/users/{uid}` update với `email` field thay đổi ✗
 - `/users/{uid}` update với fields ngoài allowlist ✗
@@ -376,6 +398,24 @@ match /avatars/{uid}/{filename} {
 - [ ] Tất cả optional fields có thể bỏ trống mà không lỗi
 
 ---
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| Avatar upload fail (network) | Toast “Tải ảnh thất bại”, giữ avatar cũ, không update Firestore |
+| Avatar upload OK nhưng Firestore update fail | Orphan Storage file — `avatarUrl` không được lưu; UI revert về avatar cũ, toast retry |
+| Avatar quá lớn (> 5MB sau compress) | Reject trước upload, toast “Ảnh quá lớn” |
+| Edit profile: `displayName` trống | Validate client-side: disable nút Save |
+| Username change: username đã bị lấy | Inline error “Tên người dùng đã tồn tại”, không gọi Firestore write |
+| Username change: `transaction` fail (race condition) | Toast “Không thể đổi username lúc này”, giữ username cũ |
+| Email change: `requires-recent-login` error | Hiện re-auth dialog, không show error chung |
+| Email change: Google user (không có password) | Reauth bằng Google credential (`GoogleAuthProvider`), không hiện password dialog |
+| Email change fail sau re-auth | Toast “Không thể cập nhật email”, giữ email cũ |
+| Grid ảnh load fail (offline) | Hiện cached images; error banner; tránh empty grid gây nhầm lẫn |
+| Photo detail swipe ra ngoài giới hạn (trước ảnh đầu / sau ảnh cuối) | Swipe bounce lại, không crash |
+| Photo detail: post bị xóa trong khi đang xem | Firestore `permission-denied` → navigate back + toast “Biểu tượng này không còn tồn tại” |
+| Tap “Gỡ ảnh” đại diện khi không có avatar | Nút “Gỡ ảnh” ẩn / disabled — không có ảnh để gỡ |
 
 ## Risks
 

--- a/docs/specs/2026-05-22-streak.md
+++ b/docs/specs/2026-05-22-streak.md
@@ -1,0 +1,314 @@
+# Spec: Streak / Kỷ niệm Module
+
+**Date:** 2026-05-22  
+**Status:** Locked  
+**Owner:** ThienPDM (leader assign trước khi giao)  
+**Tier:** T1 — Stretch goal (unlock sau retro 13/5 + 27/5)  
+**Epic:** Streak/Kỷ niệm Calendar — read-only
+
+---
+
+## Goal
+
+Cho phép user xem lại lịch sử ảnh đã post theo dạng calendar (tháng) và chi tiết từng ngày (carousel swipe). Chức năng **read-only** — không tạo mới post từ đây. Không có streak notification, không có streak counter logic phức tạp (hiển thị thô từ post data).
+
+---
+
+## User stories
+
+- Là user, tôi muốn xem tất cả ngày tôi đã post ảnh trong tháng qua dạng calendar.
+- Là user, tôi muốn tap vào 1 ngày để xem ảnh của ngày đó (carousel swipe).
+- Là user, tôi muốn biết tổng số khoảnh khắc và số ngày chuỗi liên tiếp hiện tại.
+- Là user, tôi muốn chia sẻ một ảnh trong calendar ra ngoài (Chia sẻ/Messenger/Instagram).
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Mô tả |
+|---|---|---|
+| Trang Streak_1 — Calendar | `269:1983` | Màn chính: header "Kỷ niệm" + calendar tháng + pill stats |
+| Trang Streak_2 — Photo detail | `630:1923` | Xem ảnh ngày cụ thể: carousel + thumbnail strip |
+| Trang Streak_3 — Share modal | `633:3546` | Overlay Share modal trên Photo detail |
+
+---
+
+## Scope
+
+### In-scope (T1 stretch)
+
+1. **Calendar screen** — hiện tháng hiện tại, các ngày có ảnh = ô sáng, ngày không có = ô tối
+2. **Pill stats** — `[N Khoảnh khắc | Nd chuỗi]` ở dưới calendar
+3. **Photo detail** — tap ngày → full-screen carousel (swipe trái/phải qua các ngày trong tháng có ảnh)
+4. **Thumbnail strip** — hàng ảnh nhỏ scroll ngang dưới carousel, ảnh đang xem = enlarged + outline turquoise
+5. **Share modal** — tap icon share trên Photo detail → bottom sheet (Chia sẻ / Messenger / Instagram / Tin nhắn-disabled) + actions (Lưu / Xoá)
+6. **Navigate từ Taskbar** — tab `calendar-days` (icon đầu tiên Taskbar) → Streak screen
+
+### Out-of-scope
+
+- Streak notification (M3 — Push Notification module)
+- Edit/delete post từ Streak screen — chỉ Xoá qua Share modal (reuse PostController)
+- RollCall 168h archive — Tier 2 cut
+- Streak counter server-side — tính client-side từ post timestamps
+
+---
+
+## Luồng đầy đủ
+
+### Calendar screen (Trang Streak_1)
+
+```
+Taskbar → tap icon calendar-days (tab 1)
+    → StreakScreen
+        ├─ [loading] → skeleton calendar (placeholder ô mờ) trong khi loadMonth()
+        ├─ Title: "Kỷ niệm" (center) + avatar góc phải
+        ├─ Calendar widget: tháng đang xem (mặc định = tháng hiện tại)
+        │   ├─ Header: "tháng MM YYYY"
+        │   ├─ Swipe PHẢI → TRÁI = tháng cũ hơn (không giới hạn)
+        │   ├─ Swipe TRÁI → PHẢI = tháng mới hơn (không vượt tháng hiện tại)
+        │   ├─ Grid 7 cột (CN T2 T3 T4 T5 T6 T7)
+        │   │   ├─ Ngày có ảnh → ô sáng (blur glassmorphism) → tap → Photo detail
+        │   │   └─ Ngày không có ảnh → ô tối (mờ)
+        │   └─ Ngày hôm nay → outlined (border highlight)
+        │
+        ├─ [Empty state — tháng đang xem không có post]
+        │   → Calendar vẫn hiện, toàn ô tối
+        │   → Subtitle: "Chưa có khoảnh khắc nào trong tháng này"
+        │
+        ├─ [Empty state — chưa có post nào bao giờ]
+        │   → Subtitle: "Gửi khoảnh khắc đầu tiên của bạn tại Meep !"
+        │   → Pill stats: "0 Khoảnh khắc | 0d chuỗi"
+        │
+        └─ Pill stats: "[N] Khoảnh khắc | [Xd] chuỗi" (toàn cục, không đổi khi swipe tháng)
+```
+
+### Photo detail (Trang Streak_2)
+
+```
+Calendar → tap ô ngày có ảnh
+    → PhotoDetailScreen (push)
+        ├─ Topbar: [X close] [Ngày M tháng D (center)] [share icon]
+        │   (X → pop về Calendar)
+        ├─ Carousel full-screen (350×350, cornerRadius 50)
+        │   ├─ Swipe PHẢI → TRÁI = ngày cũ hơn (trong tháng đang xem)
+        │   ├─ Swipe TRÁI → PHẢI = ngày mới hơn (trong tháng đang xem)
+        │   ├─ Swipe đến ảnh đầu/cuối tháng → bounce nhẹ, chặn lại (không jump tháng)
+        │   ├─ Note pill (caption)
+        │   └─ Tag (giờ đăng, vd "17:03")
+        └─ Thumbnail strip (scroll ngang — ảnh của tháng đang xem)
+            ├─ Ảnh 50×50 cornerRadius 10, mỗi thumbnail = 1 ngày có post trong tháng
+            ├─ Thứ tự: trái = cũ nhất, phải = mới nhất
+            └─ Ảnh đang xem = 60×60 + outline turquoise #00DEEE
+```
+
+### Share modal (Trang Streak_3)
+
+```
+Photo detail → tap share icon (topbar)
+    → Bottom sheet slide up (reuse ShareModal từ Feed module)
+        ├─ Title: "Chia sẻ đến..."
+        ├─ Share targets (4 icon):
+        │   ├─ "Chia sẻ" → native OS share sheet
+        │   ├─ "Messenger" → deep link Messenger
+        │   ├─ "Instagram" → deep link Instagram
+        │   └─ "Tin nhắn" → disabled M2 (Chat module Tier 1)
+        ├─ Actions:
+        │   ├─ [Lưu] → lưu ảnh xuống gallery
+        │   │   └─ fail → toast "Không thể lưu ảnh, thử lại"
+        │   └─ [Xoá] → chỉ hiện khi post.authorId == currentUid (check client-side)
+        │       → Firestore rule enforce: allow delete if request.auth.uid == resource.data.authorId
+        │       → success → pop modal + pop PhotoDetail → Calendar (ô ngày đó tắt sáng)
+        │       └─ fail → toast "Không thể xoá, thử lại"
+        └─ Dismiss: tap ngoài modal → đóng, không có gì thay đổi
+```
+
+---
+
+## Data model
+
+Streak **không có Firestore collection riêng** — đọc từ `/posts` collection đã có.
+
+### Fields cần dùng từ `/posts/{postId}`
+
+```
+authorId:     string   — filter theo currentUid
+imageUrl:     string   — hiển thị ảnh carousel + thumbnail
+caption:      string?  — Note pill
+createdAt:    Timestamp — sắp xếp, tính streak, tính ngày hiển thị trên calendar
+```
+
+> Chỉ read các fields trên — không cần `audienceType`, `audienceUids`, `captionType`.
+
+### Timezone contract
+
+Mọi so sánh ngày đều convert `createdAt` về **local timezone của device** trước:
+```dart
+final localDate = createdAt.toDate().toLocal();
+final dayKey = DateTime(localDate.year, localDate.month, localDate.day);
+```
+Không dùng UTC trực tiếp để tránh drift ngày khi user ở UTC+7.
+
+### Queries
+
+```dart
+// Query 1: posts trong tháng đang xem (calendar + thumbnail strip)
+Firestore.collection('posts')
+  .where('authorId', isEqualTo: currentUid)
+  .where('createdAt', isGreaterThanOrEqualTo: startOfViewingMonth)  // Timestamp UTC
+  .where('createdAt', isLessThan: startOfNextMonth)
+  .orderBy('createdAt', descending: false)
+
+// Query 2: TẤT CẢ ngày có post (cho pill stats — chỉ cần createdAt)
+// Dùng .select(['createdAt']) nếu Firestore SDK hỗ trợ để giảm payload
+Firestore.collection('posts')
+  .where('authorId', isEqualTo: currentUid)
+  .orderBy('createdAt', descending: true)
+  // Cache kết quả trong StreakController, chỉ re-fetch khi mở màn
+```
+
+### Client-side stats calculation
+
+```dart
+// Tổng khoảnh khắc — đơn giản
+int totalMoments = allPosts.length;
+
+// Tính streak hiện tại — liên tiếp từ hôm nay trở về
+// Chuỗi = mỗi ngày có ít nhất 1 post; 1 ngày bỏ = chuỗi đứt
+int calculateCurrentStreak(List<DateTime> allPostDates) {
+  final today = DateTime.now().toLocal();
+  final postDaySet = allPostDates
+      .map((d) => DateTime(d.year, d.month, d.day))
+      .toSet();
+  int streak = 0;
+  var day = DateTime(today.year, today.month, today.day);
+  while (postDaySet.contains(day)) {
+    streak++;
+    day = day.subtract(const Duration(days: 1));
+  }
+  return streak; // vd: chuỗi bắt đầu từ 1/3, duy trì đến hôm nay 23/5 → 83d
+}
+```
+
+> **Không lưu streak counter vào Firestore** — tính lại mỗi lần mở màn. Tránh drift khi user xóa post.
+
+---
+
+## Architecture
+
+```
+Presentation                Application               Data
+─────────────────────       ─────────────────         ────────────────────
+StreakScreen                StreakController           PostRepository (reuse)
+ ├─ StreakCalendar           ├─ StreakState              └─ abstract interface
+ │   ├─ CalendarHeader       ├─ loadMonth(month)             từ Feed module
+ │   └─ CalendarDayCell      ├─ loadAllPostDates()
+StreakPhotoDetailScreen      ├─ calculateStreak(dates)
+ ├─ StreakPhotoCarousel       └─ onDeletePost(postId)
+ └─ StreakThumbnailStrip
+ └─ StreakStatsPill
+ShareModal (reuse từ Feed)
+```
+
+**Reuse:** `ShareModal`, `PostRepository` (abstract interface từ Feed module), `Post` freezed model từ `lib/features/feed/data/post.dart` — không duplicate.
+
+---
+
+## Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| ~~`table_calendar`~~ | ~~Calendar widget~~ | ❌ **Không dùng** — tự build `CustomCalendarGrid` bằng `GridView` |
+| `cached_network_image` | Thumbnail strip + carousel | ✅ (từ Feed module) |
+| `gal` | Lưu ảnh | ✅ (từ Feed module) |
+| `share_plus` | Share intent | ✅ (từ Friend module) |
+
+> **Quyết định:** Custom `GridView` — không thêm dependency mới, kiểm soát hoàn toàn style để match Figma glassmorphism.
+
+---
+
+## Security
+
+Không có rule mới — Streak reuse rules đã deploy từ Feed module:
+
+```javascript
+// /posts/{postId} — từ Feed spec, áp dụng cho Streak read + delete
+match /posts/{postId} {
+  allow read:   if isAuthed() && request.auth.uid == resource.data.authorId;
+  allow delete: if isAuthed() && request.auth.uid == resource.data.authorId;
+  // update: if false — posts bất biến
+}
+```
+
+> Streak không ghi Firestore (read-only), chỉ `delete` khi user chọn Xoá qua Share modal. Rule `delete` enforce server-side — client check `authorId == currentUid` chỉ để ẩn/hiện nút Xoá trên UI.
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+| Test | Target |
+|---|---|
+| `calculateStreak([today, yesterday, 2d ago])` → 3 | `StreakController` |
+| `calculateStreak([today, 3d ago])` → 1 (bị gián đoạn) | `StreakController` |
+| `calculateStreak([])` → 0 (chưa có post) | `StreakController` |
+| `loadMonth` → trả đúng posts trong tháng | `StreakController` |
+| `loadMonth` tháng không có post → empty list | `StreakController` |
+| `loadAllPostDates` → trả đúng list dates | `StreakController` |
+| timezone: post lúc 23:00 UTC = ngày hôm sau ở UTC+7 → tính đúng ngày local | `StreakController` |
+
+### Widget tests
+
+| Test | Screen |
+|---|---|
+| Calendar hiện ô sáng cho ngày có post | `StreakCalendar` |
+| Calendar tháng không có post → toàn ô tối + subtitle empty | `StreakCalendar` |
+| Tap ô ngày → navigate PhotoDetail | `StreakCalendar` |
+| Swipe carousel đến ảnh cuối → bounce, không navigate | `StreakPhotoCarousel` |
+| Thumbnail strip: ảnh active = enlarged + outline | `StreakThumbnailStrip` |
+| Pill stats hiển thị đúng N + streak count | `StreakStatsPill` |
+| Share modal: nút Xoá chỉ hiện khi `isAuthor == true` | `ShareModal` |
+
+### Firestore rules tests
+
+| Test | Expected |
+|---|---|
+| Owner đọc `/posts/{id}` của mình | ✅ allowed |
+| Stranger đọc `/posts/{id}` của người khác | ❌ denied |
+| Owner xoá `/posts/{id}` của mình | ✅ allowed |
+| Stranger xoá `/posts/{id}` của người khác | ❌ denied |
+| Unauthenticated đọc bất kỳ post | ❌ denied |
+
+---
+
+## Contract bàn giao
+
+| Artifact | File | Status |
+|---|---|---|
+| `Post` freezed model (reuse) | `lib/features/feed/data/post.dart` | ❌ (Feed module tạo) |
+| `PostRepository` abstract (reuse) | `lib/features/feed/data/post_repository.dart` | ❌ (Feed module tạo) |
+| `StreakController` stub + `StreakState` | `lib/features/streak/application/streak_controller.dart` | ❌ |
+| `StreakScreen` stub | `lib/features/streak/presentation/streak_screen.dart` | ❌ |
+| `StreakPhotoDetailScreen` stub | `lib/features/streak/presentation/streak_photo_detail_screen.dart` | ❌ |
+| `ShareModal` widget (reuse) | `lib/shared/widgets/share_modal.dart` | ❌ (Feed module tạo) |
+| Route: `/streak`, `/streak/photo/:postId` | `lib/core/router/app_router.dart` | ❌ |
+| TODO markers | — | ⏳ |
+
+---
+
+## Open questions — đã resolved
+
+| # | Câu hỏi | Quyết định |
+|---|---|---|
+| OQ1 | Navigate tháng trước/sau? | **✅ Resolved** — Swipe phải→trái = tháng cũ hơn (không giới hạn), swipe trái→phải = tháng mới hơn (không vượt tháng hiện tại). Không có nút prev/next — dùng gesture. |
+| OQ2 | Pill stats tính trong tháng hay toàn bộ? | **✅ Resolved** — `N Khoảnh khắc` = tổng TẤT CẢ posts từ trước đến nay (toàn cục). `Xd chuỗi` = độ dài chuỗi hiện tại tính từ ngày bắt đầu → hôm nay (có thể nhiều tháng, không giới hạn). Cả 2 không đổi khi swipe tháng. |
+| OQ3 | Thumbnail strip hiển thị ảnh bao nhiêu? | **✅ Resolved** — Ảnh của tháng đang xem trên calendar. Đồng bộ với calendar khi swipe tháng. |
+
+---
+
+## Risks
+
+- **Custom calendar performance:** nếu user có nhiều posts, calendar grid cần load ảnh thumbnail nhỏ. Mitigation: chỉ load ngày nào có post, còn lại render placeholder.
+- **Streak calculation drift:** nếu timezone device và `serverTimestamp` khác nhau → `createdAt` ngày khác. Mitigation: convert về local timezone khi tính streak (xem Timezone contract).
+- **Reuse ShareModal:** đảm bảo ShareModal không bị coupled với FeedScreen state — cần extract thành standalone widget trước khi reuse.
+- **Query không limit (loadAllPostDates):** user post nhiều năm → hàng nghìn docs → latency cao + Firestore read cost tăng. Mitigation: cache `allPostDates` trong controller, chỉ re-fetch khi mở màn (không watch realtime). Nếu tổng posts > 1000, cân nhắc lưu `totalPostCount` + `currentStreakDays` vào `/users/{uid}` (leader quyết định khi gần đến ngưỡng).

--- a/docs/specs/2026-05-22-streak.md
+++ b/docs/specs/2026-05-22-streak.md
@@ -306,6 +306,24 @@ match /posts/{postId} {
 
 ---
 
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| `loadMonth` query fail (network) | Hiện cached data tháng trước (nếu có); nếu cold start thì hiện skeleton + retry button |
+| `loadAllPostDates` timeout / fail | Pill stats hiện "—" hoặc "0 Khoảnh khắc \| 0d chuỗi"; không crash; retry khi user mở lại màn |
+| `deletePost` Firestore fail | Toast "Không thể xoá, thử lại"; modal vẫn mở, ô calendar không thay đổi |
+| `saveToGallery` permission denied (Android) | Request permission dialog; nếu denied lần 2 → mở Settings app; toast "Cần quyền truy cập thư viện" |
+| Share target app (Messenger/Instagram) chưa cài | Messenger/Instagram: fallback `url_launcher` open browser; toast "Đang mở trình duyệt" |
+| User swipe calendar sang tháng tương lai | Block swipe + bounce animation; không vượt tháng hiện tại |
+| User xoá post → thumbnail strip không cập nhật ngay | Controller refetch sau khi `deletePost` thành công; skeleton reload thumbnail strip |
+| Timezone drift: `createdAt` UTC gần midnight, device UTC+7 | Convert về local timezone trước khi tính `dayKey` — đã có timezone contract; không thể drift |
+| Tháng có nhiều post (>100) — scroll performance | `GridView.builder` lazy load; thumbnail dùng `CachedNetworkImage` với thumbnail URL; không load full image |
+| `loadAllPostDates` trả về list rỗng (chưa có post bao giờ) | Calendar toàn ô tối; pill: "0 Khoảnh khắc \| 0d chuỗi"; subtitle "Gửi khoảnh khắc đầu tiên của bạn tại Meep !" |
+| User tap ảnh trong ShareModal → swipe back → ô calendar chưa tắt sáng | Controller lắng nghe stream thay đổi; ô tắt sáng sau khi deletePost CF hoàn tất (eventual consistency ~1s) |
+
+---
+
 ## Risks
 
 - **Custom calendar performance:** nếu user có nhiều posts, calendar grid cần load ảnh thumbnail nhỏ. Mitigation: chỉ load ngày nào có post, còn lại render placeholder.

--- a/docs/specs/2026-05-23-chat.md
+++ b/docs/specs/2026-05-23-chat.md
@@ -3,7 +3,7 @@
 **Date:** 2026-05-23  
 **Status:** Locked  
 **Owner:** ThienPDM (leader assign trước khi giao)  
-**Tier:** T1 — Stretch goal  
+**Tier:** T1 Stretch — **ngoại lệ: Group Chat của Space là T0+ (ship cùng Space module M3)**  
 **Epic:** NEW (chưa có Epic number — leader tạo khi unlock)
 
 ---
@@ -87,10 +87,23 @@ Taskbar → tap icon chat (tab 3)
 
 ### Luồng chat 1-1 (từ Feed reply)
 
+> **Conversation tạo lúc kết bạn** — CF `acceptFriendRequest` tự động tạo empty `/conversations/{pairId}`. Khi user reply từ Feed, conversation đã tồn tại sẵn, chỉ cần ghi message vào.
+
 ```
-FeedScreen → tap "Reply" trên post
+FeedScreen → tap vùng text "Gửi tin nhắn..." trên ActText bar của post
+    → Inline TextField expand ngay trên Feed (không navigate ra khỏi Feed)
+        ├─ Quoted photo thumbnail (thu nhỏ) phía trên input
+        ├─ TextField: "Gửi tin nhắn..."
+        └─ [Gửi] button
+    → User gõ tin nhắn → tap [Gửi]
+        → ChatController.sendMessageFromFeed(postId, authorId, text)
+        → Ghi vào /conversations/{pairId}/messages/{msgId}
+        → Input collapse, ActText bar trở về trạng thái bình thường
+    → Tap [X] hoặc tap ra ngoài → collapse input (không gửi)
+
+Từ InboxScreen → tap conversation
     → ChatScreen (1-1 với author)
-        ├─ Topbar: [←] [avatar + displayName] [⋯ menu]
+        ├─ Topbar: [←] [avatar + displayName] [⋯ menu]  // navigate từ Inbox
         ├─ [loading] skeleton messages
         ├─ Quoted photo block (đầu thread):
         │   ├─ Thumbnail 301×301, cornerRadius 12
@@ -160,7 +173,8 @@ GroupChatScreen → tap ⋯ → [Xem thành viên]
 ### `/conversations/{conversationId}`
 
 ```
-conversationId:  string      — auto Firestore ID
+conversationId:  string      — **pairId** (sorted uid1_uid2) cho direct; auto Firestore ID cho space
+                             // direct: pairId đồng bộ với /friendships/{pairId} (CF acceptFriendRequest tạo cả hai)
 type:            'direct' | 'space'  — loại conversation
 participantIds:  string[]    — array uid (max 2 với direct, max 10 với space)
 spaceId:         string?     — null nếu direct, spaceId nếu space
@@ -183,12 +197,10 @@ createdAt:   Timestamp  — serverTimestamp()
 
 > **Không lưu quoted photo trong message** — chỉ lưu `quotedPostId` ở conversation level. Client fetch post data riêng để render thumbnail.
 
-### `/blocked_users/{uid}/blocked/{blockedUid}`
-
-```
-blockedUid:  string     — uid bị block
-createdAt:   Timestamp  — serverTimestamp()
-```
+> **[C2-FIX] Block data model:** Lưu trong `/blocks/{blockId}` (Settings module owns) — xem `docs/specs/2026-05-23-settings.md` §Data model.  
+> `blockId = "{blockerUid}_{blockedUid}"` (NOT sorted, giữ direction).  
+> Chat module import `BlockRepository` từ `lib/features/settings/data/block_repository.dart`, **KHÔNG tự định nghĩa collection riêng**.  
+> Rule cho `/blocked_users` trong Security section bên dưới cũng phải xoá — dùng rule `/blocks` từ Settings spec.
 
 ---
 
@@ -201,16 +213,19 @@ InboxScreen                ChatController             ConversationRepository
  └─ ConversationTile        ├─ ChatState               ├─ getConversations()
 ChatScreen (1-1)            ├─ loadMessages()          ├─ getOrCreateConversation()
  ├─ QuotedPhotoBlock        ├─ sendMessage()           ├─ sendMessage()
- ├─ MessageBubble           ├─ blockUser()             └─ watchMessages()
- └─ ChatInputBar            └─ deleteConversation()
+ ├─ MessageBubble           └─ blockUser()             └─ watchMessages()
+ └─ ChatInputBar            // deleteConversation() KO có — conversations không bị xóa,
+                            // getConversations() tự filter status != 'blocked' cho inbox
 GroupChatScreen (Space)    FriendController (reuse)    FriendRepository (reuse)
  ├─ QuotedPhotoBlock        └─ unfriend()
- ├─ GroupMessageBubble      SpaceController (reuse)    BlockRepository
- └─ ChatInputBar            └─ leaveSpace()             └─ blockUser()
+ ├─ GroupMessageBubble      SpaceController (reuse)    BlockRepository (import từ Settings module)
+ └─ ChatInputBar            └─ leaveSpace()             └─ blockUser() — check isBlocked()
 SpaceMembersSheet
 ```
 
 **Reuse:** `FriendController.unfriend()`, `SpaceController.leaveSpace()`, `PostRepository` (fetch quoted post).
+
+> `BlockRepository` được **owned by Settings module** (`lib/features/settings/data/block_repository.dart`). Chat module inject interface này để check block status khi gửi tin — không tự define.
 
 ---
 
@@ -233,18 +248,18 @@ match /conversations/{conversationId}/messages/{messageId} {
   allow read:   if isAuthed() && isParticipant(conversationId);
   allow create: if isAuthed() &&
     isParticipant(conversationId) &&
+    // [C4-FIX] Chỉ gửi được khi conversation đang active
+    // status 'blocked'/'unfriended' = readonly (CF blockUser/onFriendshipDeleted phải update status)
+    get(/databases/$(database)/documents/conversations/$(conversationId)).data.status == 'active' &&
     request.resource.data.senderId == request.auth.uid &&
     request.resource.data.text.size() <= 500;
   allow update: if false;  // không cho edit
   allow delete: if false;  // không cho xóa
 }
 
-// /blocked_users/{uid}/blocked/{blockedUid}
-match /blocked_users/{uid}/blocked/{blockedUid} {
-  allow read:   if isAuthed() && request.auth.uid == uid;
-  allow create: if isAuthed() && request.auth.uid == uid;
-  allow delete: if isAuthed() && request.auth.uid == uid;  // unblock
-}
+// [C2-FIX] /blocked_users KHÔNG tồn tại — xem /blocks/{blockId} trong Settings spec.
+// Firestore rules cho /blocks được define trong 2026-05-23-settings.md §Security.
+// isBlocked() helper function cũng ở đó.
 
 function isParticipant(conversationId) {
   return get(/databases/$(database)/documents/conversations/$(conversationId))
@@ -274,7 +289,7 @@ function isParticipant(conversationId) {
 | `sendMessage(text)` → message xuất hiện trong stream | `ChatController` |
 | `sendMessage(text > 500 chars)` → validation error | `ChatController` |
 | `sendMessage(text rỗng)` → validation error | `ChatController` |
-| `blockUser(uid)` → tạo doc `/blocked_users/{me}/blocked/{uid}` | `ChatController` |
+| `blockUser(uid)` → gọi CF `blockUser` (Settings), tạo doc `/blocks/{me}_{uid}` | `ChatController` |
 | `getOrCreateConversation(direct, uid)` → tạo mới hoặc trả existing | `ConversationRepository` |
 | `getConversations()` → sort by `lastMessageAt` DESC | `ChatController` |
 
@@ -309,7 +324,7 @@ function isParticipant(conversationId) {
 | `Conversation` freezed model | `lib/features/chat/data/conversation.dart` | ❌ |
 | `Message` freezed model | `lib/features/chat/data/message.dart` | ❌ |
 | `ConversationRepository` abstract interface | `lib/features/chat/data/conversation_repository.dart` | ❌ |
-| `BlockRepository` abstract interface | `lib/features/chat/data/block_repository.dart` | ❌ |
+| `BlockRepository` abstract interface | ~~`lib/features/chat/data/block_repository.dart`~~ — **import từ Settings module** (`lib/features/settings/data/block_repository.dart`) | ⬅️ Settings own |
 | `ChatController` stub + `ChatState` | `lib/features/chat/application/chat_controller.dart` | ❌ |
 | `InboxScreen` stub | `lib/features/chat/presentation/inbox_screen.dart` | ❌ |
 | `ChatScreen` stub | `lib/features/chat/presentation/chat_screen.dart` | ❌ |
@@ -330,8 +345,24 @@ function isParticipant(conversationId) {
 
 ---
 
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| Send message fail (network) | Toast "Gửi thất bại — thử lại", message KHÔNG append vào bubble list (no optimistic) |
+| Conversation doc không tồn tại (CF `acceptFriendRequest` fail trước đó) | ChatController detect `null` conversation → tự tạo lại + retry; không crash |
+| Inline reply từ Feed: conversation missing | `sendMessageFromFeed()` gọi `getOrCreate` conversation → idempotent, không tạo duplicate |
+| User bị block: cố gửi tin nhắn | Firestore rule deny → `permission-denied`; toast "Bạn không thể nhắn tin với người này" |
+| Unfriend giữa chừng conversation đang mở | `onFriendshipDeleted` CF update `conversation.status = 'unfriended'`; Firestore rule block tin mới (status != active); toast "Bạn và người này không còn là bạn bè" |
+| Message > 500 chars | Disable send button khi vượt giới hạn; counter `X/500` đỏ |
+| Inbox load fail (offline) | Hiện cached conversations; error banner; không show empty state nhầm |
+| Tap conversation của người đã unfriend | Conversation hiện readonly — input bar ẩn, banner "Hãy thêm bạn lại để nhắn tin" |
+| Group chat: không còn là member của Space | Firestore rule deny đọc group conversation; navigate back + toast |
+| Tap “Gửi tin nhắn” trên post của chính mình | ActText bar ẩn hoặc disabled trên `OwnPostCard` — không tự gửi tin cho bản thân |
+| Bị đối phương block: cố gửi tin nhắn | Firestore rule deny (`isBlocked`); toast “Không thể nhắn tin với người này” (cùng message với trường hợp chố mình block) |
+
 ## Risks
 
 - **Real-time message sync:** Firestore `snapshots()` tốn reads nếu conversation nhiều message. Mitigation: giới hạn query `limit(50)` + load more khi scroll lên trên.
-- **Block không block Firestore access ngay:** client cần check blocked list trước khi cho gửi tin. Server-side enforcement cần Cloud Function hoặc rule kiểm tra blocked collection. Mitigation: Firestore rule check `/blocked_users/{receiverId}/blocked/{senderId}` trước khi cho create message.
-- **Conversation creation race:** 2 user reply cùng 1 ảnh → tạo 2 conversation? Mitigation: `getOrCreateConversation` dùng `postId + sorted participantIds` làm composite key để idempotent.
+- **Block enforcement:** `blockUser` CF (Settings) cập nhật `conversation.status = 'blocked'`. Firestore rule check `status == 'active'` trước khi cho create message. Rule tham chiếu `/blocks/{blockId}` trong Settings spec.
+- **Conversation creation:** Conversation 1-1 được tạo sẵn bởi CF `acceptFriendRequest` (pairId = conversationId). `getOrCreateConversation` trong `ConversationRepository` chỉ là fallback khi conversation bị missing (CF fail). Không có race condition vì doc ID = pairId (deterministic, idempotent set).

--- a/docs/specs/2026-05-23-chat.md
+++ b/docs/specs/2026-05-23-chat.md
@@ -1,0 +1,337 @@
+# Spec: Chat Module
+
+**Date:** 2026-05-23  
+**Status:** Locked  
+**Owner:** ThienPDM (leader assign trước khi giao)  
+**Tier:** T1 — Stretch goal  
+**Epic:** NEW (chưa có Epic number — leader tạo khi unlock)
+
+---
+
+## Goal
+
+Cho phép user nhắn tin 1-1 (photo-anchored, chỉ từ Feed) và nhắn tin nhóm trong Space. Không có chat standalone. Sau block/unfriend: conversation giữ readonly (lịch sử vẫn thấy, không gửi được). Block/unfriend có thể trigger từ trong chat.
+
+---
+
+## User stories
+
+- Là user, tôi muốn xem danh sách tất cả cuộc trò chuyện của mình (1-1 + group Space).
+- Là user, tôi muốn reply một ảnh trong Feed → mở chat 1-1 với tác giả của ảnh đó.
+- Là user, tôi muốn nhắn tin trong Group Chat của Space khi reply ảnh Space.
+- Là user, tôi muốn xem lịch sử tin nhắn theo thứ tự thời gian.
+- Là user, tôi muốn chặn (block) một người từ trong chat 1-1.
+- Là user, tôi muốn xóa bạn (unfriend) từ trong chat 1-1.
+- Là user (Space member), tôi muốn rời khỏi Space từ trong Group Chat.
+- Là user (Space member), tôi muốn xem danh sách thành viên Space từ trong Group Chat.
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Mô tả |
+|---|---|---|
+| Danh sách tin nhắn | `269:942` | Inbox: list tất cả conversations (1-1 + group) |
+| Tin nhắn 1-1 | `564:6934` | Chat screen 1-1: tin nhắn + quoted photo |
+| Tin nhắn 1-1 — Menu | `564:6965` | Dropdown menu: Xóa bạn / Chặn |
+| Tin nhắn 1-1 — Chặn | `564:7080` | Bottom sheet confirm chặn |
+| Tin nhắn 1-1 — Xóa bạn | `564:7131` | Popup confirm xóa bạn |
+| Tin nhắn Space (Group Chat) | `564:8603` | Group chat: nhiều avatar + tin nhắn |
+| Tin nhắn Space — Menu | `564:8733` | Dropdown: Chỉnh sửa theme / Xem thành viên / Rời khỏi Space |
+| Tin nhắn Space — Rời khỏi | `564:9063` | Dialog confirm rời Space |
+| Tin nhắn Space — Thành viên | `564:8896` | Bottom sheet list members Space |
+
+---
+
+## Scope
+
+### In-scope (T1 stretch)
+
+1. **Inbox** — danh sách conversations (1-1 + group Space), sort by last message time
+2. **Chat 1-1** — chỉ từ reply ảnh (Feed/Streak), không tạo chat standalone
+3. **Group Chat Space** — tích hợp với Space module, reply ảnh Space
+4. **Quoted photo** — tin nhắn đầu tiên kèm thumbnail ảnh + caption gốc
+5. **Text message** — plain text, max 500 chars
+6. **Block user** — từ menu chat 1-1 → block dialog confirm
+7. **Unfriend** — từ menu chat 1-1 → unfriend popup confirm
+8. **Leave Space** — từ menu Group Chat → dialog confirm (reuse Space leave flow)
+9. **View members** — bottom sheet danh sách members của Space
+
+### Out-of-scope
+
+- Chat standalone (không từ reply ảnh) cho 1-1 — thuộc Tier 2
+- Media message (gửi ảnh mới trong chat) — Tier 2
+- Message reactions — Tier 2
+- Read receipts / seen — Tier 2
+- Message delete/edit — Tier 2
+- Message search — Tier 2
+- Audio/video call — Tier 2
+- Chat notification sound (defer đến Push Notification module)
+
+---
+
+## Luồng đầy đủ
+
+### Luồng mở Inbox
+
+```
+Taskbar → tap icon chat (tab 3)
+    → InboxScreen
+        ├─ [loading] skeleton list
+        ├─ List conversations (sort by lastMessageAt DESC):
+        │   ├─ 1-1: [avatar] [displayName] [lastMessage preview] [timestamp]
+        │   └─ Group: [Space icon] [Space name] [lastMessage preview] [timestamp]
+        ├─ [empty state] "Chưa có tin nhắn nào — reply một ảnh để bắt đầu"
+        └─ Tap conversation → ChatScreen
+```
+
+### Luồng chat 1-1 (từ Feed reply)
+
+```
+FeedScreen → tap "Reply" trên post
+    → ChatScreen (1-1 với author)
+        ├─ Topbar: [←] [avatar + displayName] [⋯ menu]
+        ├─ [loading] skeleton messages
+        ├─ Quoted photo block (đầu thread):
+        │   ├─ Thumbnail 301×301, cornerRadius 12
+        │   ├─ Note/caption pill bên dưới ảnh
+        │   └─ Timestamp "DD thg M HH:mm"
+        ├─ Message bubbles (chronological ASC):
+        │   ├─ Bubble trái = đối phương: [avatar] [bubble text]
+        │   └─ Bubble phải = mình: [bubble text]
+        ├─ Input bar (bottom):
+        │   └─ TextField + send button
+        └─ ⋯ menu → [Xóa bạn] / [Chặn]
+```
+
+### Luồng chat Group Space
+
+```
+FeedScreen (Space post) → tap "Reply"
+    → GroupChatScreen (Space)
+        ├─ Topbar: [←] [Space icon + Space name] [⋯ menu]
+        ├─ Quoted photo block (đầu thread)
+        ├─ Message bubbles:
+        │   ├─ Bubble trái = member khác: [avatar] [displayName] (trên bubble) [bubble text]
+        │   └─ Bubble phải = mình: [bubble text]
+        ├─ Input bar (bottom)
+        └─ ⋯ menu:
+            ├─ [Chỉnh sửa theme] → navigate Space settings (Space module)
+            ├─ [Xem thành viên] → bottom sheet members list
+            └─ [Rời khỏi Space] → dialog confirm → leave (reuse SpaceController.leaveSpace())
+```
+
+### Luồng Block user
+
+```
+ChatScreen 1-1 → tap ⋯ → [Chặn]
+    → Bottom sheet "Chặn [displayName]?"
+        ├─ Icon ban (vòng tròn + slash)
+        ├─ Mô tả: "Họ sẽ không thể nhắn tin cho bạn, xem các khoảnh khắc..."
+        ├─ Note: "Họ sẽ không được thông báo rằng mình đã bị chặn"
+        ├─ [Chặn] → block → đóng chat → về Inbox (conversation ẩn)
+        └─ [Bỏ qua] → đóng bottom sheet
+```
+
+### Luồng Unfriend
+
+```
+ChatScreen 1-1 → tap ⋯ → [Xóa bạn]
+    → Popup "Xóa [displayName] khỏi Meep của bạn?"
+        ├─ Mô tả: "Các bạn sẽ không còn có thể gửi ảnh cho nhau..."
+        ├─ Note: "Lịch sử có thể phục hồi nếu thêm lại nhau"
+        ├─ [Xoá] → unfriend (reuse FriendController) → về Inbox
+        └─ [Lưu] → đóng popup (cancel)
+```
+
+### Luồng xem thành viên Space
+
+```
+GroupChatScreen → tap ⋯ → [Xem thành viên]
+    → Bottom sheet "Thành viên Space"
+        ├─ Header "Mọi người (N)"
+        └─ List members: [avatar] [displayName] [role badge nếu creator]
+```
+
+---
+
+## Data model
+
+### `/conversations/{conversationId}`
+
+```
+conversationId:  string      — auto Firestore ID
+type:            'direct' | 'space'  — loại conversation
+participantIds:  string[]    — array uid (max 2 với direct, max 10 với space)
+spaceId:         string?     — null nếu direct, spaceId nếu space
+quotedPostId:    string?     — postId của ảnh trigger tạo conversation (có thể null nếu old)
+lastMessage:     string      — preview text của tin nhắn cuối (max 50 chars, truncated)
+lastMessageAt:   Timestamp   — serverTimestamp() khi gửi tin cuối
+lastSenderId:    string      — uid người gửi tin cuối
+status:          'active' | 'blocked' | 'unfriended'  — 'blocked'/'unfriended' = readonly
+createdAt:       Timestamp   — serverTimestamp()
+```
+
+### `/conversations/{conversationId}/messages/{messageId}`
+
+```
+messageId:   string     — auto Firestore ID
+senderId:    string     — uid người gửi
+text:        string     — nội dung, max 500 chars, không rỗng
+createdAt:   Timestamp  — serverTimestamp()
+```
+
+> **Không lưu quoted photo trong message** — chỉ lưu `quotedPostId` ở conversation level. Client fetch post data riêng để render thumbnail.
+
+### `/blocked_users/{uid}/blocked/{blockedUid}`
+
+```
+blockedUid:  string     — uid bị block
+createdAt:   Timestamp  — serverTimestamp()
+```
+
+---
+
+## Architecture
+
+```
+Presentation               Application                Data
+────────────────           ──────────────────         ────────────────────────
+InboxScreen                ChatController             ConversationRepository
+ └─ ConversationTile        ├─ ChatState               ├─ getConversations()
+ChatScreen (1-1)            ├─ loadMessages()          ├─ getOrCreateConversation()
+ ├─ QuotedPhotoBlock        ├─ sendMessage()           ├─ sendMessage()
+ ├─ MessageBubble           ├─ blockUser()             └─ watchMessages()
+ └─ ChatInputBar            └─ deleteConversation()
+GroupChatScreen (Space)    FriendController (reuse)    FriendRepository (reuse)
+ ├─ QuotedPhotoBlock        └─ unfriend()
+ ├─ GroupMessageBubble      SpaceController (reuse)    BlockRepository
+ └─ ChatInputBar            └─ leaveSpace()             └─ blockUser()
+SpaceMembersSheet
+```
+
+**Reuse:** `FriendController.unfriend()`, `SpaceController.leaveSpace()`, `PostRepository` (fetch quoted post).
+
+---
+
+## Security
+
+```javascript
+// /conversations/{conversationId}
+match /conversations/{conversationId} {
+  allow read: if isAuthed() && isParticipant(conversationId);
+  allow create: if isAuthed() &&
+    request.resource.data.participantIds.hasAll([request.auth.uid]);
+  allow update: if isAuthed() && isParticipant(conversationId)
+    && request.resource.data.diff(resource.data).affectedKeys()
+       .hasOnly(['lastMessage', 'lastMessageAt', 'lastSenderId']);
+  allow delete: if false;
+}
+
+// /conversations/{conversationId}/messages/{messageId}
+match /conversations/{conversationId}/messages/{messageId} {
+  allow read:   if isAuthed() && isParticipant(conversationId);
+  allow create: if isAuthed() &&
+    isParticipant(conversationId) &&
+    request.resource.data.senderId == request.auth.uid &&
+    request.resource.data.text.size() <= 500;
+  allow update: if false;  // không cho edit
+  allow delete: if false;  // không cho xóa
+}
+
+// /blocked_users/{uid}/blocked/{blockedUid}
+match /blocked_users/{uid}/blocked/{blockedUid} {
+  allow read:   if isAuthed() && request.auth.uid == uid;
+  allow create: if isAuthed() && request.auth.uid == uid;
+  allow delete: if isAuthed() && request.auth.uid == uid;  // unblock
+}
+
+function isParticipant(conversationId) {
+  return get(/databases/$(database)/documents/conversations/$(conversationId))
+    .data.participantIds.hasAll([request.auth.uid]);
+}
+```
+
+---
+
+## Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `cached_network_image` | Avatar + quoted photo thumbnail | ✅ (Feed) |
+| `cloud_firestore` | Real-time messages `snapshots()` | ✅ |
+
+> Không cần package thêm — dùng Firestore `snapshots()` cho real-time sync.
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+| Test | Target |
+|---|---|
+| `sendMessage(text)` → message xuất hiện trong stream | `ChatController` |
+| `sendMessage(text > 500 chars)` → validation error | `ChatController` |
+| `sendMessage(text rỗng)` → validation error | `ChatController` |
+| `blockUser(uid)` → tạo doc `/blocked_users/{me}/blocked/{uid}` | `ChatController` |
+| `getOrCreateConversation(direct, uid)` → tạo mới hoặc trả existing | `ConversationRepository` |
+| `getConversations()` → sort by `lastMessageAt` DESC | `ChatController` |
+
+### Widget tests
+
+| Test | Screen |
+|---|---|
+| Send button disabled khi input rỗng | `ChatInputBar` |
+| Bubble trái/phải đúng side theo senderId | `MessageBubble` |
+| Quoted photo block hiện thumbnail + caption | `QuotedPhotoBlock` |
+| Members count đúng trong SpaceMembersSheet | `SpaceMembersSheet` |
+
+### Firestore rules tests
+
+| Test | Expected |
+|---|---|
+| Participant đọc conversation | ✅ allowed |
+| Non-participant đọc conversation | ❌ denied |
+| Participant gửi message ≤500 chars | ✅ allowed |
+| Participant gửi message >500 chars | ❌ denied |
+| Participant edit message | ❌ denied |
+| Non-participant tạo message | ❌ denied |
+| User đọc blocked list của người khác | ❌ denied |
+| Unauthenticated đọc conversation | ❌ denied |
+
+---
+
+## Contract bàn giao
+
+| Artifact | File | Status |
+|---|---|---|
+| `Conversation` freezed model | `lib/features/chat/data/conversation.dart` | ❌ |
+| `Message` freezed model | `lib/features/chat/data/message.dart` | ❌ |
+| `ConversationRepository` abstract interface | `lib/features/chat/data/conversation_repository.dart` | ❌ |
+| `BlockRepository` abstract interface | `lib/features/chat/data/block_repository.dart` | ❌ |
+| `ChatController` stub + `ChatState` | `lib/features/chat/application/chat_controller.dart` | ❌ |
+| `InboxScreen` stub | `lib/features/chat/presentation/inbox_screen.dart` | ❌ |
+| `ChatScreen` stub | `lib/features/chat/presentation/chat_screen.dart` | ❌ |
+| `GroupChatScreen` stub | `lib/features/chat/presentation/group_chat_screen.dart` | ❌ |
+| `SpaceMembersSheet` stub | `lib/features/chat/presentation/widgets/space_members_sheet.dart` | ❌ |
+| Route: `/inbox`, `/chat/:conversationId` | `lib/core/router/app_router.dart` | ❌ |
+| TODO markers format | `// TODO(<task-id>/<DevName>): implement <artifact> — see docs/specs/2026-05-23-chat.md` | ⏳ |
+
+---
+
+## Open questions
+
+| # | Câu hỏi | Status |
+|---|---|---|
+| OQ1 | Block → conversation trong Inbox? | ✅ **Giữ readonly** — vẫn thấy lịch sử, cả 2 phía, nhưng không gửi được |
+| OQ2 | Unfriend → conversation? | ✅ **Giữ readonly** — vẫn thấy lịch sử, phục hồi khi thêm bạn lại |
+| OQ3 | Chat 1-1 từ Streak? | ✅ **Không** — Streak chỉ hiện ảnh của chính mình, không có đối tượng reply |
+
+---
+
+## Risks
+
+- **Real-time message sync:** Firestore `snapshots()` tốn reads nếu conversation nhiều message. Mitigation: giới hạn query `limit(50)` + load more khi scroll lên trên.
+- **Block không block Firestore access ngay:** client cần check blocked list trước khi cho gửi tin. Server-side enforcement cần Cloud Function hoặc rule kiểm tra blocked collection. Mitigation: Firestore rule check `/blocked_users/{receiverId}/blocked/{senderId}` trước khi cho create message.
+- **Conversation creation race:** 2 user reply cùng 1 ảnh → tạo 2 conversation? Mitigation: `getOrCreateConversation` dùng `postId + sorted participantIds` làm composite key để idempotent.

--- a/docs/specs/2026-05-23-diary.md
+++ b/docs/specs/2026-05-23-diary.md
@@ -1,0 +1,578 @@
+# Spec: Diary Module (v2)
+
+**Date:** 2026-05-23
+**Status:** Locked
+**Owner:** ThienPDM
+**Epic:** Diary basic — Milestone M3 (Tier 0+)
+
+---
+
+## Goal
+
+Cho phép user viết nhật ký cá nhân theo dạng blog: chọn ảnh mood làm cover, viết text, chèn thêm ảnh với frame template. Mặc định riêng tư; có thể public để bạn bè xem qua Profile.
+
+---
+
+## User stories
+
+- Là user, tôi muốn tạo nhật ký với ảnh mood và text nội dung.
+- Là user, tôi muốn chèn thêm nhiều ảnh vào nhật ký với các khung hình khác nhau.
+- Là user, tôi muốn chọn kiểu chữ cho nội dung text.
+- Là user, tôi muốn đặt nhật ký là riêng tư (chỉ mình thấy) hoặc công khai (bạn bè xem được qua Profile).
+- Là user, tôi muốn xem lại danh sách nhật ký của mình.
+- Là user, tôi muốn tìm kiếm nhật ký theo từ khoá.
+
+---
+
+## Scope
+
+### In-scope
+
+1. **Diary tab** — trigger từ `book-heart` icon trong bottom taskbar
+2. **Empty state** — khi chưa có nhật ký
+3. **Danh sách nhật ký** — grid "Diary Mood" cards (ảnh cover + date)
+4. **Tạo nhật ký** — chọn ảnh mood từ gallery (với frame templates)
+5. **Canvas editor** — viết text + chèn thêm ảnh (blog-style) + frame templates
+6. **Chọn kiểu text** — text style picker (Normal, Heading, Quote, v.v.)
+7. **Privacy toggle** — Riêng tư / Công khai + [Xong]
+8. **Lưu nhật ký** — [✓ check] trong topbar
+9. **Xem nhật ký** — read mode (canvas view-only)
+10. **Tìm kiếm nhật ký** — full-text search trong entries của chính mình
+
+### Out-of-scope
+
+- Sticker, GIF insertion (toolbar hiện disabled)
+- Share trực tiếp vào feed (diary KHÔNG phải post)
+- Chia sẻ vào Space
+- Comment / reaction trên nhật ký (post-MVP)
+- Diary visible trên feed (chỉ trên Profile)
+
+> **Xoá / Sửa:** logic backend có (Firestore update/delete), UI chưa thiết kế — defer UI sang sprint sau. API sẵn sàng.
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Ghi chú |
+|---|---|---|
+| Empty state | `656:1945` | "Bạn chưa có nhật ký nào" + [+] FAB |
+| Danh sách Nhật ký | `656:1831` | Grid Diary Mood cards + search icon |
+| Tạo - Nhật ký | `656:1953` | Ảnh mood overlay "Hôm nay bạn thế nào?" |
+| Canvas - Nhật ký | `658:6070` | Editor: cover photo + text + toolbar |
+| Viết nhật ký | `667:11520` | Canvas + GBoard keyboard visible |
+| Tìm kiếm Nhật ký | `712:4356` | Search input → result cards |
+| Cập nhật quyền | `718:4643` | Privacy: Riêng tư / Công khai + [Xong] |
+| Chọn kiểu text | `724:2975` | Text style picker trong canvas |
+
+---
+
+## Luồng đầy đủ
+
+### Trigger
+
+```
+Bottom taskbar → tap [book-heart] icon (thứ 2 từ trái)
+    → navigate to Diary tab
+    → nếu chưa có entry: Empty state
+    → nếu có entry: Danh sách Nhật ký
+```
+
+---
+
+### Empty state
+
+```
+"Bạn chưa có nhật ký nào"
+[+] FAB (Turquoise/500, bottom-center)
+    → tap → Tạo nhật ký
+```
+
+---
+
+### Danh sách Nhật ký
+
+```
+Topbar: [🔍 search] | "Nhật ký" | [Avatar]
+Body:   Grid các "Diary Mood" card:
+        [Circular cover photo 79x79] + date label "22 th 5" bên dưới
+FAB [+] (bottom-center, Turquoise)
+
+→ tap một card → Xem nhật ký (Canvas read mode)
+→ tap [🔍] → Tìm kiếm Nhật ký
+→ tap [+] → Tạo nhật ký
+```
+
+---
+
+### Tạo nhật ký (chọn mood image)
+
+```
+Overlay slide up trên Diary list:
+    Title: "Hôm nay bạn thế nào?"
+    Body: ảnh gần nhất từ gallery hiển thị trong 5 mood frames (hàng ngang scroll):
+        - Vui vẻ   (happy)      ← icon image + frame PNG riêng
+        - Chán nản  (bored)      ← icon image + frame PNG riêng
+        - Mệt mỏi  (tired)      ← icon image + frame PNG riêng
+        - Buồn bã   (sad)        ← icon image + frame PNG riêng
+        - Ngại ngùng (shy)       ← icon image + frame PNG riêng
+    [X] đóng overlay (button tối, bottom-center)
+
+→ tap 1 mood → ảnh đó + frame template tương ứng trở thành cover → mở Canvas editor
+→ Canvas: user tự gõ mood caption (placeholder: "Hôm nay bạn thế nào?")
+```
+
+> **Frame template = 2 layer:**
+> - **Layer dưới:** ảnh user clip theo shape của mood (được designer quyết định per mood)
+> - **Layer trên:** asset PNG trang trí có vùng trong suốt ở giữa (export bởi designer HanDHG)
+>
+> ```dart
+> Stack(
+>   children: [
+>     ClipPath(clipper: FrameClipper(template), child: Image(photo)),
+>     Image.asset('assets/frames/frame_${template.name}.png'), // overlay decoration
+>   ]
+> )
+> ```
+>
+> **Designer (HanDHG) cần export:** 5 icon images (cho mood picker) + 5 frame PNG assets (transparent center), đặt vào `assets/frames/`. **Clip shape per mood** do designer quyết định khi thiết kế frame PNG.
+
+---
+
+### Canvas editor
+
+```
+Topbar (light bg): [←] | "22 tháng 5" | [🔒 lock] [✓ check]
+Body:
+    [Cover photo — circular, 102x102]
+    [Mood caption: "Happy!" — text, có underline accent màu turquoise]
+    [Text cursor "|" — gõ nội dung]
+    [Chèn ảnh inline — giống blog]
+
+Bottom toolbar (keyboard bar):
+    [←] [sticker — disabled] [GIF — disabled] [clipboard] [settings] [more] [mic]
+
+→ tap text area → GBoard keyboard hiện + bottom toolbar
+→ tap [text style button trong toolbar] → Chọn kiểu text sheet
+→ tap [🔒 lock] → Privacy sheet (Cập nhật quyền)
+→ tap [✓ check] → lưu entry + navigate về Danh sách
+→ tap [←] back (create mode) → DiscardChangesDialog:
+        "Bỏ nhật ký này?"
+        [Bỏ] → discard, về Danh sách
+        [Tiếp tục viết] → dismiss
+→ tap [←] back (read/edit mode) → về Danh sách trực tiếp (không discard dialog)
+```
+
+---
+
+### Chọn kiểu text
+
+```
+Canvas + keyboard đang visible
+→ tap text style icon trong toolbar
+    → Bottom sheet hoặc inline picker slide up:
+        Text styles: Normal | Heading | Sub-heading | Quote | ...
+    → Chọn style → apply cho đoạn text đang chọn
+    → keyboard vẫn visible
+```
+
+---
+
+### Cập nhật quyền (Privacy)
+
+```
+Canvas → tap [🔒 lock icon]
+    → Privacy sheet:
+        [Riêng tư]  — icon lock   — mặc định, chỉ mình xem
+        [Công khai] — icon unlock — bạn bè xem qua Profile
+        [Xong] button
+    → tap [Riêng tư] / [Công khai] → highlight selection
+    → tap [Xong] → đóng sheet, icon topbar đổi theo (lock/unlock)
+```
+
+---
+
+### Lưu nhật ký
+
+```
+Canvas → tap [✓ check]
+    → validate: phải có ít nhất 1 ảnh cover + 1 ký tự text
+    → show loading indicator
+    → (1) upload cover image  → diary/{uid}/{entryId}/cover.jpg  → lấy coverUrl
+    → (2) upload inline images tuần tự → diary/{uid}/{entryId}/img_1.jpg, img_2.jpg...
+    → (3) tất cả URLs sẵn sàng → create /diary/{entryId} document với URLs đã có
+    → navigate về Danh sách Nhật ký
+    → card mới hiện ở đầu grid (newest first)
+    → nếu upload fail ở bước (1)/(2) → toast error, KHÔNG tạo Firestore doc
+```
+
+> Upload images TRƯỚC, Firestore write SAU — tránh broken state (doc tồn tại nhưng imageUrl trống).
+
+---
+
+### Tìm kiếm Nhật ký
+
+```
+Danh sách → tap [🔍]
+    → Search screen:
+        Input field + cursor "|"
+        → gõ → filter real-time theo text content
+        → "N kết quả"
+        → Result cards: [keyword highlight] + [date full: "22 tháng 5 năm 2026"]
+    → tap result → Xem nhật ký
+```
+
+> Search chỉ trong entries của chính user (không search public entries của người khác).
+
+---
+
+### Xem nhật ký (read mode)
+
+```
+Tap card từ Danh sách → Canvas read mode:
+    Topbar: [←] | date | [lock/unlock icon] [✏️ edit?]
+    Body: render các content blocks (text + images)
+    → tap [←] → về Danh sách
+```
+
+> Edit mode cho phép sửa nội dung và đổi privacy. Tap [✏️] hoặc re-open từ Danh sách.
+
+---
+
+### Cross-module: Diary trên Profile
+
+```
+Profile screen → section "Nhật ký"
+    → dùng lại DiaryMoodCard grid (cùng layout v2 DiaryListScreen)
+    → chỉ hiện entries có privacy = 'public'
+    → viewer là bạn bè của owner → có thể xem
+    → viewer không phải bạn bè → ẩn section
+    → tap một card → Canvas read-only (không edit)
+```
+
+> Profile module (HanDHG) gọi `DiaryRepository.getPublicEntries(authorUid)`.  
+> Contract cần export interface này trước khi Profile module implement.
+
+---
+
+## Data model
+
+### `/diary/{entryId}`
+
+```
+{
+  authorUid:     string,                   // owner
+  moodTemplate:  'happy' | 'bored' | 'tired' | 'shy' | 'sad',
+                 // happy=Vui vẻ | bored=Chán nản | tired=Mệt mỏi | shy=Ngại ngùng | sad=Buồn bã
+                 // quyết định background shape + cover clip shape của Mood zone
+  coverImageUrl: string,                   // Cloud Storage URL — ảnh cover trong Mood zone
+  moodCaption:   string,                   // title của nhật ký, VD: "Happy!" — bắt buộc, max 50 chars
+  content:       DiaryContentBlock[],      // ordered list of content blocks (text + images)
+  privacy:       'private' | 'public',    // default: 'private'
+  createdAt:     Timestamp,               // serverTimestamp
+  updatedAt:     Timestamp,               // serverTimestamp
+}
+```
+
+> **Mood zone** là khu vực cố định ở đầu canvas, render từ `moodTemplate` + `coverImageUrl` + `moodCaption`. Không phải là 1 content block — là header riêng biệt.
+
+### `DiaryContentBlock` (embedded array, không sub-collection)
+
+```typescript
+// Text block — 4 styles supported
+{
+  type:  'text',
+  value: string,          // nội dung text, max 2000 chars per block
+  style: 'normal' | 'heading' | 'subheading' | 'quote',
+  // 'normal'     — body text mặc định
+  // 'heading'    — H1-size, bold
+  // 'subheading' — H2-size, semibold
+  // 'quote'      — italic + left border accent
+}
+
+// Image block — inline image trong content area
+{
+  type:     'image',
+  imageUrl: string,  // Cloud Storage URL
+  // frameTemplate: không có — inline image dùng 1 frame shape cố định từ Figma
+  // Shape cụ thể do designer (HanDHG) xác nhận — render bằng assets/frames/frame_inline.png
+}
+```
+
+> Max content blocks per entry: 20 (mix text + image).  
+> Max images per entry: 5 (cover + 4 inline).  
+> Dùng embedded array trong document (không sub-collection) vì content luôn load cùng entry.
+
+### Storage paths
+
+```
+diary/{uid}/{entryId}/cover.jpg        ← cover/mood image
+diary/{uid}/{entryId}/img_1.jpg        ← inline image 1
+diary/{uid}/{entryId}/img_2.jpg        ← inline image 2
+...
+```
+
+---
+
+## Technical approach
+
+### Architecture
+
+```
+Presentation                  Application                 Data
+──────────────────            ──────────────────          ────────────────────
+DiaryListScreen               DiaryController             DiaryRepository (abstract)
+ ├─ DiaryMoodCard              ├─ createEntry()            FirebaseDiaryRepository
+ ├─ DiaryEmptyState            ├─ getEntries()
+DiaryCreateScreen             ├─ getPublicEntries(uid)    ← Profile cross-module
+DiaryCanvasScreen             ├─ updatePrivacy()
+ ├─ ContentBlockRenderer       ├─ searchEntries()
+ ├─ TextStylePicker            ├─ saveEntry()  ← gọi create/update theo mode
+ ├─ PrivacySheet               ├─ getEntry(id)
+ ├─ DiscardChangesDialog       ├─ updateEntry(id)
+DiarySearchScreen             └─ deleteEntry(id)
+```
+
+> **`saveEntry()` là method của `DiaryController`** — canvas [✓] luôn gọi `saveEntry()`. Nội bộ nó quyết định dùng `createEntry()` (mode=create) hay `updateEntry(id)` (mode=edit/read). Dev KHÔNG gọi `createEntry`/`updateEntry` trực tiếp từ UI.
+
+> Canvas light theme: `#f9fcfc` background — **intentional**, khác dark theme toàn app.
+> Dev phải hardcode `Scaffold(backgroundColor: Color(0xFFF9FCFC))` cho `DiaryCanvasScreen`, không dùng `Theme.of(context).scaffoldBackgroundColor`.
+
+### Canvas render architecture
+
+Canvas editor là `Column` của các block widget — **không phải canvas vẽ tay**, không dùng thư viện rich text editor ngoài.
+
+```dart
+// DiaryCanvasScreen body
+SingleChildScrollView(
+  child: Column(
+    children: [
+      // 1. Mood zone (cố định, không phải content block)
+      MoodZoneBlock(
+        moodTemplate: entry.moodTemplate,  // quyết định background shape + cover clip
+        coverImageUrl: entry.coverImageUrl,
+        moodCaption: entry.moodCaption,    // title bắt buộc
+      ),
+      // Structure bên trong MoodZoneBlock:
+      // Stack(
+      //   children: [
+      //     Image.asset('assets/moods/bg_${moodTemplate}.png'),  // background shape
+      //     ClipPath(clipper: MoodClipper(moodTemplate), child: Image(cover)),
+      //     MoodCaptionText(moodCaption),  // text + turquoise underline
+      //   ]
+      // )
+
+      // 2. Content blocks (text + inline images)
+      ...contentBlocks.map((block) {
+        return switch (block.type) {
+          'text'  => TextBlock(block.value, block.style),  // TextField (edit) / Text (read)
+          'image' => InlineImageBlock(block.imageUrl),     // 1 frame shape cố định từ Figma
+          _ => const SizedBox.shrink(),
+        };
+      }),
+    ]
+  )
+)
+```
+
+**Frame + mood asset requirement — đã xác nhận từ Figma `656:1831` + `769:4634`:**
+
+| Code key | Tên hiển thị | Node Figma | Loại shape | Figma size | Flutter impl |
+|---|---|---|---|---|---|
+| `happy` | Vui vẻ | `658:4065` | RECTANGLE | 51×51px | `BorderRadius.circular(38.5)` ≈ circle |
+| `bored` | Chán nản | `658:4069` | RECTANGLE | 45×45px | `BorderRadius.circular(10)` (scale: ~27px ở 120px) |
+| `tired` | Mệt mỏi | `658:4072` | **VECTOR** | 56×50px | `CustomClipper` — export SVG path từ Figma |
+| `shy` | Ngại ngùng | `658:4110` | **VECTOR** | 60×47.5px | `CustomClipper` — export SVG path từ Figma |
+| `sad` | Buồn bã | `658:4174` | **VECTOR** | 48×45px | `CustomClipper` — export SVG path từ Figma |
+
+> **3 VECTOR moods** (`tired`, `shy`, `sad`): HanDHG export từng node ra SVG file riêng. Dev dùng `flutter_svg` để render icon, và extract path data để implement `CustomClipper` tương ứng.
+
+| Asset file | Mô tả | Số lượng |
+|---|---|---|
+| `assets/moods/icon_happy.svg` ... `icon_sad.svg` | SVG icon từng mood, dùng cho mood picker và card clip | 5 files |
+| `assets/moods/bg_happy.png` ... `bg_sad.png` | Background texture/shape của Mood zone canvas | 5 files |
+| `assets/frames/frame_polaroid.png` | Khung Polaroid cho inline image (Figma: "Polaroid Frame") | 1 file |
+
+> **Tổng 11 assets tối thiểu** (5 SVG + 5 bg PNG + 1 polaroid) phải export trước khi Diary implement.
+
+### Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `cloud_firestore` | diary collection | ✅ |
+| `firebase_storage` | upload images | ✅ |
+| `image_picker` | chọn ảnh từ gallery cho mood frame | ✅ `image_picker: ^1.1.2` đã có (OQ6 resolved — share với Camera module) |
+| `go_router` | navigation | ✅ |
+| `flutter_svg` | render SVG mood icons (`assets/moods/icon_{mood}.svg`) | ❌ cần thêm |
+
+---
+
+## Components (từ Figma `656:1831` + `712:4356` + `769:4634`)
+
+### `DiaryMoodCard` — Grid view item (Figma: "Diary Mood" component)
+
+```
+Card width: 150.5px
+Image area: 120×120px, center-aligned (margin-x: 15.25px)
+Clip shape: tuỳ mood (xem bảng mood → clip shape ở trên)
+Image border: white stroke
+Title: Nunito Bold 20px, white, centered
+Date: Nunito SemiBold 14px, #656c6d (BW600), centered
+Total height: ~182px (image 120px + gap 9px + text area 53px)
+```
+
+### `DiaryListScreen` — Grid layout (Figma `656:1831`)
+
+```
+Screen bg: #050f10
+Content container: 333px wide, padding-x: 39px
+Grid: 2 columns, horizontal gap: 32px, vertical gap: 32px
+Card: DiaryMoodCard 150.5px wide
+FAB: 60×60 Turquoise/500, cornerRadius 30, centered, y=725 (above taskbar)
+Topbar: search icon (left) + "Nhật ký" (Nunito Bold 18px, center) + avatar 40×40 (right)
+```
+
+### `DiarySearchScreen` — List view (Figma `712:4356`)
+
+```
+List item: horizontal layout (khác với grid)
+Mỗi item: mood indicator (nhỏ) + title + date — đọc từ Firestore, filter in-memory
+Search input: full-width field, tìm theo title/content
+```
+
+### Canvas Mood Header (Figma `769:4634`)
+
+```
+Canvas bg: #f9fcfc (light theme — dùng hardcode)
+Mood header zone:
+  - Avatar circle: 102×102px, cornerRadius 51, white stroke
+  - Mood name text: Nunito Bold 18px, #000000
+  - Turquoise underline decoration: stroke #68f2ff (Vector 5)
+
+Polaroid Frame component (inline image):
+  - White background frame với "Textured Lattice" overlay
+  - Picture window (user's inline image)
+  - cornerRadius: 5.33px, shadow stroke #0000001a
+
+Emoji decorations: Roboto 36px text nodes (💙, ✨) — user có thể thêm
+```
+
+---
+
+## Security
+
+### Firestore rules `/diary/{entryId}`
+
+```javascript
+// Requires isFriend() helper từ Friend module rules
+match /diary/{entryId} {
+  // Owner đọc tất cả; bạn bè đọc public entries
+  allow read: if isAuthed() && (
+    resource.data.authorUid == request.auth.uid ||
+    (resource.data.privacy == 'public' && isFriend(resource.data.authorUid))
+  );
+
+  // Chỉ owner tạo
+  allow create: if isAuthed()
+    && request.auth.uid == request.resource.data.authorUid
+    && request.resource.data.privacy in ['private', 'public']
+    && request.resource.data.content.size() <= 20
+    && request.resource.data.moodCaption.size() <= 50;  // [FIX] enforce max 50 chars
+
+  // Chỉ owner update; không được đổi authorUid
+  allow update: if isAuthed()
+    && resource.data.authorUid == request.auth.uid
+    && request.resource.data.authorUid == resource.data.authorUid
+    && request.resource.data.content.size() <= 20  // [FIX] cũng enforce khi update
+    && request.resource.data.moodCaption.size() <= 50;
+
+  // Chỉ owner xoá
+  allow delete: if isAuthed()
+    && resource.data.authorUid == request.auth.uid;
+}
+```
+
+### Storage rules `diary/{uid}/**`
+
+```javascript
+match /diary/{uid}/{entryId}/{filename} {
+  allow read: if isAuthed();   // URL đã được lưu trong doc — không read trực tiếp
+  allow write: if isAuthed()
+    && request.auth.uid == uid
+    && request.resource.size < 10 * 1024 * 1024
+    && request.resource.contentType.matches('image/.*');
+}
+```
+
+---
+
+## Contract bàn giao
+
+| Artifact | File | Status |
+|---|---|---|
+| `DiaryEntry` freezed model | `lib/features/diary/data/diary_entry.dart` | ❌ |
+| `DiaryContentBlock` freezed model | `lib/features/diary/data/diary_content_block.dart` | ❌ |
+| `DiaryRepository` abstract (**phải có `getPublicEntries(authorUid)` — Profile module dùng**) | `lib/features/diary/data/diary_repository.dart` | ❌ |
+| `DiaryController` stub | `lib/features/diary/application/diary_controller.dart` | ❌ |
+| `DiaryCanvasMode` enum (`create / read / edit`) | `lib/features/diary/presentation/diary_canvas_screen.dart` | ❌ (cùng file với stub) |
+| `DiaryListScreen` stub | `lib/features/diary/presentation/diary_list_screen.dart` | ❌ |
+| `DiaryCreateScreen` stub | `lib/features/diary/presentation/diary_create_screen.dart` | ❌ |
+| `DiaryCanvasScreen` stub | `lib/features/diary/presentation/diary_canvas_screen.dart` | ❌ |
+| `DiarySearchScreen` stub | `lib/features/diary/presentation/diary_search_screen.dart` | ❌ |
+| `DiscardChangesDialog` stub | `lib/features/diary/presentation/discard_changes_dialog.dart` | ❌ |
+| `PrivacySheet` stub | `lib/features/diary/presentation/privacy_sheet.dart` | ❌ |
+| Firestore rules `/diary` | `firestore.rules` | ❌ |
+| Storage rules `diary/**` | `storage.rules` | ❌ |
+| Route `/diary` | router stub | ❌ |
+| TODO markers trên mọi stub | — | ⏳ |
+
+> `DiaryCanvasScreen` dùng chung cho create / read / edit mode — phân biệt qua `mode` param (`DiaryCanvasMode.create / read / edit`).
+
+---
+
+## Open questions
+
+| # | Câu hỏi | Impact | Status |
+|---|---|---|---|
+| OQ1 | Mood caption — user tự gõ hay preset? | Create UX | ✅ **Resolved:** user tự gõ. Caption placeholder: "Hôm nay bạn thế nào?" |
+| OQ2 | Frame templates — bao nhiêu loại? | Canvas UX | ✅ **Resolved:** Figma `656:1831` + `769:4634`. Bảng mapping mood → clip shape được xác nhận từ node names: `happy`=circle (cornerRadius≈74.5), `bored`=rounded rect (cornerRadius=21), `tired`=custom vector/organic shape. `sad` + `shy` cần HanDHG export. |
+| OQ3 | Search — client-side hay Firestore full-text? | Tech | ✅ **Resolved:** client-side filter MVP (load all entries, filter in-memory). Đủ cho < 100 entries |
+| OQ4 | Edit diary sau khi lưu? | Scope | ✅ **Resolved:** được phép edit (reuse Canvas screen) |
+| OQ5 | Diary trên Profile — layout? | Cross-module | ✅ **Resolved:** dùng lại DiaryMoodCard grid v2. Profile gọi `DiaryRepository.getPublicEntries(authorUid)` |
+| OQ6 | `image_picker` trong pubspec? | Dependency | ✅ **Resolved:** `image_picker: ^1.1.2` đã có. Share với Camera module. |
+
+---
+
+## Happy path
+
+| Flow | Happy path |
+|---|---|
+| Tạo nhật ký | Tap [+] → chọn mood frame → canvas → gõ text → [✓] → card xuất hiện ở đầu list |
+| Xem nhật ký | Tap card → canvas read mode → render blocks |
+| Edit nhật ký | Canvas read → tap [✏️] → canvas edit mode → sửa → [✓] → lưu |
+| Đổi privacy | Canvas → tap [🔒] → chọn Công khai → [Xong] → icon thay đổi |
+| Tìm kiếm | Tap [🔍] → gõ keyword → "N kết quả" → tap result → xem |
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| Upload cover fail (network lỗi) | Toast error, KHÔNG tạo Firestore doc, user retry |
+| Upload inline image fail | Toast error, KHÔNG tạo Firestore doc, user retry |
+| Tap [←] back khi đang viết mới | DiscardChangesDialog: [Bỏ] / [Tiếp tục viết] |
+| Tap [←] back ở read mode | Về Danh sách ngay, không dialog |
+| Lưu với content trống | Validate fail, toast "Vui lòng nhập nội dung", ở lại canvas |
+| Lưu với > 20 content blocks | UI disable nút thêm block khi đạt giới hạn |
+| Canvas offline khi tap [✓] | Toast error lưu thất bại, giữ nguyên canvas state |
+| Bạn bè truy cập entry vừa đổi private | Firestore rules revoke ngay; client nhận `permission-denied` |
+| Tìm kiếm với list entries rỗng | "0 kết quả" empty state |
+
+---
+
+## Risks
+
+- **Search:** Firestore không hỗ trợ full-text search native. MVP dùng client-side filter (load tất cả entries → filter in-memory). Chấp nhận với số lượng nhỏ (< 100 entries). Nếu scale cần Algolia.
+- **Content blocks array:** Max 20 blocks enforce ở Firestore rules và client. Nếu vượt → UI disable thêm block.
+- **Image upload ordering:** Upload tuần tự — cover trước, inline sau. Firestore doc chỉ tạo sau khi tất cả URLs sẵn sàng.
+- **Privacy change:** Khi owner đổi từ Public → Private, bạn bè đang xem bị revoke ngay (Firestore rules real-time). Client-side cache có thể vẫn hiện — acceptable.
+- **Profile cross-module:** `getPublicEntries(authorUid)` exposed qua `DiaryRepository` abstract interface. Profile module import interface, không import `FirebaseDiaryRepository`.
+- **Canvas light theme:** `#f9fcfc` — dev KHÔNG dùng `Theme.of(context)` cho `DiaryCanvasScreen` background.

--- a/docs/specs/2026-05-23-notification.md
+++ b/docs/specs/2026-05-23-notification.md
@@ -1,0 +1,332 @@
+# Spec: Push Notification Module
+
+**Date:** 2026-05-23
+**Status:** Locked
+**Owner:** ThienPDM (leader assign trước khi giao)
+**Epic:** [T0] Push Notification — FCM Android · Milestone M3
+
+---
+
+## Goal
+
+Gửi push notification đến thiết bị Android của user khi có sự kiện liên quan (friend request, post mới, reaction). Lưu notification history trong Firestore để user xem lại.
+
+---
+
+## User stories
+
+- Là user, tôi muốn nhận push notification khi có người gửi friend request cho tôi.
+- Là user, tôi muốn nhận push notification khi friend request của tôi được chấp nhận.
+- Là user, tôi muốn nhận push notification khi bạn bè đăng ảnh mới.
+- Là user, tôi muốn nhận push notification khi có người react vào ảnh của tôi.
+- Là user, tôi muốn xem lại danh sách notification gần đây trong app.
+
+---
+
+## Scope
+
+### In-scope (M3)
+
+1. **FCM token management** — lưu/cập nhật FCM token khi user login, xoá khi logout
+2. **4 notification events:**
+   - `friend_request_received` — A gửi friend request cho B
+   - `friend_request_accepted` — B chấp nhận friend request của A
+   - `new_post` — bạn bè đăng ảnh mới (fan-out theo friend list)
+   - `reaction_received` — ai đó react vào post của mình
+3. **Notification history** — lưu vào Firestore, đọc trong app (in-app notification list)
+4. **Notification toggle** — bật/tắt từ Profile (lưu local preference, unsubscribe FCM)
+5. **Deep link tap** — tap notification → navigate đúng màn hình trong app
+
+### Out-of-scope
+
+- Space post notification — defer sang Space module nếu cần
+- RollCall notification — **cut** (RollCall module bị loại)
+- Notification settings granular (per-type toggle) — post-MVP
+- Badge count trên app icon — post-MVP
+- Notification grouping — post-MVP
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Ghi chú |
+|---|---|---|
+| In-app notification list screen | _(chưa có — xem OQ1)_ | Optional M3; minimum = push only |
+| **Foreground notification banner (component)** | `765:4766` (expanded) / `765:4981` (collapsed) | Overlay khi app đang mở |
+
+> M3 minimum viable: push notification hoạt động đúng. In-app list là nice-to-have.
+
+### Foreground notification banner spec
+
+**Component `Noti`** — overlay slide down từ top khi app foreground:
+
+```
+Container: bg #2d2d2fe0 (semi-transparent dark), cornerRadius 20, width 364
+
+Collapsed state (h=65, Figma 765:4981):
+  [ Logo ] [senderName . timestamp    ] [chevron-down]
+                [message preview]
+
+Expanded state (h=112, Figma 765:4766):
+  [ Logo ] [senderName . timestamp    ] [chevron-up]
+                [message preview]
+  [Trả lời]  |  [Tắt thông báo]
+```
+
+Typography:
+- `senderName`: Roboto Medium 13px, `#dee5e6` (BW300)
+- `timestamp`: Roboto Light 11px, `#656c6d` (BW600)  
+- `message preview`: Roboto Light 13px, `#8d999b` (BW500)
+- Actions: Roboto Regular 12px, `#8d999b` (BW500)
+
+> **Tắt thông báo** = local preference toggle (không phải unsubscribe FCM — chỉ suppress foreground banner).
+
+---
+
+## Luồng đầy đủ
+
+### FCM token lifecycle
+
+```
+App khởi động + user đã login
+    → FirebaseMessaging.getToken() → lưu vào /users/{uid}/fcmTokens/{tokenId}
+        **[OQ3] 1 token/user policy:** saveFcmToken() phải:
+        1. Xóa tất cả token docs hiện có trong /users/{uid}/fcmTokens/*
+        2. Rồi tạo doc mới với tokenId mới
+        (Thực hiện bằng Firestore batch: delete all + create new)
+    → FirebaseMessaging.onTokenRefresh → gọi lại saveFcmToken() — tự cleanup + replace
+
+User logout (Settings module)
+    → Xoá token khỏi Firestore (xóa tất cả docs trong /users/{uid}/fcmTokens/*)
+    → FirebaseAuth.signOut()
+```
+
+### friend_request_received
+
+```
+User A gửi friend request → Firestore /friend_requests/{id} created
+    → Cloud Function onFriendRequestCreated trigger
+        → Đọc FCM token của receiverId
+        → Gửi FCM notification:
+            title: "{senderName} muốn kết bạn với bạn"
+            body:  "Tap để xem và chấp nhận"
+            data:  { type: 'friend_request', requestId }
+        → Tạo /users/{receiverId}/notifications/{id}
+    → User B nhận push → tap → app mở FriendSheet (deep link)
+```
+
+### friend_request_accepted
+
+```
+User B chấp nhận → acceptFriendRequest Cloud Function
+    → Gửi FCM notification cho User A:
+            title: "{receiverName} đã chấp nhận lời mời kết bạn"
+            body:  "Các bạn giờ là bạn bè trên Meep!"
+            data:  { type: 'friend_accepted', friendUid }
+    → Tạo /users/{senderOfRequest}/notifications/{id}
+```
+
+### new_post (fan-out)
+
+```
+User đăng ảnh → /posts/{postId} created
+    → Cloud Function onPostCreated (đã có trong index.ts)
+        → Đọc friendUids từ /friendships (arrayContains authorId)
+        → Batch gửi FCM cho từng friendUid (max 20)
+        → KHÔNG tạo notification doc (spam nếu lưu tất cả)
+    → Bạn bè nhận push → tap → app mở Feed (scroll đến post đó)
+```
+
+### reaction_received
+
+```
+User react → /posts/{postId}/reactions/{id} created
+    → Cloud Function onReactionCreated trigger
+        → Đọc post.authorId, FCM token của author
+        → Guard: nếu reactorId == authorId → skip (không tự notify mình)
+        → Gửi FCM:
+            title: "{reactorName} đã react vào ảnh của bạn"
+            body:  "{emoji}"
+            data:  { type: 'reaction', postId }
+        → Tạo /users/{authorId}/notifications/{id}
+```
+
+### Deep link navigation
+
+```
+User tap notification payload
+    → App mở (foreground / background / terminated)
+    → GoRouter đọc notification data.type:
+        'friend_request' → FriendSheet
+        'friend_accepted' → FriendSheet
+        'reaction'        → Feed (scroll đến postId)
+        'new_post'        → Feed (top)
+```
+
+---
+
+## Data model
+
+### `/users/{uid}/fcmTokens/{tokenId}`
+
+```
+{
+  token:     string,    // FCM device token
+  platform:  'android', // MVP: Android only
+  updatedAt: Timestamp,
+}
+```
+
+> **[H6-FIX] `tokenId` = SHA-256 hash (hex) của token** để tránh duplicate khi đăng nhập lại cùng thiết bị.  
+> Dart: `sha256.convert(utf8.encode(token)).toString()` (package `crypto` — đã có vì Firebase SDK depend on it).  
+> Kotlin Worker: `MessageDigest.getInstance("SHA-256").digest(token.toByteArray()).joinToString("") { "%02x".format(it) }`.
+
+### `/users/{uid}/notifications/{notifId}`
+
+```
+{
+  type:      'friend_request' | 'friend_accepted' | 'reaction',  // new_post không lưu
+  title:     string,
+  body:      string,
+  data:      Map<string, string>,  // deep link params
+  read:      boolean,   // default false
+  createdAt: Timestamp,
+}
+```
+
+---
+
+## Architecture
+
+```
+Presentation            Application                 Data
+────────────────        ──────────────────          ───────────────────────────
+(in-app list            NotificationController      NotificationRepository
+ optional M3)            ├─ initFCM()               ├─ saveFcmToken()
+                         ├─ handleForeground()       ├─ deleteFcmToken()
+                         ├─ handleBackground()       ├─ getNotifications()
+                         └─ markAsRead()             └─ markAsRead()
+```
+
+**Cloud Functions liên quan:**
+
+| Function | Trigger | Việc làm |
+|---|---|---|
+| `onFriendRequestCreated` | Firestore onCreate `/friend_requests/{id}` | Gửi FCM cho receiver, tạo notification doc |
+| `onFriendRequestAccepted` | Firestore onUpdate `/friend_requests/{id}` (status → accepted) | Gửi FCM cho sender |
+| `onPostCreated` | Firestore onCreate `/posts/{id}` | **[H10-NOTE] Function này được define trong `home-camera-feed.md` — không tạo function mới.** Logic FCM fan-out cho friends được gọi bên trong `onPostCreated` của Camera/Feed spec. |
+| `onReactionCreated` | Firestore onCreate `/posts/{id}/reactions/{id}` | Gửi FCM cho post author, tạo notification doc |
+
+---
+
+## Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `firebase_messaging` | FCM token + receive push | ❌ cần thêm |
+| `flutter_local_notifications` | Hiện notification khi app foreground | ❌ cần thêm |
+| `go_router` | Deep link navigation từ notification tap | ✅ |
+
+---
+
+## Security
+
+```javascript
+match /users/{uid}/notifications/{notifId} {
+  allow read:   if isAuthed() && request.auth.uid == uid;
+  allow update: if isAuthed() && request.auth.uid == uid
+                && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['read']);
+  allow create: if false;  // Cloud Function Admin SDK only
+  allow delete: if false;
+}
+
+match /users/{uid}/fcmTokens/{tokenId} {
+  allow read:   if isAuthed() && request.auth.uid == uid;
+  allow write:  if isAuthed() && request.auth.uid == uid;
+}
+```
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+| Test | Target |
+|---|---|
+| `saveFcmToken(uid, token)` → doc tạo đúng | `NotificationRepository` |
+| `deleteFcmToken(uid)` → doc xoá | `NotificationRepository` |
+| `getNotifications(uid)` → list sort by createdAt DESC | `NotificationRepository` |
+| `markAsRead(notifId)` → `read = true` | `NotificationRepository` |
+
+### Cloud Function tests
+
+| Test | Expected |
+|---|---|
+| `onFriendRequestCreated`: receiver có FCM token → FCM gửi + notification doc tạo | ✅ |
+| `onFriendRequestCreated`: receiver không có FCM token → skip, không crash | ✅ |
+| `onReactionCreated`: reactorId == authorId → skip (không self-notify) | ✅ |
+| `onPostCreated`: fan-out đúng số friendUids (max 20) | ✅ |
+
+### Firestore rules tests
+
+- `/users/{uid}/notifications/{id}` read by owner ✓
+- `/users/{uid}/notifications/{id}` read by stranger ✗
+- `/users/{uid}/notifications/{id}` update `read` field by owner ✓
+- `/users/{uid}/notifications/{id}` update other field ✗
+- `/users/{uid}/notifications/{id}` create by client ✗ (CF only)
+
+---
+
+## Contract bàn giao
+
+| Artifact | File | Status |
+|---|---|---|
+| `AppNotification` freezed model | `lib/features/notification/data/app_notification.dart` | ❌ |
+| `NotificationRepository` abstract | `lib/features/notification/data/notification_repository.dart` | ❌ |
+| `NotificationController` stub | `lib/features/notification/application/notification_controller.dart` | ❌ |
+| FCM init trong `main.dart` | `apps/mobile/lib/main.dart` | ❌ |
+| Deep link handler trong router | `lib/core/router/app_router.dart` | ❌ |
+| Cloud Function `onFriendRequestCreated` stub | `firebase/functions/src/index.ts` | ❌ |
+| Cloud Function `onFriendRequestAccepted` stub | `firebase/functions/src/index.ts` | ❌ |
+| Cloud Function `onReactionCreated` stub | `firebase/functions/src/index.ts` | ❌ |
+| Firestore rules `/users/{uid}/notifications` + `/fcmTokens` | `firestore.rules` | ❌ |
+| TODO markers trên mọi stub | — | ⏳ |
+
+---
+
+## Open questions
+
+| # | Câu hỏi | Status |
+|---|---|---|
+| OQ1 | In-app notification list screen | ⏳ **Foreground banner đã có** (Figma `765:4766`/`765:4981`). Full notification list screen vẫn pending — MVP acceptable bằng banner only. |
+| OQ2 | `new_post` notification — có lưu notification doc không? | **✅ Không** — tránh spam, chỉ push FCM |
+| OQ3 | Multiple devices per user? | **MVP: 1 token/user** — overwrite khi login lại |
+
+---
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| `saveFcmToken` Firestore fail khi login | Retry tự động khi `onTokenRefresh` trigger; nếu không save được, notification không gửi được — chấp nhận (non-blocking) |
+| FCM token stale (user reinstall app) | `onTokenRefresh` callback ghi token mới vào Firestore; CF phát hiện FCM invalid-argument error → xoá token cũ khỏi Firestore |
+| `onFriendRequestCreated` CF fail | Notification không gửi; không retry tự động (non-blocking); user vẫn nhìn thấy request trong Friend module |
+| `onPostCreated` fan-out CF fail giữa chừng | Một số friends không nhận push; không retry (fan-out là best-effort); bài post vẫn lưu đúng |
+| User tap notification khi app killed → deep link fail | `go_router` initial route nhận `initialLocation` từ `getInitialMessage()`; nếu post đã xoá → navigate home + toast "Bài viết không còn tồn tại" |
+| User tap notification khi app background → navigate sai màn | `onMessageOpenedApp` stream xử lý deep link; fallback: navigate home nếu route không giải quyết được |
+| Android 13+ `POST_NOTIFICATIONS` permission bị denied | `firebase_messaging.requestPermission()` trả `denied`; chạy in-app only mode (không có push); không crash; hiện banner nhắc enable lại trong Settings |
+| `markAsRead` Firestore fail | Notification badge/dot giữ nguyên; retry khi user re-open notification list; non-blocking |
+| User logout nhưng `deleteFcmToken` fail | Token orphan trong Firestore; CF gửi notification cho token cũ → FCM trả invalid → CF catch + xoá token; tự clean up |
+| `onReactionCreated` với `reactorId == authorId` (self-react) | CF skip (đã có guard); không gửi notification; không tạo doc |
+| Notification doc tạo thất bại (Admin SDK error) | Log lỗi server-side; FCM vẫn đã gửi (push và notification doc độc lập); in-app list thiếu item nhưng push đã hiện |
+| Multiple notifications tap nhanh (double tap) | `go_router` navigate idempotent; nếu đang ở đúng route rồi → no-op; không push duplicate screens |
+
+---
+
+## Risks
+
+- **FCM token stale:** user reinstall app → token đổi nhưng Firestore vẫn có token cũ → FCM delivery fail. Mitigation: `onTokenRefresh` cập nhật token, server catch FCM invalid token error và xoá token cũ.
+- **Fan-out 20 friends:** Firestore batch FCM với 20 tokens/post — nằm trong giới hạn FCM batch (500). OK.
+- **Foreground notification:** FCM mặc định không hiện UI khi app foreground → cần `flutter_local_notifications` để show local notification.
+- **Android 13+ notification permission:** `POST_NOTIFICATIONS` runtime permission bắt buộc từ Android 13. `firebase_messaging` tự request nhưng cần handle denied state gracefully.

--- a/docs/specs/2026-05-23-reaction.md
+++ b/docs/specs/2026-05-23-reaction.md
@@ -1,0 +1,270 @@
+# Spec: Reaction Module
+
+**Date:** 2026-05-23
+**Status:** Locked
+**Owner:** ThienPDM (leader assign trước khi giao)
+**Epic:** [T0] Reaction — Thả emoji vào bài viết · Milestone M3
+
+---
+
+## Goal
+
+Cho phép user react một emoji vào post của bạn bè (hoặc bản thân). Mỗi user chỉ react được 1 emoji/post — react emoji khác = thay thế cũ. Un-react bằng cách tap lại emoji đang active.
+
+---
+
+## User stories
+
+- Là user, tôi muốn tap emoji trong ActText bar để react vào ảnh của bạn.
+- Là user, tôi muốn thay đổi emoji đã react bằng cách chọn emoji khác.
+- Là user, tôi muốn bỏ react bằng cách tap lại vào emoji đang active của mình.
+- Là user, tôi muốn xem tất cả reactions trên ảnh của mình (ai react, emoji gì).
+- Là user, tôi muốn nhận notification khi có người react vào ảnh của mình (Notification module).
+
+---
+
+## Scope
+
+### In-scope (M3)
+
+1. **React emoji** — tap emoji trong ActText bar → gửi reaction
+2. **3 quick emoji preset** — light-blue-heart / 🤣 / 🥰 (confirm từ Figma `472:2252`, node `501:1008/1009/1010`) + nút `smile-plus` mở full picker
+3. **Full emoji picker** — bottom sheet chọn emoji bất kỳ (giới hạn một số category)
+4. **Un-react** — tap lại emoji đang active của mình → xoá reaction
+5. **Change react** — tap emoji khác → replace reaction cũ (1 user = 1 reaction/post)
+6. **Reaction count display** — tổng số reactions hiển thị trên ActText bar
+7. **Reaction list modal** — tap vào count → bottom sheet list ai react gì
+
+### Out-of-scope
+
+- Reaction notification — thuộc **Notification module** (trigger `onReactionCreated`)
+- Reaction trên Diary entry — post-MVP
+- Reaction trên Space post — dùng lại cơ chế này, implement trong Space module
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Ghi chú |
+|---|---|---|
+| Feed card — ActText bar (M3 active) | `472:2241` | ActText bar enabled; 3 emoji: light-blue-heart / 🤣 / 🥰 + smile-plus |
+| Reaction list bottom sheet | _(cần designer cung cấp)_ | Tap count → list |
+| Full emoji picker sheet | _(cần designer cung cấp)_ | Mở từ smile-plus |
+
+> M2: ActText bar render nhưng disabled (no-op). M3: enable react logic.
+
+---
+
+## Luồng đầy đủ
+
+### React lần đầu
+
+```
+Feed → PostCard → ActText bar
+    ├─ [light-blue-heart] [🤣] [🥰] + [smile-plus]  ← Figma `472:2252` (node 501:1008/1009/1010)
+    │
+    ├─ Tap emoji preset (vd 🤣):
+    │   → ReactionController.toggleReact(postId, '🤣')
+    │   → Upsert /posts/{postId}/reactions/{currentUid}
+    │   → Emoji highlight (active state)
+    │   → Count tăng +1 (optimistic update)
+    │
+    └─ Tap [smile-plus] → EmojiPickerSheet
+        → Chọn emoji → gọi toggleReact(postId, emoji)
+        → sheet đóng, emoji đó hiện active trong bar
+```
+
+### Un-react
+
+```
+ActText bar — emoji active (đang react)
+    → Tap lại emoji đó
+    → ReactionController.toggleReact(postId, emoji)
+        → Phát hiện reaction doc đã tồn tại với cùng emoji → xoá
+    → Emoji về trạng thái inactive
+    → Count giảm -1 (optimistic update)
+```
+
+### Change react
+
+```
+ActText bar — emoji A đang active
+    → Tap emoji B
+    → ReactionController.toggleReact(postId, emojiB)
+        → Phát hiện reaction doc tồn tại với emoji khác → overwrite emoji field
+    → Emoji A inactive, emoji B active
+    → Count giữ nguyên
+```
+
+### Xem reaction list
+
+```
+ActText bar → tap "[N] reactions" hoặc vùng count
+    → ReactionListSheet slide up:
+        List: [avatar] [displayName] [emoji]
+        Sort: newest first
+    → Tap avatar → FriendProfileScreen (nếu là bạn bè)
+```
+
+---
+
+## Data model
+
+### `/posts/{postId}/reactions/{reactorUid}`
+
+```
+{
+  reactorUid:   string,    // documentId = reactorUid (enforce 1 reaction/user/post)
+  reactorName:  string,    // denormalized displayName
+  emoji:        string,    // single emoji char, vd "😂"
+  createdAt:    Timestamp, // serverTimestamp() — dùng cho sort
+}
+```
+
+> **Document ID = `reactorUid`** — tự enforce 1 reaction/user/post. Set (upsert) thay vì add.  
+> Thay đổi emoji = overwrite cùng documentId. Bỏ react = delete document.
+
+---
+
+## Architecture
+
+```
+Presentation              Application                 Data
+────────────────          ──────────────────          ────────────────────────
+ActTextBar                ReactionController          ReactionRepository (abstract)
+ ├─ EmojiButton            ├─ ReactionState            FirebaseReactionRepository
+ └─ EmojiPickerSheet       ├─ toggleReact()            ├─ watchReactions(postId)
+ReactionListSheet          ├─ watchReactions()         ├─ upsertReaction()
+                           └─ loadReactors()           ├─ deleteReaction()
+                                                       └─ getMyReaction(postId, uid)  ← [H2-FIX]
+```
+
+> **[H2-FIX] `getMyReaction(postId, uid)`:** Bắt buộc có trong interface — dùng trong `toggleReact()` logic (line bên dưới) để detect existing reaction trước khi decide react/un-react/change. Dev thiếu method này sẽ không implement được `toggleReact` đúng.
+
+**`toggleReact(postId, emoji)` logic:**
+
+```dart
+Future<void> toggleReact(String postId, String emoji) async {
+  final existing = await repo.getMyReaction(postId, currentUid);
+  if (existing == null) {
+    await repo.upsertReaction(postId, currentUid, emoji);  // react lần đầu
+  } else if (existing.emoji == emoji) {
+    await repo.deleteReaction(postId, currentUid);          // un-react
+  } else {
+    await repo.upsertReaction(postId, currentUid, emoji);  // change react
+  }
+}
+```
+
+---
+
+## Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `cloud_firestore` | reactions subcollection | ✅ |
+| `emoji_picker_flutter` | Full emoji picker sheet (MIT) | ❌ cần thêm (cũng dùng ở Space module) |
+
+---
+
+## Security
+
+```javascript
+match /posts/{postId}/reactions/{reactorUid} {
+  // [H9-FIX] Chỉ đọc được reactions nếu có quyền read post đó
+  // (author hoặc có feed doc — tương tự rule /posts/{postId})
+  allow read:   if isAuthed() && (
+    request.auth.uid == get(/databases/$(database)/documents/posts/$(postId)).data.authorId ||
+    exists(/databases/$(database)/documents/users/$(request.auth.uid)/feed/$(postId))
+  );
+  // Chỉ chính user tạo/sửa reaction của mình
+  allow create: if isAuthed()
+                && request.auth.uid == reactorUid
+                && request.auth.uid == request.resource.data.reactorUid;
+  allow update: if isAuthed()
+                && request.auth.uid == reactorUid
+                && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emoji', 'createdAt']);
+  allow delete: if isAuthed() && request.auth.uid == reactorUid;
+}
+```
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+| Test | Target |
+|---|---|
+| `toggleReact` — chưa react → tạo doc | `ReactionController` |
+| `toggleReact` — đang react cùng emoji → xoá doc | `ReactionController` |
+| `toggleReact` — đang react emoji khác → overwrite | `ReactionController` |
+| `watchReactions(postId)` → stream đúng list | `FirebaseReactionRepository` |
+| `loadReactors(postId)` → sort by createdAt DESC | `FirebaseReactionRepository` |
+
+### Widget tests
+
+| Test | Screen |
+|---|---|
+| Tap emoji → highlight active state | `ActTextBar` |
+| Tap active emoji → un-highlight (un-react) | `ActTextBar` |
+| Count display đúng số reactions | `ActTextBar` |
+| EmojiPickerSheet hiện khi tap smile-plus | `ActTextBar` |
+
+### Firestore rules tests
+
+- `/posts/{postId}/reactions/{reactorUid}` create by owner (post author hoặc has feed doc) ✓
+- `/posts/{postId}/reactions/{reactorUid}` create by stranger (uid mismatch) ✗
+- `/posts/{postId}/reactions/{reactorUid}` update emoji by owner ✓
+- `/posts/{postId}/reactions/{reactorUid}` update reactorUid field ✗
+- `/posts/{postId}/reactions/{reactorUid}` delete by owner ✓
+- `/posts/{postId}/reactions/{reactorUid}` delete by stranger ✗
+- `/posts/{postId}/reactions/{reactorUid}` read by user không có feed doc (non-audience) ✗
+
+---
+
+## Contract bàn giao
+
+| Artifact | File | Status |
+|---|---|---|
+| `Reaction` freezed model | `lib/features/reaction/data/reaction.dart` | ❌ |
+| `ReactionRepository` abstract | `lib/features/reaction/data/reaction_repository.dart` | ❌ |
+| `ReactionController` stub + `ReactionState` | `lib/features/reaction/application/reaction_controller.dart` | ❌ |
+| `ActTextBar` widget — M3 enable (update từ stub M2) | `lib/shared/widgets/app_act_text_bar.dart` | ❌ update từ M2 stub |
+| `EmojiPickerSheet` stub | `lib/features/reaction/presentation/emoji_picker_sheet.dart` | ❌ |
+| `ReactionListSheet` stub | `lib/features/reaction/presentation/reaction_list_sheet.dart` | ❌ |
+| Firestore rules `/posts/{id}/reactions` | `firestore.rules` | ❌ |
+| TODO markers trên mọi stub | — | ⏳ |
+
+> `ActTextBar` hiện là M2 stub (disabled). M3: leader update stub để inject `ReactionController`.
+
+---
+
+## Open questions
+
+| # | Câu hỏi | Status |
+|---|---|---|
+| OQ1 | 3 quick emoji preset là gì? | ✅ **Resolved** — Figma `472:2252` node 501:1008/1009/1010: light-blue-heart / 🤣 / 🥰 |
+| OQ2 | Emoji picker có search không? | **MVP: Không** — chỉ grid scroll, không search |
+| OQ3 | Reaction count hiện ở đâu trong ActText bar? | ⏳ Pending Figma M3 frame |
+
+---
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| `upsertReaction` fail (network) | Rollback optimistic count + emoji highlight; toast "Thả cảm xúc thất bại — thử lại" |
+| `deleteReaction` fail (un-react) | Rollback: emoji về trạng thái active lại; toast retry |
+| Double-tap emoji nhanh (debounce miss) | `toggleReact` có in-flight lock — bỏ qua tap thứ 2 cho đến khi request đầu resolve |
+| Change react fail (overwrite) | Rollback: emoji cũ giữ active, emoji mới không highlight; toast retry |
+| React trên post `permission-denied` (đã unfriend) | `toggleReact` nhận Firestore error → toast "Không thể thực hiện"; post card ẩn (xử lý ở Feed) |
+| Reaction list: post đã xoá | `permission-denied` khi load subcollection → sheet hiện empty + banner "Bài viết không còn tồn tại" |
+| EmojiPickerSheet: không tìm thấy emoji phù hợp | User cuộn tự do, không crash — không có search MVP |
+| React count âm (optimistic glitch) | Clamp `max(0, count)` — không hiện số âm |
+
+## Risks
+
+- **Optimistic update race:** client cập nhật count UI trước khi server confirm → nếu lỗi cần rollback. Mitigation: dùng Riverpod `AsyncValue` + revert on error.
+- **Subcollection cost:** mỗi post reaction load = 1 read/reaction. Với 20 bạn react = 20 reads/post visible. Acceptable cho MVP.
+- **`emoji_picker_flutter` shared với Space module** — cần confirm package đã được thêm vào `pubspec.yaml` trước khi cả 2 module implement.

--- a/docs/specs/2026-05-23-settings.md
+++ b/docs/specs/2026-05-23-settings.md
@@ -1,0 +1,553 @@
+# Spec: Settings Module
+
+**Date:** 2026-05-23
+**Status:** Locked
+**Owner:** ThienPDM
+**Epic:** Settings — Milestone M2/M3
+
+---
+
+## Goal
+
+Cho phép user quản lý tài khoản, quyền riêng tư, widget, space, và truy cập thông tin pháp lý từ một bottom sheet trung tâm. Trigger: tap **avatar** góc phải topbar homepage.
+
+---
+
+## User stories
+
+- Là user, tôi muốn xem và copy link profile của mình để chia sẻ.
+- Là user, tôi muốn truy cập danh sách bạn bè và space nhanh từ Settings.
+- Là user, tôi muốn thêm Meep Widget vào màn hình chờ Android.
+- Là user, tôi muốn xem và bỏ chặn các tài khoản đã chặn.
+- Là user, tôi muốn đăng xuất an toàn.
+- Là user, tôi muốn xoá tài khoản khi cần (với xác nhận).
+- Là user, tôi muốn xem Điều khoản dịch vụ và Chính sách quyền riêng tư.
+
+---
+
+## Scope
+
+### In-scope
+
+1. **Settings bottom sheet** — trigger từ avatar topbar homepage
+2. **Header** — avatar + username + `meep://profile/{username}` copy link (deep link scheme — xem profile.md Q3)
+3. **Quick actions** — [Bạn bè] → Friend sheet | [Chia sẻ] → share profile sheet
+4. **Space quick-access** — horizontal scroll cards, nút [Sửa] mỗi Space, nút [Tạo]
+5. **Thêm tiện ích** (Widget setup) — confirm sheet → mở Android widget picker
+6. **Tài khoản đã chặn** — danh sách + bỏ chặn
+7. **Block user** — initiated từ `PhotoActionSheet` (feed/photo view), NOT từ Settings
+8. **Report user** — nút có trong `PhotoActionSheet` nhưng **stub only** (show toast "Tính năng sắp có")
+9. **Quyền riêng tư và dữ liệu** — sub-page static content
+10. **Điều khoản dịch vụ** — long-scroll static text page
+11. **Chính sách quyền riêng tư** — long-scroll static text page
+12. **Đăng xuất** — logout + clear session
+13. **Xoá tài khoản** — confirm dialog + re-auth + cascade delete
+
+### Out-of-scope
+
+- Edit profile (thuộc Profile module)
+- Space management chi tiết (tạo/sửa Space — thuộc Space module; Settings chỉ quick-access)
+- Notification settings (thuộc Push Notification module)
+- Block/report từ trong chat (thuộc Chat module)
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Ghi chú |
+|---|---|---|
+| Settings main sheet | `572:4183` | Bottom sheet scrollable ~1400px |
+| Settings (variant 2) | `639:3160` | Same structure, another state |
+| Thêm tiện ích (widget) | `662:3341` | Confirm bottom sheet |
+| Thêm tiện ích (variant) | `678:2321` | Variant state |
+| Sau khi thêm widget | `693:2617` | Screenshot lock screen |
+| Tài khoản bị chặn 1 | `572:4490` | Danh sách blocked accounts |
+| Tài khoản bị chặn 2 | `572:4839` | Single blocked user + Bỏ chặn |
+| Quyền riêng tư & dữ liệu | `572:4965` | Static sub-page |
+| Điều khoản dịch vụ | `572:4605` | Long-scroll text |
+| Chính sách QRT | `572:4722` | Long-scroll text |
+| Block bạn (state 1) | `605:1769` | Overlay từ photo view |
+| Block bạn (state 1.1) | `605:1991` | Confirm dialog |
+| Block bạn (state 1.2) | `624:1906` | Sau khi block |
+
+---
+
+## Luồng đầy đủ
+
+### Trigger mở Settings
+
+```
+Homepage → tap [Avatar] (góc phải topbar)
+    → SettingsSheet slide up từ dưới
+    → Background dimmed (#00000073)
+```
+
+---
+
+### Cấu trúc Settings sheet
+
+```
+┌─────────────────────────────────────────┐
+│  ▬  (drag handle)                        │
+│                                          │
+│  [Avatar]  username                           │
+│            meep://profile/username [🔗 copy]  │
+│                                          │
+│  [👥 15 người bạn]  [↗ Chia sẻ]         │  ← 2 button row
+│                                          │
+│  Space ❤                                 │  ← section header (scan-heart icon)
+│  [BFF][Gia đình][...][+Tạo]             │  ← horizontal scroll
+│                                          │
+│  ── Setup ──────────────────────────    │
+│  📱 Thêm tiện ích              >         │
+│                                          │
+│  ── Riêng tư & Bảo mật ────────────    │
+│  🚫 Tài khoản đã chặn         >         │
+│  🔒 Quyền riêng tư và dữ liệu >         │
+│                                          │
+│  ── Giới thiệu ─────────────────────   │
+│  📄 Điều khoản dịch vụ        >         │
+│  🛡  Chính sách quyền riêng tư >         │
+│                                          │
+│  ── Tài khoản ──────────────────────   │
+│  ↩  Đăng xuất                 >         │
+│  🗑  Xoá tài khoản (đỏ)       >         │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### Luồng Header — copy link profile
+
+```
+Settings sheet → tap "meep://profile/{username}" hoặc icon 🔗
+    → copy to clipboard
+    → toast "Đã sao chép liên kết"
+```
+
+---
+
+### Luồng Quick action — Bạn bè
+
+```
+Settings sheet → tap [👥 15 người bạn]
+    → đóng Settings sheet
+    → mở FriendSheet (bottom sheet — xem Friend module)
+```
+
+---
+
+### Luồng Quick action — Chia sẻ
+
+```
+Settings sheet → tap [↗ Chia sẻ]
+    → Share profile sheet slide up:
+        Title:   "Kết bạn với tôi trên Meep nhé!"
+        URL:     meep://profile/{username}  ← deep link scheme (Q3 resolved)
+        Options: [Gửi qua Messenger] [Sao chép liên kết]
+        Logo:    Meep logomark
+```
+
+---
+
+### Luồng Space quick-access
+
+```
+Settings sheet → Space section → horizontal scroll các Space card
+    ├─ Tap [Sửa] trên card → navigate to Space edit (Space module)
+    └─ Tap [Tạo] → navigate to Space creation (Space module)
+
+Empty state (chưa có Space hoặc Space module chưa implement pre-M3):
+    → SpaceQuickRow hiện mock card placeholder
+    → Tap [Tạo] → toast "Tính năng đang phát triển" (stub cho đến M3)
+```
+
+> ⚠️ Settings chỉ hiện quick-access. Logic tạo/sửa Space thuộc Space module.  
+> Khi Space module chưa implement (pre-M3): dùng mock data + disabled navigation.
+
+---
+
+### Luồng Thêm tiện ích (Widget)
+
+```
+Settings sheet → tap "Thêm tiện ích"
+    → Widget confirm sheet slide up:
+        Title:  "Thêm vào màn hình chờ?"
+        Body:   "Thêm và giữ Widget hoặc ấn Thêm để thêm vào màn hình chờ"
+        Preview: [Meep Widget 2 x 2] — hiện avatar friends + "15 người bạn"
+        [Thêm] (turquoise) → mở Android widget picker (system intent)
+        [Huỷ]             → đóng sheet
+    → Sau khi thêm: hiện confirmation screen (screenshot widget trên lock screen)
+```
+
+> Android widget picker là system intent — app không control UX sau khi intent được gọi.
+
+---
+
+### Luồng Tài khoản đã chặn
+
+```
+Settings sheet → tap "Tài khoản đã chặn"
+    → BlockedAccountsPage slide/navigate:
+        Title: "Tài khoản bị chặn"
+        List: [Avatar] [username] [Bỏ chặn button]
+    → Tap [Bỏ chặn]:
+        → Confirm dialog: "Bỏ chặn {username}?"
+        → [Xác nhận] → xoá block record, user quay lại bình thường
+        → [Huỷ] → đóng dialog
+```
+
+---
+
+### PhotoActionSheet — "Chia sẻ đến..." (shared component)
+
+```
+Feed → xem ảnh bạn → tap [↑ share/upload icon] (topbar)
+    → PhotoActionSheet slide up (state 605:1769):
+        Title: "Chia sẻ đến..."
+        Row 1 (share externally): [Chia sẻ] [Messenger] [Instagram] [Tin nhắn]
+        Row 2:
+          [Báo cáo]  → toast "Tính năng sắp có" (stub, out of scope)
+          [Chặn]     → mở BlockConfirmDialog
+          [Lưu]      → save image to device gallery (xử lý ở home-camera-feed spec)
+          [Xoá]      → chỉ hiện khi là ảnh của chính mình (xử lý ở home-camera-feed spec)
+```
+
+> `PhotoActionSheet` là **shared component**, owned by home-camera-feed module.  
+> Settings module chỉ own `BlockConfirmDialog` + `BlockRepository`.
+
+---
+
+### Luồng Block user (từ PhotoActionSheet)
+
+```
+PhotoActionSheet → tap [Chặn]
+    → BlockConfirmDialog hiện overlay (state 605:1991):
+        Title:   "Chặn {username}?"
+        Body:    "Họ sẽ không thể nhắn tin cho bạn, xem các khoảnh khắc
+                  của bạn hoặc gửi lời mời kết bạn. Hai người vẫn có thể
+                  được thêm vào cùng một nhóm, nhưng sẽ không thể xem
+                  tin nhắn hoặc khoảnh khắc của nhau."
+        Note:    "Họ sẽ không được thông báo rằng mình đã bị chặn"
+        [Chặn] | [Bỏ qua]
+    → [Chặn]:
+        → gọi Cloud Function blockUser(targetUid):
+            - atomic: create /blocks/{blockerUid}_{targetUid}
+            - atomic: delete /friendships/{pairId} nếu là bạn bè
+            - [C4] atomic: update /conversations/{pairId}.status = 'blocked' nếu tồn tại
+            - onFriendshipDeleted trigger cập nhật friendCount
+        → button đổi thành [Đã chặn!] (state 624:1906)
+        → FeedController lọc bỏ posts của targetUid khỏi feed ngay lập tức
+        → [Bỏ qua] dismiss dialog + PhotoActionSheet → trở về feed
+    → [Bỏ qua]: đóng dialog, quay lại PhotoActionSheet
+```
+
+---
+
+### Luồng Đăng xuất
+
+```
+Settings sheet → tap "Đăng xuất"
+    → LogoutConfirmDialog:
+        Title: "Đăng xuất khỏi tài khoản?"
+        [Đăng xuất] | [Huỷ]
+    → [Đăng xuất]:
+        → FirebaseAuth.signOut()
+        → clear local cache (SharedPreferences, app cache)
+        → GoRouter.go('/intro')
+```
+
+---
+
+### Luồng Xoá tài khoản
+
+```
+Settings sheet → tap "Xoá tài khoản" (đỏ)
+    → DeleteAccountDialog step 1 — Confirm intent:
+        Title: "Bạn có chắc muốn xoá tài khoản?"
+        Body:  "Tất cả dữ liệu sẽ bị xoá vĩnh viễn. Không thể phục hồi."
+        [Xoá] | [Huỷ]
+    → [Xoá] → step 2 — Re-authentication inline:
+        → Email/password user: hiện password field
+        → Google user: trigger reauthenticateWithCredential (Google prompt)
+        → Catch FirebaseAuthException code = 'requires-recent-login':
+            → giữ nguyên step 2, show error "Vui lòng xác thực lại để tiếp tục"
+        → Re-auth thành công → step 3 — gọi Cloud Function deleteAccount(uid):
+            (1) Storage (tất cả bucket paths của user, pagination 1000 files/batch mỗi bucket):
+                - posts/{uid}/**
+                - avatars/{uid}/**
+                - diary/{uid}/**
+            (2) Firestore batch:
+                - /users/{uid}/feed/* subcollection  ← [C5-FIX] fan-out feed docs
+                - /diary where authorUid == uid      ← [C5-FIX] diary entries
+                - /posts where authorId == uid
+                - /friendships where uidA == uid OR uidB == uid
+                - /friend_requests where senderId == uid OR receiverId == uid
+                - /blocks where blockerUid == uid OR blockedUid == uid
+                - /users/{uid}/notifications/* subcollection
+                - /users/{uid}/fcmTokens/* subcollection
+                - /conversations where participantIds arrayContains uid (set status=deleted)
+                - /users/{uid}
+                - /usernames/{username}
+            (3) FirebaseAuth Admin: deleteUser(uid)
+            > Thứ tự: subcollection trước, document sau (tránh orphan docs).
+        → Navigate về /intro
+    → Nếu CF fail: show error toast, KHÔNG xoá Auth account → user có thể retry
+```
+
+> **Idempotency:** CF `deleteAccount` kiểm tra user tồn tại trước khi xoá từng bước. Gọi lần 2 sau partial fail sẽ tiếp tục từ bước chưa xong.
+
+---
+
+## Data model
+
+### `/blocks/{blockId}`
+
+```
+blockId = "{blockerUid}_{blockedUid}"   ← KHÔNG sorted, giữ direction
+
+{
+  blockerUid:  string,   // người thực hiện block
+  blockedUid:  string,   // người bị block
+  createdAt:   Timestamp (serverTimestamp),
+}
+```
+
+> **Lý do KHÔNG sorted:** query `getBlockedUsers()` cần `where('blockerUid', ==, uid)`.  
+> Sorted sẽ mất thông tin direction, không query được 1 phía.  
+> `isBlocked()` helper tự check cả 2 chiều bằng `blockId1` + `blockId2`.  
+> Không có `status` field — existence = blocked. Delete = unblock.
+
+### `/users/{uid}` — không thêm field mới
+
+Block list lấy từ `/blocks` collection query `where('blockerUid', isEqualTo: currentUid)`.
+
+---
+
+## Technical approach
+
+### Architecture
+
+```
+Presentation                    Application                Data
+──────────────────              ──────────────────         ────────────────────
+SettingsSheet                   SettingsController         SettingsRepository (abstract)
+ ├─ SettingsHeader               ├─ copyProfileLink()       FirebaseSettingsRepository
+ ├─ QuickActionsRow              ├─ shareProfile()
+ ├─ SpaceQuickRow                ├─ logout()
+ ├─ WidgetConfirmSheet           ├─ deleteAccount()
+ ├─ BlockedAccountsPage          ├─ blockUser()             BlockRepository (abstract)
+ │   └─ BlockedUserItem          ├─ unblockUser()           FirebaseBlockRepository
+ ├─ PrivacyDataPage              └─ getBlockedUsers()
+ ├─ TermsPage
+ ├─ PrivacyPolicyPage
+ └─ DeleteAccountDialog
+```
+
+### Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `firebase_auth` | logout, re-auth, delete user | ✅ |
+| `cloud_firestore` | blocks collection, cascade delete | ✅ |
+| `firebase_storage` | xoá posts images khi delete account | ✅ |
+| `share_plus` | share profile link | ❌ cần thêm (cũng dùng ở Friend module) |
+| `Clipboard.setData` | copy link (flutter/services built-in, không cần package) | ✅ |
+| `go_router` | navigate sau logout/delete | ✅ |
+
+---
+
+## Security
+
+### Firestore rules
+
+```javascript
+match /blocks/{blockId} {
+  // Cả blocker và blocked đọc được — tradeoff MVP:
+  // blocked user có thể phát hiện mình bị block nếu query trực tiếp.
+  // Chấp nhận known limitation này; cải thiện post-MVP với subcollection.
+  allow read: if isAuthed() && (
+    resource.data.blockerUid == request.auth.uid ||
+    resource.data.blockedUid == request.auth.uid
+  );
+  // Chỉ blocker tạo (qua Cloud Function blockUser — không cho client trực tiếp)
+  // Nếu dùng CF: rules chặn client write, CF dùng Admin SDK bypass rules
+  allow create: if false;  // CF Admin SDK bypasses
+  // Chỉ blocker unblock (client trực tiếp OK vì chỉ xoá doc của mình)
+  allow delete: if isAuthed()
+    && resource.data.blockerUid == request.auth.uid;
+  allow update: if false;
+}
+```
+
+> **Lý do `create: false`:** Block action dùng Cloud Function `blockUser` để atomic với unfriend.  
+> Admin SDK bypass Firestore rules → CF tạo block doc + xoá friendship trong 1 transaction.
+
+### Cloud Function `blockUser` (HTTPS Callable)
+
+```typescript
+// blockUser(data: { targetUid: string }, context)
+// 1. Verify context.auth — chỉ chính user gọi
+// 2. Guard: context.auth.uid != data.targetUid (no self-block)
+// 3. Admin SDK batch:
+//    a. create /blocks/{blockerUid}_{targetUid}
+//    b. delete /friendships/{pairId} nếu tồn tại (triggers onFriendshipDeleted)
+//    c. [C4-FIX] update /conversations/{pairId}.status = 'blocked' nếu conversation tồn tại
+//       (dấu hiệu cần thiết để Firestore rule chặn gửi tin mới)
+// Return: { success: true }
+```
+
+### Cloud Function `deleteAccount` (HTTPS Callable)
+
+```typescript
+// deleteAccount(data: {}, context)
+// 1. Verify context.auth
+// 2. uid = context.auth.uid
+// 3. Storage (tất cả bucket paths, pagination 1000 files/batch mỗi bucket):
+//    - posts/{uid}/**
+//    - avatars/{uid}/**
+//    - diary/{uid}/**
+// 4. Firestore batch (paginated nếu cần, subcollection TRƯỚC document):
+//    - /users/{uid}/feed/*      ← fan-out feed docs
+//    - /diary WHERE authorUid == uid
+//    - /posts WHERE authorId == uid
+//    - /friendships WHERE uidA == uid OR uidB == uid
+//    - /friend_requests WHERE senderId OR receiverId == uid
+//    - /blocks WHERE blockerUid == uid OR blockedUid == uid
+//    - /users/{uid}/notifications/* subcollection
+//    - /users/{uid}/fcmTokens/* subcollection
+//    - /conversations WHERE participantIds arrayContains uid (set status=deleted)
+//    - /users/{uid}
+//    - /usernames/{username}
+// 5. admin.auth().deleteUser(uid)
+// Idempotent: check existence trước mỗi bước, bỏ qua nếu đã xoá
+```
+
+> **Re-authentication bắt buộc** trước khi gọi `deleteAccount`. Firebase Auth yêu cầu `reauthenticateWithCredential` cho sensitive operations.
+
+### `isBlocked` helper cho Firestore rules
+
+```javascript
+function isBlocked(uid) {
+  let blockId1 = request.auth.uid + '_' + uid;
+  let blockId2 = uid + '_' + request.auth.uid;
+  return exists(/databases/$(database)/documents/blocks/$(blockId1))
+      || exists(/databases/$(database)/documents/blocks/$(blockId2));
+}
+```
+
+> **Note:** `isBlocked()` hiện được add vào `/posts` read rule của home-camera-feed.md như là defense-in-depth (ngăn blocked user thấy post trong race condition giữa blockUser CF + onFriendshipDeleted CF). Xem home-camera-feed.md §Security rules để biết cách sử dụng.
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+| Test | Target |
+|---|---|
+| `blockUser(uid)` → doc tạo đúng blockId | `FirebaseBlockRepository` |
+| `unblockUser(uid)` → doc xoá | `FirebaseBlockRepository` |
+| `getBlockedUsers()` → list đúng | `FirebaseBlockRepository` |
+| `logout()` → signOut + navigate | `SettingsController` |
+| `deleteAccount()` → cascade delete order | `FirebaseSettingsRepository` |
+| `copyProfileLink(username)` → clipboard value đúng | `SettingsController` |
+
+### Widget tests
+
+| Test | Screen |
+|---|---|
+| Settings sheet mở khi tap avatar | `SettingsSheet` |
+| Tap "Bỏ chặn" → confirm dialog hiện | `BlockedAccountsPage` |
+| Tap "Đăng xuất" → confirm dialog hiện | `SettingsSheet` |
+| Tap "Xoá tài khoản" → confirm dialog hiện (đỏ) | `DeleteAccountDialog` |
+| Widget confirm sheet: tap [Thêm] → system intent fired | `WidgetConfirmSheet` |
+
+### Firestore rules tests
+
+- `/blocks/{id}`: blocker read ✓, blocked read ✓, stranger read ✗
+- `/blocks/{id}`: client create trực tiếp (bất kể uid) → rejected ✗ (CF Admin SDK bypass rules)
+- `/blocks/{id}`: self-block guard trong CF `blockUser` → CF return error, không tạo doc ✗
+- `/blocks/{id}`: blocker delete ✓, stranger delete ✗
+- `/blocks/{id}`: update → rejected ✗
+
+### Cloud Function tests
+
+- `deleteAccount`: không có re-auth token → reject
+- `deleteAccount`: cascade delete thứ tự đúng
+- `deleteAccount`: idempotent (gọi 2 lần không crash)
+
+---
+
+## Contract bàn giao (leader merge trước khi giao dev)
+
+| Artifact | File | Status |
+|---|---|---|
+| `Block` freezed model | `lib/features/settings/data/block.dart` | ❌ |
+| `BlockRepository` abstract | `lib/features/settings/data/block_repository.dart` — **canonical owner** (Chat module import từ đây) | ❌ |
+| `SettingsController` stub | `lib/features/settings/application/settings_controller.dart` | ❌ |
+| `SettingsSheet` widget stub | `lib/features/settings/presentation/settings_sheet.dart` | ❌ |
+| `BlockedAccountsPage` stub | `lib/features/settings/presentation/blocked_accounts_page.dart` | ❌ |
+| `BlockConfirmDialog` stub | `lib/features/settings/presentation/block_confirm_dialog.dart` | ❌ |
+| `LogoutConfirmDialog` stub | `lib/features/settings/presentation/logout_confirm_dialog.dart` | ❌ |
+| `WidgetConfirmSheet` stub | `lib/features/settings/presentation/widget_confirm_sheet.dart` | ❌ |
+| `DeleteAccountDialog` stub | `lib/features/settings/presentation/delete_account_dialog.dart` | ❌ |
+| `ShareProfileSheet` stub | `lib/shared/widgets/share_profile_sheet.dart` — **shared component**, leader own | ⬅️ Shared |
+| `PhotoActionSheet` stub | `lib/features/home/presentation/photo_action_sheet.dart` | ❌ (home-camera-feed module) |
+| Firestore rules `/blocks` | `firestore.rules` | ❌ |
+| Cloud Function `blockUser` stub | `firebase/functions/src/index.ts` | ❌ |
+| Cloud Function `deleteAccount` stub | `firebase/functions/src/index.ts` | ❌ |
+| `isBlocked()` rule helper | `firestore.rules` | ❌ |
+| TODO markers trên mọi stub | — | ⏳ |
+
+---
+
+## Open questions
+
+| # | Câu hỏi | Impact | Status |
+|---|---|---|---|
+| OQ1 | Block ID format sorted hay unsorted? | Data model | ✅ **Resolved:** `{blockerUid}_{blockedUid}` unsorted |
+| OQ2 | Re-auth UX khi xoá tài khoản | UX | ✅ **Resolved:** inline trong `DeleteAccountDialog` step 2 |
+| OQ3 | "Quyền riêng tư và dữ liệu" — static hay có action? | Scope | ✅ **Resolved:** static text page (MVP) |
+| OQ4 | Widget 2x2 hiện avatars hay ảnh? | Widget contract | ✅ **Resolved:** deferred to Widget module spec |
+| OQH1 | Block trigger & menu options | UX | ✅ **Resolved:** `PhotoActionSheet` — Chia sẻ / Messenger / Instagram / Tin nhắn / Báo cáo (stub) / Chặn / Lưu / Xoá |
+| OQH2 | Navigation sau khi block | UX | ✅ **Resolved:** modal đổi sang [Đã chặn!] → tap [Bỏ qua] → về feed (blocked posts hidden) |
+| OQH3 | SpaceQuickRow trước M3 | UX | ✅ **Resolved:** mock card + disabled navigation + toast |
+| OQH4 | `meep.cam` vs deep link scheme | Content | ✅ **Resolved:** Dùng `AppConfig.shareBaseUrl = 'meep://profile'` (constant, không hardcode). Profile OQ3 đã chốt `meep://profile/{username}` là URL của Meep. Khi có HTTP domain thật (ví dụ `https://meep.cam`) thì đổi 1 chỗ trong `AppConfig`. |
+
+---
+
+## Happy path
+
+| Flow | Happy path |
+|---|---|
+| Copy link | Tap link → clipboard → toast |
+| Block từ photo | Tap [Chặn] → confirm → [Đã chặn!] → feed ẩn posts |
+| Unblock | Settings → Tài khoản đã chặn → [Bỏ chặn] → confirm → user quay lại bình thường |
+| Widget | Tap Thêm tiện ích → confirm sheet → tap [Thêm] → Android widget picker |
+| Logout | Tap Đăng xuất → confirm → về /intro |
+| Delete account | Confirm → re-auth → CF deleteAccount → về /intro |
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| Block + unfriend fail atomically | CF `blockUser` transaction rollback — toast error, không partial state |
+| Delete account CF timeout | Error toast; Auth account giữ nguyên; user retry |
+| Delete account `requires-recent-login` | Step 2 hiện error "Vui lòng xác thực lại", không auto-dismiss |
+| Logout khi đang nhận FCM notification | `signOut()` revoke token → notification bị drop; acceptable |
+| Unblock user đã bị xoá tài khoản | Bỏ chặn thành công (xoá doc), không cần user tồn tại |
+| Widget add intent — user cancel | App không nhận callback; `693:2617` không hiện; sheet đóng lại |
+| Tap [Chặn] trên user đã bị chặn | CF guard: kiểm tra block doc tồn tại → return no-op |
+| Tap [Đăng xuất] offline | `signOut()` vẫn hoạt động locally (Firebase clears local session) |
+
+---
+
+## Risks
+
+- **Cascade delete race condition:** CF dùng batch writes + idempotent check. Resolved bằng design trong Flow Xoá tài khoản.
+- **Re-auth timeout (`requires-recent-login`):** Handled trong flow — step 2 show lại form thay vì crash.
+- **Block + friendship overlap:** Resolved — dùng CF `blockUser` atomic transaction.
+- **Widget system intent:** Android `requestPinAppWidget()` không có success callback. `693:2617` là instructional UI, không phải confirmation từ OS.
+- **`isBlocked` read quota:** 2 `exists()` reads/post. Với 20 posts = 40 extra reads/load. Acceptable cho MVP.
+- **OQH4 pending:** `meep.cam` vs `meep.camera` — dùng placeholder `meep.cam/{username}` trong code cho đến khi domain được confirm. Extracted sang constant `AppConfig.shareBaseUrl`.

--- a/docs/specs/2026-05-23-space.md
+++ b/docs/specs/2026-05-23-space.md
@@ -142,23 +142,30 @@ Camera (đã chọn Space context) → chụp → preview → tap "Gửi"
 ```
 Space screen (từ Profile tab hoặc Camera) → tap Space
     → FeedScreen với filter spaceId
-        └─ Query: posts WHERE spaceId == spaceId ORDER BY createdAt DESC
-        (reuse Feed module, chỉ thêm filter param)
+        └─ Query: /users/{currentUid}/feed WHERE spaceId == spaceId ORDER BY createdAt DESC
+        (reuse Feed module — fan-out subcollection, chỉ thêm filter param)
 ```
+
+> **[C6-FIX] Feed architecture:** Space feed KHÔNG query `/posts` trực tiếp. Dùng fan-out subcollection `/users/{uid}/feed` (giống All-friends feed).  
+> Điều kiện: fan-out feed doc phải có field `spaceId` (xem `home-camera-feed.md` §Data model).  
+> CF `onPostCreated` khi `post.spaceId != null` → fan-out vào feed của tất cả Space members với `spaceId` field.  
+> Feed filter: `FeedFilter.space(spaceId)` → query `.where('spaceId', isEqualTo: spaceId)`.
 
 ### Luồng Space management
 
 ```
 Space screen → menu "..." (hoặc Settings icon)
     ├─ [Leave Space] →
-    │   ├─ Nếu là member thường: dialog confirm → xóa uid khỏi space_members
+    │   ├─ Nếu là member thường: dialog confirm → gọi CF leaveSpace(spaceId)
     │   └─ Nếu là creator: phải chọn member khác làm creator mới trước
     │       → dialog "Chọn creator mới" (list members, trừ bản thân)
-    │       → confirm → update role mới creator → leave
-    ├─ [Delete Space] (chỉ creator) → dialog confirm → soft delete
-    │   → Space ẩn, post Space vẫn giữ (hiện trong Streak/Diary của author)
-    └─ [Kick member] (chỉ creator) → chọn member → dialog confirm → xóa khỏi members
+    │       → confirm → gọi CF transferOwnership(spaceId, newCreatorUid) → gọi CF leaveSpace()
+    ├─ [Delete Space] (chỉ creator) → dialog confirm → update spaces/{spaceId}.deletedAt (soft delete)
+    │   → CF onSpaceDeleted cleanup; Space ẩn, post Space vẫn giữ
+    └─ [Kick member] (chỉ creator) → chọn member → dialog confirm → gọi CF kickMember(spaceId, targetUid)
 ```
+
+> Tất cả các thao tác member management (leave/kick/transfer) đều qua **HTTPS Callable CF** — không client trực tiếp write Firestore (đảm bảo sync `memberIds` array).
 
 ---
 
@@ -211,8 +218,9 @@ SpaceCreateSheet           SpaceController            SpaceRepository
  ├─ FriendSelectStep        ├─ SpaceState              ├─ createSpace()
  ├─ SpaceConfigStep         ├─ createSpace()           ├─ getMySpaces()
  └─ IconBuilderStep         ├─ loadMySpaces()          ├─ addMember()
-SpaceContextBottomSheet     ├─ leaveSpace()            ├─ removeMember()
+SpaceContextBottomSheet     ├─ leaveSpace()  ← gọi CF   ├─ removeMember()  ← CF-internal
  └─ SpaceListTile           └─ deleteSpace()           └─ deleteSpace()
+                                                        > addMember/removeMember: chỉ CFs gọi
 CameraTopBar (reuse)
  └─ SpaceContextBadge      FeedController (reuse)      PostRepository (reuse)
 FeedScreen (reuse)          └─ loadFeed(spaceId?)       └─ createPost(spaceId?)
@@ -237,9 +245,14 @@ FeedScreen (reuse)          └─ loadFeed(spaceId?)       └─ createPost(sp
 
 | Function | Trigger | Việc làm |
 |---|---|---|
+| `createSpace` | HTTPS Callable | Tạo `/spaces/{spaceId}` + add members vào `space_members` (batch); **tạo `/conversations/{spaceId}` với `type=space, participantIds=memberIds`** (group chat cho Space) |
+| `leaveSpace` | HTTPS Callable | Xóa `/space_members/{spaceId}/members/{uid}` + update `spaces/{spaceId}.memberIds` (atomic batch) |
+| `kickMember` | HTTPS Callable | Creator kick member: xóa member khỏi `space_members` + update `memberIds` (atomic batch) |
+| `transferOwnership` | HTTPS Callable | Đổi role `/space_members/{spaceId}/members/{newUid}.role = 'creator'` + `/space_members/{spaceId}/members/{oldUid}.role = 'member'` + update `/spaces/{spaceId}.creatorId` (atomic batch) |
 | `onSpacePostCreated` | Firestore onCreate `/posts/{postId}` where `spaceId != null` | Đọc `space_members`, fan-out FCM cho members |
-| `onSpaceMemberRemoved` | Firestore onDelete `/space_members/{spaceId}/members/{uid}` | Decrement `memberCount` |
-| `onSpaceDeleted` | Firestore onUpdate `/spaces/{spaceId}` where `deletedAt != null` | Cleanup: xóa `space_members`, ẩn posts |
+| `onSpaceMemberAdded` | Firestore onCreate `/space_members/{spaceId}/members/{uid}` | Increment `memberCount` trên `/spaces/{spaceId}`; increment `spaceCount` trên `/users/{uid}` |
+| `onSpaceMemberRemoved` | Firestore onDelete `/space_members/{spaceId}/members/{uid}` | Decrement `memberCount` trên `/spaces/{spaceId}`; decrement `spaceCount` trên `/users/{uid}` |
+| `onSpaceDeleted` | Firestore onUpdate `/spaces/{spaceId}` where `deletedAt != null` | Cleanup: xóa `space_members`, ẩn posts, set `conversations/{spaceId}.status = deleted` |
 
 ---
 
@@ -249,8 +262,8 @@ FeedScreen (reuse)          └─ loadFeed(spaceId?)       └─ createPost(sp
 // /spaces/{spaceId}
 match /spaces/{spaceId} {
   allow read:   if isAuthed() && isMember(spaceId);
-  allow create: if isAuthed() && request.resource.data.creatorId == request.auth.uid;
-  allow update: if isAuthed() && isCreator(spaceId);  // chỉ creator edit
+  allow create: if false;  // [FIX] CF createSpace (Admin SDK) — client KHÔNG tự tạo
+  allow update: if isAuthed() && isCreator(spaceId);  // chỉ creator edit (vd: soft delete, rename)
   allow delete: if false;  // soft delete qua update deletedAt
 }
 
@@ -258,10 +271,9 @@ match /spaces/{spaceId} {
 match /space_members/{spaceId}/members/{uid} {
   allow read:   if isAuthed() && isMember(spaceId);
   allow create: if false;  // Cloud Function only
-  allow delete: if isAuthed() && (
-    request.auth.uid == uid ||  // self leave
-    isCreator(spaceId)           // creator kick
-  );
+  // [C8-FIX] Client KHÔNG tự xóa — phải qua CF leaveSpace/kickMember
+  // để đảm bảo sync với spaces.memberIds array (client không có quyền update memberIds).
+  allow delete: if false;  // Cloud Function only (leaveSpace + kickMember CFs)
 }
 
 // Helper functions
@@ -273,11 +285,19 @@ function isCreator(spaceId) {
   return get(/databases/$(database)/documents/spaces/$(spaceId)).data.creatorId == request.auth.uid;
 }
 
-// /posts/{postId} — thêm điều kiện Space
+// /posts/{postId} — rule này được MERGE vào rule của home-camera-feed.md trong firestore.rules
+// KHÔNG có 2 match /posts/{postId} blocks riêng — chỉ 1 block combined:
+// allow read: if isAuthed() && (
+//   resource.data.authorId == request.auth.uid ||
+//   exists(.../users/{uid}/feed/{postId})   ← đủ để cover cả All-friends và Space posts
+//   // vì CF onPostCreated fan-out vào feed của Space members với spaceId field
+// );
+// Rule isMember(spaceId) check bên dưới là REDUNDANT nếu fan-out đúng, nhưng giữ lại
+// như defense-in-depth cho trường hợp fan-out bị miss:
 match /posts/{postId} {
-  // read: author (đã có) HOẶC member của Space bài đó
   allow read: if isAuthed() && (
     resource.data.authorId == request.auth.uid ||
+    exists(/databases/$(database)/documents/users/$(request.auth.uid)/feed/$(postId)) ||
     (resource.data.spaceId != null && isMember(resource.data.spaceId))
   );
 }
@@ -340,7 +360,8 @@ match /posts/{postId} {
 | `Post` model — thêm field `spaceId` | `lib/features/feed/data/post.dart` | ❌ (Feed module — leader gate) |
 | `FeedScreen` — thêm param `spaceId` | `lib/features/feed/presentation/feed_screen.dart` | ❌ (Feed module — leader gate) |
 | Route: `/space/create`, `/space/:spaceId` | `lib/core/router/app_router.dart` | ❌ |
-| Cloud Functions: `onSpacePostCreated`, `onSpaceMemberRemoved`, `onSpaceDeleted` | `firebase/functions/src/index.ts` | ❌ |
+| Cloud Functions HTTPS Callable: `createSpace`, `leaveSpace`, `kickMember`, `transferOwnership` | `firebase/functions/src/index.ts` | ❌ |
+| Cloud Functions Firestore triggers: `onSpacePostCreated`, `onSpaceMemberAdded`, `onSpaceMemberRemoved`, `onSpaceDeleted` | `firebase/functions/src/index.ts` | ❌ |
 | TODO markers format | `// TODO(<task-id>/<DevName>): implement <artifact> — see docs/specs/2026-05-23-space.md` | ⏳ |
 
 ---
@@ -355,6 +376,22 @@ match /posts/{postId} {
 | OQ4 | Màn Space main/detail riêng? | ✅ **Không có** — Feed per Space = `FeedScreen(spaceId:)` |
 
 ---
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| `createSpace` fail (network) | Toast “Tạo Space thất bại”, không tạo Firestore doc, nhóm chưa tồn tại |
+| Invite member fail | Toast retry; các member đã invite trước không bị ảnh hưởng (idempotent batch) |
+| Member limit (max 10) được nhận khi invite | Disable checkbox khi đã chọn đủ 9 members + creator; toast “Space tối đa 10 người” |
+| Creator leave Space mà chưa transfer ownership | Disable nút “Rời khỏi” — hiện dialog “Bạn phải chọn người quản trị mới trước” |
+| Transfer ownership fail | Toast retry; creator vẫn giữ quyền, Space không thay đổi |
+| `deleteSpace` fail | Toast retry; Space vẫn tồn tại; không soft-delete một phần |
+| Post đang upload khi Space bị xóa | Post được tạo nhưng `spaceId` trỏ về Space đã xóa — CF `onSpaceDeleted` cleanup; post bị ẩn khỏi feed |
+| Context switch: user quên đang ở Space context, gửi nhầm | Badge “Đang gửi: [SpaceName]” luôn hiển — trách nhiệm của user; không có undo post |
+| Member bị kick trong khi đang xem Space feed | Firestore rule deny read; navigate back + toast “Bạn không còn là thành viên của Space này” |
+| `deleteSpace` với Space đã có group conversation | CF `onSpaceDeleted` ẩn conversation (không xóa, giữ lịch sử) — không gửi được tin nhắn mới |
+| Space không còn member nào (tất cả leave) | Không thể xảy ra — creator phải transfer trước khi leave; rule block last-member-leave |
 
 ## Risks
 

--- a/docs/specs/2026-05-23-space.md
+++ b/docs/specs/2026-05-23-space.md
@@ -1,0 +1,364 @@
+# Spec: Space Module
+
+**Date:** 2026-05-23  
+**Status:** Locked  
+**Owner:** ThienPDM (leader assign trước khi giao)  
+**Tier:** T0+ — Meep differentiator, must ship M3  
+**Epic:** #10
+
+---
+
+## Goal
+
+Cho phép user tạo nhóm nhỏ (Space) với bạn bè để chia sẻ ảnh riêng tư trong nhóm, kèm group chat đính kèm. Tích hợp vào Camera để context switch rõ ràng (đang gửi cho ai). **Không có public discovery. "Theme" ở đây = color accent của Camera UI khi chọn Space — không phải theme switch toàn màn hình.**
+
+---
+
+## User stories
+
+- Là user, tôi muốn tạo Space với tên + icon preset để nhóm bạn bè lại.
+- Là user, tôi muốn mời bạn bè vào Space từ friend list của mình.
+- Là user, tôi muốn chụp ảnh và gửi vào Space cụ thể (context switch trên Camera).
+- Là user, tôi muốn xem feed ảnh riêng của từng Space.
+- Là user, tôi muốn reply ảnh trong Space → nhắn tin trong Group Chat của Space đó.
+- Là user, tôi muốn leave Space khi tôi không muốn ở đó nữa (creator phải transfer ownership trước).
+- Là user (creator), tôi muốn xóa Space khi không cần nhóm này nữa.
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Mô tả |
+|---|---|---|
+| Tạo Space — Chọn bạn bè | `269:1193` | Bottom sheet: search bạn bè + checkbox chọn nhiều người |
+| Tạo Space — Đặt tên & theme | `269:1257` | Đặt tên Space + chọn icon preset (3×3 grid emoji) |
+| Tạo Space — Tạo biểu tượng | `269:1334` | Tạo icon tùy chỉnh: chọn emoji + color |
+| Tạo Space — Chọn Emoji | `596:1601` | Picker emoji từ keyboard |
+| Tạo Space — Chọn màu | `600:3498` | Color picker với preset + color wheel |
+
+> **Lưu ý:** Không có màn "Space main screen" riêng — Feed per Space = Feed module filter `spaceId`. Space list hiện qua bottom sheet từ Camera.
+
+---
+
+## Scope
+
+### In-scope (T0+ M3)
+
+1. **Tạo Space** — name + icon preset (emoji + color) → create
+2. **Invite members** — từ friend list, max 10 members (bao gồm creator)
+3. **Context switch Camera** — long-press FriendsButton → bottom sheet Space list → chọn Space → Camera UI đổi theme
+4. **Broadcast post** — chụp trong Space context → auto-broadcast tất cả members (không chọn thủ công)
+5. **Feed per Space** — filter `posts` theo `spaceId`, reuse Feed module
+6. **Group Chat** — reply ảnh Space → Group Chat Space (reuse Chat module)
+7. **Space management** — Leave Space, Delete Space (creator only), Kick member (creator only)
+8. **Space list** — danh sách Space của user (hiện trên Profile tab + Camera bottom sheet)
+
+### Out-of-scope
+
+- Public Space discovery — only invited (Tier 2)
+- Custom icon upload — chỉ preset (Tier 2)
+- Custom hex color input — chỉ preset (đã chốt trong modules.md)
+- Admin role hierarchy — creator = admin duy nhất (Tier 2)
+- Space settings phức tạp (Tier 2)
+- Theme switch per Space (Tier 2)
+- Group chat standalone (không đính kèm ảnh) — chat trong Space chỉ qua reply ảnh
+
+---
+
+## Luồng đầy đủ
+
+### Luồng tạo Space
+
+```
+Camera topbar → long-press FriendsButton
+    → Bottom sheet "Thêm Space mới"
+        ├─ Subtitle: "Tạo một không gian kết nối với bạn bè"
+        ├─ Search bar "Tìm kiếm bạn bè"
+        ├─ Section "Chọn bạn bè để thêm vào Space"
+        │   └─ List friends: [avatar] [displayName] [checkbox]
+        │       ├─ Unchecked: vòng tròn empty
+        │       └─ Checked: vòng tròn turquoise #00DEEE + checkmark
+        ├─ Nút "Tiếp tục" (active khi ≥ 1 friend chọn) → Step 2
+        └─ Back gesture / swipe down → đóng bottom sheet, về Camera
+
+Step 2 — "Cấu hình Space" bottom sheet:
+    ├─ Section "Đặt tên cho Space"
+    │   └─ TextField placeholder "Meepsie" (max 30 chars)
+    ├─ Section "Space theme" — grid 3×3 emoji preset:
+    │   ├─ 8 preset: 👨‍👩‍👧‍👦 ❤️ 🎃 🐸 🌼 🐻‍❄️ 🥰 🫃
+    │   ├─ 1 ô "+" → Step 3 (tạo icon tùy chỉnh)
+    │   └─ Selected = outline turquoise + checkmark badge
+    ├─ Nút "Hoàn tất" (turquoise, disabled khi name rỗng)
+    │   → [loading] spinner thay nút trong khi tạo Space
+    │   → [success] đóng bottom sheet, navigate Feed per Space mới tạo
+    │   → [error — network] toast "Không thể tạo Space, thử lại"
+    └─ Back gesture → quay về Step 1 (giữ friends đã chọn)
+
+Step 3 — "Tạo theme cho Space" (optional, từ nút "+"):
+    ├─ Preview icon đã chọn (100×100 circle)
+    ├─ Section "Gợi ý" — grid emoji
+    │   ├─ Tab Emoji: emoji_picker_flutter
+    │   └─ Tab Màu: color preset grid + color wheel (custom hex)
+    ├─ Nút "Xong" → quay về Step 2 với icon mới
+    └─ Back gesture → quay về Step 2, bỏ thay đổi icon
+```
+
+### Luồng context switch Camera
+
+```
+Camera screen → long-press FriendsButton (top bar)
+    → Bottom sheet danh sách Space
+        ├─ [All friends] (default)
+        └─ [Space 1] / [Space 2] / ... (tên + icon)
+
+Chọn Space:
+    → Bottom sheet đóng
+    → Camera UI đổi theme:
+        ├─ Viền viewfinder = colorHex của Space
+        ├─ Nút chụp = colorHex của Space
+        └─ Badge "Đang gửi: [SpaceName]" hiện topbar
+    → Chụp ảnh → preview → "Gửi" → broadcast tất cả members Space
+
+Về lại "Tất cả bạn bè":
+    → Camera UI reset về mặc định
+```
+
+### Luồng broadcast post vào Space
+
+```
+Camera (đã chọn Space context) → chụp → preview → tap "Gửi"
+    → [loading] progress indicator
+    → PostRepository.createPost(spaceId: spaceId, ...)
+    → [success]
+        → Firestore: /posts/{postId} với field spaceId
+        → Cloud Function onSpacePostCreated fan-out FCM
+        → Navigate về Feed (Space context)
+    → [error — upload fail] toast "Gửi ảnh thất bại, thử lại"
+        → Về preview, cho gửi lại (giữ nguyên ảnh + caption)
+```
+
+### Luồng xem Feed per Space
+
+```
+Space screen (từ Profile tab hoặc Camera) → tap Space
+    → FeedScreen với filter spaceId
+        └─ Query: posts WHERE spaceId == spaceId ORDER BY createdAt DESC
+        (reuse Feed module, chỉ thêm filter param)
+```
+
+### Luồng Space management
+
+```
+Space screen → menu "..." (hoặc Settings icon)
+    ├─ [Leave Space] →
+    │   ├─ Nếu là member thường: dialog confirm → xóa uid khỏi space_members
+    │   └─ Nếu là creator: phải chọn member khác làm creator mới trước
+    │       → dialog "Chọn creator mới" (list members, trừ bản thân)
+    │       → confirm → update role mới creator → leave
+    ├─ [Delete Space] (chỉ creator) → dialog confirm → soft delete
+    │   → Space ẩn, post Space vẫn giữ (hiện trong Streak/Diary của author)
+    └─ [Kick member] (chỉ creator) → chọn member → dialog confirm → xóa khỏi members
+```
+
+---
+
+## Data model
+
+### `/spaces/{spaceId}`
+
+```
+spaceId:     string     — auto Firestore ID
+name:        string     — max 30 chars, không rỗng
+iconEmoji:   string     — emoji char (vd "👨‍👩‍👧‍👦"), default "👥"
+colorHex:    string     — hex color 7 chars (vd "#00DEEE") — từ preset
+creatorId:   string     — uid của người tạo
+memberCount: number     — số member hiện tại (denormalized, max 10)
+                          lý do denormalize: tránh count query tốn read
+memberIds:   string[]   — array uid của tất cả members (max 10 phần tử)
+                          lý do denormalize: dùng `array-contains` query
+                          để lấy "spaces của tôi" trong 1 query O(1)
+createdAt:   Timestamp  — serverTimestamp()
+deletedAt:   Timestamp? — null nếu chưa xóa (soft delete)
+```
+
+### `/space_members/{spaceId}/members/{uid}`
+
+```
+uid:       string   — member uid
+role:      'creator' | 'member'
+joinedAt:  Timestamp — serverTimestamp()
+```
+
+> **Hai cấu trúc song song** (`memberIds` array + subcollection `space_members`):
+> - `memberIds` array trong `/spaces/{spaceId}`: dùng `array-contains` để query "spaces của tôi" — 1 query duy nhất.
+> - Subcollection `space_members`: dùng cho Firestore rules `isMember()` check + list members trong UI.
+> - Khi add/remove member: cập nhật cả 2 (trong Cloud Function, atomic batch write).
+
+### `/posts/{postId}` — thêm field
+
+```
+spaceId:   string?  — null nếu post "All friends", spaceId nếu post Space
+```
+
+---
+
+## Architecture
+
+```
+Presentation               Application                Data
+────────────────           ──────────────────         ──────────────────────
+SpaceCreateSheet           SpaceController            SpaceRepository
+ ├─ FriendSelectStep        ├─ SpaceState              ├─ createSpace()
+ ├─ SpaceConfigStep         ├─ createSpace()           ├─ getMySpaces()
+ └─ IconBuilderStep         ├─ loadMySpaces()          ├─ addMember()
+SpaceContextBottomSheet     ├─ leaveSpace()            ├─ removeMember()
+ └─ SpaceListTile           └─ deleteSpace()           └─ deleteSpace()
+CameraTopBar (reuse)
+ └─ SpaceContextBadge      FeedController (reuse)      PostRepository (reuse)
+FeedScreen (reuse)          └─ loadFeed(spaceId?)       └─ createPost(spaceId?)
+```
+
+**Reuse:** `FeedScreen` (thêm `spaceId` param), `PostRepository.createPost()`, `FriendsButton` component, `ChatScreen` (group chat).
+
+---
+
+## Dependencies
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `cached_network_image` | Space icon/avatar | ✅ (Feed) |
+| `emoji_picker_flutter` | Emoji picker (MIT, miễn phí) | ❌ cần thêm |
+
+> **Quyết định:** Dùng `emoji_picker_flutter` (MIT, miễn phí) — match Figma design (in-app emoji grid), có search. Thêm vào `pubspec.yaml` khi implement.
+
+---
+
+## Cloud Functions
+
+| Function | Trigger | Việc làm |
+|---|---|---|
+| `onSpacePostCreated` | Firestore onCreate `/posts/{postId}` where `spaceId != null` | Đọc `space_members`, fan-out FCM cho members |
+| `onSpaceMemberRemoved` | Firestore onDelete `/space_members/{spaceId}/members/{uid}` | Decrement `memberCount` |
+| `onSpaceDeleted` | Firestore onUpdate `/spaces/{spaceId}` where `deletedAt != null` | Cleanup: xóa `space_members`, ẩn posts |
+
+---
+
+## Security
+
+```javascript
+// /spaces/{spaceId}
+match /spaces/{spaceId} {
+  allow read:   if isAuthed() && isMember(spaceId);
+  allow create: if isAuthed() && request.resource.data.creatorId == request.auth.uid;
+  allow update: if isAuthed() && isCreator(spaceId);  // chỉ creator edit
+  allow delete: if false;  // soft delete qua update deletedAt
+}
+
+// /space_members/{spaceId}/members/{uid}
+match /space_members/{spaceId}/members/{uid} {
+  allow read:   if isAuthed() && isMember(spaceId);
+  allow create: if false;  // Cloud Function only
+  allow delete: if isAuthed() && (
+    request.auth.uid == uid ||  // self leave
+    isCreator(spaceId)           // creator kick
+  );
+}
+
+// Helper functions
+function isMember(spaceId) {
+  return exists(/databases/$(database)/documents/space_members/$(spaceId)/members/$(request.auth.uid));
+}
+
+function isCreator(spaceId) {
+  return get(/databases/$(database)/documents/spaces/$(spaceId)).data.creatorId == request.auth.uid;
+}
+
+// /posts/{postId} — thêm điều kiện Space
+match /posts/{postId} {
+  // read: author (đã có) HOẶC member của Space bài đó
+  allow read: if isAuthed() && (
+    resource.data.authorId == request.auth.uid ||
+    (resource.data.spaceId != null && isMember(resource.data.spaceId))
+  );
+}
+```
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+| Test | Target |
+|---|---|
+| `createSpace(name, emoji, color, members)` → trả spaceId | `SpaceController` |
+| `createSpace` với members > 10 → throw error | `SpaceController` |
+| `createSpace` với name rỗng → validation error | `SpaceController` |
+| `leaveSpace` → uid bị xóa khỏi members | `SpaceController` |
+| `deleteSpace` bởi non-creator → throw Unauthorized | `SpaceController` |
+| `loadMySpaces` → trả đúng list spaces của uid | `SpaceController` |
+
+### Widget tests
+
+| Test | Screen |
+|---|---|
+| Friend select: tap checkbox → checked | `FriendSelectStep` |
+| "Tiếp tục" disabled khi 0 friend chọn | `FriendSelectStep` |
+| Icon preset: tap → selected + outline turquoise | `SpaceConfigStep` |
+| "Hoàn tất" disabled khi name rỗng | `SpaceConfigStep` |
+| Camera badge hiện SpaceName khi đã chọn context | `SpaceContextBadge` |
+| Camera badge ẩn khi về "All friends" | `SpaceContextBadge` |
+
+### Firestore rules tests
+
+| Test | Expected |
+|---|---|
+| Member đọc Space | ✅ allowed |
+| Non-member đọc Space | ❌ denied |
+| Creator update Space | ✅ allowed |
+| Member update Space | ❌ denied |
+| Creator kick member | ✅ allowed |
+| Member kick member khác | ❌ denied |
+| Unauthenticated đọc Space | ❌ denied |
+| Member đọc post có `spaceId` đúng Space | ✅ allowed |
+| Non-member đọc post Space | ❌ denied |
+
+---
+
+## Contract bàn giao
+
+| Artifact | File | Status |
+|---|---|---|
+| `Space` freezed model | `lib/features/space/data/space.dart` | ❌ |
+| `SpaceMember` freezed model | `lib/features/space/data/space_member.dart` | ❌ |
+| `SpaceRepository` abstract interface | `lib/features/space/data/space_repository.dart` | ❌ |
+| `SpaceController` stub + `SpaceState` | `lib/features/space/application/space_controller.dart` | ❌ |
+| `SpaceCreateSheet` stub | `lib/features/space/presentation/space_create_sheet.dart` | ❌ |
+| `SpaceContextBottomSheet` stub | `lib/features/space/presentation/space_context_bottom_sheet.dart` | ❌ |
+| `SpaceListTile` stub | `lib/features/space/presentation/widgets/space_list_tile.dart` | ❌ |
+| `SpaceContextBadge` stub | `lib/features/space/presentation/widgets/space_context_badge.dart` | ❌ |
+| `Post` model — thêm field `spaceId` | `lib/features/feed/data/post.dart` | ❌ (Feed module — leader gate) |
+| `FeedScreen` — thêm param `spaceId` | `lib/features/feed/presentation/feed_screen.dart` | ❌ (Feed module — leader gate) |
+| Route: `/space/create`, `/space/:spaceId` | `lib/core/router/app_router.dart` | ❌ |
+| Cloud Functions: `onSpacePostCreated`, `onSpaceMemberRemoved`, `onSpaceDeleted` | `firebase/functions/src/index.ts` | ❌ |
+| TODO markers format | `// TODO(<task-id>/<DevName>): implement <artifact> — see docs/specs/2026-05-23-space.md` | ⏳ |
+
+---
+
+## Open questions
+
+| # | Câu hỏi | Status |
+|---|---|---|
+| OQ1 | Group Chat trong Space có không? | ✅ **Có** — "send photo to space" = broadcast + group chat đi kèm. Reply ảnh → mở Group Chat Space (reuse Chat module) |
+| OQ2 | Creator leave Space: transfer hay xóa? | ✅ **Transfer** — creator chọn member khác làm creator mới, sau đó leave |
+| OQ3 | Emoji picker package? | ✅ **`emoji_picker_flutter`** (MIT, miễn phí, match Figma in-app grid) |
+| OQ4 | Màn Space main/detail riêng? | ✅ **Không có** — Feed per Space = `FeedScreen(spaceId:)` |
+
+---
+
+## Risks
+
+- **`isMember()` function trong Firestore rules:** mỗi rule check phải làm 1 `get()` call → tốn Firestore reads. Mitigation: cache membership check hoặc denormalize `memberIds` array vào `/spaces/{spaceId}` (tradeoff: max 10 members → array nhỏ, OK).
+- **Camera context switch UX:** user dễ quên đang ở Space context → gửi nhầm. Mitigation: badge rõ ràng "Đang gửi: [SpaceName]" + màu viền đổi rõ ràng.
+- **Soft delete Space:** posts của Space vẫn còn trong `/posts` sau khi Space bị xóa. Mitigation: Cloud Function cleanup + `deletedAt` check khi query.
+- **Cross-module contract:** Space cần sửa `Post` model (thêm `spaceId`) và `FeedScreen` (thêm filter param) — thuộc Feed module. Leader cần gate change này trước khi Space dev start.

--- a/docs/specs/2026-05-23-widget-android.md
+++ b/docs/specs/2026-05-23-widget-android.md
@@ -1,0 +1,242 @@
+# Spec: Widget Android Module
+
+**Date:** 2026-05-23
+**Status:** Locked
+**Owner:** ThienPDM (leader assign trước khi giao)
+**Epic:** [T0] Widget Android — Ảnh mới nhất + Tap deep link · Milestone M3
+**Platform:** Android only (iOS WidgetKit deferred per ADR-0002)
+
+---
+
+## Goal
+
+Hiển thị ảnh mới nhất từ bạn bè trên home screen / lock screen Android dưới dạng AppWidget 2×2. Tap vào ảnh → mở Meep app tại post đó (deep link). Widget tự cập nhật khi có post mới.
+
+---
+
+## User stories
+
+- Là user, tôi muốn thêm Meep Widget vào home screen Android để thấy ảnh mới nhất của bạn bè.
+- Là user, tôi muốn tap vào ảnh trong widget để mở app xem đầy đủ.
+- Là user, tôi muốn widget tự cập nhật khi bạn bè đăng ảnh mới (không cần mở app).
+
+---
+
+## Scope
+
+### In-scope (M3)
+
+1. **AppWidget 2×2** — hiện 1 ảnh mới nhất từ feed (bạn bè + bản thân)
+2. **Tap deep link** — tap widget → mở Meep → navigate đến post đó
+3. **Auto-update** — WorkManager job chạy background, fetch ảnh mới, update widget
+4. **Widget setup flow** — trigger từ Settings → "Thêm tiện ích" → Android widget picker
+5. **Placeholder state** — khi chưa có ảnh hoặc chưa login: hiện logo Meep + text "Mở Meep để bắt đầu"
+
+### Out-of-scope
+
+- Widget 4×2 hoặc size khác — post-MVP
+- Multiple photos / carousel widget — post-MVP
+- iOS WidgetKit — defer per ADR-0002
+- Widget hiện avatar friends (Settings OQ4 resolved: hiện ảnh, không phải avatars)
+- Glance API (Android 12+) — post-MVP
+
+---
+
+## Màn hình & Figma IDs
+
+| Màn hình | Figma ID | Ghi chú |
+|---|---|---|
+| Widget confirm sheet (trong Settings) | `662:3341` | Bottom sheet "Thêm vào màn hình chờ?" |
+| Widget confirm variant | `678:2321` | Variant state |
+| Sau khi thêm widget | `693:2617` | Screenshot lock screen instructional UI |
+| Widget on home screen | _(native Android — không có Figma)_ | Render bằng RemoteViews |
+
+---
+
+## Luồng đầy đủ
+
+### Setup widget
+
+```
+Settings sheet → tap "Thêm tiện ích"
+    → WidgetConfirmSheet (662:3341):
+        Preview: [Meep Widget 2×2 — ảnh mới nhất]
+        [Thêm] → requestPinAppWidget() (Android API)
+             → Android system widget picker mở
+             → User đặt widget lên home screen
+             → Không có callback thành công → hiện instructional screen 693:2617
+        [Huỷ]  → đóng sheet
+```
+
+### Widget hiển thị ảnh
+
+```
+WorkManager PeriodicWorkRequest (interval: 15 phút)
+    → WidgetSyncWorker.doWork():
+        (1) [H7-FIX] Lấy token: FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()
+            Nếu currentUser == null → update widget với placeholder, return Result.success()
+        (2) Lấy currentUid từ FirebaseAuth.currentUser.uid
+        (3) Query Firestore (dùng fan-out subcollection, không dùng whereIn):
+            /users/{currentUid}/feed ORDER BY createdAt DESC LIMIT 1
+            Sau đó fetch /posts/{feedDoc.postId} để lấy imageUrl
+        (4) Download ảnh → cache vào app's files directory (Glide)
+        (5) AppWidgetManager.updateAppWidget() với RemoteViews mới
+```
+
+### Tap widget
+
+```
+User tap ảnh trong widget
+    → PendingIntent → MainActivity với extras:
+        action: "OPEN_POST"
+        postId: "{postId}"
+    → App mở (hoặc resume từ background)
+    → Flutter side nhận intent từ MethodChannel
+    → GoRouter.go('/feed?highlight={postId}')
+```
+
+---
+
+## Technical approach
+
+### Stack
+
+- **Widget UI:** Android `AppWidgetProvider` (Kotlin) + `RemoteViews` — native Android, nằm trong `apps/widget/` hoặc `apps/mobile/android/`
+- **Background sync:** `WorkManager` (AndroidX) — `PeriodicWorkRequest` 15 phút
+- **Data sharing Flutter ↔ Widget:** `SharedPreferences` (Android native) — Flutter plugin lưu **latest post display data** (`postId`, `imageUrl`, `authorName`) vào `shared_prefs` mà Kotlin đọc được. **KHÔNG lưu auth token** (xem H7 bên dưới).
+- **[H7-FIX] Auth token trong Worker:** Firebase ID token hết hạn sau 1h — không thể lưu vào SharedPreferences rồi đọc lại. Worker phải gọi `FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()` để lấy token mới mỗi lần chạy (Firebase SDK tự refresh internally). Nếu `currentUser == null` → skip query, hiện placeholder.
+- **Image caching:** Glide (Kotlin side) — download + cache ảnh vào internal storage
+- **Deep link:** `MethodChannel` Flutter ↔ Android để truyền `postId` khi tap widget
+
+### File structure
+
+```
+apps/mobile/android/app/src/main/
+├─ kotlin/.../
+│   ├─ MainActivity.kt          ← xử lý widget tap intent
+│   ├─ MeepWidget.kt            ← AppWidgetProvider
+│   └─ WidgetSyncWorker.kt      ← WorkManager worker
+└─ res/
+    ├─ layout/meep_widget.xml   ← RemoteViews layout
+    └─ xml/meep_widget_info.xml ← AppWidget metadata (size, update interval)
+```
+
+### Flutter side
+
+```dart
+// Lưu data cho widget sau mỗi lần fetch feed
+class WidgetDataService {
+  static Future<void> updateWidgetData({
+    required String latestPostId,
+    required String latestImageUrl,
+    required String authorName,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('widget_post_id', latestPostId);
+    await prefs.setString('widget_image_url', latestImageUrl);
+    await prefs.setString('widget_author_name', authorName);
+    // Trigger widget update via MethodChannel
+    await _channel.invokeMethod('updateWidget');
+  }
+}
+```
+
+---
+
+## Dependencies
+
+### Flutter (pubspec.yaml)
+
+| Package | Lý do | Có sẵn? |
+|---|---|---|
+| `shared_preferences` | Share data Flutter ↔ Android widget | ❌ cần thêm (cũng dùng Profile notification toggle) |
+| `workmanager` | Trigger WorkManager từ Flutter (optional) | ❌ cần thêm hoặc dùng native only |
+
+### Android (build.gradle)
+
+| Dependency | Lý do |
+|---|---|
+| `androidx.work:work-runtime-ktx` | WorkManager background sync |
+| `com.github.bumptech.glide:glide` | Image download + cache |
+| `com.google.firebase:firebase-firestore-ktx` | Query latest post từ Kotlin |
+| `com.google.firebase:firebase-auth-ktx` | Đọc auth token trong worker |
+
+---
+
+## Security
+
+- Widget chỉ đọc post data của user đang login — dùng Firebase Auth SDK trực tiếp trong WorkManager worker
+- **[H7] Auth token KHÔNG lưu SharedPreferences** — Worker gọi `FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()` mỗi lần chạy. Firebase SDK tự refresh token nếu cần.
+- SharedPreferences chỉ lưu display data (postId, imageUrl, authorName) — không lưu credentials
+- Nếu `currentUser == null` (chưa login / logout) → worker skip update, widget hiện placeholder
+- Không lưu password hay sensitive credentials trong SharedPreferences
+
+---
+
+## Testing strategy
+
+### Unit tests (Kotlin)
+
+| Test | Target |
+|---|---|
+| `WidgetSyncWorker` không có token → return `Result.success()` (skip gracefully) | `WidgetSyncWorker` |
+| `WidgetSyncWorker` có token → fetch post + update widget | `WidgetSyncWorker` (mock Firestore) |
+| `MeepWidget.onUpdate()` với valid RemoteViews → không crash | `MeepWidget` |
+
+### Manual smoke tests (device required)
+
+- [ ] Widget thêm được vào home screen từ Android widget picker
+- [ ] Widget hiện ảnh mới nhất sau khi đăng ảnh từ app
+- [ ] Tap widget → app mở đúng post
+- [ ] Widget hiện placeholder khi logout
+- [ ] Widget tự update sau ≤ 15 phút khi bạn đăng ảnh mới
+
+---
+
+## Contract bàn giao
+
+| Artifact | File | Status |
+|---|---|---|
+| `MeepWidget.kt` (AppWidgetProvider) | `android/app/src/main/kotlin/.../MeepWidget.kt` | ❌ |
+| `WidgetSyncWorker.kt` (WorkManager) | `android/app/src/main/kotlin/.../WidgetSyncWorker.kt` | ❌ |
+| `meep_widget.xml` (RemoteViews layout) | `android/app/src/main/res/layout/meep_widget.xml` | ❌ |
+| `meep_widget_info.xml` (AppWidget metadata) | `android/app/src/main/res/xml/meep_widget_info.xml` | ❌ |
+| `AndroidManifest.xml` — khai báo widget + WorkManager | `android/app/src/main/AndroidManifest.xml` | ❌ update |
+| `WidgetDataService` (Flutter) | `lib/features/widget/application/widget_data_service.dart` | ❌ |
+| `MethodChannel` handler trong `MainActivity.kt` | `android/app/src/main/kotlin/.../MainActivity.kt` | ❌ update |
+| TODO markers trên mọi stub | — | ⏳ |
+
+---
+
+## Open questions
+
+| # | Câu hỏi | Status |
+|---|---|---|
+| OQ1 | Widget 2×2 hiện ảnh hay avatars? | **✅ Resolved:** hiện ảnh mới nhất (từ Settings spec OQ4) |
+| OQ2 | Update interval: 15 phút hay khác? | **15 phút** — minimum WorkManager interval. Có thể trigger thêm khi mở app |
+| OQ3 | Dùng `workmanager` Flutter plugin hay native WorkManager? | **Gợi ý: native WorkManager** — tránh thêm Flutter plugin, logic đơn giản đủ viết Kotlin |
+
+---
+
+## Worst path
+
+| Scenario | Expected behavior |
+|---|---|
+| Auth token hết hạn trong Worker | Worker skip update (`Result.success()`), widget hiện placeholder "Mở Meep để đăng nhập lại" |
+| Network fail trong Worker | Giữ ảnh Glide đã cache trước đó; không update timestamp; không crash |
+| OS defer Worker (Doze mode) | Widget hiện ảnh cũ (stale tối đa 15+ phút) — known limitation, document trong README |
+| Deep link tap: post đã bị xóa | App mở, navigate đến Feed Home (fallback); toast "Khoảnh khắc này không còn tồn tại" |
+| SharedPreferences chưa có data (lần đầu / sau xóa cache) | Widget hiện placeholder Meep logo + "Mở Meep để bắt đầu" |
+| User logout khi widget đang cài | Flutter ghi `null` vào SharedPreferences → Worker next run detect no token → widget hiện placeholder ngay |
+| Feed rỗng (chưa có post nào) | Worker query trả empty → widget hiện placeholder, không crash |
+| Image download fail (Glide) | Widget giữ ảnh cached cũ (nếu có) hoặc hiện placeholder; không show broken image |
+| User thêm widget trước khi đăng nhập | Placeholder state, tự update khi app được mở và đăng nhập |
+| Nhiều widget instance trên home screen | Tất cả cùng hiện ảnh mới nhất — `AppWidgetManager.updateAppWidget(ids, views)` update all |
+
+## Risks
+
+- **WorkManager 15 phút minimum:** Android không cho schedule dưới 15 phút. Widget có thể chậm tối đa 15 phút sau khi bạn đăng ảnh. Mitigation: trigger sync thêm khi user mở app (Flutter push FCM → update widget).
+- **Doze mode / battery optimization:** Android có thể defer WorkManager trên device tiết kiệm pin. Mitigation: document known limitation trong README.
+- **SharedPreferences race condition:** Flutter write + Kotlin read đồng thời → stale data. Mitigation: Kotlin luôn đọc fresh từ Firestore trong Worker, SharedPreferences chỉ là cache.
+- **Glide vs Coil:** nếu project đã có Coil trong Android deps → dùng Coil thay Glide để avoid duplicate image library.
+- **RemoteViews limitation:** không support tất cả Flutter widget — UI widget bị giới hạn bởi Android RemoteViews API. Design phải đơn giản (ImageView + TextView).

--- a/docs/team-onboarding/plan-prompt-template.md
+++ b/docs/team-onboarding/plan-prompt-template.md
@@ -1,0 +1,200 @@
+# ROLE
+You are a senior Flutter tech lead generating implementation plans for ALL modules of a project.
+You will process 11 specs in strict dependency order, output a complete plan for each, then
+run a final cross-module verification. Do not skip any step. Do not ask clarifying questions.
+
+---
+
+# PROJECT CONTEXT: Meep
+
+## Tech stack (locked)
+- Flutter + Dart, Riverpod 2 (code-gen @riverpod), freezed + json_serializable
+- Firebase: Auth, Firestore, Storage, Cloud Functions (Node 20 + TypeScript), FCM, go_router
+- Tests: flutter_test + fake_cloud_firestore + firebase_auth_mocks (Flutter), vitest (TS)
+
+## File structure
+apps/mobile/lib/
+  core/theme/ | core/error/
+  features/<feature>/data/ | application/ | presentation/
+  shared/widgets/
+firebase/functions/src/index.ts
+
+## Rules (non-negotiable)
+- Dart: snake_case files, UpperCamelCase classes, lowerCamelCase vars
+- Firestore: plural lower_snake_case collections, camelCase fields
+- Riverpod: always @riverpod code-gen, never manual Provider()
+- Freezed: always @freezed, never plain classes for data models
+- Repository pattern: abstract class in data/ + FirebaseXxxRepository implementation
+- Contract-first: leader merges stubs to develop BEFORE dev starts. Stubs throw UnimplementedError.
+- Stub TODO format: // TODO(<taskId>/<DevName>): <description>
+- Devs never touch another module. Cross-module = import only, never edit.
+- App always compiles. No broken imports.
+
+## Team
+- DevNames: ThienPDM (leader), KhoaLND, HanDHG, NganTNK
+- Branch: <type>/<DevName>/<short-desc>
+- Commit: <type>(<scope>): <Vietnamese description>
+
+## Task sizes
+- XS ≤ 2h | S ~4h | M ~8h | L 2-3 days | NEVER > L (break it down)
+
+## Definition of Done
+1. All acceptance criteria pass (measurable — no "should work", "properly", "correctly")
+2. Unit tests: controller + repository happy + edge + error cases
+3. Widget tests: critical UI flows
+4. flutter analyze + dart format clean
+5. PR approved by leader, CI green, merged to develop
+
+---
+
+# PROCESSING INSTRUCTIONS
+
+Process each module in the exact order below. For each module:
+1. Read its spec
+2. Note which contracts it IMPORTS from other modules (already processed)
+3. Generate its plan
+4. Proceed to next module
+
+PROCESSING ORDER (dependency-sorted):
+1. auth          — no dependencies
+2. friend        — imports: UserProfile from auth
+3. settings      — imports: Friendship/FriendRequest from friend (blockUser unfriends)
+4. chat          — imports: BlockRepository from settings, Friendship from friend
+5. home-camera-feed — imports: Friendship from friend, BlockRepository from settings
+6. notification  — imports: Post from home-camera-feed, Conversation from chat
+7. reaction      — imports: Post from home-camera-feed
+8. diary         — imports: UserProfile from auth
+9. profile       — imports: DiaryRepository from diary, FriendCount from friend
+10. space        — imports: Friendship from friend, NotificationRepository from notification
+11. widget-android — imports: feed subcollection from home-camera-feed, Auth from auth
+
+For EACH module, output the following 4 parts:
+
+---
+## MODULE: <name> (processing <N>/11)
+
+### PART 1 — Contract artifacts (leader merges to develop FIRST)
+Table format:
+| File path | Type | Key contents |
+|-----------|------|-------------|
+| lib/features/<f>/data/<model>.dart | freezed model | list all fields with types |
+| lib/features/<f>/data/<repo>.dart | abstract class | list all method signatures |
+| lib/features/<f>/application/<ctrl>.dart | Riverpod stub | provider signature, throws UnimplementedError |
+| firebase/functions/src/index.ts | CF stub | function name + signature |
+
+### PART 2 — Tasks
+Number tasks globally across ALL modules: T1, T2, T3... (never restart from T1 for a new module).
+
+For each task:
+---
+**T<N> · <module> · <Conventional Commits title>**
+| Field | Value |
+|-------|-------|
+| Assignee | <DevName or TBD> |
+| Estimate | XS/S/M/L |
+| Branch | `<type>/<DevName>/<desc>` |
+| Blocked by | T<N> or "contracts from Part 1" or "None" |
+
+Files:
+- `path/to/file.dart` — what to implement
+- `path/to/test_file.dart` — test cases: <list 3+ specific test descriptions>
+
+Acceptance criteria:
+- [ ] <measurable criterion — no vague words>
+- [ ] <measurable criterion>
+- [ ] <measurable criterion>
+
+Cross-module imports: <list exact class names + source module, or "None">
+---
+
+### PART 3 — Module dependency graph
+Show tasks as: T<N> → T<N> → (parallel: T<N>, T<N>) → T<N>
+
+### PART 4 — Module open questions
+Format: OQ: <question> | Blocks: <task IDs>
+Write "None" if spec is complete.
+
+---
+
+After processing ALL 11 modules, output:
+
+## FINAL CROSS-MODULE VERIFICATION
+
+Run every check. Output ✅ or ❌ with a one-line note if ❌.
+
+### A. Contract consistency
+- [ ] Every abstract interface imported by another module exists in Part 1 of the source module
+- [ ] No two modules define a class with the same name for different purposes
+- [ ] BlockRepository is defined in settings, imported (not redefined) in chat and home-camera-feed
+- [ ] DiaryRepository.getPublicEntries() exists in diary Part 1 and is imported by profile
+- [ ] Feed subcollection (/users/{uid}/feed) access is only done by home-camera-feed and widget
+
+### B. Firestore coverage
+- [ ] Every collection from all specs has exactly one "repository owner" module
+- [ ] No collection is written to directly from client without a CF or repository
+- [ ] /users/{uid}/feed is written ONLY by onPostCreated and onFriendshipDeleted CFs
+- [ ] /blocks is written ONLY by blockUser CF (never direct client write)
+- [ ] /spaces member management is ONLY done by joinSpace/leaveSpace/createSpace CFs
+
+### C. Cloud Function completeness
+List all CFs across all specs and confirm each has a task:
+| CF name | Module | Task ID | ✅/❌ |
+|---------|--------|---------|-------|
+(fill in every CF from every spec)
+
+### D. Task numbering
+- [ ] Task IDs are globally unique (no duplicate T<N>)
+- [ ] No gaps in task numbering
+- [ ] Total task count is reasonable (estimate: 60-100 tasks for 11 modules)
+
+### E. Cross-module task conflicts
+- [ ] No task in module A modifies a file owned by module B
+- [ ] Shared components (shared/widgets/) are owned by leader (ThienPDM), not individual modules
+- [ ] firestore.rules is NOT in any module task — it is a separate leader task
+
+### F. End-to-end user flows
+Verify each critical flow has tasks that cover it end-to-end:
+- [ ] User registers → auth T<N> (screen) → T<N> (Firebase Auth) → T<N> (save /users doc)
+- [ ] User posts photo → camera T<N> → upload T<N> → onPostCreated CF T<N> → feed fan-out T<N>
+- [ ] User reacts → reaction T<N> (UI) → T<N> (Firestore write) → onReactionCreated T<N> (notif)
+- [ ] User blocks → settings T<N> (UI) → blockUser CF T<N> → feed filters T<N>
+- [ ] Widget shows latest photo → widget T<N> (WorkManager) → T<N> (Firestore read feed sub)
+
+If ANY check is ❌, output a CORRECTION section listing exactly what to fix before using this plan.
+
+---
+
+# SPECS (paste each file in full)
+
+## [SPEC_AUTH]
+<paste 2026-05-04-auth.md here>
+
+## [SPEC_FRIEND]
+<paste 2026-05-22-friend.md here>
+
+## [SPEC_SETTINGS]
+<paste 2026-05-23-settings.md here>
+
+## [SPEC_CHAT]
+<paste 2026-05-23-chat.md here>
+
+## [SPEC_HOME_CAMERA_FEED]
+<paste 2026-05-22-home-camera-feed.md here>
+
+## [SPEC_NOTIFICATION]
+<paste 2026-05-23-notification.md here>
+
+## [SPEC_REACTION]
+<paste 2026-05-23-reaction.md here>
+
+## [SPEC_DIARY]
+<paste 2026-05-23-diary.md here>
+
+## [SPEC_PROFILE]
+<paste 2026-05-22-profile.md here>
+
+## [SPEC_SPACE]
+<paste 2026-05-23-space.md here>
+
+## [SPEC_WIDGET]
+<paste 2026-05-23-widget-android.md here>

--- a/firebase/CLAUDE.md
+++ b/firebase/CLAUDE.md
@@ -1,0 +1,87 @@
+# Firestore / Storage Rules
+
+> Loaded when working in `firebase/`. Supplements root `CLAUDE.md`.
+
+## Firestore data modeling
+
+- **Denormalize** when read frequency >> write frequency (e.g. copy `authorName` into `posts/{postId}`).
+- Keep document size **< 100KB**.
+- **Subcollections** for unbounded lists (`/users/{uid}/notifications/{notifId}`).
+- `serverTimestamp()` for `createdAt` / `updatedAt` — **never trust client clocks**.
+
+## Firestore security rules
+
+- **Default deny everything**, then open per collection with smallest needed access.
+- **Rules unit-tested** with `@firebase/rules-unit-testing` — run via `firebase emulators:exec`.
+- **No `allow read, write: if true`** ever, even temporarily.
+- Validate field types and lengths in rules.
+
+```javascript
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isAuthed() { return request.auth != null; }
+    function isOwner(uid) { return isAuthed() && request.auth.uid == uid; }
+    function isFriend(uidA, uidB) {
+      let pairId = uidA < uidB ? uidA + '_' + uidB : uidB + '_' + uidA;
+      return exists(/databases/$(database)/documents/friendships/$(pairId));
+    }
+
+    match /posts/{postId} {
+      allow read: if isAuthed() && (
+        isOwner(resource.data.authorId) ||
+        isFriend(request.auth.uid, resource.data.authorId)
+      );
+      allow create: if isOwner(request.resource.data.authorId)
+        && request.resource.data.caption.size() <= 200
+        && request.resource.data.keys().hasAll(['authorId','caption','imageUrl','createdAt']);
+      allow update, delete: if isOwner(resource.data.authorId);
+    }
+  }
+}
+```
+
+## Storage security rules
+
+- Read requires authentication.
+- Write requires `request.auth.uid == uid`.
+- Size cap: `request.resource.size < 10 * 1024 * 1024` (10MB).
+- MIME check: `request.resource.contentType.matches('image/.*')`.
+
+```javascript
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /posts/{uid}/{filename} {
+      allow read: if request.auth != null;
+      allow write: if request.auth.uid == uid
+        && request.resource.size < 10 * 1024 * 1024
+        && request.resource.contentType.matches('image/.*');
+    }
+  }
+}
+```
+
+## Indexes
+
+- Compound queries → declare in `firestore.indexes.json` (commit it).
+- Don't manually create indexes in Console only — they'll get lost on re-deploy.
+
+## Pre-deploy checklist
+
+- [ ] No `allow read, write: if true`.
+- [ ] Every collection with user data has explicit `isOwner()` / `isFriend()` checks.
+- [ ] Field types and sizes validated.
+- [ ] Sensitive subcollections are owner-only.
+- [ ] Rules unit tests: owner / friend / stranger / unauthenticated.
+- [ ] `firebase emulators:exec --only firestore "npm run test:rules"` passes.
+
+## Common gotchas
+
+| Issue | Fix |
+|---|---|
+| Rules pass locally but fail in prod | Emulator is sometimes more lenient — test against real staging Firestore |
+| Query empty in prod, not local | Compound query missing index — check Firebase Console > Firestore > Indexes |
+| Field name typo | Field names are case-sensitive — match Dart `fromJson` exactly |
+| Rule recursion / lookup limit | Max 10 `get()` / `exists()` per rule eval — denormalize if you hit it |

--- a/firebase/functions/CLAUDE.md
+++ b/firebase/functions/CLAUDE.md
@@ -1,0 +1,86 @@
+# Node.js + TypeScript Rules
+
+> Loaded when working in `firebase/functions/`. Supplements root `CLAUDE.md`.
+
+## Strictness — non-negotiable
+
+`tsconfig.json` must enable: `strict`, `noUncheckedIndexedAccess`, `noImplicitOverride`, `noFallthroughCasesInSwitch`, `exactOptionalPropertyTypes`. Target `ES2022`, module + moduleResolution `NodeNext`.
+
+Don't downgrade these "to make TypeScript shut up". Fix the type.
+
+## Input validation — every external boundary
+
+All external input (HTTP body, query, callable function payload, Firestore trigger document) MUST be validated with **zod** before use.
+
+Rule: every callable / HTTP handler starts with `if (!request.auth)` check, then `safeParse` of input, then business logic on `parsed.data`. NEVER use `request.data` directly.
+
+## Error model
+
+```ts
+export class AppError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly message: string,
+    public readonly statusCode: number,
+    public readonly cause?: unknown,
+  ) { super(message); this.name = 'AppError'; }
+}
+// Subclass: ValidationError, UnauthenticatedError, ForbiddenError, NotFoundError
+```
+
+- Don't throw raw strings or numbers.
+- Every async function that can throw → has try/catch at the handler boundary.
+
+## Logging
+
+- Don't `console.log` in production code; use `pino` or Cloud Functions' built-in `logger`.
+- **Never log PII** — no email, phone, caption body, full request body. Log IDs only.
+- Structured logs: `logger.info({ uid, postId }, 'post created')`.
+
+## Testing — vitest
+
+```bash
+npm test
+npm test -- file.test.ts
+npm test -- --coverage
+npm run lint
+npm run typecheck
+```
+
+- 1 file per source file: `foo.ts` ↔ `foo.test.ts`.
+- Use `vi.mock` sparingly — prefer dependency injection + in-memory fakes.
+- Tests run in < 5s baseline.
+
+## Cloud Functions v2 specifics
+
+- Use **v2 functions** (`onRequest`, `onCall`, `onDocumentCreated`, `onObjectFinalized`).
+- Region: `asia-southeast1`.
+- Set `timeoutSeconds` and `memory` explicitly per function.
+- **Idempotency:** triggers can fire twice — make handlers safe to retry.
+- **Cold start:** lazy-import expensive packages (`sharp`, `firebase-admin/messaging`) inside the handler, not top-level.
+
+```ts
+initializeApp();
+setGlobalOptions({ region: 'asia-southeast1', maxInstances: 10 });
+
+export const sendFriendRequest = onCall(async (request) => {
+  if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
+  const parsed = schema.safeParse(request.data);
+  if (!parsed.success) throw new HttpsError('invalid-argument', parsed.error.message);
+  // ... business logic
+});
+```
+
+## Secrets
+
+- Firebase Secret Manager: `firebase functions:secrets:set <NAME>`.
+- Access via `defineSecret('NAME')` and pass to function options.
+- No hardcoded API keys.
+
+## Common gotchas
+
+| Issue | Fix |
+|---|---|
+| `Cannot use import statement` | `"type": "module"` in package.json + `.js` extension on import paths |
+| Firebase Admin SDK initialised multiple times | `initializeApp()` at module top once |
+| Cloud Function timeout | Set `timeoutSeconds` explicitly. Long task → Cloud Tasks / Pub/Sub |

--- a/tasks/todo-all-modules.md
+++ b/tasks/todo-all-modules.md
@@ -1,0 +1,60 @@
+# TODO Index — Meep All Modules
+
+> Mỗi module có todo file riêng. File này là index + sprint tracking.
+
+---
+
+## Leader tasks (ThienPDM — ongoing)
+
+- [ ] **TX1** — Merge contract artifacts từng module vào `develop` (theo dependency order bên dưới) trước khi giao dev
+- [ ] **TX2** — Viết `firestore.rules` cuối cùng: merge tất cả helper functions + match blocks từ 12 specs
+- [ ] **TX3** — Update `app_router.dart` với tất cả routes từ 12 modules
+- [ ] **TX4** — Update `pubspec.yaml`: thêm packages (share_plus, camera, flutter_image_compress, gal, geolocator, cached_network_image, http, intl, image_picker, firebase_messaging, flutter_local_notifications, emoji_picker_flutter, flutter_svg, shared_preferences); confirm workmanager
+
+---
+
+## Leader todos (ThienPDM — làm TRƯỚC khi giao dev)
+
+| Task | Todo | Mô tả |
+|------|------|-------|
+| Leader plan | [todo-leader.md](todo-leader.md) | Contract creation + shared infrastructure (LX0–LX12 + LX-RULES + LX-PUBSPEC) |
+
+---
+
+## Module todos (theo dependency order)
+
+| # | Module | Todo | Tier | Milestone | Blocked by |
+|---|--------|------|------|-----------|-----------|
+| 1 | Auth | [todo-auth.md](todo-auth.md) | T0 | M1 | — |
+| 2 | Friend | [todo-friend.md](todo-friend.md) | T0 | M2 | Auth |
+| 3 | Settings | [todo-settings.md](todo-settings.md) | T0 | M2/M3 | Auth, Friend |
+| 4 | Chat | [todo-chat.md](todo-chat.md) | T1/T0+ | M3 | Friend, Settings |
+| 5 | Home/Camera/Feed | [todo-home-camera-feed.md](todo-home-camera-feed.md) | T0 | M2 | Friend, Settings |
+| 6 | Notification | [todo-notification.md](todo-notification.md) | T0 | M3 | Feed, Friend |
+| 7 | Reaction | [todo-reaction.md](todo-reaction.md) | T0 | M3 | Feed |
+| 8 | Diary | [todo-diary.md](todo-diary.md) | T0+ | M3 | Auth |
+| 9 | Profile | [todo-profile.md](todo-profile.md) | T0+ | M2 | Auth, Friend, Diary |
+| 10 | Space | [todo-space.md](todo-space.md) | T0+ | M3 | Friend, Feed |
+| 11 | Widget Android | [todo-widget-android.md](todo-widget-android.md) | T0 | M3 | Feed, Auth |
+| 12 | Streak | [todo-streak.md](todo-streak.md) | T1 | Post-M3 | Feed |
+
+---
+
+## Global task numbering (tham khảo)
+
+Dùng khi cần cross-reference giữa modules:
+
+| Global range | Module | Local tasks |
+|---|---|---|
+| T1–T11 | Auth | A/T1–T11 |
+| T12–T18 | Friend | F/T1–T7 |
+| T19–T26 | Settings | SE/T1–T8 |
+| T27–T33 | Chat | C/T1–T7 |
+| T34–T44 | Feed/Camera | FE/T1–T11 |
+| T45–T52 | Notification | N/T1–T8 |
+| T53–T57 | Reaction | R/T1–T5 |
+| T58–T65 | Diary | D/T1–T8 |
+| T66–T74 | Profile | P/T1–T9 |
+| T75–T85b | Space | SP/T1–T10b, T11 |
+| T86–T91 | Widget | W/T1–T6 |
+| T92–T95 | Streak | ST/T1–T4 |

--- a/tasks/todo-auth.md
+++ b/tasks/todo-auth.md
@@ -2,41 +2,48 @@
 
 > Plan: `docs/plans/2026-05-04-auth.md`
 > Spec: `docs/specs/2026-05-04-auth.md`
-> Epic: #1 — M1 (2026-05-13)
+> Tier: T0 · Milestone M1
+> Blocked by: —
 
 ---
 
-## Phase 1: Foundation
+## Phase 1 — Setup & Shared
 
-- [ ] **T1** — Firebase init + AppRouter (`main.dart` + `core/router/app_router.dart`)
-- [ ] **T2** — `UserProfile` model (freezed + json_serializable)
-- [ ] **T3** — `AuthRepository` contract update + `FirebaseAuthRepository` impl
-- [ ] **T4** — `UserRepository` abstract + `FirebaseUserRepository` (batch write users+usernames)
-- [ ] **T5** — Firestore rules: `/users/{uid}` + `/usernames/{username}`
+- [ ] **T1** — Firebase init + `main.dart` + `AppRouter` với redirect guard 3 states
+- [ ] **T11** — Shared widgets (`AppPrimaryButton`, `AppBackButton`, `AppGoogleButton`, `AppTextInput`) + design tokens (`app_colors.dart`)
+
+---
+
+## Phase 2 — Data layer
+
+- [ ] **T2** — `UserProfile` model — full schema (auth + profile fields), freezed + TimestampConverter
+- [ ] **T3** — `AuthRepository` abstract (incl. `deleteCurrentUser`, `reauthenticateWithCredential`, `updateEmail`) + `FirebaseAuthRepository` impl
+- [ ] **T4** — `UserRepository` abstract + `FirebaseUserRepository` (atomic batch write users + usernames)
+- [ ] **T5** — Firestore rules `/users/{uid}` + `/usernames/{username}` + rules tests
 
 ## Checkpoint: Data layer ✓
-- [ ] `flutter test test/features/auth/` ALL PASS
-- [ ] `firebase deploy --only firestore:rules --project meep-staging` OK
+- [ ] `flutter test test/features/auth/` — 0 failures
+- [ ] `firebase emulators:exec --only firestore "npm run test:rules"` — auth rules pass
 
 ---
 
-## Phase 2: Application Layer
+## Phase 3 — Application layer
 
-- [ ] **T6** — `SignUpController` (SignUpState + 4-step state machine + createAccount)
-- [ ] **T7** — `LoginController` + Google Sign-In (check `/users/{uid}`)
+- [ ] **T6** — `SignUpController` (4-step state machine + `checkUsername` debounce + `createAccount` + rollback `deleteCurrentUser`)
+- [ ] **T7** — `LoginController` + `signInWithGoogle` (check `/users/{uid}`) + `sendPasswordReset`
 
 ## Checkpoint: App layer ✓
-- [ ] `flutter test test/features/auth/` ALL PASS
+- [ ] `flutter test test/features/auth/` — 0 failures
 
 ---
 
-## Phase 3: UI Screens
+## Phase 4 — UI Screens
 
-- [ ] **T8** — `IntroPage` + router wiring (2 CTA → /signup/email, /login/email)
-- [ ] **T9** — Signup screens: `SignUpEmailPage` + `SignUpPasswordPage`
-- [ ] **T10** — Signup screens: `SignUpNamePage` + `SignUpUsernamePage` (username availability)
-- [ ] **T11** — Login screens: `LoginEmailPage` + `LoginPasswordPage` (forgot pw + success state)
+- [ ] **T8** — `IntroPage` (Figma 556:2136) + wire tất cả auth routes vào router
+- [ ] **T9** — Signup flow 4 màn hình: `SignUpEmailPage` + `SignUpPasswordPage` + `SignUpNamePage` + `SignUpUsernamePage`
+- [ ] **T10** — Login flow: `LoginEmailPage` + `LoginPasswordPage` (forgot password + success auto-navigate 1.5s)
 
 ## Checkpoint: Auth complete ✓
-- [ ] All tests PASS
-- [ ] Manual E2E: signup → login → auto-login → logout → Google Sign-In
+- [ ] `flutter test test/features/auth/` — 0 failures
+- [ ] `flutter analyze` + `dart format` clean
+- [ ] Manual: signup → login → auto-login → Google Sign-In new user → Google Sign-In returning → forgot password → logout

--- a/tasks/todo-chat.md
+++ b/tasks/todo-chat.md
@@ -1,0 +1,44 @@
+# TODO: Chat
+
+> Plan: `docs/plans/2026-05-23-chat.md`
+> Spec: `docs/specs/2026-05-23-chat.md`
+> Tier: T1 Stretch (1-1) + T0+ exception (Group Chat ship cùng Space M3)
+> Blocked by: Friend (CF acceptFriendRequest tạo conversation), Settings (BlockRepository)
+
+---
+
+## Phase 1 — Data layer
+
+- [ ] **T1** — `FirebaseConversationRepository` (watchConversations filter blocked + getOrCreateConversation idempotent + sendMessage + watchMessages)
+
+## Checkpoint: Data layer ✓
+- [ ] `flutter test test/features/chat/` — 0 failures
+
+---
+
+## Phase 2 — Application layer
+
+- [ ] **T2** — `ChatController` (loadMessages + sendMessage no-optimistic + sendMessageFromFeed)
+
+## Checkpoint: App layer ✓
+- [ ] `flutter test test/features/chat/` — 0 failures
+
+---
+
+## Phase 3 — UI
+
+- [ ] **T3** — `InboxScreen` (list conversations sorted lastMessageAt DESC + empty state)
+- [ ] **T4** — `ChatScreen` 1-1 (QuotedPhotoBlock + MessageBubble trái/phải + ChatInputBar + unfriended/blocked banner)
+- [ ] **T5** — `GroupChatScreen` + `SpaceMembersSheet` — **T0+ ship cùng Space M3**
+- [ ] **T6** — Block/unfriend từ chat ⋯ menu (BlockConfirmDialog từ Settings + FriendController.unfriend)
+
+---
+
+## Phase 4 — Rules
+
+- [ ] **T7** — Firestore rules tests `/conversations` + `/messages` (status=blocked → cannot create message)
+
+## Checkpoint: Chat complete ✓
+- [ ] `flutter test test/features/chat/` — 0 failures
+- [ ] `flutter analyze` clean
+- [ ] Manual: reply ảnh từ Feed → inline text → gửi → Inbox cập nhật; block từ chat → conversation ẩn; unfriend → readonly banner

--- a/tasks/todo-diary.md
+++ b/tasks/todo-diary.md
@@ -1,0 +1,52 @@
+# TODO: Diary
+
+> Plan: `docs/plans/2026-05-23-diary.md`
+> Spec: `docs/specs/2026-05-23-diary.md`
+> Tier: T0+ · Milestone M3
+> Blocked by: Auth (UserProfile, currentUid); HanDHG (export 11 assets trước T3)
+
+---
+
+## Phase 1 — Data layer
+
+- [ ] **T1** — `FirebaseDiaryRepository` (createEntry + watchEntries + **getPublicEntries(authorUid)** + getEntry + updateEntry + deleteEntry + searchEntries in-memory)
+
+## Checkpoint: Data layer ✓
+- [ ] `flutter test test/features/diary/` — 0 failures
+
+---
+
+## Phase 2 — Application layer
+
+- [ ] **T2** — `DiaryController` (saveEntry create/update mode + upload sequence cover→inline→Firestore + deleteEntry + updatePrivacy)
+
+## Checkpoint: App layer ✓
+- [ ] `flutter test test/features/diary/` — 0 failures
+
+---
+
+## Phase 3 — Assets (blocked trên HanDHG export)
+
+- [ ] **T3** — 11 assets export: 5 SVG icons + 5 bg PNG + 1 polaroid PNG → `assets/moods/` + `assets/frames/`; implement `MoodZoneBlock` + `MoodClipper` per mood; add `flutter_svg`
+
+> ⚠️ T3 không thể bắt đầu cho đến khi HanDHG export đủ 11 assets.
+
+---
+
+## Phase 4 — UI Screens
+
+- [ ] **T4** — `DiaryCreateScreen` (mood picker overlay 5 frames + fallback khi gallery trống)
+- [ ] **T5** — `DiaryCanvasScreen` (`DiaryCanvasMode` enum + Column block editor + TextStylePicker + PrivacySheet + DiscardDialog; canvas bg hardcode `#f9fcfc`)
+- [ ] **T6** — `DiaryListScreen` (grid 2 columns Figma 656:1831 + empty state + FAB)
+- [ ] **T7** — `DiarySearchScreen` (in-memory filter case-insensitive + keyword highlight)
+
+---
+
+## Phase 5 — Rules
+
+- [ ] **T8** — Firestore rules `/diary/{id}` + Storage rules `diary/{uid}/` + rules tests
+
+## Checkpoint: Diary complete ✓
+- [ ] `flutter test test/features/diary/` — 0 failures
+- [ ] `flutter analyze` clean
+- [ ] Manual: tạo → mood picker → canvas gõ text → lưu → card list → search → xem → đổi privacy public/private

--- a/tasks/todo-friend.md
+++ b/tasks/todo-friend.md
@@ -1,0 +1,50 @@
+# TODO: Friend
+
+> Plan: `docs/plans/2026-05-23-friend.md`
+> Spec: `docs/specs/2026-05-22-friend.md`
+> Tier: T0 · Milestone M2
+> Blocked by: Auth (UserProfile, currentUidProvider)
+
+---
+
+## Phase 1 — Data layer
+
+- [ ] **T1** — `FirebaseFriendRepository` + `FirebaseFriendRequestRepository` + `pairIdOf()` util
+
+## Checkpoint: Data layer ✓
+- [ ] `flutter test test/features/friend/` — 0 failures
+
+---
+
+## Phase 2 — Application layer
+
+- [ ] **T2** — `FriendController` (search debounce 500ms + loadFriends + pending requests + send/accept/decline/cancel/unfriend)
+
+## Checkpoint: App layer ✓
+- [ ] `flutter test test/features/friend/` — 0 failures
+
+---
+
+## Phase 3 — UI
+
+- [ ] **T3** — `FriendSheet` bottom sheet (search + pending requests + friend list + unfriend confirm dialog)
+- [ ] **T4** — `FriendFilterDropdown` + invite link section + deep link `/invite/:uid`
+
+---
+
+## Phase 4 — Cloud Functions
+
+- [ ] **T5** — CF `acceptFriendRequest` (validate + atomic batch: friendship + conversation + friendCount cả 2 user)
+- [ ] **T6** — CF `onFriendshipDeleted` (friendCount decrement + conversation status + cross-feed cleanup)
+
+---
+
+## Phase 5 — Rules
+
+- [ ] **T7** — Firestore rules tests `/friendships` + `/friend_requests`
+
+## Checkpoint: Friend complete ✓
+- [ ] `flutter test test/features/friend/` — 0 failures
+- [ ] CF tests pass
+- [ ] `flutter analyze` clean
+- [ ] Manual: search → send request → accept → friend list cập nhật; unfriend confirm dialog; invite link copy

--- a/tasks/todo-home-camera-feed.md
+++ b/tasks/todo-home-camera-feed.md
@@ -1,0 +1,56 @@
+# TODO: Home / Camera / Feed
+
+> Plan: `docs/plans/2026-05-23-home-camera-feed.md`
+> Spec: `docs/specs/2026-05-22-home-camera-feed.md`
+> Tier: T0 · Milestone M2
+> Blocked by: Friend (FriendRepository audience avatars), Settings (BlockRepository feed filter)
+
+---
+
+## Phase 1 — Data layer
+
+- [ ] **T1** — `FirebasePostRepository` (watchFeed fan-out subcollection + createPost + deletePost + getPostsByAuthor) + `FirebaseStorageRepository`
+
+## Checkpoint: Data layer ✓
+- [ ] `flutter test test/features/feed/` — 0 failures
+
+---
+
+## Phase 2 — Application layer (song song nhau)
+
+- [ ] **T2** — `CaptionService` (Text + Location/Nominatim + Weather/OpenMeteo + Time + Mock)
+- [ ] **T3** — `AppCameraController` + `CameraSection` UI (viewfinder 400×400 + controls + scroll behavior)
+- [ ] **T5** — `PostController.createPost` (compress ≤1MB → upload → Firestore; rollback nếu Storage fail)
+- [ ] **T6** — `FeedController` (fan-out query + cursor pagination limit 10 + prefetch index length-4 + FeedFilter)
+
+## Checkpoint: App layer ✓
+- [ ] `flutter test test/features/feed/` — 0 failures
+
+---
+
+## Phase 3 — UI
+
+- [ ] **T4** — `CapturePreviewScreen` (caption cycle 7 types + audience selector + download in-place + send)
+- [ ] **T7** — `FeedSection` UI (`FriendPostCard` + `OwnPostCard` + `ActTextBar` M2 disabled)
+- [ ] **T8** — `GridViewScreen` + `ShareModal` + `PhotoActionSheet` (share + [Báo cáo stub] + [Chặn → BlockConfirmDialog])
+
+---
+
+## Phase 4 — Cloud Functions
+
+- [ ] **T9** — CF `onPostCreated` (fan-out feed all-friends khi spaceId==null + postCount increment + FCM to friends; **skip** khi spaceId!=null)
+- [ ] **T10** — CF `onPostDeleted` (batch delete feed docs + Storage delete + postCount decrement + reactions cleanup)
+
+> ⚠️ CF `onFriendshipDeleted` (cross-feed cleanup) implement tại **Friend module T6** — không tạo CF riêng ở đây.
+
+---
+
+## Phase 5 — Rules
+
+- [ ] **T11** — Firestore rules tests `/posts` + `/users/{uid}/feed` + Storage rules tests
+
+## Checkpoint: Feed complete ✓
+- [ ] `flutter test test/features/feed/` — 0 failures
+- [ ] CF tests pass
+- [ ] `flutter analyze` clean
+- [ ] Manual: chụp ảnh → caption cycle → gửi → xuất hiện feed; grid view; save to gallery; download in-place

--- a/tasks/todo-leader.md
+++ b/tasks/todo-leader.md
@@ -1,0 +1,84 @@
+# TODO: Leader — Contract Creation + Infrastructure
+
+> Plan: `docs/plans/2026-05-23-leader.md`
+> Owner: ThienPDM
+> Rule: Commit thẳng vào `develop` sau mỗi LX task. App phải compile sau mỗi commit.
+
+---
+
+## Phase 0 — Core infrastructure (trước tất cả)
+
+- [ ] **LX0** — `AppError` hierarchy + `app_colors.dart` + `pairIdOf` util + `AppConfig` + `main.dart` skeleton
+
+## Checkpoint: Core ✓
+- [ ] `flutter analyze` clean
+
+---
+
+## Phase 1 — M1 contracts
+
+- [ ] **LX1** — Auth contracts: `UserProfile` (full schema) + `AuthRepository` (9 methods) + `UserRepository` + controllers stubs + shared widgets (4) + router + screen stubs (10 màn auth)
+- [ ] **LX-PUBSPEC** (partial) — Thêm packages cần cho M1: `google_sign_in` nếu chưa có
+
+## Checkpoint: M1 contracts ✓
+- [ ] `flutter analyze` clean, app launch về `/intro`
+
+---
+
+## Phase 2 — M2 contracts
+
+- [ ] **LX2** — Friend contracts: `Friendship` + `FriendRequest` models + repositories + controller stub + sheet stubs + `isFriend()` rule helper + `/invite/:uid` route + CF stubs
+- [ ] **LX3** — Settings contracts: `Block` model + `BlockRepository` (**canonical**) + controller stub + sheet/dialog stubs + `isBlocked()` rule helper + `ShareProfileSheet` + CF stubs
+- [ ] **LX5** — Feed contracts: `Post` model (incl. `spaceId?`) + `PostRepository` + `StorageRepository` + `CaptionService` + controller stubs + shared widgets (5) + `HomeScreen` + `PhotoActionSheet` + CF stubs
+- [ ] **LX8** — Diary contracts: `DiaryEntry` + `DiaryContentBlock` models + `DiaryRepository` (incl. `getPublicEntries`) + controller stub + screen stubs (6)
+- [ ] **LX9** — Profile contracts: `ProfileRepository` + controller stub + screen stubs (5) + router routes
+- [ ] **LX-PUBSPEC** (M2 packages) — `share_plus`, `camera`, `flutter_image_compress`, `gal`, `geolocator`, `cached_network_image`, `http`, `intl`, `image_picker`
+
+## Checkpoint: M2 contracts ✓
+- [ ] `flutter analyze` clean, app navigate được tới `/home` stub
+
+---
+
+## Phase 3 — M3 contracts
+
+- [ ] **LX4** — Chat contracts: `Conversation` + `Message` models + `ConversationRepository` + controller stub + screen stubs (4) + router routes
+- [ ] **LX6** — Notification contracts: `AppNotification` model + `NotificationRepository` + controller stub + CF stubs (3) + router deep link slots
+- [ ] **LX7** — Reaction contracts: `Reaction` model + `ReactionRepository` (incl. `getMyReaction`) + controller stub + sheet stubs + update `ActTextBar` stub với optional controller param
+- [ ] **LX10** — Space contracts: `Space` + `SpaceMember` models + `SpaceRepository` + controller stub + widget stubs (4) + **gate changes** (verify `Post.spaceId`, update `FeedScreen`) + CF stubs (8) + router routes
+- [ ] **LX11** — Widget contracts: Android Kotlin stubs (3 files) + `AndroidManifest` update + `WidgetDataService` Flutter stub + router intent handler
+- [ ] **LX12** — Streak contracts: `StreakController` stub + screen stubs (2) + router routes
+- [ ] **LX-PUBSPEC** (M3 packages) — `firebase_messaging`, `flutter_local_notifications`, `emoji_picker_flutter`, `flutter_svg`, `shared_preferences` + Android `build.gradle` WorkManager + Glide
+
+## Checkpoint: M3 contracts ✓
+- [ ] `flutter analyze` clean, Android build clean
+- [ ] `flutter pub get` không conflict
+
+---
+
+## Phase 4 — Shared infrastructure (sau tất cả contracts)
+
+- [ ] **LX-RULES** — `firestore.rules` hoàn chỉnh: merge 7 helper functions + tất cả match blocks (12 modules) + `/posts` rule là 1 block duy nhất; `storage.rules` (avatars + posts + diary)
+
+## Checkpoint: Rules ✓
+- [ ] `firebase emulators:exec --only firestore "npm run test:rules"` — tất cả rules tests pass
+- [ ] Không có `allow read, write: if true`
+
+---
+
+## Gate changes (ongoing — khi module dev request)
+
+- [ ] **Space:** Confirm `Post.spaceId` field + `FeedFilter.space` case trong `FeedController` (đã handle ở LX10 nhưng verify khi Space dev start)
+- [ ] **Reaction M3:** Update `ActTextBar` M2 stub → M3 stub khi Reaction dev start T3
+- [ ] **Profile M3:** Cập nhật Diary tab từ empty state → `getPublicEntries` khi Diary module xong
+- [ ] **Chat Group:** Confirm `GroupChatScreen` stub sẵn sàng khi Space dev cần (LX4 đã tạo)
+
+---
+
+## Pre-handoff checklist (per module)
+
+Trước khi nói "go" với dev:
+- [ ] `flutter analyze` clean
+- [ ] App launch được (không crash)
+- [ ] Providers throw `UnimplementedError` với hint
+- [ ] TODO markers: `// TODO(<prefix>/T<N>/TBD): <mô tả> — see docs/plans/...`
+- [ ] PR merged vào `develop`

--- a/tasks/todo-notification.md
+++ b/tasks/todo-notification.md
@@ -1,0 +1,47 @@
+# TODO: Notification
+
+> Plan: `docs/plans/2026-05-23-notification.md`
+> Spec: `docs/specs/2026-05-23-notification.md`
+> Tier: T0 · Milestone M3
+> Blocked by: Feed (onPostCreated CF [H10]), Friend (acceptFriendRequest CF)
+
+---
+
+## Phase 1 — Data layer
+
+- [ ] **T1** — `FirebaseNotificationRepository` (saveFcmToken 1-token policy + SHA-256 tokenId + deleteFcmToken + getNotifications + markAsRead)
+
+## Checkpoint: Data layer ✓
+- [ ] `flutter test test/features/notification/` — 0 failures
+
+---
+
+## Phase 2 — Application layer
+
+- [ ] **T2** — `NotificationController.initFCM` (requestPermission + token lifecycle + onTokenRefresh + background/terminated handlers) + wire vào `main.dart`
+- [ ] **T3** — Foreground notification banner (Figma 765:4766 expanded / 765:4981 collapsed — collapsed/expanded states + auto-dismiss 4s)
+- [ ] **T4** — Deep link routing từ notification tap (GoRouter: friend_request → FriendSheet; reaction → Feed scroll postId; new_post → Feed top)
+
+## Checkpoint: App layer ✓
+- [ ] `flutter test test/features/notification/` — 0 failures
+
+---
+
+## Phase 3 — Cloud Functions (song song nhau)
+
+- [ ] **T5** — CF `onFriendRequestCreated` (FCM + notification doc; skip nếu không có token)
+- [ ] **T6** — CF `onFriendRequestAccepted` (FCM cho sender; guard status transition)
+- [ ] **T7** — CF `onReactionCreated` (FCM + notification doc; guard reactorId != authorId)
+
+> ⚠️ `new_post` FCM **không** có CF riêng — được xử lý bên trong `onPostCreated` của Feed module ([H10]).
+
+---
+
+## Phase 4 — Rules
+
+- [ ] **T8** — Firestore rules tests `/users/{uid}/notifications` + `/fcmTokens` + CF tests
+
+## Checkpoint: Notification complete ✓
+- [ ] CF tests pass
+- [ ] `flutter analyze` clean
+- [ ] Manual (device): send friend request → B nhận push; accept → A nhận push; react → author nhận push; foreground banner hiện + dismiss

--- a/tasks/todo-profile.md
+++ b/tasks/todo-profile.md
@@ -1,0 +1,46 @@
+# TODO: Profile
+
+> Plan: `docs/plans/2026-05-23-profile.md`
+> Spec: `docs/specs/2026-05-22-profile.md`
+> Tier: T0+ · Milestone M2
+> Blocked by: Auth (UserProfile update), Friend (FriendRepository, FriendSheet), Diary (DiaryRepository.getPublicEntries — M3 only)
+
+---
+
+## Phase 1 — Data layer
+
+- [ ] **T1** — `FirebaseProfileRepository` (getUserProfile + watchUserProfile + updateProfile allowlist + updateAvatar compress/upload + removeAvatar)
+
+## Checkpoint: Data layer ✓
+- [ ] `flutter test test/features/profile/` — 0 failures
+
+---
+
+## Phase 2 — Application layer
+
+- [ ] **T2** — `ProfileController` (loadProfile + updateField + avatar ops + shareProfile + `isUsernameAvailable` delegate sang `UserRepository`)
+
+## Checkpoint: App layer ✓
+- [ ] `flutter test test/features/profile/` — 0 failures
+
+---
+
+## Phase 3 — UI Screens
+
+- [ ] **T3** — `ProfileScreen` (avatar + stats Khoảnh khắc/Bạn bè/Space + 2 action buttons + tab bar scaffold)
+- [ ] **T4** — `PhotoGrid` tab (3-column, cursor-paginated 9/batch) + `PhotoDetailScreen` (swipe carousel + thumbnail strip)
+- [ ] **T5** — `EditProfileScreen` (tất cả fields + email re-auth + username uniqueness + **notification toggle → SharedPreferences**)
+- [ ] **T6** — `AvatarPickerSheet` (gallery/camera/remove) + `ShareProfileSheet` integration
+- [ ] **T7** — `FriendProfileScreen` (view-only: avatar + stats + bio + grid; isFriend gate)
+- [ ] **T8** — Diary tab (M2: empty state "Tính năng sắp ra mắt"; M3: `DiaryMoodCard` grid từ `getPublicEntries`)
+
+---
+
+## Phase 4 — Rules
+
+- [ ] **T9** — Firestore rules `/users/{uid}` canonical update rules + Storage rules `avatars/{uid}/` + rules tests
+
+## Checkpoint: Profile complete ✓
+- [ ] `flutter test test/features/profile/` — 0 failures
+- [ ] `flutter analyze` clean
+- [ ] Manual: xem profile → stats đúng; edit displayName/bio; đổi avatar; photo detail swipe; share profile link; friend profile view-only

--- a/tasks/todo-reaction.md
+++ b/tasks/todo-reaction.md
@@ -1,0 +1,42 @@
+# TODO: Reaction
+
+> Plan: `docs/plans/2026-05-23-reaction.md`
+> Spec: `docs/specs/2026-05-23-reaction.md`
+> Tier: T0 · Milestone M3
+> Blocked by: Feed (Post model, ActTextBar M2 stub)
+
+---
+
+## Phase 1 — Data layer
+
+- [ ] **T1** — `FirebaseReactionRepository` (upsertReaction với docId=reactorUid + deleteReaction + watchReactions + getMyReaction)
+
+## Checkpoint: Data layer ✓
+- [ ] `flutter test test/features/reaction/` — 0 failures
+
+---
+
+## Phase 2 — Application layer
+
+- [ ] **T2** — `ReactionController.toggleReact` (react / un-react / change logic + optimistic update + in-flight lock)
+
+## Checkpoint: App layer ✓
+- [ ] `flutter test test/features/reaction/` — 0 failures
+
+---
+
+## Phase 3 — UI
+
+- [ ] **T3** — `ActTextBar` M3 update (3 preset emoji: light-blue-heart/🤣/🥰 + count display + optimistic + M2 fallback khi controller null)
+- [ ] **T4** — `EmojiPickerSheet` (emoji_picker_flutter, no search) + `ReactionListSheet` (list sort DESC)
+
+---
+
+## Phase 4 — Rules
+
+- [ ] **T5** — Firestore rules tests `/posts/{id}/reactions/{uid}` (read gate: author hoặc feed doc)
+
+## Checkpoint: Reaction complete ✓
+- [ ] `flutter test test/features/reaction/` — 0 failures
+- [ ] `flutter analyze` clean
+- [ ] Manual: tap emoji → active; tap lại → un-react; tap emoji khác → change; EmojiPickerSheet; ReactionListSheet

--- a/tasks/todo-settings.md
+++ b/tasks/todo-settings.md
@@ -1,0 +1,50 @@
+# TODO: Settings
+
+> Plan: `docs/plans/2026-05-23-settings.md`
+> Spec: `docs/specs/2026-05-23-settings.md`
+> Tier: T0 (block/logout/delete) · Milestone M2/M3
+> Blocked by: Auth, Friend, Notification (deleteFcmToken khi logout)
+
+---
+
+## Phase 1 — Data layer
+
+- [ ] **T1** — `FirebaseBlockRepository` (blockUser via CF + unblockUser client + watchBlockedUsers + isBlocked 2 chiều)
+
+## Checkpoint: Data layer ✓
+- [ ] `flutter test test/features/settings/` — 0 failures
+
+---
+
+## Phase 2 — UI (song song Phase 1)
+
+- [ ] **T2** — `SettingsSheet` full layout (Figma 572:4183): header + quick actions + SpaceQuickRow stub + menu sections + static pages (Terms/Privacy)
+- [ ] **T4** — `BlockedAccountsPage` + `BlockConfirmDialog` + `WidgetConfirmSheet`
+
+---
+
+## Phase 3 — Application layer
+
+- [ ] **T3** — `SettingsController` (`logout` + `copyProfileLink` + `shareProfile` + **`deleteAccount()`** gọi CF)
+- [ ] **T6** — `DeleteAccountDialog` (2-step: confirm → re-auth inline) + `LogoutConfirmDialog`
+
+## Checkpoint: App + UI ✓
+- [ ] `flutter test test/features/settings/` — 0 failures
+
+---
+
+## Phase 4 — Cloud Functions
+
+- [ ] **T5** — CF `blockUser` (atomic: /blocks create + /friendships delete + /conversations status update)
+- [ ] **T7** — CF `deleteAccount` (cascade: Storage → Firestore subcollections → documents → Auth.deleteUser)
+
+---
+
+## Phase 5 — Rules
+
+- [ ] **T8** — Firestore rules tests `/blocks` + CF tests (blockUser idempotent, deleteAccount cascade order)
+
+## Checkpoint: Settings complete ✓
+- [ ] CF tests pass
+- [ ] `flutter analyze` clean
+- [ ] Manual: block từ PhotoActionSheet → blocked list → unblock; logout; Settings sheet từ avatar tap; delete account (staging)

--- a/tasks/todo-space.md
+++ b/tasks/todo-space.md
@@ -1,0 +1,54 @@
+# TODO: Space
+
+> Plan: `docs/plans/2026-05-23-space.md`
+> Spec: `docs/specs/2026-05-23-space.md`
+> Tier: T0+ · Milestone M3
+> Blocked by: Friend (FriendRepository invite members), Feed (leader gate: Post model + FeedScreen spaceId param), Chat (Conversation schema — CF `createSpace` tạo `/conversations/{spaceId}`)
+
+---
+
+## Phase 1 — Data layer
+
+- [ ] **T1** — `FirebaseSpaceRepository` (watchMySpaces arrayContains + getSpace + deleteSpace soft)
+
+## Checkpoint: Data layer ✓
+- [ ] `flutter test test/features/space/` — 0 failures
+
+---
+
+## Phase 2 — Application layer
+
+- [ ] **T2** — `SpaceController` (createSpace validation ≤9 friends + loadMySpaces + leaveSpace creator-guard + deleteSpace soft-delete)
+
+## Checkpoint: App layer ✓
+- [ ] `flutter test test/features/space/` — 0 failures
+
+---
+
+## Phase 3 — UI
+
+- [ ] **T3** — `SpaceCreateSheet` 3-step flow (FriendSelectStep + SpaceConfigStep + IconBuilderStep với emoji_picker_flutter)
+- [ ] **T4** — `SpaceContextBottomSheet` + Camera context switch (viền/nút = colorHex) + `SpaceContextBadge`
+- [ ] **T5** — Feed per Space (`FeedFilter.space(spaceId)` + `FeedScreen(spaceId)` — **leader gate change**)
+- [ ] **T10b** — `SpaceManagementSheet` + Leave/Delete/Kick/Transfer dialogs (trigger từ `...` menu FeedScreen Space context)
+
+---
+
+## Phase 4 — Cloud Functions
+
+- [ ] **T6** — CF `createSpace` (batch: /spaces + /space_members + group conversation)
+- [ ] **T7** — CF `leaveSpace` + `kickMember` + `transferOwnership`
+- [ ] **T8** — CF `onSpaceMemberAdded` + `onSpaceMemberRemoved` (memberCount + spaceCount)
+- [ ] **T9** — CF `onSpacePostCreated` (guard spaceId!=null; FCM fan-out + feed fan-out tất cả members)
+- [ ] **T10** — CF `onSpaceDeleted` (cleanup space_members + conversation status=deleted)
+
+---
+
+## Phase 5 — Rules
+
+- [ ] **T11** — Firestore rules tests `/spaces` + `/space_members`
+
+## Checkpoint: Space complete ✓
+- [ ] CF tests pass
+- [ ] `flutter analyze` clean
+- [ ] Manual: tạo Space → invite friends → camera context switch (viền đổi màu) → chụp → Space feed; leave Space (member); kick member (creator); delete Space

--- a/tasks/todo-streak.md
+++ b/tasks/todo-streak.md
@@ -1,0 +1,35 @@
+# TODO: Streak / Kỷ niệm
+
+> Plan: `docs/plans/2026-05-23-streak.md`
+> Spec: `docs/specs/2026-05-22-streak.md`
+> Tier: T1 Stretch · Unlock sau retro 27/5
+> Blocked by: Feed (PostRepository, ShareModal)
+
+---
+
+## Phase 1 — Application layer
+
+- [ ] **T1** — `StreakController` (loadMonth + loadAllPostDates cache + calculateStreak timezone-aware UTC+7 + streak/totalMoments global stats)
+
+## Checkpoint: App layer ✓
+- [ ] `flutter test test/features/streak/` — timezone edge cases pass (see T4)
+
+---
+
+## Phase 2 — UI Screens
+
+- [ ] **T2** — `StreakScreen` (custom `GridView` 7 columns — KHÔNG `table_calendar`; glassmorphism ô sáng; swipe tháng; StreakStatsPill; empty states)
+- [ ] **T3** — `StreakPhotoDetailScreen` (carousel 350×350 + thumbnail strip 50/60px + ShareModal reuse + Xoá chỉ khi isAuthor)
+
+---
+
+## Phase 3 — Tests
+
+- [ ] **T4** — Extend `streak_controller_test.dart`: edge cases calculateStreak (today only=1, gap=1, empty=0, timezone post 23:00 UTC → đúng ngày UTC+7)
+
+## Checkpoint: Streak complete ✓
+- [ ] `flutter test test/features/streak/` — 0 failures, timezone tests PASS
+- [ ] `flutter analyze` clean
+- [ ] Manual: calendar ô sáng/tối; swipe tháng; tap ngày → carousel; swipe cuối tháng → bounce; share ảnh từ calendar
+
+> ℹ️ Streak không có Firestore collection riêng — read-only từ `/posts`. Không cần rules mới.

--- a/tasks/todo-widget-android.md
+++ b/tasks/todo-widget-android.md
@@ -1,0 +1,42 @@
+# TODO: Widget Android
+
+> Plan: `docs/plans/2026-05-23-widget-android.md`
+> Spec: `docs/specs/2026-05-23-widget-android.md`
+> Tier: T0 · Milestone M3 · Android only
+> Blocked by: Feed (/users/{uid}/feed subcollection schema), Auth (FirebaseAuth token)
+
+---
+
+## Phase 1 — Android native
+
+- [ ] **T1** — `meep_widget.xml` (RemoteViews layout: normal + placeholder states) + `meep_widget_info.xml` (2×2 metadata) + `AndroidManifest.xml` khai báo
+- [ ] **T2** — `MeepWidget.kt` (`AppWidgetProvider`: đọc SharedPreferences → render RemoteViews; placeholder khi không có data)
+- [ ] **T3** — `WidgetSyncWorker.kt` (`CoroutineWorker`: [H7] auth token gọi trực tiếp không lưu SharedPreferences; query feed subcollection; Glide download; update RemoteViews)
+
+## Checkpoint: Android native ✓
+- [ ] Kotlin build clean
+- [ ] `WidgetSyncWorker` không có token → Result.success() không crash
+
+---
+
+## Phase 2 — Integration
+
+- [ ] **T4** — Deep link tap (`PendingIntent` extras → `MainActivity.onNewIntent` → `MethodChannel("meep/widget")` → GoRouter `/feed?highlight={postId}`)
+- [ ] **T5** — `WidgetDataService` Flutter (SharedPreferences write 3 keys + MethodChannel trigger + `clearWidgetData()` khi logout)
+
+## Checkpoint: Integration ✓
+- [ ] Flutter build clean, MethodChannel không crash
+
+---
+
+## Phase 3 — Tests
+
+- [ ] **T6** — Kotlin unit tests (`WidgetSyncWorkerTest`) + manual smoke test checklist
+
+## Checkpoint: Widget complete ✓
+- [ ] Manual smoke (device required):
+  - [ ] Thêm widget vào home screen từ Android widget picker
+  - [ ] Widget hiện ảnh mới nhất sau khi đăng ảnh từ app
+  - [ ] Tap widget → app mở đúng post
+  - [ ] Logout → widget hiện placeholder "Mở Meep để bắt đầu"
+  - [ ] Widget tự update sau ≤15 phút


### PR DESCRIPTION
## Summary

- Thêm specs đầy đủ cho 5 modules mới: Diary, Notification, Reaction, Settings, Widget Android
- Cập nhật 7 specs hiện có: Auth, Friend, Feed, Profile, Streak, Chat, Space
- Tạo implementation plans (template format Part 1-4) cho cả 12 modules + leader plan
- Tách todos riêng per-module (12 files) + master index `todo-all-modules.md` (100 tasks)
- Thêm CLAUDE.md cho root, apps/mobile, firebase, firebase/functions
- Thêm `docs/team-onboarding/plan-prompt-template.md` (prompt template all-modules planning)

## Phạm vi thay đổi

Toàn bộ là tài liệu planning — không có code source thay đổi.

## Test plan

- [ ] Đọc qua `docs/plans/2026-05-23-leader.md` — verify dependency order đúng
- [ ] Đọc qua `tasks/todo-all-modules.md` — verify 100 tasks, 12 modules, leader tasks
- [ ] Confirm không có file `.claude/` trong PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)