### PR TITLE
docs(settings): cập nhật spec + plan — review NganTNK 2026-05-28

### DIFF
--- a/docs/plans/2026-05-23-settings.md
+++ b/docs/plans/2026-05-23-settings.md
@@ -46,7 +46,7 @@ Files:
 
 Acceptance criteria:
 - [ ] `blockUser(targetUid)` gọi CF callable `blockUser` — KHÔNG write Firestore trực tiếp (CF Admin SDK bypass rules)
-- [ ] `unblockUser(targetUid)` xóa `/blocks/{currentUid}_{targetUid}` trực tiếp (client delete OK)
+- [ ] `unblockUser(targetUid)` — ⚠️ **blocked by OQ5**: implement sau khi ThienPDM quyết client writes hay CF atomic. Tạm stub `UnimplementedError`.
 - [ ] `isBlocked(uid)` check cả 2 chiều: tồn tại `/blocks/{me}_{uid}` OR `/blocks/{uid}_{me}` → true
 - [ ] `watchBlockedUsers()` query `where('blockerUid', isEqualTo, currentUid)` — chỉ list người mình block
 
@@ -68,14 +68,13 @@ Files:
 - `lib/features/settings/presentation/widgets/space_quick_row.dart` — horizontal scroll Space cards + "Tạo" button (mock pre-M3)
 - `lib/features/settings/presentation/terms_page.dart` — long-scroll static text
 - `lib/features/settings/presentation/privacy_policy_page.dart` — long-scroll static text
-- `lib/features/settings/presentation/privacy_data_page.dart` — static sub-page
 - `test/features/settings/settings_sheet_test.dart` — widget tests: tap avatar → sheet opens, tap Bạn bè → FriendSheet opens, tap Chia sẻ → ShareProfileSheet opens
 
 Acceptance criteria:
 - [ ] Settings sheet trigger: tap avatar góc phải topbar → SettingsSheet slide up
 - [ ] Tap "👥 N người bạn" → đóng SettingsSheet → mở FriendSheet
 - [ ] Tap "↗ Chia sẻ" → ShareProfileSheet với URL `meep://profile/{username}`
-- [ ] SpaceQuickRow pre-M3: mock card placeholder + tap "Tạo" → toast "Tính năng đang phát triển"
+- [ ] SpaceQuickRow: hiện mock cards (pre-M3 data) — tap [Sửa] → navigate Space edit (Space module), tap [Tạo] → navigate Space creation (Space module)
 - [ ] Tap "Thêm tiện ích" → mở WidgetConfirmSheet
 - [ ] Copy link → clipboard + toast "Đã sao chép liên kết" + AppConfig.shareBaseUrl không hardcode
 
@@ -115,15 +114,17 @@ Cross-module imports: `AuthRepository` từ **auth**, `NotificationRepository` t
 Files:
 - `lib/features/settings/presentation/blocked_accounts_page.dart` — list blocked users (Figma `572:4490`, `572:4839`)
 - `lib/features/settings/presentation/block_confirm_dialog.dart` — overlay (Figma `605:1991`) dùng từ `PhotoActionSheet` trong feed module
-- `lib/features/settings/presentation/widget_confirm_sheet.dart` — bottom sheet (Figma `662:3341`) + `requestPinAppWidget()` Android intent
-- `test/features/settings/blocked_accounts_page_test.dart` — widget tests: list hiện đúng, tap "Bỏ chặn" → confirm dialog
+- `lib/features/settings/presentation/widget_confirm_sheet.dart` — bottom sheet (Figma `662:3341`) + `requestPinAppWidget()` Android intent + toast thành công
+- `lib/features/settings/presentation/privacy_data_page.dart` — sub-page với toggle `isSearchable` (⚠️ blocked by OQ6 — chờ ThienPDM thêm field vào UserProfile)
+- `test/features/settings/blocked_accounts_page_test.dart` — widget tests: list hiện đúng, tap "Bỏ chặn" → user bị xoá khỏi danh sách ngay (không có confirm dialog)
 
 Acceptance criteria:
 - [ ] `BlockedAccountsPage` load stream `watchBlockedUsers()` — list avatar + username + "Bỏ chặn" button
