### PR TITLE
chore(contracts): LX8 — Diary module contracts

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -11,6 +11,9 @@ import 'package:meep/features/auth/presentation/signup/signup_email_page.dart';
 import 'package:meep/features/auth/presentation/signup/signup_name_page.dart';
 import 'package:meep/features/auth/presentation/signup/signup_password_page.dart';
 import 'package:meep/features/auth/presentation/signup/signup_username_page.dart';
+import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
+import 'package:meep/features/diary/presentation/diary_create_screen.dart';
+import 'package:meep/features/diary/presentation/diary_list_screen.dart';
 import 'package:meep/features/home/presentation/home_page.dart';
 
 part 'app_router.g.dart';
@@ -77,6 +80,19 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/dev/widgets',
         builder: (_, __) => const WidgetCatalogPage(),
+      ),
+      // TODO(D/T13/TBD): wire diary routes — DiaryListScreen/CreateScreen/CanvasScreen
+      GoRoute(path: '/diary', builder: (_, __) => const DiaryListScreen()),
+      GoRoute(
+        path: '/diary/create',
+        builder: (_, __) => const DiaryCreateScreen(),
+      ),
+      GoRoute(
+        path: '/diary/:entryId',
+        builder: (_, state) => DiaryCanvasScreen(
+          mode: DiaryCanvasMode.read,
+          entryId: state.pathParameters['entryId'],
+        ),
       ),
     ],
   );

--- a/apps/mobile/lib/features/diary/application/diary_controller.dart
+++ b/apps/mobile/lib/features/diary/application/diary_controller.dart
@@ -1,0 +1,62 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/data/diary_repository.dart';
+
+part 'diary_controller.freezed.dart';
+part 'diary_controller.g.dart';
+
+@freezed
+class DiaryState with _$DiaryState {
+  const factory DiaryState({
+    @Default([]) List<DiaryEntry> entries,
+    @Default(false) bool isLoading,
+    @Default(false) bool isSaving,
+    String? errorMessage,
+  }) = _DiaryState;
+}
+
+@Riverpod(keepAlive: true)
+DiaryRepository diaryRepository(DiaryRepositoryRef ref) =>
+    throw UnimplementedError(
+      'diaryRepositoryProvider must be overridden — '
+      'wire FirebaseDiaryRepository in main.dart (TODO: D/T1/TBD)',
+    );
+
+@riverpod
+class DiaryController extends _$DiaryController {
+  @override
+  DiaryState build() => const DiaryState();
+
+  Future<void> loadEntries(String authorUid) async {
+    // TODO(D/T2/TBD): implement loadEntries
+    throw UnimplementedError('loadEntries — TODO: D/T2/TBD');
+  }
+
+  Future<void> saveEntry(DiaryEntry entry) async {
+    // TODO(D/T3/TBD): implement saveEntry — decides create vs update by entryId
+    throw UnimplementedError('saveEntry — TODO: D/T3/TBD');
+  }
+
+  Future<void> updatePrivacy({
+    required String entryId,
+    required DiaryPrivacy privacy,
+  }) async {
+    // TODO(D/T4/TBD): implement updatePrivacy
+    throw UnimplementedError('updatePrivacy — TODO: D/T4/TBD');
+  }
+
+  Future<List<DiaryEntry>> searchEntries({
+    required String authorUid,
+    required String query,
+  }) async {
+    // TODO(D/T5/TBD): implement searchEntries
+    throw UnimplementedError('searchEntries — TODO: D/T5/TBD');
+  }
+
+  Future<void> deleteEntry(String entryId) async {
+    // TODO(D/T6/TBD): implement deleteEntry
+    throw UnimplementedError('deleteEntry — TODO: D/T6/TBD');
+  }
+}

