### PR TITLE
chore(contracts): LX3 — Settings module contracts

### DIFF
--- a/apps/mobile/lib/features/settings/application/settings_controller.dart
+++ b/apps/mobile/lib/features/settings/application/settings_controller.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/settings/data/block_repository.dart';
+
+part 'settings_controller.g.dart';
+
+@Riverpod(keepAlive: true)
+BlockRepository blockRepository(Ref ref) => throw UnimplementedError(
+      'blockRepositoryProvider must be overridden — '
+      'wire FirestoreBlockRepository in main.dart (TODO: SE/T1/TBD)',
+    );
+
+@riverpod
+class SettingsController extends _$SettingsController {
+  @override
+  void build() {}
+
+  Future<void> blockUser(String targetUid) async {
+    // TODO(SE/T2/TBD): implement blockUser
+    throw UnimplementedError('blockUser — TODO: SE/T2/TBD');
+  }
+
+  Future<void> unblockUser(String targetUid) async {
+    // TODO(SE/T3/TBD): implement unblockUser
+    throw UnimplementedError('unblockUser — TODO: SE/T3/TBD');
+  }
+
+  Future<void> logout() async {
+    // TODO(SE/T4/TBD): implement logout — clear session + navigate to intro
+    throw UnimplementedError('logout — TODO: SE/T4/TBD');
+  }
+
+  Future<void> deleteAccount() async {
+    // TODO(SE/T5/TBD): implement deleteAccount — re-auth + cascade delete
+    throw UnimplementedError('deleteAccount — TODO: SE/T5/TBD');
+  }
+}

--- a/apps/mobile/lib/features/settings/data/block.dart
+++ b/apps/mobile/lib/features/settings/data/block.dart
@@ -1,0 +1,33 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'block.freezed.dart';
+part 'block.g.dart';
+
+/// A block record. Doc ID = `{blockerUid}_{blockedUid}` — NOT sorted.
+/// This is asymmetric: blocker initiates, blocked is the target.
+@freezed
+class Block with _$Block {
+  const factory Block({
+    required String blockId,
+    required String blockerUid,
+    required String blockedUid,
+    @TimestampConverter() required DateTime createdAt,
+  }) = _Block;
+
+  factory Block.fromJson(Map<String, dynamic> json) => _$BlockFromJson(json);
+}
+
+class TimestampConverter implements JsonConverter<DateTime, Object> {
+  const TimestampConverter();
+
+  @override
+  DateTime fromJson(Object json) {
+    if (json is Timestamp) return json.toDate();
+    if (json is String) return DateTime.parse(json);
+    return DateTime.fromMillisecondsSinceEpoch(json as int);
+  }
+
+  @override
+  Object toJson(DateTime date) => Timestamp.fromDate(date);
+}

--- a/apps/mobile/lib/features/settings/data/block_repository.dart
+++ b/apps/mobile/lib/features/settings/data/block_repository.dart
@@ -1,0 +1,24 @@
+import 'package:meep/features/settings/data/block.dart';
+
+/// Canonical owner of block logic.
+/// Chat and Feed modules import from this path —
+/// do NOT define a separate BlockRepository in those modules.
+abstract class BlockRepository {
+  /// Block [targetUid]. Creates `/blocks/{blockerUid}_{targetUid}`.
+  Future<void> blockUser({
+    required String blockerUid,
+    required String targetUid,
+  });
+
+  /// Unblock [targetUid].
+  Future<void> unblockUser({
+    required String blockerUid,
+    required String targetUid,
+  });
+
+  /// Stream of users blocked by [blockerUid].
+  Stream<List<Block>> watchBlockedUsers(String blockerUid);
+
+  /// True if either direction has a block between [uid1] and [uid2].
+  Future<bool> isBlocked({required String uid1, required String uid2});
+}

