### PR TITLE
chore(claude): nâng cấp config sau AUTH reference architecture

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -143,7 +143,13 @@ pwsh -File scripts/set-issue-status.ps1 -IssueNum <issue-id> -Status "Review"
 
 ## Flutter + Firebase patterns (quick reference)
 
+> **Reference architecture:** `.claude/reference-architectures/auth.md` có 11 patterns chuẩn với file paths cụ thể. Snippets dưới đây là intro — đọc reference khi cần chi tiết / edge cases.
+
 ### Repository pattern
+
+> Full pattern: AUTH reference §2 — abstract + Firebase impl + `_mapXxxError` boundary
+> Files: [auth_repository.dart](../../apps/mobile/lib/features/auth/data/auth_repository.dart), [firebase_auth_repository.dart](../../apps/mobile/lib/features/auth/data/firebase_auth_repository.dart)
+
 ```dart
 abstract class PostRepository {
   Future<Post> createPost({required String caption, required String imageUrl});
@@ -152,10 +158,15 @@ abstract class PostRepository {
 
 class FirestorePostRepository implements PostRepository {
   // All Firebase I/O here. NEVER in widgets/controllers.
+  // try { ... } on FirebaseException catch (e) { throw _mapXxxError(e); }
 }
 ```
 
 ### Riverpod controller
+
+> Full pattern: AUTH reference §4 — `_afterFailure(e)` helper + `clearError()`
+> File: [login_controller.dart](../../apps/mobile/lib/features/auth/application/login_controller.dart)
+
 ```dart
 @riverpod
 class FeedController extends _$FeedController {
@@ -167,6 +178,10 @@ class FeedController extends _$FeedController {
 ```
 
 ### freezed data class
+
+> Full pattern: AUTH reference §1 — folder layout
+> File: [user_profile.dart](../../apps/mobile/lib/features/auth/data/user_profile.dart)
+
 ```dart
 @freezed
 class Post with _$Post {
@@ -183,9 +198,18 @@ class Post with _$Post {
 ```
 
 ### Error model
+
+> Full pattern: AUTH reference §3 — `AppError.fromUnknown` + `OperationCancelledError`
+> File: [app_error.dart](../../apps/mobile/lib/core/error/app_error.dart)
+
 ```dart
 // ✅ Typed AppError — never raw Exception
 if (uid == null) throw const UnauthenticatedError();
+
+// Helper to collapse try-catch boilerplate
+} catch (e) {
+  state = _afterFailure(e);   // uses AppError.fromUnknown internally
+}
 ```
 
 ## Anti-patterns

--- a/.claude/commands/figma-to-flutter.md
+++ b/.claude/commands/figma-to-flutter.md
@@ -1,34 +1,57 @@
 # /figma-to-flutter — Figma → Flutter Widget
 
-> Solo-dev model: HanDHG + NganTNK kiêm Figma + module owner. Skill này guide chuyển 1 Figma node → 1 Flutter widget **clean, không drift design token**.
+> Solo-dev model: HanDHG + NganTNK kiêm Figma + module owner. Skill này guide chuyển 1 Figma node → 1 Flutter widget **clean, match codebase reality, không drift design token**.
 
 ## Core principle
 
-**3-round iteration:** Extract → Verify → Refine. Không pixel-perfect 1 lần.
+**Iterative refinement.** Simple widget (button, text input) → 1-2 rounds. Complex visual (gradient beam, custom painter, multi-layer animation) → có thể 5+ rounds. Đừng ép pixel-perfect 1 lần, cũng đừng stop ép buộc sau 3 rounds.
+
+**Compare with codebase first.** Trước khi generate widget mới, **đọc** `apps/mobile/lib/shared/widgets/` xem widget tương tự đã tồn tại chưa. Vd Figma có "primary button" → kiểm tra `app_primary_button.dart` đã có chưa, dùng/extend thay vì viết mới.
 
 ## Scope (strict)
 
 - ✅ 1 Figma frame = 1 widget Flutter class.
-- ✅ Compose nhiều widget nhỏ thành page ở PR riêng sau.
+- ✅ Extract sub-widget vào `presentation/widgets/` khi dùng ≥ 2 lần trong feature.
+- ✅ Custom visual (gradient, beam, glass effect) → `CustomPainter` nếu SVG quá phức tạp.
 - ❌ KHÔNG generate `MaterialApp`, route config, navigation logic.
 - ❌ KHÔNG generate Riverpod controller / business logic — chỉ `presentation/`.
+- ❌ KHÔNG duplicate widget đã có trong `shared/widgets/` — extend hoặc compose.
+
+## Codebase reality — Meep design system
+
+Meep KHÔNG dùng `Theme.of(context).colorScheme.primary` style đầy đủ Material 3. Codebase dùng **abstract final class tokens** trực tiếp:
+
+```dart
+import 'package:meep/core/theme/app_colors.dart';        // AppColors.bw900, turquoise300, error700
+import 'package:meep/core/theme/app_text_styles.dart';   // AppTextStyles.mdBold, xlBold
+import 'package:meep/core/theme/app_radii.dart';         // AppRadii.pill, circle
+import 'package:meep/core/theme/app_spacing.dart';       // AppSpacing.md (nếu có)
+```
+
+**Reference files:**
+- [`app_colors.dart`](../../apps/mobile/lib/core/theme/app_colors.dart) — turquoise / bw / success / error / warning / info palettes
+- [`app_text_styles.dart`](../../apps/mobile/lib/core/theme/app_text_styles.dart) — xs/sm/md/lg/xl/xl2/xl3 với Regular/SemiBold/Bold variants
+- [`app_radii.dart`](../../apps/mobile/lib/core/theme/app_radii.dart) — sm/md/circle/pill
+
+`Theme.of(context)` chỉ dùng cho `colorScheme.surface`, `appBarTheme` ở `AppBarTheme` config — NOT cho widget styling.
 
 ## Design token gate — STRICT
 
 **Color / font / spacing / radius không có trong `core/theme/` → STOP.** Không inline hex, không hardcode font size.
 
 Quy trình unblock:
-1. Liệt kê token thiếu.
+1. Liệt kê token thiếu (vd `#1A73E8` không match palette nào trong `app_colors.dart`).
 2. Module owner ping leader: "Cần thêm token X vào `core/theme/`".
-3. Leader merge token vào `develop` qua PR riêng (chore branch).
+3. Leader merge token vào `develop` qua **chore branch** PR riêng.
 4. Pull develop → resume.
 
 Lý do: `core/theme/` là shared code — 1 dev tự thêm = drift design system.
 
 ## Pre-flight
 
