### PR TITLE
chore(contracts): LX9 — Profile module contracts

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -16,6 +16,9 @@ import 'package:meep/features/diary/presentation/diary_create_screen.dart';
 import 'package:meep/features/diary/presentation/diary_list_screen.dart';
 import 'package:meep/features/feed/presentation/home_screen.dart';
 import 'package:meep/features/home/presentation/home_page.dart';
+import 'package:meep/features/profile/presentation/edit_profile_screen.dart';
+import 'package:meep/features/profile/presentation/photo_detail_screen.dart';
+import 'package:meep/features/profile/presentation/profile_screen.dart';
 
 part 'app_router.g.dart';
 
@@ -111,6 +114,25 @@ GoRouter appRouter(Ref ref) {
         builder: (_, __) => const HomeScreen(),
       ),
       GoRoute(path: '/grid-view', builder: (_, __) => const HomeScreen()),
+      // TODO(P/T10/TBD): wire Profile routes
+      GoRoute(
+        path: '/profile',
+        builder: (_, state) => ProfileScreen(uid: state.extra as String? ?? ''),
+      ),
+      GoRoute(
+        path: '/profile/edit',
+        builder: (_, __) => const EditProfileScreen(),
+      ),
+      GoRoute(
+        path: '/profile/photo/:postId',
+        builder: (_, state) =>
+            PhotoDetailScreen(postId: state.pathParameters['postId'] ?? ''),
+      ),
+      GoRoute(
+        path: '/friend-profile/:uid',
+        builder: (_, state) =>
+            ProfileScreen(uid: state.pathParameters['uid'] ?? ''),
+      ),
     ],
   );
 }

--- a/apps/mobile/lib/features/auth/data/user_profile.dart
+++ b/apps/mobile/lib/features/auth/data/user_profile.dart
@@ -4,36 +4,45 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'user_profile.freezed.dart';
 part 'user_profile.g.dart';
 
+/// Full user profile — source of truth is Profile spec.
+/// Auth creates the doc with initial values; Profile module owns the full schema.
 @freezed
 class UserProfile with _$UserProfile {
   const factory UserProfile({
     required String uid,
     required String email,
-    required String firstName,
-    required String lastName,
+    required String displayName,
     required String username,
-    String? photoUrl,
+    String? avatarUrl,
     String? bio,
-    @TimestampConverter() required DateTime? createdAt,
+    String? dateOfBirth,
+    String? phoneNumber,
+
+    /// 'male' | 'female' | 'other'
+    String? gender,
+
+    /// Denormalized counters — updated by Cloud Functions.
+    @Default(0) int postCount,
+    @Default(0) int friendCount,
+    @Default(0) int spaceCount,
+    @TimestampConverter() required DateTime createdAt,
+    @TimestampConverter() required DateTime updatedAt,
   }) = _UserProfile;
 
   factory UserProfile.fromJson(Map<String, dynamic> json) =>
       _$UserProfileFromJson(json);
 }
 