--- a/apps/mobile/lib/features/settings/presentation/block_confirm_dialog.dart
+++ b/apps/mobile/lib/features/settings/presentation/block_confirm_dialog.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+// TODO(SE/T8/TBD): implement BlockConfirmDialog per Figma — 605:1991
+class BlockConfirmDialog extends StatelessWidget {
+  const BlockConfirmDialog({super.key, required this.targetName});
+
+  final String targetName;
+
+  static Future<bool?> show(BuildContext context, String targetName) =>
+      showDialog<bool>(
+        context: context,
+        builder: (_) => BlockConfirmDialog(targetName: targetName),
+      );
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/features/settings/presentation/blocked_accounts_page.dart
+++ b/apps/mobile/lib/features/settings/presentation/blocked_accounts_page.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+// TODO(SE/T7/TBD): implement BlockedAccountsPage per Figma — 572:4490
+class BlockedAccountsPage extends StatelessWidget {
+  const BlockedAccountsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+}

--- a/apps/mobile/lib/features/settings/presentation/delete_account_dialog.dart
+++ b/apps/mobile/lib/features/settings/presentation/delete_account_dialog.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+// TODO(SE/T11/TBD): implement DeleteAccountDialog per Figma
+class DeleteAccountDialog extends StatelessWidget {
+  const DeleteAccountDialog({super.key});
+
+  static Future<bool?> show(BuildContext context) => showDialog<bool>(
+        context: context,
+        builder: (_) => const DeleteAccountDialog(),
+      );
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/features/settings/presentation/logout_confirm_dialog.dart
+++ b/apps/mobile/lib/features/settings/presentation/logout_confirm_dialog.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+// TODO(SE/T9/TBD): implement LogoutConfirmDialog per Figma
+class LogoutConfirmDialog extends StatelessWidget {
+  const LogoutConfirmDialog({super.key});
+
+  static Future<bool?> show(BuildContext context) => showDialog<bool>(
+        context: context,
+        builder: (_) => const LogoutConfirmDialog(),
+      );
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/features/settings/presentation/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/presentation/settings_sheet.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+// TODO(SE/T6/TBD): implement SettingsSheet per Figma — 572:4183
+class SettingsSheet extends StatelessWidget {
+  const SettingsSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/features/settings/presentation/widget_confirm_sheet.dart
+++ b/apps/mobile/lib/features/settings/presentation/widget_confirm_sheet.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+// TODO(SE/T10/TBD): implement WidgetConfirmSheet per Figma — 662:3341
+class WidgetConfirmSheet extends StatelessWidget {
+  const WidgetConfirmSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/shared/widgets/share_profile_sheet.dart
+++ b/apps/mobile/lib/shared/widgets/share_profile_sheet.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+/// Shared widget — used by both Settings and Profile modules.
+// TODO(SE/T12/TBD): implement ShareProfileSheet per Figma — 573:3648
+class ShareProfileSheet extends StatelessWidget {
+  const ShareProfileSheet({super.key, required this.uid});
+
+  final String uid;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -24,6 +24,14 @@ service cloud.firestore {
       );
     }
 
+    /// True if there is a block in either direction between the calling user and [uid].
+    function isBlocked(uid) {
+      return isAuthed() && (
+        exists(/databases/$(database)/documents/blocks/$(request.auth.uid + '_' + uid)) ||
+        exists(/databases/$(database)/documents/blocks/$(uid + '_' + request.auth.uid))
+      );
+    }
+
     // ===== /users/{uid} =====
     match /users/{uid} {
       allow read: if isAuthed();
@@ -89,6 +97,17 @@ service cloud.firestore {
         && request.resource.data.status == 'pending';
       // Status transitions handled server-side.
       allow update, delete: if false;
+    }
+
+    // ===== /blocks/{blockId} =====
+    // blockId = "{blockerUid}_{blockedUid}" — NOT sorted
+    match /blocks/{blockId} {
+      allow read: if isAuthed() && (
+        request.auth.uid == resource.data.blockerUid ||
+        request.auth.uid == resource.data.blockedUid
+      );
+      // Write is server-side only (via blockUser Cloud Function).
+      allow create, update, delete: if false;
     }
 
     // ===== Default deny =====

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -100,3 +100,35 @@ export const onFriendshipDeleted = onDocumentDeleted(
     // TODO(F/impl): see comment above.
   },
 );
+
+// ===== Settings module stubs =====
+
+/**
+ * Block a user: create /blocks doc + remove friendship + update conversation status.
+ *
+ * TODO(SE/impl):
+ *   - verify target exists + caller != target
+ *   - create /blocks/{blockerUid}_{targetUid}
+ *   - delete /friendships/{pairId} if exists
+ *   - update /conversations/{pairId}.status = 'blocked' if exists
+ */
+export const blockUser = onCall((request) => {
+  if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
+  // TODO(SE/impl): see comment above.
+  return { ok: true };
+});
+
+/**
+ * Delete account: re-authenticate, then cascade-delete all user data.
+ *
+ * TODO(SE/impl):
+ *   - delete /users/{uid} + subcollections
+ *   - delete /posts by uid from Storage + Firestore
+ *   - delete /friendships where uid is member
+ *   - delete Firebase Auth account
+ */
+export const deleteAccount = onCall((request) => {
+  if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
+  // TODO(SE/impl): see comment above.
+  return { ok: true };
+});


### PR DESCRIPTION
## Tóm tắt

LX3 từ plan `docs/plans/2026-05-23-leader.md` — Settings module contracts.
Depends on LX2 (BlockRepository canonical path — Chat + Feed import từ đây).

### Files thêm mới
- `features/settings/data/block.dart` — @freezed · blockId=`{blockerUid}_{targetUid}` NOT sorted
- `features/settings/data/block_repository.dart` — abstract canonical · blockUser/unblockUser/watchBlockedUsers/isBlocked(uid1, uid2)
- `features/settings/application/settings_controller.dart` — @riverpod stub
- `features/settings/presentation/`: SettingsSheet, BlockedAccountsPage, BlockConfirmDialog, LogoutConfirmDialog, WidgetConfirmSheet, DeleteAccountDialog
- `shared/widgets/share_profile_sheet.dart` — leader-owned, dùng bởi Settings + Profile

### Files cập nhật
- `firebase/firestore.rules` — `isBlocked(uid)` check **cả 2 chiều** + `/blocks/{blockId}` match rule (server-write only)
- `firebase/functions/src/index.ts` — stub `blockUser` callable + `deleteAccount` callable

## Acceptance criteria
- [x] `BlockRepository` tại `lib/features/settings/data/block_repository.dart` (canonical path)
- [x] `isBlocked(uid)` check `blockerUid_uid` VÀ `uid_blockerUid` — không miss trường hợp ngược
- [x] `/blocks` rule: write = `false` (server-side only)
- [x] TODO markers format `// TODO(SE/T<N>/TBD)`
- [x] `flutter analyze` — 0 issues · `npm lint` clean · 4/4 tests pass

Refs #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)