### PR TITLE
chore(contracts): LX5 — Feed/Camera/Home module contracts

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -14,6 +14,7 @@ import 'package:meep/features/auth/presentation/signup/signup_username_page.dart
 import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
 import 'package:meep/features/diary/presentation/diary_create_screen.dart';
 import 'package:meep/features/diary/presentation/diary_list_screen.dart';
+import 'package:meep/features/feed/presentation/home_screen.dart';
 import 'package:meep/features/home/presentation/home_page.dart';
 
 part 'app_router.g.dart';
@@ -99,6 +100,17 @@ GoRouter appRouter(Ref ref) {
         path: '/invite/:uid',
         builder: (_, __) => const HomePage(),
       ),
+      // TODO(FE/T20/KhoaLND): wire Feed routes
+      GoRoute(path: '/home', builder: (_, __) => const HomeScreen()),
+      GoRoute(
+        path: '/capture-preview',
+        builder: (_, __) => const HomeScreen(),
+      ),
+      GoRoute(
+        path: '/caption-modal',
+        builder: (_, __) => const HomeScreen(),
+      ),
+      GoRoute(path: '/grid-view', builder: (_, __) => const HomeScreen()),
     ],
   );
 }

--- a/apps/mobile/lib/features/feed/application/app_camera_controller.dart
+++ b/apps/mobile/lib/features/feed/application/app_camera_controller.dart
@@ -1,0 +1,43 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'app_camera_controller.freezed.dart';
+part 'app_camera_controller.g.dart';
+
+@freezed
+class CameraState with _$CameraState {
+  const factory CameraState({
+    @Default(false) bool isInitialized,
+    @Default(false) bool isFrontCamera,
+    @Default(false) bool flashEnabled,
+    @Default(false) bool isCapturing,
+  }) = _CameraState;
+}
+
+/// Camera controller — named AppCameraController to avoid conflict
+/// with the `camera` package's CameraController.
+@riverpod
+class AppCameraController extends _$AppCameraController {
+  @override
+  CameraState build() => const CameraState();
+
+  Future<void> initialize() async {
+    // TODO(FE/T5/KhoaLND): initialize camera
+    throw UnimplementedError('initialize — TODO: FE/T5/KhoaLND');
+  }
+
+  Future<String?> capture() async {
+    // TODO(FE/T6/KhoaLND): capture photo, return local path
+    throw UnimplementedError('capture — TODO: FE/T6/KhoaLND');
+  }
+
+  void toggleCamera() {
+    // TODO(FE/T7/KhoaLND): flip front/back
+    throw UnimplementedError('toggleCamera — TODO: FE/T7/KhoaLND');
+  }
+
+  void toggleFlash() {
+    // TODO(FE/T8/KhoaLND): toggle flash
+    throw UnimplementedError('toggleFlash — TODO: FE/T8/KhoaLND');
+  }
+}

--- a/apps/mobile/lib/features/feed/application/caption_service.dart
+++ b/apps/mobile/lib/features/feed/application/caption_service.dart
@@ -1,0 +1,8 @@
+import 'package:meep/features/feed/data/post.dart';
+
+/// Resolves a caption preset for [type].
+/// Each implementation returns localised, contextual text
+/// (e.g. current time, location name, weather description).
+abstract class CaptionService {
+  Future<String> resolve(CaptionType type);
+}

--- a/apps/mobile/lib/features/feed/application/feed_controller.dart
+++ b/apps/mobile/lib/features/feed/application/feed_controller.dart
@@ -1,0 +1,55 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/feed/data/post_repository.dart';
+import 'package:meep/features/feed/data/storage_repository.dart';
+
+part 'feed_controller.g.dart';
+
+/// Feed filter mode.
+enum FeedFilter {
+  all,
+
+  /// Filter by a specific friend's uid.
+  person,
+
+  /// Reserved — Space feed (Space module implements).
+  space,
+}
+
+// ignore: avoid_classes_with_only_static_members
+class FeedState {
+  const FeedState._();
+}
+
+@Riverpod(keepAlive: true)
+PostRepository postRepository(PostRepositoryRef ref) =>
+    throw UnimplementedError(
+      'postRepositoryProvider must be overridden — '
+      'wire FirestorePostRepository in main.dart (TODO: FE/T1/KhoaLND)',
+    );
+
+@Riverpod(keepAlive: true)
+StorageRepository storageRepository(StorageRepositoryRef ref) =>
+    throw UnimplementedError(
+      'storageRepositoryProvider must be overridden — '
+      'wire FirebaseStorageRepository in main.dart (TODO: FE/T2/KhoaLND)',
+    );
+
+@riverpod
+class FeedController extends _$FeedController {
+  @override
+  Future<List<Post>> build({
+    FeedFilter filter = FeedFilter.all,
+    String? filterUid,
+  }) async {
+    // TODO(FE/T3/KhoaLND): implement watchFeed stream
+    throw UnimplementedError('FeedController.build — TODO: FE/T3/KhoaLND');
+  }
+
+  Future<void> loadMore() async {
+    // TODO(FE/T4/KhoaLND): implement pagination
+    throw UnimplementedError('loadMore — TODO: FE/T4/KhoaLND');
+  }
+}

