### PR TITLE
feat(auth): nâng router guard lên 3-state (T1)

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -29,19 +29,37 @@ import 'package:meep/features/streak/presentation/streak_screen.dart';
 part 'app_router.g.dart';
 
 /// Pure redirect logic — testable without GoRouter.
+///
+/// 3-state machine:
+///   uid = null                           → /intro
+///   uid != null, profileExists = null    → wait (still resolving)
+///   uid != null, profileExists = false   → /signup/name (Google Sign-In incomplete)
+///   uid != null, profileExists = true    → /home
 String? authRedirect({
   required bool isLoading,
-  required bool isSignedIn,
+  required String? uid,
+  required bool? profileExists,
   required String location,
 }) {
   if (isLoading) return null;
+
   final onAuthRoute = location.startsWith('/login') ||
       location.startsWith('/signup') ||
       location.startsWith('/dev') ||
       location == '/intro';
-  if (isSignedIn && onAuthRoute) return '/home';
-  if (!isSignedIn && !onAuthRoute) return '/intro';
-  return null;
+
+  if (uid == null) return onAuthRoute ? null : '/intro';
+
+  // uid != null — wait until profile state is resolved
+  if (profileExists == null) return null;
+
+  if (!profileExists) {
+    // Google Sign-In first time or incomplete signup — resume from name step
+    return location.startsWith('/signup') ? null : '/signup/name';
+  }
+
+  // uid != null, profile exists
+  return onAuthRoute ? '/home' : null;
 }
 
 // NOTE: mỗi khi currentUidProvider emit giá trị mới, provider này rebuild và tạo
@@ -49,13 +67,25 @@ String? authRedirect({
 // lúc login/logout). Post-MVP nên refactor sang RouterNotifier + refreshListenable.
 @Riverpod(keepAlive: true)
 GoRouter appRouter(Ref ref) {
-  final authState = ref.watch(currentUidProvider);
+  final uidState = ref.watch(currentUidProvider);
+  final profileState = ref.watch(currentUserProfileProvider);
+
+  final uid = uidState.valueOrNull;
+  // isLoading: uid resolving OR (uid exists but profile still loading)
+  final isLoading =
+      uidState.isLoading || (uid != null && profileState.isLoading);
+  // profileExists: null when error/loading (unknown), else whether profile doc exists
+  final bool? profileExists = switch (profileState) {
+    AsyncData(:final value) => value != null,
+    _ => null,
+  };
 
   return GoRouter(
     initialLocation: '/intro',
     redirect: (context, state) => authRedirect(
-      isLoading: authState.isLoading,
-      isSignedIn: authState.valueOrNull != null,
+      isLoading: isLoading,
+      uid: uid,
+      profileExists: profileExists,
       location: state.matchedLocation,
     ),
     routes: [

--- a/apps/mobile/test/core/router/app_router_test.dart
+++ b/apps/mobile/test/core/router/app_router_test.dart
@@ -2,68 +2,231 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:meep/core/router/app_router.dart';
 
 void main() {
-  group('authRedirect', () {
-    test('signed-in + /intro → redirect /home', () {
+  group('authRedirect — 3-state guard', () {
+    // ── loading ──────────────────────────────────────────────
+    test('isLoading → null (any location)', () {
       expect(
-        authRedirect(isLoading: false, isSignedIn: true, location: '/intro'),
+        authRedirect(
+          isLoading: true,
+          uid: null,
+          profileExists: null,
+          location: '/home',
+        ),
+        isNull,
+      );
+      expect(
+        authRedirect(
+          isLoading: true,
+          uid: 'u1',
+          profileExists: true,
+          location: '/intro',
+        ),
+        isNull,
+      );
+    });
+
+    // ── uid = null ───────────────────────────────────────────
+    test('uid null + /intro → null (stay)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: null,
+          profileExists: null,
+          location: '/intro',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid null + /login/email → null (stay)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: null,
+          profileExists: null,
+          location: '/login/email',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid null + /signup/email → null (stay)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: null,
+          profileExists: null,
+          location: '/signup/email',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid null + /home → /intro', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: null,
+          profileExists: null,
+          location: '/home',
+        ),
+        '/intro',
+      );
+    });
+
+    test('uid null + /profile → /intro', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: null,
+          profileExists: null,
+          location: '/profile',
+        ),
+        '/intro',
+      );
+    });
+
+    // ── uid != null, profileExists unknown ───────────────────
+    test('uid exists + profileExists null → null (wait)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: null,
+          location: '/home',
+        ),
+        isNull,
+      );
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: null,
+          location: '/intro',
+        ),
+        isNull,
+      );
+    });
+
+    // ── uid != null, no profile (Google Sign-In incomplete) ──
+    test('uid + no profile + /signup/name → null (stay)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: false,
+          location: '/signup/name',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid + no profile + /signup/username → null (stay)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: false,
+          location: '/signup/username',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid + no profile + /home → /signup/name', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: false,
+          location: '/home',
+        ),
+        '/signup/name',
+      );
+    });
+
+    test('uid + no profile + /intro → /signup/name', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: false,
+          location: '/intro',
+        ),
+        '/signup/name',
+      );
+    });
+
+    // ── uid != null, profile exists ──────────────────────────
+    test('uid + profile + /home → null (stay)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          location: '/home',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid + profile + /profile → null (stay)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          location: '/profile',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid + profile + /intro → /home', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          location: '/intro',
+        ),
         '/home',
       );
     });
 