-- [ ] Tap "Bỏ chặn" → confirm dialog "Bỏ chặn {username}?" → [Xác nhận] → `unblockUser()` → user removed from list
+- [ ] Tap "Bỏ chặn" → KHÔNG hiện confirm dialog → `unblockUser()` + xoá friendship → user bị xoá khỏi danh sách ngay lập tức (⚠️ blocked by OQ5 — cách implement unblock+unfriend chờ ThienPDM quyết)
 - [ ] `BlockConfirmDialog` (shared với Feed): hiện đúng title/body/note từ spec §Luồng Block user
 - [ ] Block success → button đổi sang "[Đã chặn!]" state (Figma `624:1906`)
-- [ ] Widget confirm sheet: tap [Thêm] → `requestPinAppWidget()` Android API → không có success callback → hiện instructional screen (Figma `693:2617`)
+- [ ] Widget confirm sheet: tap [Thêm] → `requestPinAppWidget()` Android API → toast "Đã thêm tiện ích vào màn hình chờ thành công" (auto-dismiss hoặc user tap [x])
+- [ ] `PrivacyDataPage`: load `isSearchable` từ `/users/{uid}` → hiện toggle — Switch ON/OFF → write `isSearchable` ngay (⚠️ blocked by OQ6)
 
 Cross-module imports: Được dùng bởi **home-camera-feed** (`PhotoActionSheet` gọi `BlockConfirmDialog`)
 
@@ -239,4 +240,8 @@ T5 (CF blockUser) có thể start song song với T1 ngay sau contracts merge.
 
 ## PART 4 — Open questions
 
-Tất cả đã resolved trong spec (`docs/specs/2026-05-23-settings.md`). None blocking.
+> **⚠️ 2 OQ đang block implement — chờ ThienPDM resolve:**
+> - **OQ5** block T1 (`unblockUser` implementation) và T4 (unblock+unfriend flow)
+> - **OQ6** block T4 (`PrivacyDataPage` toggle — cần `isSearchable` field trong `UserProfile`)
+>
+> Chi tiết xem `docs/specs/2026-05-23-settings.md` §Pending — Cần ThienPDM quyết định.

--- a/docs/specs/2026-05-23-settings.md
+++ b/docs/specs/2026-05-23-settings.md
@@ -18,7 +18,8 @@ Cho phép user quản lý tài khoản, quyền riêng tư, widget, space, và t
 - Là user, tôi muốn xem và copy link profile của mình để chia sẻ.
 - Là user, tôi muốn truy cập danh sách bạn bè và space nhanh từ Settings.
 - Là user, tôi muốn thêm Meep Widget vào màn hình chờ Android.
-- Là user, tôi muốn xem và bỏ chặn các tài khoản đã chặn.
+- Là user, tôi muốn xem và bỏ chặn các tài khoản đã chặn ngay lập tức mà không cần xác nhận.
+- Là user, tôi muốn bật/tắt cho phép người khác tìm kiếm tôi bằng username.
 - Là user, tôi muốn đăng xuất an toàn.
 - Là user, tôi muốn xoá tài khoản khi cần (với xác nhận).
 - Là user, tôi muốn xem Điều khoản dịch vụ và Chính sách quyền riêng tư.
@@ -37,7 +38,7 @@ Cho phép user quản lý tài khoản, quyền riêng tư, widget, space, và t
 6. **Tài khoản đã chặn** — danh sách + bỏ chặn
 7. **Block user** — initiated từ `PhotoActionSheet` (feed/photo view), NOT từ Settings
 8. **Report user** — nút có trong `PhotoActionSheet` nhưng **stub only** (show toast "Tính năng sắp có")
-9. **Quyền riêng tư và dữ liệu** — sub-page static content
+9. **Quyền riêng tư và dữ liệu** — sub-page với toggle "Cho phép tìm kiếm bằng username"
 10. **Điều khoản dịch vụ** — long-scroll static text page
 11. **Chính sách quyền riêng tư** — long-scroll static text page
 12. **Đăng xuất** — logout + clear session
