### PR TITLE
chore(contracts): LX2 — Friend module contracts

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -94,6 +94,11 @@ GoRouter appRouter(Ref ref) {
           entryId: state.pathParameters['entryId'],
         ),
       ),
+      // TODO(F/T11/KhoaLND): implement InvitePage — profile invite link landing
+      GoRoute(
+        path: '/invite/:uid',
+        builder: (_, __) => const HomePage(),
+      ),
     ],
   );
 }

--- a/apps/mobile/lib/features/friend/application/friend_controller.dart
+++ b/apps/mobile/lib/features/friend/application/friend_controller.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/friend/data/friend_repository.dart';
+import 'package:meep/features/friend/data/friend_request.dart';
+import 'package:meep/features/friend/data/friend_request_repository.dart';
+
+part 'friend_controller.g.dart';
+
+@Riverpod(keepAlive: true)
+FriendRepository friendRepository(Ref ref) => throw UnimplementedError(
+      'friendRepositoryProvider must be overridden — '
+      'wire FirestoreFriendRepository in main.dart (TODO: F/T1/KhoaLND)',
+    );
+
+@Riverpod(keepAlive: true)
+FriendRequestRepository friendRequestRepository(Ref ref) =>
+    throw UnimplementedError(
+      'friendRequestRepositoryProvider must be overridden — '
+      'wire FirestoreFriendRequestRepository in main.dart (TODO: F/T1/KhoaLND)',
+    );
+
+@riverpod
+class FriendController extends _$FriendController {
+  @override
+  Future<List<UserProfile>> build(String uid) async {
+    // TODO(F/T2/KhoaLND): implement watchFriends stream
+    throw UnimplementedError('FriendController.build — TODO: F/T2/KhoaLND');
+  }
+
+  Future<void> searchUsers(String query) async {
+    // TODO(F/T3/KhoaLND): implement user search
+    throw UnimplementedError('searchUsers — TODO: F/T3/KhoaLND');
+  }
+
+  Future<void> sendRequest(String receiverUid) async {
+    // TODO(F/T4/KhoaLND): implement sendFriendRequest
+    throw UnimplementedError('sendRequest — TODO: F/T4/KhoaLND');
+  }
+
+  Future<void> cancelRequest(String requestId) async {
+    // TODO(F/T5/KhoaLND): implement cancelFriendRequest
+    throw UnimplementedError('cancelRequest — TODO: F/T5/KhoaLND');
+  }
+
+  Future<void> declineRequest(String requestId) async {
+    // TODO(F/T6/KhoaLND): implement declineFriendRequest
+    throw UnimplementedError('declineRequest — TODO: F/T6/KhoaLND');
+  }
+
+  Future<void> unfriend(String friendUid) async {
+    // TODO(F/T7/KhoaLND): implement unfriend
+    throw UnimplementedError('unfriend — TODO: F/T7/KhoaLND');
+  }
+
+  Future<List<FriendRequest>> watchPendingRequests() async {
+    // TODO(F/T8/KhoaLND): implement watchPendingRequests
+    throw UnimplementedError('watchPendingRequests — TODO: F/T8/KhoaLND');
+  }
+}

--- a/apps/mobile/lib/features/friend/data/friend_repository.dart
+++ b/apps/mobile/lib/features/friend/data/friend_repository.dart
@@ -1,0 +1,15 @@
+import 'package:meep/features/auth/data/user_profile.dart';
+
+abstract class FriendRepository {
+  /// Search users by display name or username prefix. Max 20 results.
+  Future<List<UserProfile>> searchUser(String query);
+
+  /// Stream of current user's accepted friends.
+  Stream<List<UserProfile>> watchFriends(String uid);
+
+  /// Returns UIDs of all friends — used for feed filtering.
+  Future<List<String>> getFriendUids(String uid);
+
+  /// Remove an existing friendship. Bidirectional.
+  Future<void> unfriend({required String uid, required String friendUid});
+}