--- a/apps/mobile/lib/features/feed/application/post_controller.dart
+++ b/apps/mobile/lib/features/feed/application/post_controller.dart
@@ -1,0 +1,46 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/feed/data/post.dart';
+
+part 'post_controller.freezed.dart';
+part 'post_controller.g.dart';
+
+@freezed
+class PostState with _$PostState {
+  const factory PostState({
+    @Default(false) bool isUploading,
+    String? pendingImagePath,
+    String? caption,
+    CaptionType? captionType,
+    @Default(AudienceType.all) AudienceType audienceType,
+    @Default([]) List<String> selectedUids,
+    String? errorMessage,
+  }) = _PostState;
+}
+
+@riverpod
+class PostController extends _$PostController {
+  @override
+  PostState build() => const PostState();
+
+  Future<void> submit() async {
+    // TODO(FE/T9/KhoaLND): upload + create Firestore doc
+    throw UnimplementedError('submit — TODO: FE/T9/KhoaLND');
+  }
+
+  void setCaptionType(CaptionType? type) {
+    // TODO(FE/T10/KhoaLND): update captionType + resolve caption text
+    throw UnimplementedError('setCaptionType — TODO: FE/T10/KhoaLND');
+  }
+
+  void setAudience(AudienceType type, List<String> uids) {
+    // TODO(FE/T11/KhoaLND): update audience selection
+    throw UnimplementedError('setAudience — TODO: FE/T11/KhoaLND');
+  }
+
+  Future<void> deletePost(String postId) async {
+    // TODO(FE/T12/KhoaLND): delete post + Storage assets
+    throw UnimplementedError('deletePost — TODO: FE/T12/KhoaLND');
+  }
+}

--- a/apps/mobile/lib/features/feed/data/post.dart
+++ b/apps/mobile/lib/features/feed/data/post.dart
@@ -1,0 +1,45 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'post.freezed.dart';
+part 'post.g.dart';
+
+enum CaptionType { text, location, weather, music, star, time, streak }
+
+enum AudienceType { all, select }
+
+@freezed
+class Post with _$Post {
+  const factory Post({
+    required String postId,
+    required String authorId,
+    required String authorName,
+    String? authorAvatarUrl,
+    required String imageUrl,
+    String? caption,
+    CaptionType? captionType,
+    required AudienceType audienceType,
+    @Default([]) List<String> audienceUids,
+
+    /// Reserved for Space module. Null = all-friends post.
+    /// When set: broadcast to all Space members; audienceType/audienceUids ignored.
+    String? spaceId,
+    @TimestampConverter() required DateTime createdAt,
+  }) = _Post;
+
+  factory Post.fromJson(Map<String, dynamic> json) => _$PostFromJson(json);
+}
+
+class TimestampConverter implements JsonConverter<DateTime, Object> {
+  const TimestampConverter();
+
+  @override
+  DateTime fromJson(Object json) {
+    if (json is Timestamp) return json.toDate();
+    if (json is String) return DateTime.parse(json);
+    return DateTime.fromMillisecondsSinceEpoch(json as int);
+  }
+
+  @override
+  Object toJson(DateTime date) => Timestamp.fromDate(date);
+}

--- a/apps/mobile/lib/features/feed/data/post_repository.dart
+++ b/apps/mobile/lib/features/feed/data/post_repository.dart
@@ -1,0 +1,15 @@
+import 'package:meep/features/feed/data/post.dart';
+
+abstract class PostRepository {
+  /// Upload photo + create Firestore post doc. Returns created post.
+  Future<Post> createPost(Post post);
+
+  /// Stream of paginated feed for [uid], newest first.
+  Stream<List<Post>> watchFeed(String uid);
+
+  /// Delete a post and its Storage assets.
+  Future<void> deletePost(String postId);
+
+  /// All posts authored by [authorId], newest first.
+  Future<List<Post>> getPostsByAuthor(String authorId);
+}

--- a/apps/mobile/lib/features/feed/data/storage_repository.dart
+++ b/apps/mobile/lib/features/feed/data/storage_repository.dart
@@ -1,0 +1,12 @@
+abstract class StorageRepository {
+  /// Upload image bytes and return the download URL.
+  Future<String> uploadImage({
+    required String uid,
+    required String postId,
+    required List<int> bytes,
+    required String mimeType,
+  });
+
+  /// Delete image at [storagePath].
+  Future<void> deleteImage(String storagePath);
+}

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+// TODO(FE/T13/KhoaLND): implement HomeScreen per Figma — camera + feed CustomScrollView
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: CustomScrollView(slivers: []),
+    );
+  }
+}

