### PR TITLE
feat(auth): T2+T3+T4+T5 — Data layer Auth module

### DIFF
--- a/apps/mobile/lib/features/auth/application/auth_controller.dart
+++ b/apps/mobile/lib/features/auth/application/auth_controller.dart
@@ -25,13 +25,11 @@ final currentUidProvider = StreamProvider<String?>((ref) {
 });
 
 /// Stream of the current user's full profile (null when signed out or profile not yet created).
-// TODO(A/T2/KhoaLND): watch profile from Firestore via UserRepository
 final currentUserProfileProvider = StreamProvider<UserProfile?>((ref) {
   final uid = ref.watch(currentUidProvider).valueOrNull;
   if (uid == null) return Stream.value(null);
-  throw UnimplementedError(
-    'currentUserProfileProvider — wire FirebaseUserRepository first',
-  );
+  final repo = ref.watch(userRepositoryProvider);
+  return repo.watchProfile(uid);
 });
 
 /// Convenience — true when there's a signed-in user.

--- a/apps/mobile/lib/features/auth/data/firebase_auth_repository.dart
+++ b/apps/mobile/lib/features/auth/data/firebase_auth_repository.dart
@@ -1,0 +1,129 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/data/auth_repository.dart';
+
+class FirebaseAuthRepository implements AuthRepository {
+  FirebaseAuthRepository({required FirebaseAuth auth}) : _auth = auth;
+
+  final FirebaseAuth _auth;
+
+  @override
+  String? get currentUid => _auth.currentUser?.uid;
+
+  @override
+  Stream<String?> watchUid() =>
+      _auth.authStateChanges().map((user) => user?.uid);
+
+  @override
+  Future<void> signUpWithEmail({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      await _auth.createUserWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+    } on FirebaseAuthException catch (e) {
+      throw _mapSignUpError(e);
+    }
+  }
+
+  @override
+  Future<void> signInWithEmail({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      await _auth.signInWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+    } on FirebaseAuthException catch (e) {
+      throw _mapSignInError(e);
+    }
+  }
+
+  @override
+  Future<void> signInWithGoogle() async {
+    // TODO(A/T7/ThienPDM): implement Google Sign-In với GoogleSignIn package
+    throw UnimplementedError('signInWithGoogle — implement at T7');
+  }
+
+  @override
+  Future<void> signInWithApple() async {
+    throw UnimplementedError('signInWithApple — iOS deferred post-MVP');
+  }
+
+  @override
+  Future<void> sendPasswordResetEmail({required String email}) async {
+    try {
+      await _auth.sendPasswordResetEmail(email: email);
+    } on FirebaseAuthException catch (e) {
+      throw _mapGenericError(e);
+    }
+  }
+
+  @override
+  Future<void> signOut() => _auth.signOut();
+
+  @override
+  Future<void> deleteCurrentUser() async {
+    final user = _auth.currentUser;
+    if (user == null) return;
+    try {
+      await user.delete();
+    } on FirebaseAuthException catch (e) {
+      throw _mapGenericError(e);
+    }
+  }
+
+  @override
+  Future<void> reauthenticateWithCredential(AuthCredential credential) async {
+    // TODO(A/T7/ThienPDM): implement — needed by Profile/Settings for sensitive ops
+    throw UnimplementedError('reauthenticateWithCredential — implement at T7');
+  }
+
+  @override
+  Future<void> updateEmail(String newEmail) async {
+    // TODO(A/T7/ThienPDM): implement — needed by Profile for email change
+    throw UnimplementedError('updateEmail — implement at T7');
+  }
+
+  // ── Error mapping ─────────────────────────────────────────────────────────
+
+  AppError _mapSignUpError(FirebaseAuthException e) => switch (e.code) {
+        'email-already-in-use' =>
+          const ValidationError(message: 'Email này đã được sử dụng'),
+        'weak-password' => const ValidationError(
+            message: 'Mật khẩu quá ngắn (tối thiểu 8 ký tự)',
+          ),
+        'invalid-email' => const ValidationError(message: 'Email không hợp lệ'),
+        'network-request-failed' =>
+          const NetworkError(message: 'Không có kết nối mạng'),
+        _ => UnexpectedError(message: e.message ?? e.code, cause: e),
+      };
+
+  AppError _mapSignInError(FirebaseAuthException e) => switch (e.code) {
+        'wrong-password' ||
+        'invalid-credential' =>
+          const UnauthenticatedError(message: 'Mật khẩu không đúng'),
+        'user-not-found' => const UnauthenticatedError(
+            message: 'Không tìm thấy tài khoản với email này',
+          ),
+        'user-disabled' =>
+          const UnauthenticatedError(message: 'Tài khoản đã bị vô hiệu hóa'),
+        'too-many-requests' => const UnauthenticatedError(
+            message: 'Quá nhiều lần thử. Vui lòng thử lại sau',
+          ),
+        'network-request-failed' =>
+          const NetworkError(message: 'Không có kết nối mạng'),
+        _ => UnexpectedError(message: e.message ?? e.code, cause: e),
+      };
+
+  AppError _mapGenericError(FirebaseAuthException e) => switch (e.code) {
+        'network-request-failed' =>
+          const NetworkError(message: 'Không có kết nối mạng'),
+        _ => UnexpectedError(message: e.message ?? e.code, cause: e),
+      };
+}