@@ -60,10 +61,10 @@ Cho phép user quản lý tài khoản, quyền riêng tư, widget, space, và t
 | Settings (variant 2) | `639:3160` | Same structure, another state |
 | Thêm tiện ích (widget) | `662:3341` | Confirm bottom sheet |
 | Thêm tiện ích (variant) | `678:2321` | Variant state |
-| Sau khi thêm widget | `693:2617` | Screenshot lock screen |
+| Sau khi thêm widget | `693:2617` | ~~Screenshot lock screen~~ — **không dùng**, replaced by toast (2026-05-28) |
 | Tài khoản bị chặn 1 | `572:4490` | Danh sách blocked accounts |
 | Tài khoản bị chặn 2 | `572:4839` | Single blocked user + Bỏ chặn |
-| Quyền riêng tư & dữ liệu | `572:4965` | Static sub-page |
+| Quyền riêng tư & dữ liệu | `572:4965` | Sub-page với toggle tìm kiếm username |
 | Điều khoản dịch vụ | `572:4605` | Long-scroll text |
 | Chính sách QRT | `572:4722` | Long-scroll text |
 | Block bạn (state 1) | `605:1769` | Overlay từ photo view |
@@ -156,14 +157,9 @@ Settings sheet → tap [↗ Chia sẻ]
 Settings sheet → Space section → horizontal scroll các Space card
     ├─ Tap [Sửa] trên card → navigate to Space edit (Space module)
     └─ Tap [Tạo] → navigate to Space creation (Space module)
-
-Empty state (chưa có Space hoặc Space module chưa implement pre-M3):
-    → SpaceQuickRow hiện mock card placeholder
-    → Tap [Tạo] → toast "Tính năng đang phát triển" (stub cho đến M3)
 ```
 
-> ⚠️ Settings chỉ hiện quick-access. Logic tạo/sửa Space thuộc Space module.  
-> Khi Space module chưa implement (pre-M3): dùng mock data + disabled navigation.
+> ⚠️ Settings chỉ hiện quick-access. Logic tạo/sửa Space thuộc Space module.
 
 ---
 
@@ -175,12 +171,14 @@ Settings sheet → tap "Thêm tiện ích"
         Title:  "Thêm vào màn hình chờ?"
         Body:   "Thêm và giữ Widget hoặc ấn Thêm để thêm vào màn hình chờ"
         Preview: [Meep Widget 2 x 2] — hiện avatar friends + "15 người bạn"
-        [Thêm] (turquoise) → mở Android widget picker (system intent)
+        [Thêm] (turquoise) → requestPinAppWidget() Android intent
+                           → widget xuất hiện trên màn hình chờ
+                           → toast "Đã thêm tiện ích vào màn hình chờ thành công"
+                               (auto-dismiss sau vài giây, hoặc user tap [x])
         [Huỷ]             → đóng sheet
-    → Sau khi thêm: hiện confirmation screen (screenshot widget trên lock screen)
 ```
 
-> Android widget picker là system intent — app không control UX sau khi intent được gọi.
+> Android `requestPinAppWidget()` không có success callback — toast hiện ngay sau khi intent được gọi, không chờ xác nhận từ OS.
 
 ---
 
@@ -192,10 +190,30 @@ Settings sheet → tap "Tài khoản đã chặn"
         Title: "Tài khoản bị chặn"
         List: [Avatar] [username] [Bỏ chặn button]
     → Tap [Bỏ chặn]:
-        → Confirm dialog: "Bỏ chặn {username}?"
-        → [Xác nhận] → xoá block record, user quay lại bình thường
-        → [Huỷ] → đóng dialog
+        → KHÔNG hiện confirm dialog
+        → unblockUser() — xoá /blocks/{me}_{targetUid}
+        → đồng thời xoá /friendships/{pairId} nếu tồn tại
+        → user bị xoá khỏi danh sách ngay lập tức
 ```
+
+> **Unblock + unfriend là atomic:** cần CF hoặc Firestore batch — xem OQ5 bên dưới.
+
+---
+
+### Luồng Quyền riêng tư và dữ liệu
+
+```
+Settings sheet → tap "Quyền riêng tư và dữ liệu"
+    → PrivacyDataPage (Figma 572:4965):
+        Toggle: "Cho phép tìm kiếm bằng username"
+            Switch ON  → isSearchable = true
+                       → người khác có thể search username → thêm bạn trực tiếp
+            Switch OFF → isSearchable = false
+                       → ẩn khỏi search results
+                       → chỉ kết bạn được qua link cá nhân
+```
+
+> Trạng thái toggle load từ `/users/{uid}.isSearchable`.
 
 ---
 
@@ -318,9 +336,15 @@ blockId = "{blockerUid}_{blockedUid}"   ← KHÔNG sorted, giữ direction
 > `isBlocked()` helper tự check cả 2 chiều bằng `blockId1` + `blockId2`.  
 > Không có `status` field — existence = blocked. Delete = unblock.
 
-### `/users/{uid}` — không thêm field mới
+### `/users/{uid}` — thêm field `isSearchable`
+
+```
+isSearchable: bool (default: true)
+```
 
 Block list lấy từ `/blocks` collection query `where('blockerUid', isEqualTo: currentUid)`.
+
+> **⚠️ [OQ5] Cần ThienPDM confirm:** thêm `isSearchable: bool` vào freezed model `UserProfile` và contract `/users/{uid}`. Friend search query phải filter `where('isSearchable', isEqualTo: true)` trước khi trả kết quả.
 
 ---
 
@@ -458,7 +482,7 @@ function isBlocked(uid) {
 | Test | Screen |
 |---|---|
 | Settings sheet mở khi tap avatar | `SettingsSheet` |
-| Tap "Bỏ chặn" → confirm dialog hiện | `BlockedAccountsPage` |
+| Tap "Bỏ chặn" → user bị xoá khỏi danh sách ngay, không có confirm dialog | `BlockedAccountsPage` |
 | Tap "Đăng xuất" → confirm dialog hiện | `SettingsSheet` |
 | Tap "Xoá tài khoản" → confirm dialog hiện (đỏ) | `DeleteAccountDialog` |
 | Widget confirm sheet: tap [Thêm] → system intent fired | `WidgetConfirmSheet` |
@@ -502,17 +526,52 @@ function isBlocked(uid) {
 
 ---
 
+## ⚠️ Pending — Cần ThienPDM quyết định
+
+> Ghi chú ngày 2026-05-28 (NganTNK). Hai vấn đề dưới đây block implement T1 và T4 — cần leader resolve trước khi NganTNK code phần liên quan.
+
+### [OQ5] Unblock + unfriend — client writes hay CF atomic?
+
+**Bối cảnh:** Luồng unblock mới (2026-05-28) yêu cầu tap [Bỏ chặn] phải đồng thời:
+1. Xoá `/blocks/{me}_{targetUid}`
+2. Xoá `/friendships/{pairId}` nếu tồn tại
+
+**Vấn đề:** Hiện tại `BlockRepository.unblockUser()` là client delete trực tiếp (Firestore rules `allow delete` cho blocker). Nếu cần atomic với unfriend thì phải dùng CF `unblockUser`.
+
+**Hai hướng:**
+- **A — CF `unblockUser`:** atomic, nhất quán với `blockUser`. Cần thêm CF stub + đổi Firestore rules `allow delete: if false`. Tốn thêm ~1 ngày.
+- **B — 2 client writes sequential:** đơn giản hơn, nhưng nếu write 2 fail thì partial state (block xoá nhưng friendship còn). Acceptable cho MVP?
+
+**Quyết định cần:** A hay B? Nếu A → ThienPDM cần thêm CF stub `unblockUser` vào contract và đổi Firestore rules.
+
+---
+
+### [OQ6] Field `isSearchable` trong `UserProfile` freezed model
+
+**Bối cảnh:** Luồng Quyền riêng tư mới (2026-05-28) có toggle cho phép/tắt tìm kiếm bằng username. Cần field `isSearchable: bool` trong `/users/{uid}`.
+
+**Vấn đề:** Field này chưa có trong freezed model `UserProfile` hiện tại. NganTNK không được tự thêm field vào model của leader (Strict gate rule).
+
+**Việc cần ThienPDM làm:**
+1. Thêm `isSearchable: bool` (default `true`) vào `UserProfile` freezed model.
+2. Thêm field vào Firestore `/users/{uid}` schema.
+3. Thông báo cho module Friend: search query phải filter `where('isSearchable', isEqualTo: true)`.
+
+---
+
 ## Open questions
 
 | # | Câu hỏi | Impact | Status |
 |---|---|---|---|
 | OQ1 | Block ID format sorted hay unsorted? | Data model | ✅ **Resolved:** `{blockerUid}_{blockedUid}` unsorted |
 | OQ2 | Re-auth UX khi xoá tài khoản | UX | ✅ **Resolved:** inline trong `DeleteAccountDialog` step 2 |
-| OQ3 | "Quyền riêng tư và dữ liệu" — static hay có action? | Scope | ✅ **Resolved:** static text page (MVP) |
+| OQ3 | "Quyền riêng tư và dữ liệu" — static hay có action? | Scope | 🔄 **Revised (2026-05-28, NganTNK):** không còn static — có toggle `isSearchable` |
 | OQ4 | Widget 2x2 hiện avatars hay ảnh? | Widget contract | ✅ **Resolved:** deferred to Widget module spec |
+| OQ5 | Unblock + unfriend — client 2 writes hay CF atomic? | Architecture | ⏳ **Cần ThienPDM confirm:** unblock hiện là client delete, nhưng cần đồng thời xoá friendship → nên dùng CF `unblockUser` để atomic, hoặc chấp nhận 2 client writes sequential? |
+| OQ6 | `isSearchable` field trong `UserProfile` freezed model | Contract | ⏳ **Cần ThienPDM thêm:** field `isSearchable: bool` vào `/users/{uid}` + freezed model. Friend search module phải filter theo field này. |
 | OQH1 | Block trigger & menu options | UX | ✅ **Resolved:** `PhotoActionSheet` — Chia sẻ / Messenger / Instagram / Tin nhắn / Báo cáo (stub) / Chặn / Lưu / Xoá |
 | OQH2 | Navigation sau khi block | UX | ✅ **Resolved:** modal đổi sang [Đã chặn!] → tap [Bỏ qua] → về feed (blocked posts hidden) |
-| OQH3 | SpaceQuickRow trước M3 | UX | ✅ **Resolved:** mock card + disabled navigation + toast |
+| OQH3 | SpaceQuickRow trước M3 | UX | 🔄 **Revised (2026-05-28, NganTNK):** không dùng toast — navigate thẳng vào Space module (Sửa/Tạo) |
 | OQH4 | `meep.cam` vs deep link scheme | Content | ✅ **Resolved:** Dùng `AppConfig.shareBaseUrl = 'meep://profile'` (constant, không hardcode). Profile OQ3 đã chốt `meep://profile/{username}` là URL của Meep. Khi có HTTP domain thật (ví dụ `https://meep.cam`) thì đổi 1 chỗ trong `AppConfig`. |
 
 ---