-- [ ] Đang trên feature branch (KHÔNG develop/deploy).
-- [ ] Read `apps/mobile/lib/core/theme/`: `color_scheme.dart`, `text_theme.dart`, `spacing.dart`, `radii.dart`.
+- [ ] Đang trên feature branch `<type>/<DevName>/<short-desc>` (KHÔNG `develop`/`deploy`).
+- [ ] Read các file theme: `app_colors.dart`, `app_text_styles.dart`, `app_radii.dart`.
+- [ ] Read `shared/widgets/` — có widget similar đã tồn tại chưa?
 - [ ] User đã attach: **Figma node URL** + **PNG @2x hoặc SVG** (không dùng @1x / JPG).
 
 ## Phase 1 — Extract (dual source)
@@ -43,7 +66,7 @@ Output cần: layer tree, Auto-Layout config, color values (hex), text styles, c
 
 ### 1.2 Image "look at"
 
-Đọc PNG/SVG attached để catch visual intent và lỗi MCP (layer ẩn, overlay missing).
+Đọc PNG/SVG attached để catch visual intent và lỗi MCP (layer ẩn, overlay missing, gradient direction).
 
 ### 1.3 Cross-check
 
@@ -58,40 +81,51 @@ MCP 5 children → image phải thấy 5 phần tử. Nếu lệch → STOP, bá
 | Auto-Layout vertical | `Column` |
 | Auto-Layout horizontal | `Row` |
 | Stack (overlap) | `Stack` + `Positioned` |
-| Auto-Layout padding | `Padding(padding: EdgeInsets.all(Spacing.md))` |
-| Item spacing | `SizedBox` token hoặc `Column(spacing: Spacing.sm)` (Flutter 3.27+) |
+| Auto-Layout padding | `Padding(padding: EdgeInsets.all(...))` |
+| Item spacing | `SizedBox(height/width: ...)` |
 | Constraint Stretch | `Expanded` |
 | Constraint Fixed (W,H) | `SizedBox(width: X, height: Y)` |
 | Constraint Hug | default (no wrapper) |
+| Safe-area aware | `SafeArea(child: ...)` |
 
 ### Color
 
 | Figma | Flutter |
 |---|---|
-| Hex `#1A73E8` | Tra `core/theme/color_scheme.dart` → `Theme.of(context).colorScheme.primary` |
+| Hex `#050F10` (bw900) | `AppColors.bw900` |
+| Hex `#C7F7FB` (turquoise300) | `AppColors.turquoise300` |
+| Hex `#FF3D00` (error700) | `AppColors.error700` |
 | Token thiếu | **STOP** — ping leader |
+
+Tra cứu palette trong `app_colors.dart`. KHÔNG dùng `Color(0xFF050F10)` inline.
 
 ### Typography
 
-| Figma | Flutter |
+| Figma style | Flutter |
 |---|---|
-| Style "Headline/Large" | `Theme.of(context).textTheme.headlineLarge` |
-| Custom font size không match style | **STOP** — designer adjust Figma trước |
+| `Nunito Bold 16 / line-height 22` | `AppTextStyles.mdBold` |
+| `Nunito SemiBold 14 / line-height 18` | `AppTextStyles.smSemiBold` |
+| `Nunito Bold 24 / line-height 30` | `AppTextStyles.xlBold` |
+| Override color | `AppTextStyles.mdBold.copyWith(color: AppColors.bw100)` |
+| Font size không match style | **STOP** — designer adjust Figma trước |
 
 ### Spacing & Radius
 
 | Figma | Flutter |
 |---|---|
-| 4/8/16/24/32px | `Spacing.xs/sm/md/lg/xl` |
-| Border radius | `Radii.xs/sm/md/lg` |
-| Value không match scale | **STOP** — propose round, ping leader |
+| Border radius 30 (pill) | `BorderRadius.circular(AppRadii.pill)` |
+| Border radius 22.5 (circle) | `BorderRadius.circular(AppRadii.circle)` |
+| Pixel spacing (16/24/32) | Hardcode pixel OK nếu chưa có `AppSpacing` token (codebase hiện tại) |
 
 ### Component variants
 
 | Figma | Flutter |
 |---|---|
-| Variant "primary/secondary/ghost" | Factory: `Button.primary()`, `Button.secondary()` |
-| Variant "size: sm/md/lg" | Enum: `Button.primary(size: ButtonSize.lg)` |
+| Variant "primary/secondary/ghost" | Enum + state-based styling trong widget class |
+| Variant "size: sm/md/lg" | Constructor params |
+| State Default/Active/Error/Success | Enum như `AppTextInputStatus` |
+
+**Reference variant pattern:** [`app_text_input.dart`](../../apps/mobile/lib/shared/widgets/app_text_input.dart) có 4 enum types + 4 status states.
 
 ## Phase 3 — Validate before generate
 
@@ -99,65 +133,318 @@ Print summary trước khi generate:
 
 ```
 Figma node: <name>
-File: <feature>/presentation/widgets/<widget_name>.dart
+File: <feature>/presentation/<page>.dart hoặc <feature>/presentation/widgets/<widget>.dart
 Layout: Column / Row / Stack
 Children: <count>
 
-Tokens used:    ✅ colorScheme.primary, textTheme.headlineLarge, Spacing.md
-Tokens MISSING: ❌ colorScheme.tertiary (hex #FF6B35) — STOP, ping leader
+Existing widgets reused:
+  ✅ AppPrimaryButton (label, onPressed, isLoading)
+  ✅ AppTextInput (inputType, status, errorText)
+  ✅ AppBackButton
 
-Proceed? (yes / wait for tokens)
+Tokens used:
+  ✅ AppColors.bw900, turquoise300, error700
+  ✅ AppTextStyles.xlBold, mdSemiBold
+  ✅ AppRadii.pill
+
+Tokens MISSING:
+  ❌ Color #1A73E8 — không match palette nào → STOP, ping leader
+
+Custom paint needed:
+  ⚠️ Beam gradient overlay — CustomPainter required (xem IntroBeam pattern)
+
+Animations:
+  ⚠️ Entry stagger + breathing pulse — AnimationController pattern
+
+Proceed? (yes / wait for tokens / discuss with leader)
 ```
 
 ## Phase 4 — Generate widget code
 
-File: `apps/mobile/lib/features/<my-module>/presentation/widgets/<widget_name>.dart`
+### Widget file path
 