--- a/apps/mobile/lib/features/auth/data/firebase_user_repository.dart
+++ b/apps/mobile/lib/features/auth/data/firebase_user_repository.dart
@@ -1,0 +1,52 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/user_repository.dart';
+
+class FirebaseUserRepository implements UserRepository {
+  FirebaseUserRepository({required FirebaseFirestore firestore})
+      : _firestore = firestore;
+
+  final FirebaseFirestore _firestore;
+
+  @override
+  Future<void> createProfile(UserProfile profile) async {
+    final username = profile.username.toLowerCase();
+    final batch = _firestore.batch();
+
+    final userRef = _firestore.doc('users/${profile.uid}');
+    batch.set(userRef, {
+      ...profile.toJson(),
+      'username': username,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+
+    final usernameRef = _firestore.doc('usernames/$username');
+    batch.set(usernameRef, {'uid': profile.uid});
+
+    await batch.commit();
+  }
+
+  @override
+  Future<UserProfile?> getProfile(String uid) async {
+    final snap = await _firestore.doc('users/$uid').get();
+    if (!snap.exists) return null;
+    return UserProfile.fromJson(snap.data()!);
+  }
+
+  @override
+  Future<bool> isUsernameAvailable(String username) async {
+    final snap =
+        await _firestore.doc('usernames/${username.toLowerCase()}').get();
+    return !snap.exists;
+  }
+
+  /// Stream of the user's profile — emits null when doc doesn't exist.
+  @override
+  Stream<UserProfile?> watchProfile(String uid) {
+    return _firestore.doc('users/$uid').snapshots().map((snap) {
+      if (!snap.exists) return null;
+      return UserProfile.fromJson(snap.data()!);
+    });
+  }
+}

--- a/apps/mobile/lib/features/auth/data/user_repository.dart
+++ b/apps/mobile/lib/features/auth/data/user_repository.dart
@@ -4,4 +4,7 @@ abstract class UserRepository {
   Future<void> createProfile(UserProfile profile);
   Future<UserProfile?> getProfile(String uid);
   Future<bool> isUsernameAvailable(String username);
+
+  /// Real-time stream of a user's profile. Emits null when doc doesn't exist.
+  Stream<UserProfile?> watchProfile(String uid);
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,33 +1,30 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:meep/core/router/app_router.dart';
 import 'package:meep/core/theme/app_theme.dart';
+import 'package:meep/features/auth/application/auth_controller.dart';
+import 'package:meep/features/auth/data/firebase_auth_repository.dart';
 import 'package:meep/firebase_options.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 
-  // TODO(T2+3/KhoaLND): override authRepositoryProvider + userRepositoryProvider
-  // sau khi FirebaseAuthRepository + FirebaseUserRepository được implement.
-  // Ví dụ:
-  //   authRepositoryProvider.overrideWithValue(
-  //     FirebaseAuthRepository(auth: FirebaseAuth.instance),
-  //   ),
-  //   userRepositoryProvider.overrideWithValue(
-  //     FirebaseUserRepository(firestore: FirebaseFirestore.instance),
-  //   ),
-
-  // TODO(N/T2/TBD): FCM init sau khi firebase_messaging được add vào pubspec:
-  //   final messaging = FirebaseMessaging.instance;
-  //   await messaging.requestPermission();
-  //   final token = await messaging.getToken();
-  //   if (token != null) notificationController.initFcm();
-  //   FirebaseMessaging.onMessage.listen(notificationController.handleForeground);
-  //   FirebaseMessaging.onMessageOpenedApp.listen(notificationController.handleTap);
-  runApp(const ProviderScope(child: MeepApp()));
+  runApp(
+    ProviderScope(
+      overrides: [
+        authRepositoryProvider.overrideWithValue(
+          FirebaseAuthRepository(auth: FirebaseAuth.instance),
+        ),
+        // TODO(A/T4/ThienPDM): override userRepositoryProvider khi
+        // FirebaseUserRepository được implement.
+      ],
+      child: const MeepApp(),
+    ),
+  );
 }
 
 class MeepApp extends ConsumerWidget {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
@@ -7,6 +8,7 @@ import 'package:meep/core/router/app_router.dart';
 import 'package:meep/core/theme/app_theme.dart';
 import 'package:meep/features/auth/application/auth_controller.dart';
 import 'package:meep/features/auth/data/firebase_auth_repository.dart';
+import 'package:meep/features/auth/data/firebase_user_repository.dart';
 import 'package:meep/firebase_options.dart';
 
 void main() async {
@@ -19,8 +21,9 @@ void main() async {
         authRepositoryProvider.overrideWithValue(
           FirebaseAuthRepository(auth: FirebaseAuth.instance),
         ),
-        // TODO(A/T4/ThienPDM): override userRepositoryProvider khi
-        // FirebaseUserRepository được implement.
+        userRepositoryProvider.overrideWithValue(
+          FirebaseUserRepository(firestore: FirebaseFirestore.instance),
+        ),
       ],
       child: const MeepApp(),
     ),

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -1024,7 +1024,7 @@ packages:
     source: hosted
     version: "2.0.0"
   mock_exceptions:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: mock_exceptions
       sha256: "6e3e623712d2c6106ffe9e14732912522b565ddaa82a8dcee6cd4441b5984056"

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -69,6 +69,7 @@ dev_dependencies:
   # Testing
   fake_cloud_firestore: ^3.0.3
   firebase_auth_mocks: ^0.14.1
+  mock_exceptions: ^0.8.2
   mocktail: ^1.0.4
 
   # Lints

--- a/apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart
+++ b/apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart
@@ -1,0 +1,170 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/data/firebase_auth_repository.dart';
+import 'package:mock_exceptions/mock_exceptions.dart';
+
+void main() {
+  late MockFirebaseAuth mockAuth;
+  late FirebaseAuthRepository repo;
+
+  setUp(() {
+    mockAuth = MockFirebaseAuth();
+    repo = FirebaseAuthRepository(auth: mockAuth);
+  });
+
+  group('watchUid', () {
+    test('emits null khi chưa sign in', () async {
+      final uid = await repo.watchUid().first;
+      expect(uid, isNull);
+    });
+
+    test('emits uid sau khi sign in', () async {
+      mockAuth = MockFirebaseAuth(
+        mockUser: MockUser(uid: 'uid-alice', email: 'alice@example.com'),
+        signedIn: true,
+      );
+      repo = FirebaseAuthRepository(auth: mockAuth);
+      final uid = await repo.watchUid().first;
+      expect(uid, 'uid-alice');
+    });
+  });
+
+  group('currentUid', () {
+    test('null khi chưa sign in', () {
+      expect(repo.currentUid, isNull);
+    });
+
+    test('trả uid khi đã sign in', () {
+      mockAuth = MockFirebaseAuth(
+        mockUser: MockUser(uid: 'uid-bob'),
+        signedIn: true,
+      );
+      repo = FirebaseAuthRepository(auth: mockAuth);
+      expect(repo.currentUid, 'uid-bob');
+    });
+  });
+
+  group('signUpWithEmail', () {
+    test('thành công với email và password hợp lệ', () async {
+      await expectLater(
+        repo.signUpWithEmail(email: 'new@example.com', password: 'password123'),
+        completes,
+      );
+    });
+
+    test('ném ValidationError khi email đã tồn tại', () async {
+      whenCalling(Invocation.method(#createUserWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'email-already-in-use'));
+      await expectLater(
+        repo.signUpWithEmail(email: 'taken@example.com', password: 'pass123'),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+
+    test('ValidationError message tiếng Việt — email đã dùng', () async {
+      whenCalling(Invocation.method(#createUserWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'email-already-in-use'));
+      Object? caught;
+      try {
+        await repo.signUpWithEmail(
+          email: 'taken@example.com',
+          password: 'pass123',
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<ValidationError>());
+      expect((caught as ValidationError).message, contains('đã được sử dụng'));
+    });
+
+    test('ném ValidationError khi password yếu', () async {
+      whenCalling(Invocation.method(#createUserWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'weak-password'));
+      await expectLater(
+        repo.signUpWithEmail(email: 'a@b.com', password: '123'),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+  });
+
+  group('signInWithEmail', () {
+    test('thành công với creds đúng', () async {
+      mockAuth = MockFirebaseAuth(mockUser: MockUser(uid: 'uid-1'));
+      repo = FirebaseAuthRepository(auth: mockAuth);
+      await expectLater(
+        repo.signInWithEmail(email: 'alice@example.com', password: 'correct'),
+        completes,
+      );
+    });
+
+    test('ném UnauthenticatedError khi sai mật khẩu', () async {
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'wrong-password'));
+      await expectLater(
+        repo.signInWithEmail(email: 'a@b.com', password: 'wrong'),
+        throwsA(isA<UnauthenticatedError>()),
+      );
+    });
+
+    test('UnauthenticatedError message tiếng Việt — sai mật khẩu', () async {
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'wrong-password'));
+      Object? caught;
+      try {
+        await repo.signInWithEmail(email: 'a@b.com', password: 'wrong');
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<UnauthenticatedError>());
+      expect((caught as UnauthenticatedError).message, contains('Mật khẩu'));
+    });
+
+    test('ném UnauthenticatedError khi email không tồn tại', () async {
+      whenCalling(Invocation.method(#signInWithEmailAndPassword, null))
+          .on(mockAuth)
+          .thenThrow(FirebaseAuthException(code: 'user-not-found'));
+      await expectLater(
+        repo.signInWithEmail(email: 'ghost@example.com', password: 'pass'),
+        throwsA(isA<UnauthenticatedError>()),
+      );
+    });
+  });
+
+  group('signOut', () {
+    test('clear session sau khi sign out', () async {
+      mockAuth = MockFirebaseAuth(
+        mockUser: MockUser(uid: 'uid-1'),
+        signedIn: true,
+      );
+      repo = FirebaseAuthRepository(auth: mockAuth);
+      await repo.signOut();
+      expect(repo.currentUid, isNull);
+    });
+  });
+
+  group('sendPasswordResetEmail', () {
+    test('hoàn thành (Firebase luôn success kể cả email không tồn tại)',
+        () async {
+      await expectLater(
+        repo.sendPasswordResetEmail(email: 'anyone@example.com'),
+        completes,
+      );
+    });
+  });
+
+  group('signInWithGoogle', () {
+    test('ném UnimplementedError (implement tại T7)', () async {
+      await expectLater(
+        repo.signInWithGoogle(),
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+  });
+}

--- a/apps/mobile/test/features/auth/data/firebase_user_repository_test.dart
+++ b/apps/mobile/test/features/auth/data/firebase_user_repository_test.dart
@@ -1,0 +1,104 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/auth/data/firebase_user_repository.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+
+void main() {
+  late FakeFirebaseFirestore fakeFirestore;
+  late FirebaseUserRepository repo;
+
+  final alice = UserProfile(
+    uid: 'uid-alice',
+    email: 'alice@example.com',
+    displayName: 'Alice Nguyen',
+    username: 'alice',
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  setUp(() {
+    fakeFirestore = FakeFirebaseFirestore();
+    repo = FirebaseUserRepository(firestore: fakeFirestore);
+  });
+
+  group('createProfile', () {
+    test('tạo /users/{uid} + /usernames/{username} trong cùng batch', () async {
+      await repo.createProfile(alice);
+
+      final userDoc = await fakeFirestore.doc('users/${alice.uid}').get();
+      final usernameDoc =
+          await fakeFirestore.doc('usernames/${alice.username}').get();
+
+      expect(userDoc.exists, isTrue);
+      expect(usernameDoc.exists, isTrue);
+      expect(usernameDoc.data()?['uid'], alice.uid);
+    });
+
+    test('username stored lowercase', () async {
+      final profile = alice.copyWith(username: 'Alice');
+      await repo.createProfile(profile);
+
+      final usernameDoc = await fakeFirestore.doc('usernames/alice').get();
+      expect(usernameDoc.exists, isTrue);
+    });
+
+    test('user doc có đầy đủ required fields', () async {
+      await repo.createProfile(alice);
+      final data =
+          (await fakeFirestore.doc('users/${alice.uid}').get()).data()!;
+      expect(data['uid'], alice.uid);
+      expect(data['email'], alice.email);
+      expect(data['displayName'], alice.displayName);
+      expect(data['username'], alice.username);
+    });
+  });
+
+  group('getProfile', () {
+    test('trả null khi uid không tồn tại', () async {
+      final result = await repo.getProfile('nonexistent');
+      expect(result, isNull);
+    });
+
+    test('trả UserProfile đúng khi tồn tại', () async {
+      await repo.createProfile(alice);
+      final result = await repo.getProfile(alice.uid);
+      expect(result, isNotNull);
+      expect(result!.uid, alice.uid);
+      expect(result.email, alice.email);
+      expect(result.displayName, alice.displayName);
+      expect(result.username, alice.username);
+    });
+  });
+
+  group('isUsernameAvailable', () {
+    test('trả true khi username chưa có', () async {
+      final available = await repo.isUsernameAvailable('newuser');
+      expect(available, isTrue);
+    });
+
+    test('trả false khi username đã được dùng', () async {
+      await repo.createProfile(alice); // username = 'alice'
+      final available = await repo.isUsernameAvailable('alice');
+      expect(available, isFalse);
+    });
+
+    test('case-insensitive — alice và Alice là cùng username', () async {
+      await repo.createProfile(alice);
+      final available = await repo.isUsernameAvailable('Alice');
+      expect(available, isFalse);
+    });
+  });
+
+  group('watchProfile', () {
+    test('emits null khi uid không tồn tại', () async {
+      final profile = await repo.watchProfile('nonexistent').first;
+      expect(profile, isNull);
+    });
+
+    test('emits profile sau khi tạo', () async {
+      await repo.createProfile(alice);
+      final profile = await repo.watchProfile(alice.uid).first;
+      expect(profile?.uid, alice.uid);
+    });
+  });
+}

--- a/apps/mobile/test/features/auth/data/user_profile_test.dart
+++ b/apps/mobile/test/features/auth/data/user_profile_test.dart
@@ -1,0 +1,90 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+
+void main() {
+  group('UserProfile', () {
+    final baseJson = {
+      'uid': 'uid-123',
+      'email': 'alice@example.com',
+      'displayName': 'Alice Nguyen',
+      'username': 'alice',
+      'createdAt': Timestamp.fromDate(DateTime(2026, 1, 1)),
+      'updatedAt': Timestamp.fromDate(DateTime(2026, 1, 2)),
+    };
+
+    test('fromJson với Firestore Timestamp → DateTime', () {
+      final profile = UserProfile.fromJson(baseJson);
+      expect(profile.createdAt, DateTime(2026, 1, 1));
+      expect(profile.updatedAt, DateTime(2026, 1, 2));
+    });
+
+    test('fromJson với String ISO → DateTime', () {
+      final json = {
+        ...baseJson,
+        'createdAt': '2026-01-01T00:00:00.000',
+        'updatedAt': '2026-01-02T00:00:00.000',
+      };
+      final profile = UserProfile.fromJson(json);
+      expect(profile.createdAt, DateTime(2026, 1, 1));
+    });
+
+    test('counter fields default to 0 khi không có trong json', () {
+      final profile = UserProfile.fromJson(baseJson);
+      expect(profile.postCount, 0);
+      expect(profile.friendCount, 0);
+      expect(profile.spaceCount, 0);
+    });
+
+    test('nullable fields trả null khi không có trong json', () {
+      final profile = UserProfile.fromJson(baseJson);
+      expect(profile.avatarUrl, isNull);
+      expect(profile.bio, isNull);
+      expect(profile.dateOfBirth, isNull);
+      expect(profile.phoneNumber, isNull);
+      expect(profile.gender, isNull);
+    });
+
+    test('toJson → Timestamp cho DateTime fields', () {
+      final profile = UserProfile.fromJson(baseJson);
+      final json = profile.toJson();
+      expect(json['createdAt'], isA<Timestamp>());
+      expect(json['updatedAt'], isA<Timestamp>());
+    });
+
+    test('fromJson/toJson round-trip không mất data', () {
+      final original = UserProfile(
+        uid: 'uid-1',
+        email: 'test@example.com',
+        displayName: 'Test User',
+        username: 'testuser',
+        avatarUrl: 'https://example.com/avatar.jpg',
+        bio: 'Hello world',
+        postCount: 5,
+        friendCount: 10,
+        spaceCount: 2,
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 2),
+      );
+      final json = original.toJson();
+      final restored = UserProfile.fromJson(json);
+      expect(restored.uid, original.uid);
+      expect(restored.email, original.email);
+      expect(restored.displayName, original.displayName);
+      expect(restored.username, original.username);
+      expect(restored.avatarUrl, original.avatarUrl);
+      expect(restored.bio, original.bio);
+      expect(restored.postCount, original.postCount);
+      expect(restored.friendCount, original.friendCount);
+      expect(restored.spaceCount, original.spaceCount);
+    });
+
+    test('copyWith chỉ thay đổi field được chỉ định', () {
+      final profile = UserProfile.fromJson(baseJson);
+      final updated = profile.copyWith(bio: 'New bio');
+      expect(updated.bio, 'New bio');
+      expect(updated.uid, profile.uid);
+      expect(updated.email, profile.email);
+    });
+  });
+}

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -56,8 +56,15 @@ service cloud.firestore {
     // ===== /users/{uid} =====
     match /users/{uid} {
       allow read: if isAuthed();
-      allow create: if isOwner(uid);
-      allow update: if isOwner(uid);
+      allow create: if isOwner(uid)
+        && request.resource.data.keys().hasAll(['uid', 'email', 'displayName', 'username', 'createdAt'])
+        && request.resource.data.username is string
+        && request.resource.data.username.size() >= 3
+        && request.resource.data.username.size() <= 20
+        && request.resource.data.username.matches('^[a-z0-9_]+$');
+      allow update: if isOwner(uid)
+        && !request.resource.data.diff(resource.data).affectedKeys()
+            .hasAny(['uid', 'createdAt', 'email']);
       allow delete: if false; // use deleteAccount CF
 
       match /private/{docId} {
@@ -77,6 +84,16 @@ service cloud.firestore {
       match /fcmTokens/{tokenId} {
         allow read, write: if isOwner(uid);
       }
+    }
+
+    // ===== /usernames/{username} =====
+    match /usernames/{username} {
+      allow read: if isAuthed();
+      allow create: if isAuthed()
+        && request.resource.data.uid == request.auth.uid;
+      allow delete: if isAuthed()
+        && resource.data.uid == request.auth.uid;
+      allow update: if false;
     }
 
     // ===== /posts/{postId} — combined: Feed + Space + Reaction =====

--- a/firebase/functions/src/firestore.rules.test.ts
+++ b/firebase/functions/src/firestore.rules.test.ts
@@ -82,7 +82,13 @@ describe('/users/{uid}', () => {
   test('owner can create own doc', async () => {
     const alice = uid('alice');
     await assertSucceeds(
-      authed(alice).firestore().doc(`users/${alice}`).set({ displayName: 'Alice' }),
+      authed(alice).firestore().doc(`users/${alice}`).set({
+        uid: alice,
+        email: 'alice@example.com',
+        displayName: 'Alice',
+        username: 'alice',
+        createdAt: new Date(),
+      }),
     );
   });
 
@@ -107,6 +113,149 @@ describe('/users/{uid}', () => {
     await assertFails(
       authed(alice).firestore().doc(`users/${alice}/feed/post1`).set({ postId: 'post1' }),
     );
+  });
+});
+
+// ===== /users/{uid} — field validation (T5) =====
+
+describe('/users/{uid} — field validation', () => {
+  const alice = uid('alice');
+  const validProfile = {
+    uid: uid('alice'),
+    email: 'alice@example.com',
+    displayName: 'Alice Nguyen',
+    username: 'alice',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    postCount: 0,
+    friendCount: 0,
+    spaceCount: 0,
+  };
+
+  test('owner can create with valid fields', async () => {
+    await assertSucceeds(authed(alice).firestore().doc(`users/${alice}`).set(validProfile));
+  });
+
+  test('missing required field — rejected', async () => {
+    // omit displayName to test required field check
+    const { displayName: _, ...missingDisplayName } = validProfile;
+    void _;
+    await assertFails(authed(alice).firestore().doc(`users/${alice}`).set(missingDisplayName));
+  });
+
+  test('username too short (< 3) — rejected', async () => {
+    await assertFails(
+      authed(alice).firestore().doc(`users/${alice}`).set({ ...validProfile, username: 'ab' }),
+    );
+  });
+
+  test('username too long (> 20) — rejected', async () => {
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`users/${alice}`)
+        .set({ ...validProfile, username: 'a'.repeat(21) }),
+    );
+  });
+
+  test('username with uppercase — rejected (must be lowercase)', async () => {
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`users/${alice}`)
+        .set({ ...validProfile, username: 'Alice' }),
+    );
+  });
+
+  test('owner can update non-immutable field', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}`).set(validProfile);
+    });
+    await assertSucceeds(
+      authed(alice).firestore().doc(`users/${alice}`).update({ displayName: 'Alice Updated' }),
+    );
+  });
+
+  test('owner cannot update uid — immutable', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}`).set(validProfile);
+    });
+    await assertFails(
+      authed(alice).firestore().doc(`users/${alice}`).update({ uid: 'different-uid' }),
+    );
+  });
+
+  test('owner cannot update email — immutable', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}`).set(validProfile);
+    });
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`users/${alice}`)
+        .update({ email: 'newemail@example.com' }),
+    );
+  });
+
+  test('delete always denied', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}`).set(validProfile);
+    });
+    await assertFails(authed(alice).firestore().doc(`users/${alice}`).delete());
+  });
+});
+
+// ===== /usernames/{username} (T5) =====
+
+describe('/usernames/{username}', () => {
+  const alice = uid('alice');
+  const bob = uid('bob');
+
+  test('authed user can read any username doc', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc('usernames/alice').set({ uid: alice });
+    });
+    await assertSucceeds(authed(bob).firestore().doc('usernames/alice').get());
+  });
+
+  test('unauthenticated cannot read', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc('usernames/alice').set({ uid: alice });
+    });
+    await assertFails(unauthed().firestore().doc('usernames/alice').get());
+  });
+
+  test('owner can create username doc with matching uid', async () => {
+    await assertSucceeds(
+      authed(alice).firestore().doc('usernames/alice').set({ uid: alice }),
+    );
+  });
+
+  test('cannot create username doc with different uid', async () => {
+    await assertFails(
+      authed(bob).firestore().doc('usernames/alice').set({ uid: alice }),
+    );
+  });
+
+  test('owner can delete own username doc', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc('usernames/alice').set({ uid: alice });
+    });
+    await assertSucceeds(authed(alice).firestore().doc('usernames/alice').delete());
+  });
+
+  test('non-owner cannot delete', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc('usernames/alice').set({ uid: alice });
+    });
+    await assertFails(authed(bob).firestore().doc('usernames/alice').delete());
+  });
+
+  test('update always denied', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc('usernames/alice').set({ uid: alice });
+    });
+    await assertFails(authed(alice).firestore().doc('usernames/alice').update({ uid: bob }));
   });
 });
 