--- a/apps/mobile/lib/features/home/presentation/photo_action_sheet.dart
+++ b/apps/mobile/lib/features/home/presentation/photo_action_sheet.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(FE/T14/KhoaLND): implement PhotoActionSheet per Figma
+class PhotoActionSheet extends StatelessWidget {
+  const PhotoActionSheet({super.key, required this.postId});
+
+  final String postId;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/shared/widgets/app_act_text_bar.dart
+++ b/apps/mobile/lib/shared/widgets/app_act_text_bar.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+/// M2 stub — disabled, no-op. Reactions are M3.
+/// In M3: inject ReactionController to enable interactions.
+// TODO(FE/T17/KhoaLND): implement AppActTextBar per Figma — M3 reaction bar
+class AppActTextBar extends StatelessWidget {
+  const AppActTextBar({super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/shared/widgets/app_camera_button.dart
+++ b/apps/mobile/lib/shared/widgets/app_camera_button.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(FE/T15/KhoaLND): implement AppCameraButton per Figma
+class AppCameraButton extends StatelessWidget {
+  const AppCameraButton({super.key, this.onPressed});
+
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/shared/widgets/app_note_pill.dart
+++ b/apps/mobile/lib/shared/widgets/app_note_pill.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(FE/T16/KhoaLND): implement AppNotePill per Figma — caption overlay on photo
+class AppNotePill extends StatelessWidget {
+  const AppNotePill({super.key, required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/shared/widgets/post_card.dart
+++ b/apps/mobile/lib/shared/widgets/post_card.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(FE/T18/KhoaLND): implement PostCard per Figma — full-width photo card
+class PostCard extends StatelessWidget {
+  const PostCard({super.key, required this.postId});
+
+  final String postId;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/shared/widgets/share_modal.dart
+++ b/apps/mobile/lib/shared/widgets/share_modal.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+// TODO(FE/T19/KhoaLND): implement ShareModal per Figma — audience selector sheet
+class ShareModal extends StatelessWidget {
+  const ShareModal({super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -132,3 +132,19 @@ export const deleteAccount = onCall((request) => {
   // TODO(SE/impl): see comment above.
   return { ok: true };
 });
+
+// ===== Feed module stubs =====
+
+/**
+ * Clean up Storage assets when a post is deleted.
+ *
+ * TODO(FE/impl):
+ *   - delete posts/{uid}/{postId}/photo.jpg from Storage
+ *   - remove fan-out feed entries in /users/{uid}/feed/{postId}
+ */
+export const onPostDeleted = onDocumentDeleted(
+  { document: 'posts/{postId}', region: 'asia-southeast1' },
+  (_event) => {
+    // TODO(FE/impl): see comment above.
+  },
+);


### PR DESCRIPTION
## Tóm tắt

LX5 từ plan `docs/plans/2026-05-23-leader.md` — Feed/Camera/Home contracts.
Depends on LX3 (BlockRepository path để Feed filter blocked users sau này).

### Data layer
- `feed/data/post.dart` — @freezed · `CaptionType` enum (7 types) · `AudienceType` enum · **`spaceId String?`** reserved cho Space module
- `feed/data/post_repository.dart` — abstract: createPost/watchFeed/deletePost/getPostsByAuthor
- `feed/data/storage_repository.dart` — abstract: uploadImage/deleteImage
- `feed/application/caption_service.dart` — abstract: resolve(CaptionType)

### Application layer
- `feed_controller.dart` — @riverpod stub · **`FeedFilter` enum: all/person/space** (space reserved)
- `app_camera_controller.dart` — @riverpod stub + `CameraState` @freezed · named `AppCameraController` (không phải `CameraController` — conflict camera package)
- `post_controller.dart` — @riverpod stub + `PostState` @freezed

### Presentation + shared
- `feed/presentation/home_screen.dart` — replaces `HomePage` placeholder
- `home/presentation/photo_action_sheet.dart` — stub (owned by Feed)
- Shared widgets: `AppCameraButton`, `AppNotePill`, `AppActTextBar`(M2 no-op), `PostCard`, `ShareModal`

### Router + Functions
- `app_router.dart`: `/home`→HomeScreen, `/capture-preview`, `/caption-modal`, `/grid-view`
- `functions/index.ts`: `onPostDeleted` trigger stub

## Acceptance criteria
- [x] `Post.spaceId String?` reserved — Space module dùng sau
- [x] `FeedFilter.space` case compile dù chưa implement
- [x] `AppCameraController` — không conflict với camera package
- [x] `onPostDeleted` dùng `onDocumentDeleted`
- [x] `flutter analyze` 0 issues · `npm lint` clean

Refs #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)