-Naming: Figma layer `btn_primary_lg` → class `PrimaryButtonLarge`, file `primary_button_large.dart`.
+| Scope | Path |
+|---|---|
+| Page (1 Figma frame = full screen) | `apps/mobile/lib/features/<module>/presentation/<name>_page.dart` |
+| Feature widget (reused ≥ 2 lần trong feature) | `apps/mobile/lib/features/<module>/presentation/widgets/<name>.dart` |
+| Cross-feature widget (reused ≥ 3 lần ở module khác) | `apps/mobile/lib/shared/widgets/<name>.dart` |
+
+### Naming
+
+| Figma layer | File | Class |
+|---|---|---|
+| `btn_primary_lg` | `app_primary_button.dart` (nếu đặt shared) | `AppPrimaryButton` |
+| `intro_page` | `intro_page.dart` | `IntroPage` |
+| `dialog_forgot_pw` | `forgot_password_dialog.dart` | `ForgotPasswordDialog` |
+
+**Meep convention:** shared widgets prefix `App`, dialogs suffix `Dialog`, pages suffix `Page`.
+
+### Stateless widget skeleton
 
 ```dart
 import 'package:flutter/material.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_radii.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
 
 class <WidgetName> extends StatelessWidget {
   const <WidgetName>({super.key, /* required params */});
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colors = theme.colorScheme;
-    final textStyles = theme.textTheme;
-
     return <root layout>;
   }
 }
 ```
 
-Rules:
-- `const` constructors mandatory.
-- KHÔNG `ref.watch(provider)` trong widget — consume via callback/parameter.
-- KHÔNG async method — pass `VoidCallback onTap`.
-
-### Component with variants — factory pattern
+### Stateful widget skeleton (interactive / animated)
 
 ```dart
-class MeepButton extends StatelessWidget {
-  const MeepButton._({required this.label, required this.onPressed, required this._variant});
+class <WidgetName> extends StatefulWidget {
+  const <WidgetName>({super.key});
 
-  factory MeepButton.primary({required String label, required VoidCallback onPressed}) =>
-      MeepButton._(label: label, onPressed: onPressed, _variant: _Variant.primary);
-
-  factory MeepButton.secondary({...}) => ...;
-
-  final String label;
-  final VoidCallback onPressed;
-  final _Variant _variant;
+  @override
+  State<<WidgetName>> createState() => _<WidgetName>State();
 }
-enum _Variant { primary, secondary, ghost }
+
+class _<WidgetName>State extends State<<WidgetName>> with TickerProviderStateMixin {
+  late final AnimationController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(vsync: this, duration: const Duration(milliseconds: 1000));
+    _ctrl.forward();
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+    // ❌ KHÔNG `ref.read()` trong dispose nếu widget là ConsumerStatefulWidget
+    //    — race với router teardown. Xem AUTH §7.
+  }
+
+  @override
+  Widget build(BuildContext context) { ... }
+}
+```
+
+### ConsumerStatefulWidget (cần state từ Riverpod)
+
+> Full pattern: [AUTH reference §7](../reference-architectures/auth.md) — dispose-safe + clear-on-keystroke
+> File mẫu: [`login_password_page.dart`](../../apps/mobile/lib/features/auth/presentation/login/login_password_page.dart)
+
+```dart
+class XxxPage extends ConsumerStatefulWidget { ... }
+
+class _XxxPageState extends ConsumerState<XxxPage> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();   // ❌ KHÔNG ref.read trong dispose
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(xxxControllerProvider);
+    return AppTextInput(
+      onChanged: (_) {
+        if (ref.read(xxxControllerProvider).errorMessage != null) {
+          ref.read(xxxControllerProvider.notifier).clearError();
+        }
+        setState(() {});
+      },
+      // ...
+    );
+  }
+}
+```
+
+### Component with variants — enum + factory
+
+Reference: [`app_text_input.dart`](../../apps/mobile/lib/shared/widgets/app_text_input.dart)
+
+```dart
+enum AppTextInputType { email, username, name, password }
+enum AppTextInputStatus { normal, active, error, success }
+
+class AppTextInput extends StatefulWidget {
+  const AppTextInput({
+    super.key,
+    required this.inputType,
+    this.status = AppTextInputStatus.normal,
+    // ...
+  });
+
+  final AppTextInputType inputType;
+  final AppTextInputStatus status;
+}
+```
+
+Rules:
+- `const` constructors mandatory.
+- KHÔNG `ref.watch(provider)` trong StatelessWidget — pass via param hoặc callback.
+- KHÔNG async method — pass `VoidCallback onTap`.
+- `Semantics(button: true, label: '...')` cho mọi tap target.
+- Touch target ≥ 48x48 logical pixels (CLAUDE.md a11y rule).
+
+## Phase 4.5 — Custom visual patterns (cho complex Figma)
+
+### CustomPainter cho SVG path / gradient overlay
+
+> Khi nào dùng: Figma có path/shape phức tạp, gradient direction custom, blur layer mà SVG asset không cover hết. Vd: animated background, overlay beam, particle.
+> Reference: [`intro_beam.dart`](../../apps/mobile/lib/features/auth/presentation/widgets/intro_beam.dart)
+
+```dart
+class XxxPainter extends CustomPainter {
+  const XxxPainter({required this.opacity});
+
+  final double opacity;
+
+  Shader _gradient(Size size) {
+    return const LinearGradient(
+      begin: Alignment(1.16, -0.90),
+      end: Alignment(-0.001, 0.41),
+      colors: [Color(0xFF85E9FF), Color(0x3385E9FF)],
+    ).createShader(Rect.fromLTWH(0, 0, size.width, size.height));
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Scale theo viewport — Figma node thường 412x841
+    final sx = size.width / 412;
+    final sy = size.height / 841;
+
+    final path = Path()
+      ..moveTo(400.0 * sx, -85.0 * sy)
+      ..lineTo(513.0 * sx, -44.0 * sy)
+      // ... coords từ Figma SVG export
+      ..close();
+
+    canvas.drawPath(
+      path,
+      Paint()
+        ..shader = _gradient(size)
+        ..blendMode = BlendMode.plus
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 25),
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;  // hoặc compare props
+}
+```
+
+**Khi nào KHÔNG dùng CustomPainter:**
+- Shape đơn giản (rectangle, circle) → `Container(decoration: BoxDecoration(...))`
+- SVG asset có sẵn → `SvgPicture.asset('assets/icons/xxx.svg')`
+- Static image → `Image.asset` / `Image.network`
+
+### Animation patterns
+
+> Reference: [`intro_page.dart`](../../apps/mobile/lib/features/auth/presentation/intro_page.dart) — 3 animation types trong cùng widget
+
+**1. Entry stagger (fade + slide-up cho từng phần tử)**
+
+```dart
+late final AnimationController _entryCtrl;
+
+@override
+void initState() {
+  super.initState();
+  _entryCtrl = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1000),
+  );
+  _entryCtrl.forward();
+}
+
+Widget _stagger({required double start, required double end, required Widget child}) {
+  final anim = CurvedAnimation(
+    parent: _entryCtrl,
+    curve: Interval(start, end, curve: Curves.easeOut),
+  );
+  return FadeTransition(
+    opacity: anim,
+    child: SlideTransition(
+      position: Tween<Offset>(begin: const Offset(0, 0.22), end: Offset.zero).animate(anim),
+      child: child,
+    ),
+  );
+}
+
+// Usage:
+_stagger(start: 0.10, end: 0.60, child: const Logo()),     // Logo: 100ms-600ms
+_stagger(start: 0.25, end: 0.70, child: const Title()),    // Title: 250ms-700ms
+_stagger(start: 0.50, end: 0.90, child: const Button1()),  // Button1: 500ms-900ms
+```
+
+**2. Breathing pulse (loop forever, vd background beam)**
+
+```dart
+late final AnimationController _breathCtrl;
+
+@override
+void initState() {
+  super.initState();
+  _breathCtrl = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 6000),
+  )..repeat(reverse: true);
+}
+
+// Usage:
+AnimatedBuilder(
+  animation: _breathCtrl,
+  builder: (_, __) => IntroBeam(opacity: 0.85 + 0.15 * _breathCtrl.value),
+),
+```
+
+**3. Press feedback (scale + haptic)**
+
+```dart
+class _GlassButtonState extends State<_GlassButton> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (_) {
+        setState(() => _pressed = true);
+        HapticFeedback.lightImpact();   // tactile feedback
+      },
+      onTapUp: (_) => setState(() => _pressed = false),
+      onTapCancel: () => setState(() => _pressed = false),
+      onTap: widget.onTap,
+      child: AnimatedScale(
+        scale: _pressed ? 0.96 : 1.0,
+        duration: Duration(milliseconds: _pressed ? 80 : 220),
+        curve: _pressed ? Curves.easeIn : Curves.easeOutBack,
+        child: ...,
+      ),
+    );
+  }
+}
+```
+
+**Dispose mandatory** cho mọi `AnimationController`:
+```dart
+@override
+void dispose() {
+  _entryCtrl.dispose();
+  _breathCtrl.dispose();
+  super.dispose();
+}
 ```
 
 ## Phase 5 — Generate widget test (mandatory)
 