--- a/tasks/todo-auth.md
+++ b/tasks/todo-auth.md
@@ -3,22 +3,23 @@
 > Plan: `docs/plans/2026-05-04-auth.md`
 > Spec: `docs/specs/2026-05-04-auth.md`
 > Tier: T0 · Milestone M1
+> Owner: ThienPDM (toàn bộ module — sample module cho team)
 > Blocked by: —
 
 ---
 
 ## Phase 1 — Setup & Shared
 
-- [ ] **T1** — Firebase init + `main.dart` + `AppRouter` với redirect guard 3 states
-- [ ] **T11** — Shared widgets (`AppPrimaryButton`, `AppBackButton`, `AppGoogleButton`, `AppTextInput`) + design tokens (`app_colors.dart`)
+- [x] **T1** — Firebase init + `main.dart` + `AppRouter` với redirect guard 3 states — PR #165
+- [x] **T11** — Shared widgets (`AppPrimaryButton`, `AppBackButton`, `AppGoogleButton`, `AppTextInput`) + design tokens — PR #157
 
 ---
 
 ## Phase 2 — Data layer
 
 - [ ] **T2** — `UserProfile` model — full schema (auth + profile fields), freezed + TimestampConverter
-- [ ] **T3** — `AuthRepository` abstract (incl. `deleteCurrentUser`, `reauthenticateWithCredential`, `updateEmail`) + `FirebaseAuthRepository` impl
-- [ ] **T4** — `UserRepository` abstract + `FirebaseUserRepository` (atomic batch write users + usernames)
+- [ ] **T3** — `FirebaseAuthRepository` impl (signUp, signIn, Google, signOut, deleteCurrentUser, reauthenticate, updateEmail)
+- [ ] **T4** — `FirebaseUserRepository` (atomic batch write users + usernames)
 - [ ] **T5** — Firestore rules `/users/{uid}` + `/usernames/{username}` + rules tests
 
 ## Checkpoint: Data layer ✓