-class TimestampConverter implements JsonConverter<DateTime?, Object?> {
+class TimestampConverter implements JsonConverter<DateTime, Object> {
   const TimestampConverter();
 
   @override
-  DateTime? fromJson(Object? json) {
-    if (json == null) return null;
+  DateTime fromJson(Object json) {
     if (json is Timestamp) return json.toDate();
-    if (json is String) return DateTime.tryParse(json);
-    return null;
+    if (json is String) return DateTime.parse(json);
+    return DateTime.fromMillisecondsSinceEpoch(json as int);
   }
 
   @override
-  Object? toJson(DateTime? date) {
-    return date != null ? Timestamp.fromDate(date) : null;
-  }
+  Object toJson(DateTime date) => Timestamp.fromDate(date);
 }

--- a/apps/mobile/lib/features/profile/application/profile_controller.dart
+++ b/apps/mobile/lib/features/profile/application/profile_controller.dart
@@ -1,0 +1,51 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/profile/data/profile_repository.dart';
+
+part 'profile_controller.freezed.dart';
+part 'profile_controller.g.dart';
+
+@freezed
+class ProfileState with _$ProfileState {
+  const factory ProfileState({
+    UserProfile? profile,
+    @Default(false) bool isLoading,
+    @Default(false) bool isSaving,
+    String? errorMessage,
+  }) = _ProfileState;
+}
+
+@Riverpod(keepAlive: true)
+ProfileRepository profileRepository(ProfileRepositoryRef ref) =>
+    throw UnimplementedError(
+      'profileRepositoryProvider must be overridden — '
+      'wire FirestoreProfileRepository in main.dart (TODO: P/T1/TBD)',
+    );
+
+@riverpod
+class ProfileController extends _$ProfileController {
+  @override
+  ProfileState build(String uid) => const ProfileState();
+
+  Future<void> loadProfile() async {
+    // TODO(P/T2/TBD): implement loadProfile
+    throw UnimplementedError('loadProfile — TODO: P/T2/TBD');
+  }
+
+  Future<void> updateProfile(Map<String, dynamic> fields) async {
+    // TODO(P/T3/TBD): implement updateProfile
+    throw UnimplementedError('updateProfile — TODO: P/T3/TBD');
+  }
+
+  Future<void> updateAvatar() async {
+    // TODO(P/T4/TBD): pick image + updateAvatar via ProfileRepository
+    throw UnimplementedError('updateAvatar — TODO: P/T4/TBD');
+  }
+
+  Future<void> removeAvatar() async {
+    // TODO(P/T5/TBD): implement removeAvatar
+    throw UnimplementedError('removeAvatar — TODO: P/T5/TBD');
+  }
+}

--- a/apps/mobile/lib/features/profile/data/profile_repository.dart
+++ b/apps/mobile/lib/features/profile/data/profile_repository.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+import 'package:meep/features/auth/data/user_profile.dart';
+
+abstract class ProfileRepository {
+  Future<UserProfile?> getUserProfile(String uid);
+  Stream<UserProfile?> watchUserProfile(String uid);
+
+  /// Update arbitrary profile fields (e.g. bio, displayName, dateOfBirth).
+  Future<void> updateProfile(String uid, Map<String, dynamic> fields);
+
+  /// Upload [imageFile] to Storage and update avatarUrl.
+  Future<void> updateAvatar(String uid, File imageFile);
+
+  /// Remove avatar from Storage and clear avatarUrl.
+  Future<void> removeAvatar(String uid);
+
+  // NOTE: isUsernameAvailable is NOT here — ProfileController injects
+  // UserRepository from auth and delegates to it. See plan §H4.
+}

--- a/apps/mobile/lib/features/profile/presentation/avatar_picker_sheet.dart
+++ b/apps/mobile/lib/features/profile/presentation/avatar_picker_sheet.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+// TODO(P/T9/TBD): implement AvatarPickerSheet per Figma
+class AvatarPickerSheet extends StatelessWidget {
+  const AvatarPickerSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/apps/mobile/lib/features/profile/presentation/edit_profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/edit_profile_screen.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+// TODO(P/T7/TBD): implement EditProfileScreen per Figma
+class EditProfileScreen extends StatelessWidget {
+  const EditProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+}

--- a/apps/mobile/lib/features/profile/presentation/photo_detail_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/photo_detail_screen.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(P/T8/TBD): implement PhotoDetailScreen per Figma — full-screen own photo
+class PhotoDetailScreen extends StatelessWidget {
+  const PhotoDetailScreen({super.key, required this.postId});
+
+  final String postId;
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+}

--- a/apps/mobile/lib/features/profile/presentation/profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/profile_screen.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+// TODO(P/T6/TBD): implement ProfileScreen per Figma — own profile + friend profile
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key, required this.uid});
+
+  final String uid;
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+}


### PR DESCRIPTION
## Tóm tắt

LX9 từ plan `docs/plans/2026-05-23-leader.md` — Profile module contracts.
Depends on LX2 (Friend module) + LX8 (Diary — `getPublicEntries` dùng bởi Profile).

### Cập nhật model
- `features/auth/data/user_profile.dart` — **gate change**: cập nhật đủ fields theo Profile spec:
  - `displayName` thay `firstName`+`lastName`
  - `avatarUrl` thay `photoUrl`
  - Thêm: `bio`, `dateOfBirth`, `phoneNumber`, `gender`
  - Thêm denorm counters: `postCount`, `friendCount`, `spaceCount`
  - Thêm: `updatedAt` (required)

### Profile module mới
- `profile/data/profile_repository.dart` — abstract: getUserProfile/watchUserProfile/updateProfile/updateAvatar/removeAvatar · `isUsernameAvailable` **KHÔNG** có (dùng `UserRepository`)
- `profile/application/profile_controller.dart` — @riverpod stub + `ProfileState` @freezed
- 4 presentation stubs: ProfileScreen, EditProfileScreen, PhotoDetailScreen, AvatarPickerSheet

### Router
- `app_router.dart`: `/profile`, `/profile/edit`, `/profile/photo/:postId`, `/friend-profile/:uid`

## Acceptance criteria
- [x] `isUsernameAvailable` không có trong `ProfileRepository`
- [x] `ShareProfileSheet` không tạo lại (đã tạo ở LX3)
- [x] `UserProfile` cập nhật đủ fields theo spec
- [x] TODO markers format `// TODO(P/T<N>/TBD)`
- [x] `flutter analyze` 0 issues

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)