-File: `apps/mobile/test/features/<my-module>/presentation/widgets/<widget_name>_test.dart`
+> Reference: [`app_text_input_test.dart`](../../apps/mobile/test/shared/widgets/app_text_input_test.dart) — 10 cases trên 1 widget
+
+File: `apps/mobile/test/features/<my-module>/presentation/widgets/<widget_name>_test.dart` hoặc `apps/mobile/test/shared/widgets/<widget_name>_test.dart`
 
 ```dart
 void main() {
@@ -170,11 +457,20 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('finds expected text', (tester) async {
+    testWidgets('shows expected text', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(home: Scaffold(body: <WidgetName>(...))),
       );
       expect(find.text('<expected text>'), findsOneWidget);
+    });
+
+    // Cho variant
+    testWidgets('renders error state correctly', (tester) async {
+      await tester.pumpWidget(MaterialApp(home: Scaffold(body: <WidgetName>(
+        status: <WidgetName>Status.error,
+        errorText: 'Test error',
+      ))));
+      expect(find.text('Test error'), findsOneWidget);
     });
   });
 }
@@ -184,11 +480,12 @@ Mandatory test cases:
 - [ ] Renders without throwing.
 - [ ] No layout overflow.
 - [ ] Critical text/buttons findable.
-- [ ] Tap callbacks invoke (if interactive).
+- [ ] Tap callbacks invoke (nếu interactive).
+- [ ] Variant states render correctly (nếu có enum status).
 
-## Phase 6 — Verify (3-round iteration)
+## Phase 6 — Verify (iterative)
 
-### Round 1 — Automated
+### Round 1 — Automated (mandatory mỗi round)
 
 ```bash
 flutter test test/features/<my-module>/presentation/widgets/<widget_name>_test.dart