--- a/apps/mobile/lib/features/diary/data/diary_content_block.dart
+++ b/apps/mobile/lib/features/diary/data/diary_content_block.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'diary_content_block.freezed.dart';
+part 'diary_content_block.g.dart';
+
+enum ContentBlockType { text, image }
+
+enum TextBlockStyle { normal, heading, subheading, quote }
+
+@freezed
+class DiaryContentBlock with _$DiaryContentBlock {
+  /// Text block — supports 4 styles.
+  const factory DiaryContentBlock.text({
+    required String value,
+    @Default(TextBlockStyle.normal) TextBlockStyle style,
+  }) = TextBlock;
+
+  /// Image block — inline image in content area.
+  const factory DiaryContentBlock.image({
+    required String imageUrl,
+  }) = ImageBlock;
+
+  factory DiaryContentBlock.fromJson(Map<String, dynamic> json) =>
+      _$DiaryContentBlockFromJson(json);
+}

--- a/apps/mobile/lib/features/diary/data/diary_entry.dart
+++ b/apps/mobile/lib/features/diary/data/diary_entry.dart
@@ -1,0 +1,49 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'package:meep/features/diary/data/diary_content_block.dart';
+
+part 'diary_entry.freezed.dart';
+part 'diary_entry.g.dart';
+
+/// Mood template — determines background shape + cover clip shape in Mood zone.
+enum MoodTemplate { happy, bored, tired, shy, sad }
+
+/// Privacy level for a diary entry.
+enum DiaryPrivacy { private, public }
+
+@freezed
+class DiaryEntry with _$DiaryEntry {
+  const factory DiaryEntry({
+    required String entryId,
+    required String authorUid,
+    required MoodTemplate moodTemplate,
+    required String coverImageUrl,
+
+    /// Title shown in Mood zone. Max 50 chars.
+    required String moodCaption,
+
+    /// Ordered content blocks (text + images). Max 20 blocks.
+    required List<DiaryContentBlock> content,
+    @Default(DiaryPrivacy.private) DiaryPrivacy privacy,
+    @TimestampConverter() required DateTime createdAt,
+    @TimestampConverter() required DateTime updatedAt,
+  }) = _DiaryEntry;
+
+  factory DiaryEntry.fromJson(Map<String, dynamic> json) =>
+      _$DiaryEntryFromJson(json);
+}
+
+class TimestampConverter implements JsonConverter<DateTime, Object> {
+  const TimestampConverter();
+
+  @override
+  DateTime fromJson(Object json) {
+    if (json is Timestamp) return json.toDate();
+    if (json is String) return DateTime.parse(json);
+    return DateTime.fromMillisecondsSinceEpoch(json as int);
+  }
+
+  @override
+  Object toJson(DateTime date) => Timestamp.fromDate(date);
+}

--- a/apps/mobile/lib/features/diary/data/diary_repository.dart
+++ b/apps/mobile/lib/features/diary/data/diary_repository.dart
@@ -1,0 +1,33 @@
+import 'package:meep/features/diary/data/diary_entry.dart';
+
+abstract class DiaryRepository {
+  /// Stream of the current user's diary entries, newest first.
+  Stream<List<DiaryEntry>> watchEntries(String authorUid);
+
+  /// Returns a single entry by ID.
+  Future<DiaryEntry?> getEntry(String entryId);
+
+  /// Returns public entries for [authorUid] — used by Profile module.
+  Future<List<DiaryEntry>> getPublicEntries(String authorUid);
+
+  /// Search entries by mood caption or content text.
+  Future<List<DiaryEntry>> searchEntries({
+    required String authorUid,
+    required String query,
+  });
+
+  /// Create a new entry. Returns the created entry with server timestamps.
+  Future<DiaryEntry> createEntry(DiaryEntry entry);
+
+  /// Update an existing entry.
+  Future<void> updateEntry(DiaryEntry entry);
+
+  /// Update only the privacy setting of an entry.
+  Future<void> updatePrivacy({
+    required String entryId,
+    required DiaryPrivacy privacy,
+  });
+
+  /// Permanently delete an entry and its Storage assets.
+  Future<void> deleteEntry(String entryId);
+}

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// Mode of the diary canvas screen.
+enum DiaryCanvasMode { create, read, edit }
+
+// TODO(D/T7/TBD): implement DiaryCanvasScreen per Figma — canvas editor/viewer
+class DiaryCanvasScreen extends StatelessWidget {
+  const DiaryCanvasScreen({
+    super.key,
+    required this.mode,
+    this.entryId,
+  });
+
+  final DiaryCanvasMode mode;
+  final String? entryId;
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: SizedBox.shrink());
+  }
+}