--- a/apps/mobile/lib/features/friend/data/friend_request.dart
+++ b/apps/mobile/lib/features/friend/data/friend_request.dart
@@ -1,0 +1,36 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'friend_request.freezed.dart';
+part 'friend_request.g.dart';
+
+enum FriendRequestStatus { pending, accepted, declined, cancelled }
+
+@freezed
+class FriendRequest with _$FriendRequest {
+  const factory FriendRequest({
+    required String requestId,
+    required String senderId,
+    required String receiverId,
+    required FriendRequestStatus status,
+    @TimestampConverter() required DateTime createdAt,
+    @TimestampConverter() required DateTime updatedAt,
+  }) = _FriendRequest;
+
+  factory FriendRequest.fromJson(Map<String, dynamic> json) =>
+      _$FriendRequestFromJson(json);
+}
+
+class TimestampConverter implements JsonConverter<DateTime, Object> {
+  const TimestampConverter();
+
+  @override
+  DateTime fromJson(Object json) {
+    if (json is Timestamp) return json.toDate();
+    if (json is String) return DateTime.parse(json);
+    return DateTime.fromMillisecondsSinceEpoch(json as int);
+  }
+
+  @override
+  Object toJson(DateTime date) => Timestamp.fromDate(date);
+}

--- a/apps/mobile/lib/features/friend/data/friend_request_repository.dart
+++ b/apps/mobile/lib/features/friend/data/friend_request_repository.dart
@@ -1,0 +1,18 @@
+import 'package:meep/features/friend/data/friend_request.dart';
+
+abstract class FriendRequestRepository {
+  /// Stream of incoming pending requests for [receiverUid].
+  Stream<List<FriendRequest>> watchPendingRequests(String receiverUid);
+
+  /// Send a friend request. Throws [ValidationError] if already sent.
+  Future<void> sendFriendRequest({
+    required String senderUid,
+    required String receiverUid,
+  });
+
+  /// Cancel a sent friend request.
+  Future<void> cancelFriendRequest(String requestId);
+
+  /// Decline an incoming friend request.
+  Future<void> declineFriendRequest(String requestId);
+}

--- a/apps/mobile/lib/features/friend/data/friendship.dart
+++ b/apps/mobile/lib/features/friend/data/friendship.dart
@@ -1,0 +1,36 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'friendship.freezed.dart';
+part 'friendship.g.dart';
+
+/// Bidirectional friendship between two users.
+/// Doc ID = [pairIdOf] result: `min(uid1, uid2)_max(uid1, uid2)`.
+@freezed
+class Friendship with _$Friendship {
+  const factory Friendship({
+    required String uid1,
+    required String uid2,
+
+    /// Both UIDs — convenience for Firestore array-contains queries.
+    required List<String> members,
+    @TimestampConverter() required DateTime createdAt,
+  }) = _Friendship;
+
+  factory Friendship.fromJson(Map<String, dynamic> json) =>
+      _$FriendshipFromJson(json);
+}
+
+class TimestampConverter implements JsonConverter<DateTime, Object> {
+  const TimestampConverter();
+
+  @override
+  DateTime fromJson(Object json) {
+    if (json is Timestamp) return json.toDate();
+    if (json is String) return DateTime.parse(json);
+    return DateTime.fromMillisecondsSinceEpoch(json as int);
+  }
+
+  @override
+  Object toJson(DateTime date) => Timestamp.fromDate(date);
+}