@@ -196,30 +493,54 @@ flutter analyze
 dart format --set-exit-if-changed lib/features/<my-module>/presentation/widgets/<widget_name>.dart
 ```
 
+3 lệnh exit 0 → next round. Có warning → fix trước khi proceed.
+
 ### Round 2 — Visual diff
 
-User renders on emulator, screenshots Flutter widget + attaches alongside Figma image. Compare:
+User renders trên emulator / device, screenshot widget + attach alongside Figma image. Compare:
 
 | Element | Figma | Flutter | Match? |
 |---|---|---|---|
 | Layout direction | Column | Column | ✅ |
-| Title font | textTheme.headlineLarge | textTheme.titleLarge | ❌ |
+| Title font | xl Bold | xl Bold | ✅ |
+| Beam gradient angle | -45° from top-right | -50° | ❌ — adjust Alignment |
+| Button press scale | 0.96 | 1.0 (no anim) | ❌ — add AnimatedScale |
 
 Agent fixes specific items, NOT rewrite full widget.
 
-### Round 3 — Refine
+### Round 3+ — Refine for complex visuals
 
-After Round 2 fixes, repeat Round 1 + Round 2.
+Đối với simple widget (button, input) → 1-2 rounds đủ.
+Đối với complex visual (CustomPainter gradient, multi-layer animation) → 5+ rounds OK. Vd IntroPage cần ~28 commits iteration để pixel-perfect.
 
-> 3 rounds vẫn lệch → STOP. Designer review Figma — không ép code match Figma sai.
+**STOP rules:**
+- 3 rounds vẫn lệch ở element SIMPLE (text/layout/color) → designer review Figma, không ép code match Figma sai.
+- 5 rounds vẫn lệch ở element COMPLEX (gradient/painter/animation) → discuss với leader, có thể accept "close enough" với note trong PR.
 
 ## Anti-patterns
 
 | Anti-pattern | Vấn đề |
 |---|---|
 | Inline hex `Color(0xFF1A73E8)` | Drift design system, dark mode vỡ |
-| Hardcode `TextStyle(fontSize: 16)` | Bypass textTheme → inconsistent |
+| `Theme.of(context).colorScheme.primary` cho widget styling | Codebase Meep dùng `AppColors` direct |
+| Hardcode `TextStyle(fontSize: 16)` | Bypass `AppTextStyles` → inconsistent |
 | Generate full screen 1 lần | Risk lệch cao, khó review |
 | Generate widget + Riverpod controller cùng PR | Mix concerns |
-| Auto-add token vào `core/theme` tự động | `core/` là shared code, cần leader gate |
-| Skip widget test | Presentation layer test is mandatory |
+| Auto-add token vào `core/theme` tự động | Shared code cần leader gate |
+| Duplicate widget có sẵn trong `shared/widgets/` | DRY vỡ, drift behavior |
+| Skip widget test | Presentation layer test mandatory |
+| `ref.read()` trong `dispose()` | Race với router teardown — Cannot use ref after disposed |
+| Stop sau 3 rounds khi gradient/painter chưa khớp | Complex visuals cần iterations |
+| Generate `MeepButton` mới khi đã có `AppPrimaryButton` | Naming inconsistency, drift |
+
+## Quick reference — Meep shared widgets có sẵn
+
+| Widget | File | Use case |
+|---|---|---|
+| `AppPrimaryButton` | [`app_primary_button.dart`](../../apps/mobile/lib/shared/widgets/app_primary_button.dart) | CTA button với loading + disabled state |
+| `AppTextInput` | [`app_text_input.dart`](../../apps/mobile/lib/shared/widgets/app_text_input.dart) | Email/username/name/password input với 4 status |
+| `AppGoogleButton` | [`app_google_button.dart`](../../apps/mobile/lib/shared/widgets/app_google_button.dart) | Google Sign-In button (Android only) |
+| `AppBackButton` | [`app_back_button.dart`](../../apps/mobile/lib/shared/widgets/app_back_button.dart) | 40x40 circle back button |
+| `OrDivider` | [`or_divider.dart`](../../apps/mobile/lib/shared/widgets/or_divider.dart) | Horizontal divider với "hoặc" label |
+
+Trước khi tạo widget mới, **đọc file shared widgets đầy đủ** xem có thể reuse / extend không.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -8,6 +8,7 @@ Transform a spec → an ordered list of small verifiable tasks. Each task delive
 
 1. Read the spec at `docs/specs/<feature>.md` (must be approved).
 2. Does the spec have measurable acceptance criteria? If not → go back to `/spec`.
+3. Read [`docs/plans/2026-05-04-auth.md`](../../docs/plans/2026-05-04-auth.md) — reference plan format (Part 1 Contract artifacts, Part 2 Tasks T1-Tn với acceptance criteria + cross-module imports, Part 3 Dependency graph, Part 4 Open questions). Format đã proven qua AUTH — copy structure khi plan module mới.
 
 ## Phase 1 — Analysis (read-only)
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -25,6 +25,7 @@ Override: `--deep` forces full 6 axes regardless of size.
 1. Read spec: `docs/specs/<feature>.md` + `docs/plans/<feature>.md`.
 2. Check commit messages: what did the author intend?
 3. Map changed files to layers (data / application / presentation / config / rules / functions).
+4. So sánh với [reference architecture AUTH](../reference-architectures/auth.md): module có deviate khỏi 11 patterns chuẩn không? Nếu có → có lý do rõ ràng trong PR description hay đang drift?
 
 ## Phase 2 — Run automated checks
 

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -12,6 +12,7 @@ Build a clear spec **before** writing code. Align on requirements, constraints, 
 
 1. Read `docs/specs/` to understand context and prior specs.
 2. `git status --short` — no uncommitted intentional changes.
+3. Read [`docs/specs/2026-05-04-auth.md`](../../docs/specs/2026-05-04-auth.md) — reference spec format (Goal/User stories/Scope/Technical/Security/Testing/Boundaries/Worst path/Risks). Cấu trúc này đã proven qua AUTH module — copy structure khi viết spec module mới.
 
 ## Phase 1 — Discovery (one question at a time)
 

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -2,6 +2,22 @@
 
 > Run this before `/build`. Never start coding without completing this checklist.
 
+## Step 0 — Load reference architecture (NEW module owner only)
+
+Nếu task là implement **module đầu tiên** của dev (vd HanDHG mới bắt đầu Profile, NganTNK mới bắt đầu Camera) → đọc reference trước khi start:
+
+```bash
+cat .claude/reference-architectures/auth.md   # 11 patterns chuẩn
+```
+
+Bookmark file paths của AUTH cho 4 layer:
+- Repository contract: `apps/mobile/lib/features/auth/data/auth_repository.dart`
+- Controller pattern: `apps/mobile/lib/features/auth/application/login_controller.dart`
+- Error model: `apps/mobile/lib/core/error/app_error.dart`
+- Test stratification: `apps/mobile/test/features/auth/` (5 layers)
+
+**Skip Step 0** nếu dev đã thuộc patterns từ module trước. Continue Step 1.
+
 ## Step 1 — Fetch issue details
 
 ```bash

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -130,6 +130,19 @@ test('user cannot read non-friend post', async () => {
 | Data layer (repositories) | ≥ 70% |
 | UI widgets | ≥ 50% |
 
+## Reference — AUTH test stratification
+
+> AUTH module có 142 tests qua 5 layers — copy pattern khi test module mới.
+> Detailed reference: [`.claude/reference-architectures/auth.md`](../reference-architectures/auth.md) §10
+
+| Layer | File mẫu | Tool |
+|---|---|---|
+| Data (Firestore) | [`firebase_user_repository_test.dart`](../../apps/mobile/test/features/auth/data/firebase_user_repository_test.dart) | `fake_cloud_firestore` |
+| Data (Auth) | [`firebase_auth_repository_test.dart`](../../apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart) | `firebase_auth_mocks` + `mock_exceptions` |
+| Application (Controller) | [`login_controller_test.dart`](../../apps/mobile/test/features/auth/application/login_controller_test.dart) | `ProviderContainer` + mock repos |
+| Pure logic | [`orphan_auth_check_test.dart`](../../apps/mobile/test/features/auth/application/orphan_auth_check_test.dart), [`auth_validators_test.dart`](../../apps/mobile/test/core/validators/auth_validators_test.dart) | Direct fn call |
+| Rules | [`firestore.rules.test.ts`](../../firebase/functions/src/firestore.rules.test.ts) | `@firebase/rules-unit-testing` + emulator |
+
 ## Verify before declaring done
 
 ```bash

--- a/.claude/reference-architectures/auth.md
+++ b/.claude/reference-architectures/auth.md
@@ -1,0 +1,375 @@
+# Reference Architecture — AUTH module
+
+> **Vai trò:** AUTH (`apps/mobile/lib/features/auth/`) là **module chuẩn** cho Meep. Mỗi pattern dưới đây có file thật để dev mới đọc + copy.
+> **Mục tiêu:** Khi anh giao module mới (`friend`, `feed`, `post`, ...), dev owner copy structure + chỉnh tên — không phát minh lại pattern.
+> **Last reviewed:** 2026-05-26 (sau PR #170 Round D).
+
+---
+
+## 11 patterns
+
+### 1. Folder layout — feature-first, strict 3 layers
+
+```
+features/<module>/
+├── data/
+│   ├── <model>.dart              # @freezed + json_serializable
+│   ├── <model>.freezed.dart      # generated, commit cùng
+│   ├── <model>.g.dart            # generated, commit cùng
+│   ├── <name>_repository.dart    # abstract — contract leader chốt
+│   └── firebase_<name>_repository.dart   # impl, throws AppError tại boundary
+├── application/
+│   ├── <name>_state.dart         # @freezed state
+│   ├── <name>_controller.dart    # @riverpod NotifierProvider
+│   └── <name>_controller.g.dart  # generated
+└── presentation/
+    ├── <page>_page.dart          # ConsumerStatefulWidget, ref.watch state
+    └── widgets/                  # extract khi ≥ 2 lần reuse trong feature
+```
+
+**Reference files:**
+- [`features/auth/data/user_profile.dart`](../../apps/mobile/lib/features/auth/data/user_profile.dart) — freezed model
+- [`features/auth/data/auth_repository.dart`](../../apps/mobile/lib/features/auth/data/auth_repository.dart) — abstract contract
+- [`features/auth/data/firebase_auth_repository.dart`](../../apps/mobile/lib/features/auth/data/firebase_auth_repository.dart) — Firebase impl
+- [`features/auth/presentation/widgets/forgot_password_dialog.dart`](../../apps/mobile/lib/features/auth/presentation/widgets/forgot_password_dialog.dart) — extracted widget
+
+### 2. Repository pattern — abstract + Firebase impl + error mapping
+
+**Abstract** ([`auth_repository.dart`](../../apps/mobile/lib/features/auth/data/auth_repository.dart)):
+- Method names mô tả intent: `signInWithEmail`, không phải `firebaseSignIn`
+- Doc-string mô tả contract: throws gì, khi nào
+- Trả `void` / typed model — KHÔNG Firebase types
+
+**Implementation** ([`firebase_auth_repository.dart`](../../apps/mobile/lib/features/auth/data/firebase_auth_repository.dart)):
+- `try { firebase op } on FirebaseException catch (e) { throw _mapXxxError(e); }` tại MỌI boundary
+- Private `_mapSignUpError` / `_mapSignInError` / `_mapGenericError` switch trên `e.code` → `AppError` subclass với message **tiếng Việt**
+- Helpers xếp cuối class
+
+```dart
+// snippet from firebase_auth_repository.dart
+AppError _mapSignInError(FirebaseAuthException e) => switch (e.code) {
+      'wrong-password' || 'invalid-credential' =>
+        const UnauthenticatedError(message: 'Mật khẩu không đúng'),
+      'user-not-found' => const UnauthenticatedError(
+          message: 'Không tìm thấy tài khoản với email này',
+        ),
+      'network-request-failed' =>
+        const NetworkError(message: 'Không có kết nối mạng'),
+      _ => UnexpectedError(message: e.message ?? e.code, cause: e),
+    };
+```
+
+### 3. Error model — `AppError` sealed + `fromUnknown` + `OperationCancelledError`
+
+Reference: [`core/error/app_error.dart`](../../apps/mobile/lib/core/error/app_error.dart)
+
+```dart
+sealed class AppError implements Exception { code, message, cause; }
+  ├─ UnauthenticatedError    // sai creds, hết token
+  ├─ ForbiddenError          // không quyền
+  ├─ NotFoundError           // resource không tồn tại
+  ├─ ValidationError         // input invalid
+  ├─ NetworkError            // mạng lỗi
+  ├─ UnexpectedError         // wrap cause unknown
+  └─ OperationCancelledError // user cancel — controller silent dismiss
+
+AppError.fromUnknown(e, {fallback}) → collapse try-catch boilerplate
+```
+
+**Khi nào extend:**
+- Thêm subclass nếu module có error kind khác hẳn (vd `PostError`, `FriendshipError`)
+- Hoặc dùng `code` field để phân biệt trong subclass có sẵn
+
+### 4. Controller pattern — `_afterFailure(e)` helper
+
+Reference: [`features/auth/application/login_controller.dart`](../../apps/mobile/lib/features/auth/application/login_controller.dart)
+
+```dart
+@riverpod
+class XxxController extends _$XxxController {
+  @override
+  XxxState build() => const XxxState(...);
+
+  void clearError() {
+    if (state.errorMessage != null) {
+      state = state.copyWith(errorMessage: null);
+    }
+  }
+
+  Future<void> doSomething() async {
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      await ref.read(repoProvider).operation();
+      state = state.copyWith(isLoading: false, /* success fields */);
+    } catch (e) {
+      state = _afterFailure(e);
+    }
+  }
+
+  /// Reset isLoading + map error (null cho OperationCancelledError = silent).
+  XxxState _afterFailure(Object e, {String fallback = 'Đã có lỗi xảy ra'}) {
+    final err = AppError.fromUnknown(e, fallback: fallback);
+    return state.copyWith(
+      isLoading: false,
+      errorMessage: err is OperationCancelledError ? null : err.message,
+    );
+  }
+}
+```
+
+### 5. DI — `overrideWithValue` trong `main.dart`
+
+Reference: [`features/auth/application/auth_providers.dart`](../../apps/mobile/lib/features/auth/application/auth_providers.dart), [`main.dart`](../../apps/mobile/lib/main.dart)
+
+```dart
+// 1. Provider stub trong feature
+final xxxRepositoryProvider = Provider<XxxRepository>((ref) {
+  throw UnimplementedError(
+    'override in main.dart after Firebase.initializeApp',
+  );
+});
+
+// 2. Override trong main.dart sau Firebase init
+runApp(
+  ProviderScope(
+    overrides: [
+      xxxRepositoryProvider.overrideWithValue(
+        FirebaseXxxRepository(firestore: FirebaseFirestore.instance),
+      ),
+    ],
+    child: const MeepApp(),
+  ),
+);
+```
+
+**Test override pattern** ([`firebase_auth_repository_test.dart`](../../apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart)):
+```dart
+ProviderContainer makeContainer({MockFirebaseAuth? auth}) {
+  return ProviderContainer(
+    overrides: [
+      authRepositoryProvider.overrideWithValue(
+        FirebaseAuthRepository(auth: auth ?? MockFirebaseAuth()),
+      ),
+    ],
+  );
+}
+```
+
+### 6. Router guard — pure function + `_RouterNotifier` listen-to-keepAlive
+
+Reference: [`core/router/app_router.dart`](../../apps/mobile/lib/core/router/app_router.dart), test: [`test/core/router/app_router_test.dart`](../../apps/mobile/test/core/router/app_router_test.dart)
+
+**Tách pure function** để test không cần GoRouter:
+```dart
+String? authRedirect({
+  required bool isLoading,
+  required String? uid,
+  required bool? profileExists,
+  required bool needsProfile,
+  required String location,
+}) {
+  // 5-state machine với early returns
+}
+```
+
+**`_RouterNotifier` no-op listen để keepAlive controllers cần xuyên route transition** (tránh autoDispose mất state):
+```dart
+class _RouterNotifier extends ChangeNotifier {
+  _RouterNotifier(Ref ref) {
+    ref.listen(currentUidProvider, (_, __) => notifyListeners());
+    ref.listen(currentUserProfileProvider, (_, __) => notifyListeners());
+    ref.listen(
+      loginControllerProvider.select((s) => s.needsProfile),
+      (_, __) => notifyListeners(),
+    );
+    // No-op listen — chỉ để keepAlive
+    ref.listen(signUpControllerProvider, (_, __) {});
+  }
+}
+```
+
+### 7. UI page pattern — dispose-safe + clear-on-keystroke
+
+Reference: [`features/auth/presentation/login/login_password_page.dart`](../../apps/mobile/lib/features/auth/presentation/login/login_password_page.dart)
+
+```dart
+class XxxPage extends ConsumerStatefulWidget { ... }
+
+class _XxxPageState extends ConsumerState<XxxPage> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+    // ❌ KHÔNG `ref.read()` trong dispose — race với router teardown
+    //    "Cannot use ref after the widget was disposed"
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(xxxControllerProvider);
+    return AppTextInput(
+      onChanged: (_) {
+        // Clear stale error ngay khi user gõ
+        if (ref.read(xxxControllerProvider).errorMessage != null) {
+          ref.read(xxxControllerProvider.notifier).clearError();
+        }
+        setState(() {});
+      },
+      errorText: state.errorMessage,
+      status: state.errorMessage != null
+          ? AppTextInputStatus.error
+          : AppTextInputStatus.normal,
+    );
+  }
+}
+```
+
+### 8. State model pattern — Freezed với `errorMessage` nullable
+
+Reference: [`features/auth/application/login_state.dart`](../../apps/mobile/lib/features/auth/application/login_state.dart), [`sign_up_state.dart`](../../apps/mobile/lib/features/auth/application/sign_up_state.dart)
+
+```dart
+@freezed
+class XxxState with _$XxxState {
+  const factory XxxState({
+    required SomeEnum step,         // multi-step flow
+    @Default(false) bool isLoading,
+    @Default(false) bool isSuccess,
+    String? errorMessage,           // null = no error, sentinel pattern
+  }) = _XxxState;
+}
+```
+
+### 9. Session lifecycle — `revalidateSession` + orphan listener + keepAlive
+
+Reference: [`features/auth/application/orphan_auth_check.dart`](../../apps/mobile/lib/features/auth/application/orphan_auth_check.dart), [`firebase_auth_repository.dart:157`](../../apps/mobile/lib/features/auth/data/firebase_auth_repository.dart)
+
+**3 layer:**
+
+1. **Startup `revalidateSession()`** — gọi trước `runApp`, dùng `user.reload()` detect account deleted/disabled trên server. Network/timeout → giữ session offline-friendly.
+
+2. **Orphan auth listener** — pure function `checkOrphanAuth()` trong `MeepApp.build`, signOut nếu `uid != null && profile == null && !isActiveFlow`. Check `profileState.isLoading` thay vì `hasValue` (Riverpod 2.5 previousValue quirk).
+
+3. **KeepAlive xuyên route** — `_RouterNotifier` no-op listen `signUpControllerProvider`.
+
+### 10. Test stratification — 5 layers
+
+Reference: `apps/mobile/test/features/auth/`, `firebase/functions/src/firestore.rules.test.ts`
+
+| Layer | Tool | Pattern | Example |
+|---|---|---|---|
+| Data (Firestore) | `fake_cloud_firestore` | Repo CRUD + edge cases | [`firebase_user_repository_test.dart`](../../apps/mobile/test/features/auth/data/firebase_user_repository_test.dart) |
+| Data (Auth) | `firebase_auth_mocks` + `mock_exceptions` | Repo error mapping | [`firebase_auth_repository_test.dart`](../../apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart) |
+| Application (Controller) | `ProviderContainer` + mock repos | State transitions success/error | [`login_controller_test.dart`](../../apps/mobile/test/features/auth/application/login_controller_test.dart) |
+| Pure logic | Direct fn call | Validators, router guard, orphan check | [`auth_validators_test.dart`](../../apps/mobile/test/core/validators/auth_validators_test.dart), [`orphan_auth_check_test.dart`](../../apps/mobile/test/features/auth/application/orphan_auth_check_test.dart) |
+| UI Widget | `flutter_test` | Render + interaction | [`app_text_input_test.dart`](../../apps/mobile/test/shared/widgets/app_text_input_test.dart) |
+| Rules | `@firebase/rules-unit-testing` + emulator | owner/friend/stranger/unauth matrix | [`firestore.rules.test.ts`](../../firebase/functions/src/firestore.rules.test.ts) |
+
+**Coverage targets:** business logic ≥ 80%, data ≥ 70%, UI ≥ 50%
+
+### 11. Firestore rules — helpers + per-collection + default deny
+
+Reference: [`firebase/firestore.rules`](../../firebase/firestore.rules), test: [`firestore.rules.test.ts`](../../firebase/functions/src/firestore.rules.test.ts)
+
+```javascript
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Helpers ở đầu
+    function isAuthed() { return request.auth != null; }
+    function isOwner(uid) { return isAuthed() && request.auth.uid == uid; }
+    function isFriend(uid) { ... pairId helper ... }
+
+    // Per-collection rule với explicit allow read/create/update/delete
+    match /users/{uid} {
+      allow read: if isAuthed();
+      allow create: if isOwner(uid)
+        && request.resource.data.keys().hasAll(['uid', 'email', ...])
+        && request.resource.data.username.matches('^[a-z0-9_]+$');
+      allow update: if isOwner(uid)
+        && !request.resource.data.diff(resource.data).affectedKeys()
+            .hasAny(['uid', 'createdAt', 'email', ...]);  // immutable fields
+      allow delete: if false;
+    }
+
+    // Default deny ở cuối — non-negotiable
+    match /{document=**} { allow read, write: if false; }
+  }
+}
+```
+
+**Rules tests mandatory matrix:** owner / friend / stranger / unauthenticated cho mỗi collection có user data.
+
+---
+
+## Workflow patterns đã proven trong AUTH
+
+### Multi-round refactor structure
+
+```
+Discovery → đọc spec + existing code + map files
+  ↓
+Round 1: Core layer (model + repository + error)
+Round 2: UI layer (pages + widgets)
+Round 3: Tests
+Round 4: Verify (format + analyze + test)
+Round N: Bug fix từ device testing
+  ↓
+Final report + commit
+```
+
+Mỗi round: edit → verify analyze + test → only proceed nếu green.
+
+### Pre-PR checklist
+
+```bash
+flutter analyze --no-pub                                              # 0 issues
+dart format --set-exit-if-changed --output none lib test               # clean
+flutter test                                                           # all pass
+(cd firebase/functions && npm test && npm run lint)                    # all pass
+firebase emulators:exec --only firestore "cd functions && npm run test:rules"  # all pass
+```
+
+### Conflict resolution (PR vs develop diverged)
+
+- `git fetch origin develop`
+- `git merge --no-ff origin/develop -X ours` — refactor branch wins text conflicts
+- Spot-check critical files for duplicate/legacy logic merged in (vd `LoginController.confirmPasswordReset` duplicate khi Round C extract)
+- Verify analyze + test
+- Push → PR auto-update mergeable
+
+---
+
+## Khi nào module mới copy từ AUTH
+
+**Bắt buộc** copy patterns cho mọi module có:
+- User-facing data (cần repository pattern + error mapping)
+- Multi-step UI flow (cần controller state pattern + clearError)
+- Firestore collection (cần rules + tests)
+
+**Optional** copy patterns:
+- Native widget (`apps/widget/`) — không cần Riverpod, có pattern riêng
+- Cloud Function trigger — pattern khác (xem `firebase/functions/CLAUDE.md`)
+
+**KHÔNG copy mù:**
+- Session lifecycle (Pattern #9) chỉ apply cho auth module
+- KeepAlive listen (Pattern #6) chỉ cần nếu controller phải sống xuyên route transitions
+
+---
+
+## Caveats — chỗ AUTH chưa hoàn hảo
+
+- `reauthenticateWithCredential` + `updateEmail` còn `UnimplementedError` — Profile/Settings T7 sẽ implement
+- `isEmailAvailable` yêu cầu Firebase Console > **Email Enumeration Protection TẮT** (workaround pre-MVP)
+- In-session account deletion: ~1h delay đến token refresh — chấp nhận edge case
+- Production deploy cần `assetlinks.json` + custom domain (xem ADR-0005)
+
+---
+
+## Khi pattern không khớp module mới
+
+Module có nhu cầu khác AUTH → **đừng ép pattern**. Discuss với leader, viết spec riêng, có thể tạo reference architecture mới (vd `feed.md` cho Feed module pattern).
+
+Nguyên tắc: **AUTH là chuẩn, không phải dogma.** Adapt khi có lý do rõ ràng.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,24 @@ Refs #N hoặc Closes #N
 
 ---
 
+## Reference Architectures
+
+**Module chuẩn của Meep — copy patterns khi tạo module mới.**
+
+| Module | Status | Reference doc | Khi nào copy |
+|---|---|---|---|
+| `auth` | ✅ Ready (PR #170 Round D, 2026-05-26) | [.claude/reference-architectures/auth.md](.claude/reference-architectures/auth.md) | Mọi module có user data + multi-step UI + Firestore collection |
+
+**Khi giao module mới cho dev:**
+1. Leader define spec + contract (xem ADR-0004 §2)
+2. Module owner đọc reference architecture trước khi code
+3. Copy folder layout + repository pattern + controller pattern + test stratification
+4. KHÔNG copy mù — Pattern #9 (session lifecycle) chỉ apply cho auth; Pattern #6 keepAlive chỉ cần khi controller xuyên route transitions
+
+**Khi pattern không khớp:** discuss với leader, có thể viết reference architecture mới (vd `feed.md` cho Feed module). AUTH là chuẩn, không phải dogma.
+
+---
+
 ## Dev Code Standards — Solo-Dev Model
 
 Meep dùng **solo-dev model**: mỗi dev own một module **end-to-end** (data + logic + UI + test). Không tách FE/BE.


### PR DESCRIPTION
## Summary

- Tạo `.claude/reference-architectures/auth.md` — 11 patterns chuẩn từ AUTH module PR #170 với file paths cụ thể để dev mới copy
- Cập nhật root `CLAUDE.md` với section **Reference Architectures**
- Update 6 commands (`/start`, `/build`, `/spec`, `/plan`, `/review`, `/test`) — link đến reference
- Rewrite `/figma-to-flutter` với codebase reality, CustomPainter, Animation patterns, dispose-safe, shared widgets table

## Changes

**Tier A — Reference architecture:**
- `.claude/reference-architectures/auth.md` (new) — 11 patterns + workflow playbook
- `CLAUDE.md` — section Reference Architectures, khi nào copy/adapt
- `/start` — Phase 0: đọc reference khi module mới
- `/build`, `/spec`, `/plan`, `/review`, `/test` — link đến auth.md

**Tier B — Upgrade /figma-to-flutter:**
- `AppColors.xxx` thay vì `Theme.of(context).colorScheme` (codebase reality Meep)
- `AppPrimaryButton` thay vì `MeepButton` example
- New section: CustomPainter (SVG paths, gradient overlay, viewport scaling)
- New section: Animation patterns (entry stagger, breathing pulse, press feedback)
- Bỏ rule cứng "3 rounds → STOP" → adaptive (1-2 simple, 5+ complex)
- Extract pattern: `presentation/widgets/` vs `shared/widgets/` rõ ràng
- Dispose-safe section (no `ref.read` in dispose)
- Quick reference 5 shared widgets có sẵn

## Test plan

- [ ] No code changes — config/docs only
- [ ] Verify `.claude/reference-architectures/auth.md` links đúng file paths (relative)
- [ ] Verify `/figma-to-flutter` patterns match codebase reality

🤖 Generated with [Claude Code](https://claude.com/claude-code)