--- a/apps/mobile/lib/features/diary/presentation/diary_create_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_create_screen.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(D/T9/TBD): implement DiaryCreateScreen per Figma
+class DiaryCreateScreen extends StatelessWidget {
+  const DiaryCreateScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: SizedBox.shrink());
+  }
+}

--- a/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(D/T8/TBD): implement DiaryListScreen per Figma
+class DiaryListScreen extends StatelessWidget {
+  const DiaryListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: SizedBox.shrink());
+  }
+}

--- a/apps/mobile/lib/features/diary/presentation/diary_search_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_search_screen.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(D/T10/TBD): implement DiarySearchScreen per Figma
+class DiarySearchScreen extends StatelessWidget {
+  const DiarySearchScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: SizedBox.shrink());
+  }
+}

--- a/apps/mobile/lib/features/diary/presentation/discard_changes_dialog.dart
+++ b/apps/mobile/lib/features/diary/presentation/discard_changes_dialog.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+// TODO(D/T11/TBD): implement DiscardChangesDialog per Figma
+class DiscardChangesDialog extends StatelessWidget {
+  const DiscardChangesDialog({super.key});
+
+  static Future<bool?> show(BuildContext context) => showDialog<bool>(
+        context: context,
+        builder: (_) => const DiscardChangesDialog(),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}

--- a/apps/mobile/lib/features/diary/presentation/privacy_sheet.dart
+++ b/apps/mobile/lib/features/diary/presentation/privacy_sheet.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(D/T12/TBD): implement PrivacySheet per Figma
+class PrivacySheet extends StatelessWidget {
+  const PrivacySheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}


### PR DESCRIPTION
## Tóm tắt

LX8 từ plan `docs/plans/2026-05-23-leader.md` — Diary module contracts.
Branch độc lập từ `develop` (không phụ thuộc LX2/LX3).

### Files thêm mới
- `features/diary/data/diary_content_block.dart` — @freezed union: `TextBlock(value, style)` + `ImageBlock(imageUrl)` · `TextBlockStyle` enum: normal/heading/subheading/quote
- `features/diary/data/diary_entry.dart` — @freezed · `MoodTemplate` enum: happy/bored/tired/shy/sad · `DiaryPrivacy` enum: private/public
- `features/diary/data/diary_repository.dart` — abstract · **`getPublicEntries(String authorUid): Future<List<DiaryEntry>>`** (Profile cross-module)
- `features/diary/application/diary_controller.dart` — @riverpod stub + `DiaryState` @freezed
- `features/diary/presentation/diary_canvas_screen.dart` — stub + `DiaryCanvasMode` enum (create/read/edit) cùng file
- `features/diary/presentation/diary_list_screen.dart` — stub
- `features/diary/presentation/diary_create_screen.dart` — stub
- `features/diary/presentation/diary_search_screen.dart` — stub
- `features/diary/presentation/discard_changes_dialog.dart` — stub
- `features/diary/presentation/privacy_sheet.dart` — stub

### Files cập nhật
- `core/router/app_router.dart` — thêm `/diary`, `/diary/create`, `/diary/:entryId`

## Acceptance criteria
- [x] `getPublicEntries(String authorUid)` là `Future<List<DiaryEntry>>` — không phải Stream
- [x] `DiaryCanvasMode` enum cùng file `DiaryCanvasScreen`
- [x] TODO markers format `// TODO(D/T<N>/TBD)`
- [x] `flutter analyze` — 0 issues
- [x] `dart format` — 0 changes
- [x] Pre-commit hook pass

Refs #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)