--- a/apps/mobile/lib/features/friend/presentation/friend_filter_dropdown.dart
+++ b/apps/mobile/lib/features/friend/presentation/friend_filter_dropdown.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(F/T10/KhoaLND): implement FriendFilterDropdown per Figma
+class FriendFilterDropdown extends StatelessWidget {
+  const FriendFilterDropdown({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}

--- a/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
+++ b/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(F/T9/KhoaLND): implement FriendSheet per Figma — friend list + search + requests
+class FriendSheet extends StatelessWidget {
+  const FriendSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -17,9 +17,10 @@ service cloud.firestore {
       return a < b ? a + '_' + b : b + '_' + a;
     }
 
-    function isFriend(uidA, uidB) {
-      return exists(
-        /databases/$(database)/documents/friendships/$(pairId(uidA, uidB))
+    /// True when the calling user is friends with [uid].
+    function isFriend(uid) {
+      return isAuthed() && exists(
+        /databases/$(database)/documents/friendships/$(pairId(request.auth.uid, uid))
       );
     }
 
@@ -47,7 +48,7 @@ service cloud.firestore {
     match /posts/{postId} {
       allow read: if isAuthed() && (
         isOwner(resource.data.authorId) ||
-        isFriend(request.auth.uid, resource.data.authorId)
+        isFriend(resource.data.authorId)
       );
 
       allow create: if isOwner(request.resource.data.authorId)

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -1,6 +1,6 @@
 import { setGlobalOptions } from 'firebase-functions/v2';
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
-import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+import { onDocumentCreated, onDocumentDeleted } from 'firebase-functions/v2/firestore';
 import { initializeApp } from 'firebase-admin/app';
 import { z } from 'zod';
 
@@ -94,7 +94,7 @@ export const acceptFriendRequest = onCall((request) => {
  * TODO(F/impl):
  *   - remove each member from the other's cached friend list
  */
-export const onFriendshipDeleted = onDocumentCreated(
+export const onFriendshipDeleted = onDocumentDeleted(
   { document: 'friendships/{pairId}', region: 'asia-southeast1' },
   (_event) => {
     // TODO(F/impl): see comment above.

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -69,3 +69,34 @@ export const onPostCreated = onDocumentCreated(
     console.warn(`onPostCreated fired for ${event.params.postId} — TODO: fan out`);
   },
 );
+
+// ===== Friend module stubs =====
+
+/**
+ * Accept a pending friend request and create the friendship doc.
+ *
+ * TODO(F/impl):
+ *   - verify request exists + status == 'pending'
+ *   - verify request.auth.uid == receiverId
+ *   - create /friendships/{pairId} doc
+ *   - update request status to 'accepted'
+ *   - send FCM notification to sender
+ */
+export const acceptFriendRequest = onCall((request) => {
+  if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
+  // TODO(F/impl): see comment above.
+  return { ok: true };
+});
+
+/**
+ * Clean up friend-related data when a friendship is deleted.
+ *
+ * TODO(F/impl):
+ *   - remove each member from the other's cached friend list
+ */
+export const onFriendshipDeleted = onDocumentCreated(
+  { document: 'friendships/{pairId}', region: 'asia-southeast1' },
+  (_event) => {
+    // TODO(F/impl): see comment above.
+  },
+);


### PR DESCRIPTION
## Tóm tắt

LX2 từ plan `docs/plans/2026-05-23-leader.md` — Friend module contracts.

### Files thêm mới
- `features/friend/data/friendship.dart` — @freezed: uid1/uid2/members/createdAt; doc ID = pairIdOf()
- `features/friend/data/friend_request.dart` — @freezed: requestId/senderId/receiverId/FriendRequestStatus enum/timestamps
- `features/friend/data/friend_repository.dart` — abstract: searchUser/watchFriends/getFriendUids/unfriend
- `features/friend/data/friend_request_repository.dart` — abstract: watchPending/send/cancel/decline
- `features/friend/application/friend_controller.dart` — @riverpod stub, 8 methods UnimplementedError
- `features/friend/presentation/friend_sheet.dart` — stub
- `features/friend/presentation/friend_filter_dropdown.dart` — stub

### Files cập nhật
- `core/router/app_router.dart` — thêm route `/invite/:uid`
- `firebase/firestore.rules` — refactor `isFriend(uidA,uidB)` → `isFriend(uid)` 1-param (request.auth.uid implicit)
- `firebase/functions/src/index.ts` — stub `acceptFriendRequest` callable + `onFriendshipDeleted` trigger

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `dart format` — 0 changes
- [x] `npm run lint` — clean
- [x] `npm test` — 4/4 pass
- [x] Pre-commit hook pass

## Checklist
- [x] `pairIdOf()` referenced đúng trong doc comment Friendship
- [x] `isFriend(uid)` dùng `request.auth.uid` implicit — đúng spec
- [x] `onFriendshipDeleted` dùng `onDocumentDeleted` (fixed trong review)
- [x] TODO markers format `// TODO(F/T<N>/KhoaLND)`
- [x] Không touch module khác

Refs #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)