@@ -523,8 +582,8 @@ function isBlocked(uid) {
 |---|---|
 | Copy link | Tap link → clipboard → toast |
 | Block từ photo | Tap [Chặn] → confirm → [Đã chặn!] → feed ẩn posts |
-| Unblock | Settings → Tài khoản đã chặn → [Bỏ chặn] → confirm → user quay lại bình thường |
-| Widget | Tap Thêm tiện ích → confirm sheet → tap [Thêm] → Android widget picker |
+| Unblock | Settings → Tài khoản đã chặn → [Bỏ chặn] → xoá block + friendship ngay, không confirm |
+| Widget | Tap Thêm tiện ích → confirm sheet → tap [Thêm] → widget xuất hiện → toast thành công |
 | Logout | Tap Đăng xuất → confirm → về /intro |
 | Delete account | Confirm → re-auth → CF deleteAccount → về /intro |
 
@@ -537,7 +596,7 @@ function isBlocked(uid) {
 | Delete account `requires-recent-login` | Step 2 hiện error "Vui lòng xác thực lại", không auto-dismiss |
 | Logout khi đang nhận FCM notification | `signOut()` revoke token → notification bị drop; acceptable |
 | Unblock user đã bị xoá tài khoản | Bỏ chặn thành công (xoá doc), không cần user tồn tại |
-| Widget add intent — user cancel | App không nhận callback; `693:2617` không hiện; sheet đóng lại |
+| Widget add intent — user cancel | App không nhận callback; toast vẫn hiện (intent đã gọi); acceptable |
 | Tap [Chặn] trên user đã bị chặn | CF guard: kiểm tra block doc tồn tại → return no-op |
 | Tap [Đăng xuất] offline | `signOut()` vẫn hoạt động locally (Firebase clears local session) |
 
@@ -548,6 +607,6 @@ function isBlocked(uid) {
 - **Cascade delete race condition:** CF dùng batch writes + idempotent check. Resolved bằng design trong Flow Xoá tài khoản.
 - **Re-auth timeout (`requires-recent-login`):** Handled trong flow — step 2 show lại form thay vì crash.
 - **Block + friendship overlap:** Resolved — dùng CF `blockUser` atomic transaction.
-- **Widget system intent:** Android `requestPinAppWidget()` không có success callback. `693:2617` là instructional UI, không phải confirmation từ OS.
+- **Widget system intent:** Android `requestPinAppWidget()` không có success callback — toast hiện ngay sau khi intent được gọi, không chờ xác nhận từ OS.
 - **`isBlocked` read quota:** 2 `exists()` reads/post. Với 20 posts = 40 extra reads/load. Acceptable cho MVP.
 - **OQH4 pending:** `meep.cam` vs `meep.camera` — dùng placeholder `meep.cam/{username}` trong code cho đến khi domain được confirm. Extracted sang constant `AppConfig.shareBaseUrl`.


### PR DESCRIPTION
## Tóm tắt

PR này cập nhật spec và plan của Settings module sau buổi review giữa NganTNK và Kiro (2026-05-28). Không có thay đổi code.

## Thay đổi

**Spec** (`docs/specs/2026-05-23-settings.md`):
- Luồng Space: bỏ toast "đang phát triển" — navigate thẳng vào Space module (Sửa/Tạo)
- Luồng Widget: bỏ instructional screen `693:2617` — thay bằng toast "Đã thêm tiện ích vào màn hình chờ thành công"
- Luồng Unblock: bỏ confirm dialog — tap [Bỏ chặn] xoá block + friendship ngay lập tức
- Quyền riêng tư & dữ liệu: đổi từ static page sang có toggle `isSearchable`
- Thêm 2 user stories mới
- Thêm section **⚠️ Pending** với OQ5 + OQ6 cần ThienPDM quyết định (xem bên dưới)

**Plan** (`docs/plans/2026-05-23-settings.md`):
- T1: `unblockUser` stub `UnimplementedError` chờ OQ5
- T2: bỏ `privacy_data_page.dart` khỏi file list (đã chuyển sang T4), fix SpaceQuickRow acceptance criteria
- T4: cập nhật unblock flow + widget toast + thêm PrivacyDataPage toggle
- PART 4: note rõ OQ5/OQ6 đang block

## Cần ThienPDM quyết định trước khi NganTNK implement

### OQ5 — Unblock + unfriend: client writes hay CF atomic?
Luồng mới yêu cầu tap [Bỏ chặn] phải đồng thời xoá `/blocks/` và `/friendships/`.
- **Hướng A — CF `unblockUser`**: atomic, nhất quán. Cần thêm CF stub + đổi Firestore rules `allow delete: if false`.
- **Hướng B — 2 client writes sequential**: đơn giản hơn, có thể partial state nếu write 2 fail.

### OQ6 — Field `isSearchable` trong `UserProfile`
Cần ThienPDM thêm `isSearchable: bool` (default `true`) vào freezed model + Firestore schema + thông báo Friend module filter theo field này.

Chi tiết đầy đủ trong spec §Pending.

## Test plan
- [ ] Đọc spec §Luồng đầy đủ — kiểm tra tất cả luồng còn nhất quán
- [ ] Đọc plan T1–T8 — kiểm tra acceptance criteria đúng với spec
- [ ] Resolve OQ5 + OQ6 và update spec/plan tương ứng