-    test('signed-in + /signup/email → redirect /home', () {
+    test('uid + profile + /signup/email → /home', () {
       expect(
         authRedirect(
           isLoading: false,
-          isSignedIn: true,
+          uid: 'u1',
+          profileExists: true,
           location: '/signup/email',
         ),
         '/home',
       );
     });
 
-    test('signed-in + /login/email → redirect /home', () {
+    test('uid + profile + /login/email → /home', () {
       expect(
         authRedirect(
           isLoading: false,
-          isSignedIn: true,
+          uid: 'u1',
+          profileExists: true,
           location: '/login/email',
         ),
         '/home',
       );
     });
 
-    test('signed-in + /home → không redirect', () {
+    test('uid + profile + /dev/widgets → /home', () {
       expect(
-        authRedirect(isLoading: false, isSignedIn: true, location: '/home'),
-        isNull,
-      );
-    });
-
-    test('signed-out + /home → redirect /intro', () {
-      expect(
-        authRedirect(isLoading: false, isSignedIn: false, location: '/home'),
-        '/intro',
-      );
-    });
-
-    test('signed-out + /intro → không redirect', () {
-      expect(
-        authRedirect(isLoading: false, isSignedIn: false, location: '/intro'),
-        isNull,
-      );
-    });
-
-    test('loading state → không redirect dù ở /home', () {
-      expect(
-        authRedirect(isLoading: true, isSignedIn: false, location: '/home'),
-        isNull,
-      );
-    });
-
-    test('loading state → không redirect dù ở /intro', () {
-      expect(
-        authRedirect(isLoading: true, isSignedIn: true, location: '/intro'),
-        isNull,
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          location: '/dev/widgets',
+        ),
+        '/home',
       );
     });
   });


### PR DESCRIPTION
## Mô tả

Implement T1 của Auth module: nâng `authRedirect` từ 2-state lên 3-state để hỗ trợ Google Sign-In incomplete flow.

## Thay đổi

- `app_router.dart` — `authRedirect` nhận `uid: String?` + `profileExists: bool?` thay vì `isSignedIn: bool`
- Router giờ watch cả `currentUserProfileProvider`; khi provider còn stub (UnimplementedError) → `profileExists = null` → guard wait, không crash
- `app_router_test.dart` — 17 test cases phủ full 3-state: loading / uid-null / uid+noProfile / uid+profile

## State machine

```
uid = null                         → /intro
uid != null, profileExists = null  → wait (provider chưa resolve)
uid != null, profileExists = false → /signup/name (Google Sign-In chưa hoàn tất)
uid != null, profileExists = true  → /home
```

## Test

```
flutter test test/core/router/ → 17/17 pass
flutter analyze → 0 issues
dart format → 0 changes
```

Closes #148