### PR DESCRIPTION
## Mô tả

Data layer hoàn chỉnh cho Auth module (sample module). Bao gồm model, repositories, rules và full test coverage.

## Các thay đổi

### T2 — UserProfile model tests (`Closes #149`)
- 7 test cases: Timestamp/String conversion, nullable fields, counter defaults, round-trip, copyWith

### T3 — FirebaseAuthRepository (`Closes #149`)
- Implement đầy đủ: signUpWithEmail, signInWithEmail, signOut, sendPasswordResetEmail, deleteCurrentUser
- Error mapping → Vietnamese messages: `UnauthenticatedError`, `ValidationError`, `NetworkError`, `UnexpectedError`
- signInWithGoogle/Apple/reauthenticate/updateEmail → `UnimplementedError` (implement T7)
- Wire `authRepositoryProvider` trong `main.dart`
- 14 test cases với `firebase_auth_mocks` + `mock_exceptions`

### T4 — FirebaseUserRepository (`Refs #150`)
- `createProfile`: atomic batch write `/users/{uid}` + `/usernames/{username}` (lowercase)
- `getProfile`, `isUsernameAvailable`, `watchProfile`
- `UserRepository` abstract: thêm `watchProfile(uid)`
- `currentUserProfileProvider`: wire `UserRepository.watchProfile` (bỏ UnimplementedError)
- Wire `userRepositoryProvider` trong `main.dart`
- 10 test cases với `fake_cloud_firestore`

### T5 — Firestore rules `/users` + `/usernames` (`Closes #150`)
- `/users` create: required fields, username 3–20 ký tự, lowercase `^[a-z0-9_]+$`
- `/users` update: block thay đổi `uid`, `createdAt`, `email` (immutable)
- `/usernames`: read=authed, create=owner uid match, delete=owner, update=denied
- 16 test cases mới + fix test cũ

## Test

```
flutter test test/features/auth/    → 32/32 pass
flutter analyze                     → 0 issues
firebase emulators:exec ...         → 55/55 rules tests pass
npm run lint (functions)            → clean
```

Closes #149
Closes #150