### PR TITLE
docs(space,widget): cập nhật spec + plan + gate change contracts

### DIFF
--- a/apps/mobile/lib/features/feed/application/feed_controller.dart
+++ b/apps/mobile/lib/features/feed/application/feed_controller.dart
@@ -42,7 +42,10 @@ class FeedController extends _$FeedController {
   @override
   Future<List<Post>> build({
     FeedFilter filter = FeedFilter.all,
+    // filterUid: used with FeedFilter.person — filter by friend's uid
     String? filterUid,
+    // filterSpaceId: used with FeedFilter.space — query feed WHERE spaceId == filterSpaceId
+    String? filterSpaceId,
   }) async {
     // TODO(FE/T3/KhoaLND): implement watchFeed stream
     throw UnimplementedError('FeedController.build — TODO: FE/T3/KhoaLND');

--- a/apps/mobile/lib/features/space/application/space_controller.dart
+++ b/apps/mobile/lib/features/space/application/space_controller.dart
@@ -31,6 +31,8 @@ class SpaceController extends _$SpaceController {
     required String name,
     required String iconEmoji,
     required String colorHex,
+    // friendUids: list of friend uids to invite (max 9 — creator is auto-added, total ≤ 10)
+    required List<String> friendUids,
   }) async {
     // TODO(SP/T2/TBD): call createSpace CF
     throw UnimplementedError('createSpace — TODO: SP/T2/TBD');

--- a/docs/plans/2026-05-23-space.md
+++ b/docs/plans/2026-05-23-space.md
@@ -1,6 +1,6 @@
 # Plan: Space Module
 
-> **Phụ thuộc vào:** Friend — `FriendRepository` (invite members từ friend list), `Friendship` model; Home/Camera/Feed — `PostRepository.createPost()` (thêm `spaceId` param), `FeedScreen` (thêm `spaceId` filter param), `Post` model (thêm `spaceId` field); Chat — `ConversationRepository` (group conversation tạo bởi CF `createSpace`)
+> **Phụ thuộc vào:** Friend — `FriendRepository.watchFriends()`; Home/Camera/Feed — `PostRepository.createPost(spaceId?)`, `FeedScreen(spaceId?)`, `onPostCreated` CF (KhoaLND gọi `spacePostFanOut` helper); Chat — `ConversationRepository` (group conversation tạo bởi CF `createSpace`)
 > **Được phụ thuộc bởi:** (Space là module cuối cùng trong dependency chain T0+)
 > **Spec:** `docs/specs/2026-05-23-space.md`
 > **Tier:** T0+ — Milestone M3
@@ -9,23 +9,28 @@
 
 ## PART 1 — Contract artifacts (ThienPDM merge vào `develop` TRƯỚC khi giao dev)
 
-| File path | Type | Key contents |
-|-----------|------|-------------|
-| `lib/features/space/data/space.dart` | freezed model | `spaceId String`, `name String` (≤30), `iconEmoji String`, `colorHex String` (hex 7 chars), `creatorId String`, `memberCount int`, `memberIds List<String>` (≤10), `createdAt DateTime`, `deletedAt DateTime?` |
-| `lib/features/space/data/space_member.dart` | freezed model | `uid String`, `role SpaceRole` enum (creator/member), `joinedAt DateTime` |
-| `lib/features/space/data/space_repository.dart` | abstract class | `Stream<List<Space>> watchMySpaces(String uid)`, `Future<Space?> getSpace(String spaceId)`, `Future<void> deleteSpace(String spaceId)` |
-| `lib/features/space/application/space_controller.dart` | Riverpod stub | `SpaceState` (mySpaces, currentSpace, isLoading), methods throw `UnimplementedError` |
-| `lib/features/space/presentation/space_create_sheet.dart` | widget stub | 3-step bottom sheet |
-| `lib/features/space/presentation/space_context_bottom_sheet.dart` | widget stub | |
-| `lib/features/space/presentation/widgets/space_list_tile.dart` | widget stub | |
-| `lib/features/space/presentation/widgets/space_context_badge.dart` | widget stub | |
-| `lib/features/feed/data/post.dart` | **gate change** — leader only | Thêm `spaceId String?` field (nếu chưa có) |
-| `lib/features/feed/presentation/home_screen.dart` | **gate change** — leader only | `FeedScreen` nhận `spaceId` param |
-| `firebase/functions/src/index.ts` | CF stubs | `createSpace`, `leaveSpace`, `kickMember`, `transferOwnership`, `onSpaceMemberAdded`, `onSpaceMemberRemoved`, `onSpacePostCreated`, `onSpaceDeleted` |
-| `lib/core/router/app_router.dart` | update | Routes `/space/create`, `/space/:spaceId` |
-| `pubspec.yaml` | update | Thêm `emoji_picker_flutter` (MIT) |
+| File path | Type | Status | Key contents |
+|-----------|------|--------|-------------|
+| `lib/features/space/data/space.dart` | freezed model | ✅ merged (LX10) | `spaceId`, `name` (≤30), `iconEmoji`, `colorHex` (hex 7 chars), `creatorId`, `memberCount`, `memberIds List<String>` (≤10), `createdAt`, `deletedAt?` |
+| `lib/features/space/data/space_member.dart` | freezed model | ✅ merged (LX10) | `uid`, `role SpaceRole` (creator/member), `joinedAt` |
+| `lib/features/space/data/space_repository.dart` | abstract class | ✅ merged (LX10) | `watchMySpaces(uid)`, `getSpace(spaceId)`, `deleteSpace(spaceId)` |
+| `lib/features/space/application/space_controller.dart` | Riverpod stub + gate change | ✅ stub có `friendUids`; ❌ `currentSpaceProvider` chưa thêm | Stub: `SpaceState`, `createSpace({name, iconEmoji, colorHex, friendUids})`, `leaveSpace`, `kickMember`, `transferOwnership`. Gate change (leader): thêm `currentSpaceProvider` (`@Riverpod(keepAlive:true)`, `Space?`) — watch bởi `CameraSection` (KhoaLND) |
+| `lib/features/space/presentation/space_create_sheet.dart` | widget stub | ✅ stub (TODO SP/T6) | 3-step bottom sheet |
+| `lib/features/space/presentation/space_context_bottom_sheet.dart` | widget stub | ✅ stub (TODO SP/T7) | `spaceId` param |
+| `lib/features/space/presentation/widgets/space_list_tile.dart` | widget stub | ✅ stub (TODO SP/T8) | `spaceId` param |
+| `lib/features/space/presentation/widgets/space_context_badge.dart` | widget stub | ✅ stub (TODO SP/T9) | `spaceId` param |
+| `lib/features/feed/data/post.dart` | gate change | ✅ merged (LX5) | `spaceId String?` field |
+| `lib/features/feed/application/feed_controller.dart` | gate change | ✅ merged | `FeedFilter.space` enum case + `filterSpaceId String?` param trong `build()` |
+| `lib/core/router/app_router.dart` | routes | ✅ wired (LX10) | `/space/create` → `SpaceCreateSheet`, `/space/:spaceId` → `SpaceContextBottomSheet` |
+| `lib/features/feed/presentation/feed_screen.dart` (hoặc `home_screen.dart`) | **gate change** — leader only | ❌ cần thêm | `FeedScreen` nhận `spaceId?` param + pass `filterSpaceId` tới `FeedController` |
+| `firebase/functions/src/space/spacePostFanOut.ts` | CF helper | ❌ ThienPDM implement T9 | `async function spacePostFanOut(post)`: (1) đọc Space members, (2) fan-out `/users/{uid}/feed/{postId}` với `spaceId`, (3) FCM cho members trừ author. Gọi từ `onPostCreated` (KhoaLND) khi `post.spaceId != null` |
+| `pubspec.yaml` | dep | ✅ đã có | `emoji_picker_flutter: ^4.4.0` (MIT) |
 
-> **Gate change cảnh báo:** `Post` model và `FeedScreen` thuộc Feed module. Leader phải gate change này (merge to develop) trước khi Space dev start — không để Space dev tự sửa.
+> **Gate changes còn lại trước T4+5 (#135):**
+> 1. `currentSpaceProvider` stub — ThienPDM thêm vào `space_controller.dart`
+> 2. `FeedScreen(spaceId?)` — ThienPDM gate change vào Feed module
+>
+> **CF Option A (single source of truth):** Không có `onSpacePostCreated` trigger riêng. Space fan-out được ThienPDM implement trong `spacePostFanOut.ts` helper, KhoaLND import + gọi từ bên trong `onPostCreated` khi `spaceId != null`.
 
 ---
 
@@ -43,11 +48,11 @@
 
 Files:
 - `lib/features/space/data/firebase_space_repository.dart` — impl `SpaceRepository`
-- `test/features/space/firebase_space_repository_test.dart` — test: watchMySpaces arrayContains, getSpace, deleteSpace soft delete
+- `test/features/space/firebase_space_repository_test.dart`
 
 Acceptance criteria:
-- [ ] `watchMySpaces(uid)` query `/spaces` `.where('memberIds', arrayContains, uid)` filter `deletedAt == null` — 1 query duy nhất (denormalized memberIds)
-- [ ] `deleteSpace(spaceId)` soft delete: update `deletedAt = serverTimestamp()` — KHÔNG hard delete document
+- [ ] `watchMySpaces(uid)` query `/spaces` `.where('memberIds', arrayContains, uid)` filter `deletedAt == null` — 1 query (denormalized memberIds)
+- [ ] `deleteSpace(spaceId)` soft delete: update `deletedAt = serverTimestamp()` — KHÔNG hard delete
 - [ ] Client KHÔNG create `/spaces` trực tiếp (rule `create: if false`) — chỉ CF Admin SDK
 
 Cross-module imports: None
@@ -64,12 +69,12 @@ Cross-module imports: None
 
 Files:
 - `lib/features/space/application/space_controller.dart` — `SpaceState`, full impl
-- `test/features/space/space_controller_test.dart` — test: createSpace validation, createSpace > 9 friends → error, leaveSpace creator without transfer → error, deleteSpace non-creator → error
+- `test/features/space/space_controller_test.dart`
 
 Acceptance criteria:
-- [ ] `createSpace(name, emoji, color, friendUids)`: validate `name.isNotEmpty`, `friendUids.isNotEmpty`, `friendUids.length ≤ 9` (creator + 9 = max 10) → gọi CF `createSpace`
-- [ ] `leaveSpace(spaceId)`: nếu là creator → throw `AppError("Chọn người quản trị mới trước")` — UI phải xử lý
-- [ ] `deleteSpace(spaceId)`: chỉ creator → update `spaces/{spaceId}.deletedAt = serverTimestamp()` (soft delete) → `onSpaceDeleted` CF tự trigger — non-creator → throw `AppError`
+- [ ] `createSpace({name, iconEmoji, colorHex, friendUids})`: validate `name.isNotEmpty`, `friendUids.length ≤ 9` → gọi CF `createSpace`
+- [ ] `leaveSpace(spaceId)`: nếu là creator → throw `AppError("Chọn người quản trị mới trước")`
+- [ ] `deleteSpace(spaceId)`: chỉ creator → soft delete; non-creator → throw `AppError`
 - [ ] `loadMySpaces()` watch stream từ repository, filter soft-deleted
 
 Cross-module imports: None
@@ -85,69 +90,91 @@ Cross-module imports: None
 | Blocked by | T2 |
 
 Files:
-- `lib/features/space/presentation/space_create_sheet.dart` — 3-step bottom sheet flow
-- `lib/features/space/presentation/widgets/friend_select_step.dart` — search + checkbox list (Figma `269:1193`)
-- `lib/features/space/presentation/widgets/space_config_step.dart` — tên + 3×3 emoji preset grid (Figma `269:1257`)
-- `lib/features/space/presentation/widgets/icon_builder_step.dart` — `emoji_picker_flutter` + color preset (Figma `269:1334`, `596:1601`, `600:3498`)
-- `test/features/space/space_create_sheet_test.dart` — widget tests: "Tiếp tục" disabled khi 0 friend, "Hoàn tất" disabled khi name rỗng, emoji preset tap → selected, back gesture về step trước
+- `lib/features/space/presentation/space_create_sheet.dart`
+- `lib/features/space/presentation/widgets/friend_select_step.dart` — Figma `269:1193`
+- `lib/features/space/presentation/widgets/space_config_step.dart` — Figma `269:1257`
+- `lib/features/space/presentation/widgets/icon_builder_step.dart` — Figma `269:1334`, `596:1601`, `600:3498`
+- `test/features/space/space_create_sheet_test.dart`
 
-Acceptance criteria:
-- [ ] Step 1: search friends, checkbox select, "Tiếp tục" disabled khi 0 chọn; tối đa 9 friends (10 bao gồm creator)
-- [ ] Step 2: preset 8 emoji + 1 "+" button (Figma `269:1257`); "Hoàn tất" disabled khi name rỗng; loading spinner thay button khi tạo
-- [ ] Step 3 (từ "+"): `emoji_picker_flutter` tab + color preset grid (KHÔNG custom hex) → "Xong" → về Step 2 với icon mới
-- [ ] Back gesture Step 2 → Step 1 giữ friends đã chọn
-- [ ] Back gesture Step 3 → Step 2 bỏ thay đổi icon
-- [ ] Create success → đóng sheet, navigate Feed per Space mới tạo
+Acceptance criteria — Step 1 (FriendSelectStep):
+- [ ] Search bar "Tìm kiếm bạn bè"; friend list [avatar][name][checkbox]
+- [ ] Checkbox checked = turquoise circle `#00DEEE` + white checkmark; unchecked = empty circle
+- [ ] Max 9 friends (creator = member thứ 10, tổng ≤ 10) — checkbox thứ 10 disabled
+- [ ] Nút "Tiếp tục →" fill `#39404180`: disabled khi 0 chọn, enabled khi ≥ 1
+- [ ] Back / swipe down → đóng sheet
+
+Acceptance criteria — Step 2 (SpaceConfigStep):
+- [ ] TextField placeholder "Meepsie", max 30 chars
+- [ ] Scrollable preset list: 8 emoji presets + ô "+"
+  - Preset pairs: 👨‍👩‍👧‍👦→`#bfd5ff`, ❤️→`#ffcfbf`, 🎃→`#feebca`, 🐸→`#c4f3d9`, 🌼→`#f9ffc4`, 🐻‍❄️→`#eef2f3`, 🥰→`#fff7ea`, 🫃→`#bfd5ff`
+  - Chọn preset = set cả `iconEmoji` + `colorHex` cùng lúc (paired)
+  - Selected = turquoise checkmark badge góc trên-trái
+  - Ô "+" → navigate Step 3
+- [ ] Nút "Hoàn tất" fill `#00deee`: disabled khi name rỗng → spinner khi tạo → success / error toast
+- [ ] Back → Step 1, giữ friends đã chọn
+
+Acceptance criteria — Step 3 (IconBuilderStep):
+- [ ] Preview circle lớn: hiện emoji + background color hiện tại
+- [ ] Default khi vào từ "+": emoji 😄, background mặc định
+- [ ] 2 tab buttons dưới preview:
+  - 😊 (emoji) → `emoji_picker_flutter` keyboard mở; config: `ViewOrderConfig` category bar ở dưới; search hint "Tìm kiếm biểu tượng"
+  - 🌈 (màu) → overlay "Màu nền"
+- [ ] "Gợi ý" grid: 9 circles hiện emoji hiện tại với 9 màu background — tap = chọn màu đó (emoji không đổi)
+- [ ] Overlay "Màu nền": grid ~20 preset colors (pastel + saturated) + gradient shade slider (chỉnh sắc độ)
+- [ ] Nút "Xong" fill `#00deee` → về Step 2 với icon mới; back → về Step 2, bỏ thay đổi
 
 Cross-module imports: `FriendRepository.watchFriends()` từ **friend**
 
 ---
-**T4 · feat(space): SpaceContextBottomSheet + Camera context switch + SpaceContextBadge**
+**T4 · feat(space): SpaceContextBottomSheet + currentSpaceProvider + SpaceContextBadge**
 
 | | |
 |---|---|
 | Assignee | TBD |
 | Estimate | M (~8h) |
 | Branch | `feat/TBD/space-camera-context` |
-| Blocked by | T2, T3 |
+| Blocked by | T2, T3; gate changes `currentSpaceProvider` + `FeedScreen(spaceId?)` |
 
 Files:
-- `lib/features/space/presentation/space_context_bottom_sheet.dart` — list Spaces + "All friends" option
-- `lib/features/space/presentation/widgets/space_context_badge.dart` — "Đang gửi: [SpaceName]" badge topbar
-- `lib/features/feed/presentation/widgets/camera_section.dart` — update: long-press FriendsButton → SpaceContextBottomSheet; viền viewfinder + nút chụp đổi màu theo `colorHex`
+- `lib/features/space/presentation/space_context_bottom_sheet.dart` — list Spaces + "All friends"
+- `lib/features/space/presentation/widgets/space_context_badge.dart` — "Đang gửi: [SpaceName]"
+- `lib/features/space/application/space_controller.dart` — thêm `currentSpaceProvider`
 
 Acceptance criteria:
-- [ ] Long-press FriendsButton camera topbar → `SpaceContextBottomSheet` (khác với tap FriendsButton = FriendSheet)
-- [ ] Chọn Space → Camera UI: viền viewfinder = `colorHex`, nút chụp = `colorHex`, badge "Đang gửi: [SpaceName]" hiện
-- [ ] Chọn "All friends" → reset Camera về mặc định, badge ẩn
-- [ ] Badge luôn visible khi đang trong Space context (nhắc nhở user tránh gửi nhầm)
+- [ ] `currentSpaceProvider` — `@Riverpod(keepAlive: true)` provider, giá trị là `Space?` (null = All friends)
+- [ ] Long-press FriendsButton camera → `SpaceContextBottomSheet` (khác tap = FriendSheet)
+- [ ] Chọn Space → `currentSpaceProvider` update → Camera UI: viền = `colorHex`, nút chụp = `colorHex`, badge "Đang gửi: [SpaceName]" hiện
+- [ ] Chọn "All friends" → `currentSpaceProvider` = null → Camera reset về mặc định, badge ẩn
+- [ ] Camera badge visible liên tục khi trong Space context
 
-Cross-module imports: `AppCameraController` từ **home-camera-feed** (update selectedSpaceId state)
+> **Leader gate change:** `CameraSection` (Feed module — KhoaLND) cần watch `currentSpaceProvider` + wire long-press. ThienPDM merge gate change trước khi KhoaLND implement T4+5 (#135).
+
+Cross-module imports: `currentSpaceProvider` (Space), `AppCameraController` (home-camera-feed — KhoaLND wire)
 
 ---
-**T5 · feat(space): Feed per Space (FeedFilter.space + FeedScreen spaceId param)**
+**T5 · feat(space): Feed per Space**
 
 | | |
 |---|---|
 | Assignee | TBD |
-| Estimate | S (~4h) |
+| Estimate | S (~2h) |
 | Branch | `feat/TBD/space-feed` |
-| Blocked by | T4 |
+| Blocked by | T4; `FeedScreen(spaceId?)` gate change |
 
 Files:
-- `lib/features/feed/application/feed_controller.dart` — update: `FeedFilter.space(spaceId)` → `.where('spaceId', isEqualTo, spaceId)` trên feed subcollection
-- `lib/features/feed/presentation/home_screen.dart` — update: nhận optional `spaceId` param
+- `lib/features/feed/presentation/home_screen.dart` — **leader gate change**: nhận `spaceId?` param + pass tới `FeedController(filter: FeedFilter.space, filterSpaceId: spaceId)`
 
 Acceptance criteria:
-- [ ] `FeedFilter.space(spaceId)` query `/users/{uid}/feed WHERE spaceId == spaceId` ORDER BY `createdAt DESC`
-- [ ] Feed subcollection docs phải có `spaceId` field (xem Feed module T9 — CF `onPostCreated`)
-- [ ] Navigate từ Space context → `FeedScreen(spaceId: spaceId)` hiện đúng Space posts
-- [ ] **Leader gate change** — file thuộc Feed module, Space dev KHÔNG tự sửa mà phải qua leader
+- [ ] `FeedFilter.space` + `filterSpaceId` đã có trong `FeedController.build()` ✅
+- [ ] `FeedScreen(spaceId: spaceId)` query `/users/{uid}/feed WHERE spaceId == spaceId`
+- [ ] Feed subcollection docs có `spaceId` field (CF `onPostCreated` → `spacePostFanOut.ts` ghi)
+- [ ] Navigate từ Space context → `FeedScreen(spaceId)` hiện đúng Space posts
+- [ ] **Leader gate change** — ThienPDM merge, không để Space dev tự sửa Feed module
 
-Cross-module imports: `FeedController` từ **home-camera-feed**
+Cross-module imports: `FeedController` (home-camera-feed)
 
 ---
-**T6 · feat(space): CF `createSpace` — batch create /spaces + /space_members + group conversation**
+**T6 · feat(space): CF `createSpace`**
 
 | | |
 |---|---|
@@ -158,13 +185,13 @@ Cross-module imports: `FeedController` từ **home-camera-feed**
 
 Files:
 - `firebase/functions/src/space/createSpace.ts` — HTTPS Callable
-- `firebase/functions/test/space/createSpace.test.ts` — test: success flow, > 9 members → error, empty name → error, batch atomic
+- `firebase/functions/test/space/createSpace.test.ts`
 
 Acceptance criteria:
-- [ ] Validate: `name.isNotEmpty`, `memberUids.length + 1 ≤ 10` (creator + members)
-- [ ] Firestore batch (Admin SDK): create `/spaces/{spaceId}` + create `/space_members/{spaceId}/members/{uid}` cho tất cả members (kể cả creator) + create `/conversations/{spaceId}` (type=space, participantIds=memberIds)
-- [ ] `memberIds` array và `space_members` subcollection được sync (cả 2 trong cùng batch)
-- [ ] `memberCount` = `memberUids.length + 1` (creator included)
+- [ ] Validate: `name.isNotEmpty`, `memberUids.length + 1 ≤ 10`
+- [ ] Firestore batch (Admin SDK): `/spaces/{spaceId}` + `/space_members/{spaceId}/members/{uid}` tất cả + `/conversations/{spaceId}` (type=space, participantIds=memberIds)
+- [ ] `memberIds` array + `space_members` subcollection sync trong cùng batch
+- [ ] `memberCount = memberUids.length + 1`
 - [ ] Return `{ success: true, spaceId: string }`
 
 Cross-module imports: None (Admin SDK)
@@ -180,16 +207,15 @@ Cross-module imports: None (Admin SDK)
 | Blocked by | T6 |
 
 Files:
-- `firebase/functions/src/space/leaveSpace.ts` — HTTPS Callable
-- `firebase/functions/src/space/kickMember.ts` — HTTPS Callable (creator only)
-- `firebase/functions/src/space/transferOwnership.ts` — HTTPS Callable (creator only)
-- `firebase/functions/test/space/memberManagement.test.ts` — test: leaveSpace removes member, creator leave without transfer → error, kickMember non-creator → error, transferOwnership updates roles
+- `firebase/functions/src/space/leaveSpace.ts`
+- `firebase/functions/src/space/kickMember.ts`
+- `firebase/functions/src/space/transferOwnership.ts`
+- `firebase/functions/test/space/memberManagement.test.ts`
 
 Acceptance criteria:
-- [ ] `leaveSpace`: xóa `/space_members/{spaceId}/members/{uid}` + update `spaces/{spaceId}.memberIds` (atomic batch); creator với `role == 'creator'` → throw error (phải transfer trước)
-- [ ] `kickMember`: chỉ `creatorId == caller.uid`; xóa member tương tự leaveSpace
-- [ ] `transferOwnership`: update `space_members/{spaceId}/members/{newUid}.role = 'creator'` + `{oldUid}.role = 'member'` + `spaces/{spaceId}.creatorId = newUid` (atomic batch)
-- [ ] Không cho phép kick creator (guard: `targetUid != space.creatorId`)
+- [ ] `leaveSpace`: xóa member + update `memberIds` (atomic batch); creator chưa transfer → throw error
+- [ ] `kickMember`: chỉ `creatorId == caller.uid`; không kick chính creator
+- [ ] `transferOwnership`: update roles + `creatorId` (atomic batch)
 
 Cross-module imports: None
 
@@ -204,58 +230,58 @@ Cross-module imports: None
 | Blocked by | T7 |
 
 Files:
-- `firebase/functions/src/space/onSpaceMemberAdded.ts` — Firestore onCreate `/space_members/{spaceId}/members/{uid}`
-- `firebase/functions/src/space/onSpaceMemberRemoved.ts` — Firestore onDelete
+- `firebase/functions/src/space/onSpaceMemberAdded.ts`
+- `firebase/functions/src/space/onSpaceMemberRemoved.ts`
 
 Acceptance criteria:
-- [ ] `onSpaceMemberAdded`: increment `memberCount` trên `/spaces/{spaceId}` + increment `spaceCount` trên `/users/{uid}`
-- [ ] `onSpaceMemberRemoved`: decrement `memberCount` + decrement `spaceCount`
-- [ ] Idempotent: dùng transaction để tránh double-count
+- [ ] Added: increment `memberCount` + `spaceCount`; Removed: decrement cả 2
+- [ ] Idempotent: dùng transaction
 
 Cross-module imports: None
 
 ---
-**T9 · feat(space): CF `onSpacePostCreated` — FCM fan-out to Space members**
+**T9 · feat(space): `spacePostFanOut.ts` helper — feed fan-out + FCM cho Space posts**
 
 | | |
 |---|---|
-| Assignee | TBD |
+| Assignee | TBD (ThienPDM implement, KhoaLND gọi) |
 | Estimate | S (~4h) |
-| Branch | `feat/TBD/space-cf-post-created` |
+| Branch | `feat/TBD/space-post-fanout` |
 | Blocked by | T6 |
 
 Files:
-- `firebase/functions/src/space/onSpacePostCreated.ts` — Firestore onCreate `/posts/{postId}` WHERE `spaceId != null`
+- `firebase/functions/src/space/spacePostFanOut.ts` — **helper function** (không phải Firestore trigger riêng)
+- `firebase/functions/test/space/spacePostFanOut.test.ts`
+
+> **[Option A — CF single source of truth]** `spacePostFanOut` là helper function, không phải trigger. KhoaLND gọi `await spacePostFanOut(post)` từ bên trong `onPostCreated` (Feed module) khi `post.spaceId != null`. `onPostCreated` vẫn là trigger duy nhất cho `/posts/{postId}`.
 
 Acceptance criteria:
-- [ ] Trigger chỉ khi `post.spaceId != null` (guard ở đầu function)
+- [ ] Export function: `async function spacePostFanOut(post: Post): Promise<void>`
 - [ ] Đọc `/space_members/{spaceId}/members/*` → lấy tất cả member uids
-- [ ] Gửi FCM cho tất cả members (đọc `/users/{uid}/fcmTokens`) — KHÔNG bao gồm author (guard: `uid != authorId`)
-- [ ] Fan-out feed: ghi `/users/{uid}/feed/{postId}` cho tất cả Space members (kể cả author) với `spaceId` field — **đây là nguồn duy nhất fan-out cho Space posts** (Feed module `onPostCreated` skip khi `spaceId != null`)
+- [ ] Fan-out feed: ghi `/users/{uid}/feed/{postId}` với `spaceId` field cho TẤT CẢ Space members (kể cả author)
+- [ ] FCM: gọi Notification helper cho members — **KHÔNG** bao gồm author
+- [ ] Nếu Space không tồn tại hoặc đã deleted → log + return (không throw)
 
-> **Note:** FCM token schema (`/users/{uid}/fcmTokens`) được owned bởi **Notification module** — Space CF chỉ đọc, không write.  
-> **Phân chia rõ ràng với Feed `onPostCreated`:** `onPostCreated` skip khi `spaceId != null`; `onSpacePostCreated` xử lý toàn bộ fan-out (feed + FCM) cho Space posts.
-
-Cross-module imports: None (Admin SDK, đọc schema từ Notification module)
+Cross-module imports: Notification FCM helper (đọc `/users/{uid}/fcmTokens`, không write)
 
 ---
-**T10 · feat(space): CF `onSpaceDeleted` — cleanup space_members + conversation + posts**
+**T10 · feat(space): CF `onSpaceDeleted`**
 
 | | |
 |---|---|
 | Assignee | TBD |
 | Estimate | S (~4h) |
 | Branch | `feat/TBD/space-cf-deleted` |
-| Blocked by | T9 |
+| Blocked by | T8 |
 
 Files:
-- `firebase/functions/src/space/onSpaceDeleted.ts` — Firestore onUpdate `/spaces/{spaceId}` WHERE `deletedAt != null`
+- `firebase/functions/src/space/onSpaceDeleted.ts`
 
 Acceptance criteria:
-- [ ] Trigger khi `deletedAt` chuyển từ null → timestamp (guard: `before.deletedAt == null && after.deletedAt != null`)
+- [ ] Trigger khi `deletedAt` từ null → timestamp
 - [ ] Xóa tất cả `/space_members/{spaceId}/members/*`
-- [ ] Update `/conversations/{spaceId}.status = 'deleted'` (không xóa — giữ lịch sử)
-- [ ] Posts của Space vẫn tồn tại trong `/posts` (không xóa) — chỉ ẩn khỏi feed vì `spaceId` không còn accessible
+- [ ] Update `/conversations/{spaceId}.status = 'deleted'` (không xóa, giữ lịch sử)
+- [ ] Posts không xóa — ẩn tự nhiên vì `isMember()` rule fail
 
 Cross-module imports: None
 
@@ -267,21 +293,21 @@ Cross-module imports: None
 | Assignee | TBD |
 | Estimate | M (~8h) |
 | Branch | `feat/TBD/space-management-ui` |
-| Blocked by | T7 (CFs đã có), T5 (FeedScreen với spaceId context) |
+| Blocked by | T7, T5 |
 
 Files:
-- `lib/features/space/presentation/space_management_sheet.dart` — bottom sheet trigger từ `...` icon khi trong Space context (FeedScreen + spaceId)
-- `lib/features/space/presentation/widgets/leave_space_dialog.dart` — dialog confirm (member thường) + dialog chọn creator mới (nếu là creator)
-- `lib/features/space/presentation/widgets/kick_member_dialog.dart` — list members + confirm kick (chỉ creator thấy)
-- `lib/features/space/presentation/widgets/delete_space_dialog.dart` — confirm xóa Space (chỉ creator)
+- `lib/features/space/presentation/space_management_sheet.dart`
+- `lib/features/space/presentation/widgets/leave_space_dialog.dart`
+- `lib/features/space/presentation/widgets/kick_member_dialog.dart`
+- `lib/features/space/presentation/widgets/delete_space_dialog.dart`
 
 Acceptance criteria:
-- [ ] `...` icon hiện trên FeedScreen khi `spaceId != null` → mở `SpaceManagementSheet`
-- [ ] Member thường: chỉ thấy [Rời khỏi Space] → `LeaveSpaceDialog` → confirm → `SpaceController.leaveSpace()`
-- [ ] Creator: thấy [Rời khỏi Space] + [Xóa Space] + [Kick thành viên]
-- [ ] Creator leave: dialog yêu cầu chọn creator mới trước → `SpaceController.transferOwnership()` → rồi mới `leaveSpace()`
-- [ ] Creator delete: confirm dialog → `SpaceController.deleteSpace()` (soft delete) → navigate về Camera
-- [ ] Kick member: list members (trừ bản thân) → chọn → confirm → CF `kickMember(spaceId, targetUid)`
+- [ ] `...` icon hiện trên FeedScreen khi `spaceId != null`
+- [ ] Member thường: chỉ [Rời khỏi Space] → confirm → `SpaceController.leaveSpace()`
+- [ ] Creator: [Rời khỏi Space] + [Xóa Space] + [Kick thành viên]
+- [ ] Creator leave: dialog chọn creator mới → `transferOwnership()` → `leaveSpace()`
+- [ ] Creator delete: confirm → `deleteSpace()` (soft delete) → navigate về Camera
+- [ ] Kick: list members (trừ bản thân) → confirm → CF `kickMember(spaceId, targetUid)`
 
 Cross-module imports: None
 
@@ -299,34 +325,38 @@ Files:
 - `firebase/functions/test/rules/space.rules.test.ts`
 
 Acceptance criteria:
-- [ ] `/spaces/{id}`: member read ✓, non-member read ✗, unauthenticated ✗
-- [ ] `/spaces/{id}`: client create → ✗ (CF only); creator update ✓; member update ✗
-- [ ] `/space_members/{id}/members/{uid}`: member read ✓; client create/delete → ✗ (CF only)
+- [ ] `/spaces/{id}`: member read ✓, non-member ✗, unauthenticated ✗
+- [ ] `/spaces/{id}`: client create ✗; creator update ✓; member update ✗
+- [ ] `/space_members/{id}/members/{uid}`: member read ✓; client create/delete ✗
 - [ ] `/posts/{id}` với spaceId: Space member read ✓, non-member ✗
 
-Cross-module imports: `isMember(spaceId)` helper, `isCreator(spaceId)` helper từ spec §Security
+Cross-module imports: `isMember(spaceId)`, `isCreator(spaceId)` từ spec §Security
 
 ---
 
 ## PART 3 — Dependency graph
 
 ```
-contracts Part 1 → T1 → T2 → T3 → T4 → T5 → T10b
-contracts Part 1 → T6 → T7 → T8
-                        ↘
-                   T6 → T9 → T10 → T10b → T11
+contracts Part 1 → T1 → T2 → T3 → T4 → T5 ───┐
+                   T1 → T11 (chạy sớm)          ↓
+contracts Part 1 → T6 → T7 ───────────────→ T10b
+                        T7 → T8 → T10 (cleanup, độc lập)
+                   T6 → T9 (song song T7-T8)
 ```
 
-T6 (CF createSpace) có thể chạy song song với T1-T2 (Flutter data layer) ngay sau contracts.  
-T10b (management UI) cần T7 (CFs) và T5 (FeedScreen Space context) xong trước.
+T6 (CF createSpace) chạy song song với T1-T3 (Flutter layer).  
+T9 (`spacePostFanOut`) chạy song song với T7-T8 (cùng blocked by T6).  
+T10 (`onSpaceDeleted`) blocked by T8 — cleanup CF, không block T10b.  
+T10b (management UI) cần T5 (FeedScreen) + T7 (member CFs) — không cần đợi T10.  
+T11 (rules tests) blocked by T1 — chạy song song với CF chain.
 
 ---
 
 ## PART 4 — Open questions
 
-Tất cả đã resolved trong spec (`docs/specs/2026-05-23-space.md`). None blocking.
+Tất cả đã resolved trong spec (`docs/specs/2026-05-23-space.md` OQ1–OQ5). None blocking.
 
-> **Gate changes trước khi Space dev start:**  
-> 1. Leader thêm `spaceId String?` vào `Post` model (`lib/features/feed/data/post.dart`)  
-> 2. Leader thêm `spaceId` param vào `FeedScreen` và update `FeedController` để hỗ trợ `FeedFilter.space(spaceId)`  
-> 3. Leader confirm `emoji_picker_flutter` package đã có trong `pubspec.yaml` (cũng dùng bởi Reaction module)
+> **Checklist gate changes trước khi giao dev T4+5 (#135):**
+> - [ ] `currentSpaceProvider` stub → ThienPDM thêm vào `space_controller.dart`
+> - [ ] `FeedScreen(spaceId?)` → ThienPDM gate change Feed module
+> - [ ] Confirm với KhoaLND: `onPostCreated` sẽ gọi `spacePostFanOut` helper khi `spaceId != null`

--- a/docs/plans/2026-05-23-widget-android.md
+++ b/docs/plans/2026-05-23-widget-android.md
@@ -11,22 +11,24 @@
 
 | File path | Type | Key contents |
 |-----------|------|-------------|
-| `android/app/src/main/kotlin/.../MeepWidget.kt` | AppWidgetProvider stub | Skeleton class, `onUpdate()` throws unimplemented |
-| `android/app/src/main/kotlin/.../WidgetSyncWorker.kt` | Worker stub | `doWork()` returns `Result.success()` immediately |
-| `android/app/src/main/res/layout/meep_widget.xml` | RemoteViews layout stub | Placeholder text only |
-| `android/app/src/main/res/xml/meep_widget_info.xml` | AppWidget metadata | `minWidth/minHeight = 2×2`, `updatePeriodMillis = 1800000` (30 phút — Android thực ra cap ở 30 phút, không 15 phút) |
-| `android/app/src/main/AndroidManifest.xml` | update | Khai báo widget receiver + WorkManager |
-| `lib/features/widget/application/widget_data_service.dart` | Flutter service stub | `updateWidgetData({postId, imageUrl, authorName})` → throws unimplemented |
+| `android/app/src/main/kotlin/.../MeepWidget.kt` | AppWidgetProvider stub | Skeleton class, `onUpdate()` stub |
+| `android/app/src/main/kotlin/.../WidgetDataStore.kt` | SharedPreferences helper stub | Đọc 6 keys: `widget_post_id`, `widget_image_url`, `widget_author_avatar_url`, `widget_caption`, `widget_caption_type`, `widget_last_viewed_at` |
+| `android/app/src/main/kotlin/.../WidgetSyncWorker.kt` | CoroutineWorker stub | `doWork()` returns `Result.success()` immediately |
+| `android/app/src/main/res/layout/meep_widget.xml` | RemoteViews layout stub | Placeholder text only — impl cần thêm ImageView (photo), ImageView (avatar), TextView (caption pill), TextView (count badge) |
+| `android/app/src/main/res/xml/meep_widget_info.xml` | AppWidget metadata | `minWidth/minHeight = 250dp`, `updatePeriodMillis = 900000` (15 phút schedule) |
+| `android/app/src/main/AndroidManifest.xml` | update | Khai báo widget receiver |
+| `lib/features/widget/application/widget_data_service.dart` | Flutter abstract stub | Interface: `updateWidgetData({postId, imageUrl, authorAvatarUrl, caption?, captionType?})`, `recordLastViewedAt()`, `clearData()` |
 | `lib/core/router/app_router.dart` | update | Handle intent extras `action: OPEN_POST, postId: ...` từ widget tap |
 
-> **Lưu ý Android WorkManager:** Minimum interval = 15 phút nhưng Android thường defer. Widget có thể stale tối đa 30+ phút trên devices tiết kiệm pin (Doze mode). Đây là known limitation, document trong README.
+> **Lưu ý WorkManager:** Schedule 15 phút nhưng Android có thể defer do Doze mode. Known limitation, document trong README.
+> **Lưu ý Firebase count():** Yêu cầu `firebase-firestore-ktx ≥ 24.4.0`. Server-side only — không hoạt động offline.
 
 ---
 
 ## PART 2 — Tasks
 
 ---
-**T1 · feat(widget): Android widget layout + AppWidget metadata + AndroidManifest**
+**T1 · feat(widget): Android widget layout + AppWidget metadata + build.gradle deps**
 
 | | |
 |---|---|
@@ -36,63 +38,77 @@
 | Blocked by | contracts Part 1 |
 
 Files:
-- `android/app/src/main/res/layout/meep_widget.xml` — RemoteViews layout: `RelativeLayout` → `ImageView` (ảnh 2×2) + `TextView` (authorName) + placeholder state
-- `android/app/src/main/res/xml/meep_widget_info.xml` — metadata: minWidth 250dp, minHeight 250dp, `previewImage`, `updatePeriodMillis`
-- `android/app/src/main/AndroidManifest.xml` — update: `<receiver android:name=".MeepWidget">` với intent filter + `<meta-data android:name="android.appwidget.provider">`
+- `android/app/src/main/res/layout/meep_widget.xml` — RemoteViews layout đầy đủ:
+  - `ImageView#widget_photo` — fullscreen, centerCrop
+  - `ImageView#widget_avatar` — 40×40dp, tròn (CircleDrawable background), bottom-left
+  - `TextView#widget_caption` — pill bg `#39404166`, cornerRadius 30dp, Nunito SemiBold 14sp, bottom-left cạnh avatar
+  - `TextView#widget_count` — circle bg `#00C9E3`, text trắng Bold 12sp, top-right
+  - `Group#widget_placeholder` — visible khi không có data: Meep logo + "Mở Meep để bắt đầu"
+- `android/app/src/main/res/xml/meep_widget_info.xml` — metadata: minWidth 250dp, minHeight 250dp, `updatePeriodMillis = 900000`
+- `android/app/build.gradle.kts` — thêm deps:
+  - `com.github.bumptech.glide:glide`
+  - `com.google.firebase:firebase-firestore-ktx:24.4.0` (min version cho `count()`)
+  - `com.google.firebase:firebase-auth-ktx`
 
 Acceptance criteria:
-- [ ] Widget 2×2 cells → khai báo đúng `minWidth/minHeight` trong `appwidget-provider` XML
-- [ ] `meep_widget.xml` có 2 states: normal (ImageView + TextView) + placeholder (Meep logo + "Mở Meep để bắt đầu")
-- [ ] Widget khai báo trong `AndroidManifest.xml` với đúng `ACTION_APPWIDGET_UPDATE` intent filter
-- [ ] WorkManager dependency trong `android/app/build.gradle`: `androidx.work:work-runtime-ktx`
-- [ ] Glide dependency trong `build.gradle`: `com.github.bumptech.glide:glide` (hoặc Coil nếu đã có)
+- [ ] Widget 2×2 → khai báo đúng `minWidth/minHeight = 250dp` trong `appwidget-provider` XML
+- [ ] `meep_widget.xml` có đủ 5 views: `widget_photo`, `widget_avatar`, `widget_caption`, `widget_count`, placeholder group
+- [ ] Placeholder group hiện khi normal group bị GONE
+- [ ] Glide, firebase-firestore-ktx (≥24.4.0), firebase-auth-ktx đã add vào `build.gradle.kts`
+- [ ] Kotlin build clean
 
 Cross-module imports: None
 
 ---
-**T2 · feat(widget): MeepWidget.kt — AppWidgetProvider + RemoteViews render + placeholder**
+**T2 · feat(widget): MeepWidget.kt + WidgetDataStore.kt — AppWidgetProvider + RemoteViews render**
 
 | | |
 |---|---|
 | Assignee | TBD |
-| Estimate | M (~8h) |
+| Estimate | M (~6h) |
 | Branch | `feat/TBD/widget-android-provider` |
 | Blocked by | T1 |
 
 Files:
 - `android/app/src/main/kotlin/.../MeepWidget.kt` — full `AppWidgetProvider`
-- `android/app/src/main/kotlin/.../WidgetDataStore.kt` — helper đọc `SharedPreferences` (widget_post_id, widget_image_url, widget_author_name)
+- `android/app/src/main/kotlin/.../WidgetDataStore.kt` — helper đọc SharedPreferences (6 keys)
 
 Acceptance criteria:
-- [ ] `onUpdate()`: đọc `SharedPreferences` → nếu có data → render ảnh + authorName; nếu không có → render placeholder
-- [ ] `updateWidget(context, postId, imageUrl, authorName)` static method: Glide load `imageUrl` → Bitmap → `RemoteViews.setImageViewBitmap()` → `AppWidgetManager.updateAppWidget()`
-- [ ] Placeholder state: Meep logo + "Mở Meep để bắt đầu" text (khi `imageUrl == null` hoặc chưa login)
-- [ ] `AppWidgetManager.updateAppWidget(appWidgetIds, views)` — update tất cả instances đồng thời (nhiều widget trên home screen)
+- [ ] `WidgetDataStore` đọc đúng 6 keys: `widget_post_id`, `widget_image_url`, `widget_author_avatar_url`, `widget_caption`, `widget_caption_type`, `widget_last_viewed_at`
+- [ ] `onUpdate()`: đọc `WidgetDataStore` → nếu có data → render normal state; nếu không có → render placeholder
+- [ ] `updateWidget(context, data, unreadCount)` static method:
+  - Glide load `imageUrl` → fullscreen Bitmap → `setImageViewBitmap(widget_photo)`
+  - Glide load `authorAvatarUrl` + `CircleCrop` → circular Bitmap → `setImageViewBitmap(widget_avatar)`; nếu `authorAvatarUrl == null` → hiện default avatar drawable, không crash
+  - `setTextViewText(widget_caption, caption)` + `setViewVisibility(VISIBLE/GONE)` theo `caption == null`
+  - `setTextViewText(widget_count, formatCount(unreadCount))` + `setViewVisibility(VISIBLE/GONE)` theo `unreadCount == 0`
+  - `formatCount`: 1–9 → số thực, ≥10 → "9+"
+- [ ] `AppWidgetManager.updateAppWidget(appWidgetIds, views)` — update tất cả instances
 
 Cross-module imports: None (Kotlin native)
 
 ---
-**T3 · feat(widget): WidgetSyncWorker.kt — auth check + Firestore query + Glide + RemoteViews update**
+**T3 · feat(widget): WidgetSyncWorker.kt — auth + Firestore query + unread count + Glide + RemoteViews**
 
 | | |
 |---|---|
 | Assignee | TBD |
-| Estimate | M (~8h) |
+| Estimate | L (~10h) |
 | Branch | `feat/TBD/widget-sync-worker` |
 | Blocked by | T2 |
 
 Files:
 - `android/app/src/main/kotlin/.../WidgetSyncWorker.kt` — `CoroutineWorker`, `PeriodicWorkRequest`
-- Cần register WorkManager trong `Application.onCreate()` hoặc Flutter plugin initialization
 
 Acceptance criteria:
-- [ ] **[H7] Auth token KHÔNG lưu SharedPreferences** — Worker gọi `FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()` mỗi lần chạy; nếu `currentUser == null` → update placeholder, return `Result.success()`
-- [ ] Query Firestore (Kotlin): `/users/{currentUid}/feed` ORDER BY `createdAt DESC` LIMIT 1 → lấy `postId` → fetch `/posts/{postId}` → lấy `imageUrl`
-- [ ] Glide download `imageUrl` → cache vào app's files directory → `MeepWidget.updateWidget()` với Bitmap
-- [ ] Network fail → giữ Glide cached image cũ (không crash, không clear widget)
-- [ ] `WorkManager.enqueueUniquePeriodicWork("widget_sync", KEEP, PeriodicWorkRequest)` — không duplicate worker
+- [ ] **[H7]** Auth token KHÔNG lưu SharedPreferences — `FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()` mỗi lần; `currentUser == null` → update placeholder, `Result.success()`
+- [ ] Query `/users/{uid}/feed` ORDER BY `createdAt DESC` LIMIT 1 → fetch `/posts/{postId}` → lấy `imageUrl`, `authorAvatarUrl`, `caption`, `captionType`
+- [ ] Đọc `widget_last_viewed_at` từ SharedPreferences → query `/users/{uid}/feed WHERE createdAt > lastViewedAt` dùng `count()` → `unreadCount`; nếu query fail (offline) → `unreadCount = 0`, không crash
+- [ ] Glide download `imageUrl` + `authorAvatarUrl` (CircleCrop) → cache internal storage
+- [ ] `MeepWidget.updateWidget(context, data, unreadCount)` với đúng data
+- [ ] Network fail → giữ Glide cached image cũ, không crash, không clear widget
+- [ ] `WorkManager.enqueueUniquePeriodicWork("widget_sync", KEEP, PeriodicWorkRequest(15 phút))` — không duplicate worker
 
-Cross-module imports: None (Kotlin native + Firebase SDK cho Android)
+Cross-module imports: None (Kotlin native + Firebase SDK)
 
 ---
 **T4 · feat(widget): Deep link tap — PendingIntent + MainActivity + MethodChannel + GoRouter**
@@ -106,20 +122,20 @@ Cross-module imports: None (Kotlin native + Firebase SDK cho Android)
 
 Files:
 - `android/app/src/main/kotlin/.../MeepWidget.kt` — update: `setOnClickPendingIntent()` với extras `action=OPEN_POST, postId=...`
-- `android/app/src/main/kotlin/.../MainActivity.kt` — update: handle `intent.action == "OPEN_POST"` → call `MethodChannel` với `postId`
-- `lib/core/router/app_router.dart` — update: handle method channel call → `GoRouter.go('/feed?highlight=$postId')`
+- `android/app/src/main/kotlin/.../MainActivity.kt` — update: `onNewIntent()` → call `MethodChannel("meep/widget")` với `postId`
+- `lib/core/router/app_router.dart` — update: nhận MethodChannel call → `GoRouter.go('/feed?highlight=$postId')`
 
 Acceptance criteria:
-- [ ] Tap widget → `PendingIntent` với `Intent(context, MainActivity::class.java).putExtra("action", "OPEN_POST").putExtra("postId", postId)`
-- [ ] `MainActivity.onNewIntent()` override: xử lý cả foreground + background app resume
-- [ ] `MethodChannel("meep/widget")` Flutter side nhận `postId` → `GoRouter.go('/feed?highlight=$postId')`
+- [ ] Tap widget (normal state) → `PendingIntent` với `Intent.putExtra("action", "OPEN_POST").putExtra("postId", postId)`
+- [ ] Tap widget (placeholder state, `postId == null`) → mở app tại Home
+- [ ] `MainActivity.onNewIntent()` xử lý cả foreground + background resume
+- [ ] Flutter `MethodChannel("meep/widget")` nhận `postId` → `GoRouter.go('/feed?highlight=$postId')`
 - [ ] Post đã xóa → navigate Home + toast "Khoảnh khắc này không còn tồn tại"
-- [ ] Widget tap khi `postId == null` (placeholder state) → mở app tại Home
 
 Cross-module imports: `FeedController` từ **home-camera-feed** (scroll đến postId)
 
 ---
-**T5 · feat(widget): WidgetDataService (Flutter) — SharedPreferences write + trigger update**
+**T5 · feat(widget): WidgetDataService (Flutter) — SharedPreferences write + lifecycle hook**
 
 | | |
 |---|---|
@@ -129,14 +145,15 @@ Cross-module imports: `FeedController` từ **home-camera-feed** (scroll đến 
 | Blocked by | T4 |
 
 Files:
-- `lib/features/widget/application/widget_data_service.dart` — full impl
-- Gọi `updateWidgetData()` từ `FeedController` sau mỗi lần fetch feed mới
+- `lib/features/widget/application/widget_data_service.dart` — full impl của abstract interface
+- `lib/core/router/app_router.dart` hoặc `main.dart` — wire `recordLastViewedAt()` vào `AppLifecycleState.resumed`
 
 Acceptance criteria:
-- [ ] `updateWidgetData({latestPostId, latestImageUrl, authorName})`: lưu 3 keys vào `SharedPreferences` + gọi `MethodChannel("meep/widget").invokeMethod("updateWidget")`
-- [ ] `MethodChannel` trigger Kotlin side → `MeepWidget.onUpdate()` → re-render
-- [ ] User logout → `WidgetDataService.clearWidgetData()` → SharedPreferences xóa tất cả widget keys → widget hiện placeholder
-- [ ] `shared_preferences` package đã có (cũng dùng bởi Profile notification toggle — không add 2 lần)
+- [ ] `updateWidgetData({postId, imageUrl, authorAvatarUrl, caption?, captionType?})`: lưu đúng 5 keys vào SharedPreferences + gọi `MethodChannel("meep/widget").invokeMethod("updateWidget")`
+- [ ] `recordLastViewedAt()`: ghi `widget_last_viewed_at = DateTime.now().millisecondsSinceEpoch` vào SharedPreferences — được gọi mỗi khi `AppLifecycleState.resumed`
+- [ ] `clearData()`: xóa tất cả `widget_*` keys → widget hiện placeholder
+- [ ] `updateWidgetData()` được gọi từ `FeedController` (KhoaLND) sau mỗi lần fetch feed mới
+- [ ] `clearData()` được gọi khi user logout
 
 Cross-module imports: `FeedController` từ **home-camera-feed** (gọi `updateWidgetData` sau fetch)
 
@@ -151,16 +168,18 @@ Cross-module imports: `FeedController` từ **home-camera-feed** (gọi `updateW
 | Blocked by | T3 |
 
 Files:
-- `android/app/src/test/kotlin/.../WidgetSyncWorkerTest.kt` — JUnit + Robolectric (hoặc mock)
-- `docs/plans/widget-smoke-tests.md` — manual test checklist
+- `android/app/src/test/kotlin/.../WidgetSyncWorkerTest.kt` — JUnit + mock
 
 Acceptance criteria:
-- [ ] `WidgetSyncWorker` không có token → return `Result.success()`, không crash, không throw
+- [ ] `WidgetSyncWorker` không có token → `Result.success()`, không crash, không throw
 - [ ] `WidgetSyncWorker` có token → mock Firestore → `MeepWidget.updateWidget()` được gọi với đúng data
+- [ ] `WidgetSyncWorker` có token, `authorAvatarUrl == null` → Glide load null → không crash, hiện default avatar
+- [ ] `WidgetSyncWorker` có token, `count()` query fail → `unreadCount = 0`, widget vẫn update bình thường, không crash
 - [ ] Manual smoke: widget thêm được vào home screen từ Android widget picker ✓
-- [ ] Manual smoke: widget hiện ảnh mới nhất sau khi đăng ảnh từ app ✓
+- [ ] Manual smoke: widget hiện ảnh mới nhất + avatar + caption sau khi đăng ảnh từ app ✓
+- [ ] Manual smoke: badge hiện đúng count, ẩn khi count = 0 ✓
 - [ ] Manual smoke: tap widget → app mở đúng post ✓
-- [ ] Manual smoke: widget hiện placeholder khi logout ✓
+- [ ] Manual smoke: logout → widget hiện placeholder ✓
 
 Cross-module imports: None
 
@@ -170,11 +189,11 @@ Cross-module imports: None
 
 ```
 contracts Part 1 → T1 → T2 → T3 → T6
-                      ↘
-                   T2 → T4 (parallel T3) → T5
+                           ↘
+                        T2 → T4 (parallel với T3) → T5
 ```
 
-T3 (Worker) và T4 (Deep link) có thể chạy song song sau T2 (AppWidgetProvider) xong.
+T3 (Worker) và T4 (Deep link) có thể chạy song song sau T2 (MeepWidget) xong.
 
 ---
 
@@ -182,5 +201,8 @@ T3 (Worker) và T4 (Deep link) có thể chạy song song sau T2 (AppWidgetProvi
 
 | # | Câu hỏi | Status |
 |---|---|---|
-| OQ1 | `workmanager` Flutter plugin hay native WorkManager? | ✅ **Native WorkManager** (Kotlin) — tránh thêm plugin, logic đơn giản |
-| OQ2 | Glide hay Coil? | Nếu project đã có Coil trong Android deps → dùng Coil để tránh duplicate. Kiểm tra `build.gradle` trước khi add Glide |
+| OQ1 | `workmanager` Flutter plugin hay native WorkManager? | ✅ **Native WorkManager** (Kotlin) |
+| OQ2 | Glide hay Coil? | ✅ **Glide** — project không có Coil trong Android deps |
+| OQ3 | Widget content hiện gì? | ✅ **Resolved 2026-05-27:** ảnh fullscreen + avatar (bottom-left) + caption pill + unread count badge (top-right, Turquoise/600) |
+| OQ4 | `lastViewedAt` reset khi nào? | ✅ **Resolved 2026-05-27:** mỗi lần `AppLifecycleState.resumed` — Option A |
+| OQ5 | Unread count badge format? | ✅ **Resolved 2026-05-27:** 1–9 số thực, ≥10 → "9+". Ẩn khi = 0 |

--- a/docs/specs/2026-05-23-space.md
+++ b/docs/specs/2026-05-23-space.md
@@ -30,11 +30,11 @@ Cho phép user tạo nhóm nhỏ (Space) với bạn bè để chia sẻ ảnh r
 
 | Màn hình | Figma ID | Mô tả |
 |---|---|---|
-| Tạo Space — Chọn bạn bè | `269:1193` | Bottom sheet: search bạn bè + checkbox chọn nhiều người |
-| Tạo Space — Đặt tên & theme | `269:1257` | Đặt tên Space + chọn icon preset (3×3 grid emoji) |
-| Tạo Space — Tạo biểu tượng | `269:1334` | Tạo icon tùy chỉnh: chọn emoji + color |
-| Tạo Space — Chọn Emoji | `596:1601` | Picker emoji từ keyboard |
-| Tạo Space — Chọn màu | `600:3498` | Color picker với preset + color wheel |
+| Tạo Space — Chọn bạn bè | `269:1193` | Step 1: bottom sheet "Thêm Space mới", search + checkbox, nút "Tiếp tục →" (`#39404180`) |
+| Tạo Space — Đặt tên & theme | `269:1257` | Step 2: "Cấu hình Space", TextField + scrollable preset list (8 emoji pairs + ô "+"), nút "Hoàn tất" turquoise |
+| Tạo Space — Tạo biểu tượng | `269:1334` | Step 3: "Tạo theme cho Space", preview circle + 2 tab buttons (😊 emoji / 🌈 màu) + "Gợi ý" 9 color suggestions |
+| Tạo Space — Chọn Emoji | `596:1601` | Step 3 tab emoji: `emoji_picker_flutter` keyboard mở + search "Tìm kiếm biểu tượng" |
+| Tạo Space — Chọn màu | `600:3498` | Step 3 tab màu: overlay "Màu nền" với grid ~20 preset colors + gradient shade slider |
 
 > **Lưu ý:** Không có màn "Space main screen" riêng — Feed per Space = Feed module filter `spaceId`. Space list hiện qua bottom sheet từ Camera.
 
@@ -48,7 +48,7 @@ Cho phép user tạo nhóm nhỏ (Space) với bạn bè để chia sẻ ảnh r
 2. **Invite members** — từ friend list, max 10 members (bao gồm creator)
 3. **Context switch Camera** — long-press FriendsButton → bottom sheet Space list → chọn Space → Camera UI đổi theme
 4. **Broadcast post** — chụp trong Space context → auto-broadcast tất cả members (không chọn thủ công)
-5. **Feed per Space** — filter `posts` theo `spaceId`, reuse Feed module
+5. **Feed per Space** — filter `/users/{uid}/feed` theo `spaceId`, reuse Feed module
 6. **Group Chat** — reply ảnh Space → Group Chat Space (reuse Chat module)
 7. **Space management** — Leave Space, Delete Space (creator only), Kick member (creator only)
 8. **Space list** — danh sách Space của user (hiện trên Profile tab + Camera bottom sheet)
@@ -57,7 +57,7 @@ Cho phép user tạo nhóm nhỏ (Space) với bạn bè để chia sẻ ảnh r
 
 - Public Space discovery — only invited (Tier 2)
 - Custom icon upload — chỉ preset (Tier 2)
-- Custom hex color input — chỉ preset (đã chốt trong modules.md)
+- Free-form hex color text input — color picker chỉ có preset colors + shade adjustment slider (không nhập hex tay)
 - Admin role hierarchy — creator = admin duy nhất (Tier 2)
 - Space settings phức tạp (Tier 2)
 - Theme switch per Space (Tier 2)
@@ -78,30 +78,56 @@ Camera topbar → long-press FriendsButton
         │   └─ List friends: [avatar] [displayName] [checkbox]
         │       ├─ Unchecked: vòng tròn empty
         │       └─ Checked: vòng tròn turquoise #00DEEE + checkmark
-        ├─ Nút "Tiếp tục" (active khi ≥ 1 friend chọn) → Step 2
+        ├─ Nút "Tiếp tục →" (fill `#39404180`, disabled khi 0 friend chọn) → Step 2
         └─ Back gesture / swipe down → đóng bottom sheet, về Camera
 
 Step 2 — "Cấu hình Space" bottom sheet:
     ├─ Section "Đặt tên cho Space"
     │   └─ TextField placeholder "Meepsie" (max 30 chars)
-    ├─ Section "Space theme" — grid 3×3 emoji preset:
-    │   ├─ 8 preset: 👨‍👩‍👧‍👦 ❤️ 🎃 🐸 🌼 🐻‍❄️ 🥰 🫃
-    │   ├─ 1 ô "+" → Step 3 (tạo icon tùy chỉnh)
-    │   └─ Selected = outline turquoise + checkmark badge
-    ├─ Nút "Hoàn tất" (turquoise, disabled khi name rỗng)
+    ├─ Section "Space theme" — scrollable list of preset icons (8 presets + 1 ô "+"):
+    │   ├─ Mỗi preset = circle (emoji + background color, xem bảng preset bên dưới)
+    │   ├─ Ô "+" → Step 3 (tạo icon tùy chỉnh)
+    │   └─ Selected = turquoise checkmark badge góc trên-trái
+    ├─ Nút "Hoàn tất" (fill `#00deee` turquoise, disabled khi name rỗng)
     │   → [loading] spinner thay nút trong khi tạo Space
     │   → [success] đóng bottom sheet, navigate Feed per Space mới tạo
     │   → [error — network] toast "Không thể tạo Space, thử lại"
     └─ Back gesture → quay về Step 1 (giữ friends đã chọn)
 
-Step 3 — "Tạo theme cho Space" (optional, từ nút "+"):
-    ├─ Preview icon đã chọn (100×100 circle)
-    ├─ Section "Gợi ý" — grid emoji
-    │   ├─ Tab Emoji: emoji_picker_flutter
-    │   └─ Tab Màu: color preset grid + color wheel (custom hex)
-    ├─ Nút "Xong" → quay về Step 2 với icon mới
+Step 3 — "Tạo theme cho Space" (optional, từ ô "+"):
+    ├─ Preview circle lớn (hiện emoji + background color hiện tại)
+    ├─ 2 tab buttons bên dưới preview:
+    │   ├─ 😊 (emoji button) → mở emoji picker (`emoji_picker_flutter` + search "Tìm kiếm biểu tượng")
+    │   └─ 🌈 (color button) → mở overlay "Màu nền"
+    ├─ Section "Gợi ý" — 9 circles hiện emoji hiện tại với 9 màu background khác nhau
+    │   → tap một circle = chọn màu background đó (giữ emoji không đổi)
+    ├─ Overlay "Màu nền" (khi tap 🌈):
+    │   ├─ Grid ~20 preset colors (pastel + saturated)
+    │   └─ Gradient slider bên dưới để chỉnh sắc độ (shade adjustment)
+    ├─ Default khi vào từ "+": emoji 😄, background color mặc định
+    ├─ Nút "Xong" (fill `#00deee`) → quay về Step 2 với icon mới
     └─ Back gesture → quay về Step 2, bỏ thay đổi icon
 ```
+
+### Preset icons (Step 2) — Figma source of truth
+
+Mỗi preset = (iconEmoji, colorHex) paired — không tách rời nhau trong Step 2. Chỉ Step 3 (custom) mới cho phép chọn độc lập.
+
+| # | iconEmoji | colorHex (background) |
+|---|---|---|
+| 1 | 👨‍👩‍👧‍👦 | `#bfd5ff` (xanh lam nhạt) |
+| 2 | ❤️ | `#ffcfbf` (hồng đào) |
+| 3 | 🎃 | `#feebca` (kem cam) |
+| 4 | 🐸 | `#c4f3d9` (xanh mint) |
+| 5 | 🌼 | `#f9ffc4` (vàng nhạt) |
+| 6 | 🐻‍❄️ | `#eef2f3` (xám trắng) |
+| 7 | 🥰 | `#fff7ea` (trắng ấm) |
+| 8 | 🫃 | `#bfd5ff` (xanh lam nhạt) |
+
+> Khi user chọn preset → `Space.iconEmoji` + `Space.colorHex` được set cùng lúc theo pair.
+> Khi user dùng Step 3 (custom) → `iconEmoji` và `colorHex` độc lập, có thể là bất kỳ emoji + bất kỳ màu trong color picker.
+
+---
 
 ### Luồng context switch Camera
 
@@ -131,7 +157,7 @@ Camera (đã chọn Space context) → chụp → preview → tap "Gửi"
     → PostRepository.createPost(spaceId: spaceId, ...)
     → [success]
         → Firestore: /posts/{postId} với field spaceId
-        → Cloud Function onSpacePostCreated fan-out FCM
+        → Cloud Function onPostCreated (Option A) fan-out feed + FCM cho Space members
         → Navigate về Feed (Space context)
     → [error — upload fail] toast "Gửi ảnh thất bại, thử lại"
         → Về preview, cho gửi lại (giữ nguyên ảnh + caption)
@@ -177,7 +203,7 @@ Space screen → menu "..." (hoặc Settings icon)
 spaceId:     string     — auto Firestore ID
 name:        string     — max 30 chars, không rỗng
 iconEmoji:   string     — emoji char (vd "👨‍👩‍👧‍👦"), default "👥"
-colorHex:    string     — hex color 7 chars (vd "#00DEEE") — từ preset
+colorHex:    string     — hex color 7 chars (vd "#00DEEE") — từ preset (Step 2) hoặc color picker Step 3 (shade-adjusted)
 creatorId:   string     — uid của người tạo
 memberCount: number     — số member hiện tại (denormalized, max 10)
                           lý do denormalize: tránh count query tốn read
@@ -228,6 +254,8 @@ FeedScreen (reuse)          └─ loadFeed(spaceId?)       └─ createPost(sp
 
 **Reuse:** `FeedScreen` (thêm `spaceId` param), `PostRepository.createPost()`, `FriendsButton` component, `ChatScreen` (group chat).
 
+> **`currentSpaceProvider`** — Riverpod provider (`@Riverpod(keepAlive: true)`) track Space context hiện tại trên Camera. Leader (ThienPDM) define stub trước T4+5; `SpaceController` implement. `CameraSection` (KhoaLND) watch provider này để đổi viền/màu.
+
 ---
 
 ## Dependencies
@@ -235,9 +263,9 @@ FeedScreen (reuse)          └─ loadFeed(spaceId?)       └─ createPost(sp
 | Package | Lý do | Có sẵn? |
 |---|---|---|
 | `cached_network_image` | Space icon/avatar | ✅ (Feed) |
-| `emoji_picker_flutter` | Emoji picker (MIT, miễn phí) | ❌ cần thêm |
+| `emoji_picker_flutter` | Emoji picker (MIT, miễn phí) | ✅ đã có (`^4.4.0`) |
 
-> **Quyết định:** Dùng `emoji_picker_flutter` (MIT, miễn phí) — match Figma design (in-app emoji grid), có search. Thêm vào `pubspec.yaml` khi implement.
+> **Quyết định:** Dùng `emoji_picker_flutter` (`^4.4.0`, MIT) — match Figma design (emoji grid + category tabs + search). Cần config `ViewOrderConfig` để category bar ở dưới (Figma style). Search hint text = "Tìm kiếm biểu tượng".
 
 ---
 
@@ -249,7 +277,7 @@ FeedScreen (reuse)          └─ loadFeed(spaceId?)       └─ createPost(sp
 | `leaveSpace` | HTTPS Callable | Xóa `/space_members/{spaceId}/members/{uid}` + update `spaces/{spaceId}.memberIds` (atomic batch) |
 | `kickMember` | HTTPS Callable | Creator kick member: xóa member khỏi `space_members` + update `memberIds` (atomic batch) |
 | `transferOwnership` | HTTPS Callable | Đổi role `/space_members/{spaceId}/members/{newUid}.role = 'creator'` + `/space_members/{spaceId}/members/{oldUid}.role = 'member'` + update `/spaces/{spaceId}.creatorId` (atomic batch) |
-| `onSpacePostCreated` | Firestore onCreate `/posts/{postId}` where `spaceId != null` | Đọc `space_members`, fan-out FCM cho members |
+| ~~`onSpacePostCreated`~~ | ~~Firestore trigger riêng~~ | **[Option A — merged]** Không tạo function riêng. Logic Space fan-out được nhúng vào `onPostCreated` (Feed module — KhoaLND). Khi `post.spaceId != null`: gọi helper `spacePostFanOut(post)` do ThienPDM implement tại `firebase/functions/src/space/spacePostFanOut.ts`. Helper: (1) đọc Space members, (2) fan-out `/users/{uid}/feed/{postId}` với `spaceId` field, (3) FCM cho members (trừ author). |
 | `onSpaceMemberAdded` | Firestore onCreate `/space_members/{spaceId}/members/{uid}` | Increment `memberCount` trên `/spaces/{spaceId}`; increment `spaceCount` trên `/users/{uid}` |
 | `onSpaceMemberRemoved` | Firestore onDelete `/space_members/{spaceId}/members/{uid}` | Decrement `memberCount` trên `/spaces/{spaceId}`; decrement `spaceCount` trên `/users/{uid}` |
 | `onSpaceDeleted` | Firestore onUpdate `/spaces/{spaceId}` where `deletedAt != null` | Cleanup: xóa `space_members`, ẩn posts, set `conversations/{spaceId}.status = deleted` |
@@ -311,9 +339,9 @@ match /posts/{postId} {
 
 | Test | Target |
 |---|---|
-| `createSpace(name, emoji, color, members)` → trả spaceId | `SpaceController` |
-| `createSpace` với members > 10 → throw error | `SpaceController` |
-| `createSpace` với name rỗng → validation error | `SpaceController` |
+| `createSpace({name, iconEmoji, colorHex, friendUids})` → gọi CF, trả success | `SpaceController` |
+| `createSpace` với `friendUids.length > 9` → throw validation error | `SpaceController` |
+| `createSpace` với `name.isEmpty` → throw validation error | `SpaceController` |
 | `leaveSpace` → uid bị xóa khỏi members | `SpaceController` |
 | `deleteSpace` bởi non-creator → throw Unauthorized | `SpaceController` |
 | `loadMySpaces` → trả đúng list spaces của uid | `SpaceController` |
@@ -322,10 +350,20 @@ match /posts/{postId} {
 
 | Test | Screen |
 |---|---|
-| Friend select: tap checkbox → checked | `FriendSelectStep` |
+| Friend select: tap checkbox → checked (turquoise circle + checkmark) | `FriendSelectStep` |
+| Friend select: tap checked → unchecked | `FriendSelectStep` |
 | "Tiếp tục" disabled khi 0 friend chọn | `FriendSelectStep` |
-| Icon preset: tap → selected + outline turquoise | `SpaceConfigStep` |
+| "Tiếp tục" enabled khi ≥ 1 friend chọn (fill `#39404180`) | `FriendSelectStep` |
+| Max 9 friends: checkbox thứ 10 disabled | `FriendSelectStep` |
+| Preset tap → checkmark badge góc trên-trái hiện | `SpaceConfigStep` |
+| Preset tap khác → checkmark chuyển sang preset mới | `SpaceConfigStep` |
 | "Hoàn tất" disabled khi name rỗng | `SpaceConfigStep` |
+| "Hoàn tất" enabled khi name không rỗng | `SpaceConfigStep` |
+| Ô "+" tap → navigate Step 3 | `SpaceConfigStep` |
+| Step 3: Gợi ý tap → preview circle đổi màu background | `IconBuilderStep` |
+| Step 3: emoji button tap → emoji picker hiện | `IconBuilderStep` |
+| Step 3: color button tap → overlay "Màu nền" hiện | `IconBuilderStep` |
+| Step 3: "Xong" tap → về Step 2 với icon đã chọn | `IconBuilderStep` |
 | Camera badge hiện SpaceName khi đã chọn context | `SpaceContextBadge` |
 | Camera badge ẩn khi về "All friends" | `SpaceContextBadge` |
 
@@ -349,20 +387,21 @@ match /posts/{postId} {
 
 | Artifact | File | Status |
 |---|---|---|
-| `Space` freezed model | `lib/features/space/data/space.dart` | ❌ |
-| `SpaceMember` freezed model | `lib/features/space/data/space_member.dart` | ❌ |
-| `SpaceRepository` abstract interface | `lib/features/space/data/space_repository.dart` | ❌ |
-| `SpaceController` stub + `SpaceState` | `lib/features/space/application/space_controller.dart` | ❌ |
-| `SpaceCreateSheet` stub | `lib/features/space/presentation/space_create_sheet.dart` | ❌ |
-| `SpaceContextBottomSheet` stub | `lib/features/space/presentation/space_context_bottom_sheet.dart` | ❌ |
-| `SpaceListTile` stub | `lib/features/space/presentation/widgets/space_list_tile.dart` | ❌ |
-| `SpaceContextBadge` stub | `lib/features/space/presentation/widgets/space_context_badge.dart` | ❌ |
-| `Post` model — thêm field `spaceId` | `lib/features/feed/data/post.dart` | ❌ (Feed module — leader gate) |
-| `FeedScreen` — thêm param `spaceId` | `lib/features/feed/presentation/feed_screen.dart` | ❌ (Feed module — leader gate) |
-| Route: `/space/create`, `/space/:spaceId` | `lib/core/router/app_router.dart` | ❌ |
-| Cloud Functions HTTPS Callable: `createSpace`, `leaveSpace`, `kickMember`, `transferOwnership` | `firebase/functions/src/index.ts` | ❌ |
-| Cloud Functions Firestore triggers: `onSpacePostCreated`, `onSpaceMemberAdded`, `onSpaceMemberRemoved`, `onSpaceDeleted` | `firebase/functions/src/index.ts` | ❌ |
-| TODO markers format | `// TODO(<task-id>/<DevName>): implement <artifact> — see docs/specs/2026-05-23-space.md` | ⏳ |
+| `Space` freezed model | `lib/features/space/data/space.dart` | ✅ merged (LX10) |
+| `SpaceMember` freezed model | `lib/features/space/data/space_member.dart` | ✅ merged (LX10) |
+| `SpaceRepository` abstract interface | `lib/features/space/data/space_repository.dart` | ✅ merged (LX10) |
+| `SpaceController` stub + `SpaceState` | `lib/features/space/application/space_controller.dart` | ✅ stub — `friendUids` param đã có |
+| `SpaceCreateSheet` stub | `lib/features/space/presentation/space_create_sheet.dart` | ✅ stub (TODO SP/T6) |
+| `SpaceContextBottomSheet` stub | `lib/features/space/presentation/space_context_bottom_sheet.dart` | ✅ stub (TODO SP/T7, có `spaceId` param) |
+| `SpaceListTile` stub | `lib/features/space/presentation/widgets/space_list_tile.dart` | ✅ stub (TODO SP/T8, có `spaceId` param) |
+| `SpaceContextBadge` stub | `lib/features/space/presentation/widgets/space_context_badge.dart` | ✅ stub (TODO SP/T9, có `spaceId` param) |
+| `Post` model — `spaceId` field | `lib/features/feed/data/post.dart` | ✅ merged (LX5) |
+| `FeedFilter.space` enum + `filterSpaceId` param | `lib/features/feed/application/feed_controller.dart` | ✅ cả 2 đã có |
+| `currentSpaceProvider` (Riverpod, cho Camera context) | `lib/features/space/application/space_controller.dart` | ❌ chưa có — leader gate change, ThienPDM thêm trước T4+5 (#135) |
+| `FeedScreen` — param `spaceId` | `lib/features/feed/presentation/feed_screen.dart` | ❌ leader gate change — ThienPDM merge trước T4+5 (#135) |
+| Route: `/space/create`, `/space/:spaceId` | `lib/core/router/app_router.dart` | ✅ đã wired (LX10) |
+| `spacePostFanOut.ts` helper (cho `onPostCreated` Option A) | `firebase/functions/src/space/spacePostFanOut.ts` | ❌ ThienPDM implement trong #136 |
+| Cloud Functions (7 functions) | `firebase/functions/src/space/` | ❌ dir chưa có — #136 |
 
 ---
 
@@ -374,6 +413,7 @@ match /posts/{postId} {
 | OQ2 | Creator leave Space: transfer hay xóa? | ✅ **Transfer** — creator chọn member khác làm creator mới, sau đó leave |
 | OQ3 | Emoji picker package? | ✅ **`emoji_picker_flutter`** (MIT, miễn phí, match Figma in-app grid) |
 | OQ4 | Màn Space main/detail riêng? | ✅ **Không có** — Feed per Space = `FeedScreen(spaceId:)` |
+| OQ5 | `onSpacePostCreated` riêng hay merge vào `onPostCreated`? | ✅ **Option A — merge** — Space fan-out logic implement trong `spacePostFanOut.ts` helper, gọi từ bên trong `onPostCreated` (Feed module — KhoaLND) khi `post.spaceId != null`. Single source of truth, không có 2 triggers cùng event. |
 
 ---
 
@@ -398,4 +438,14 @@ match /posts/{postId} {
 - **`isMember()` function trong Firestore rules:** mỗi rule check phải làm 1 `get()` call → tốn Firestore reads. Mitigation: cache membership check hoặc denormalize `memberIds` array vào `/spaces/{spaceId}` (tradeoff: max 10 members → array nhỏ, OK).
 - **Camera context switch UX:** user dễ quên đang ở Space context → gửi nhầm. Mitigation: badge rõ ràng "Đang gửi: [SpaceName]" + màu viền đổi rõ ràng.
 - **Soft delete Space:** posts của Space vẫn còn trong `/posts` sau khi Space bị xóa. Mitigation: Cloud Function cleanup + `deletedAt` check khi query.
-- **Cross-module contract:** Space cần sửa `Post` model (thêm `spaceId`) và `FeedScreen` (thêm filter param) — thuộc Feed module. Leader cần gate change này trước khi Space dev start.
+- **Cross-module contract:** `Post.spaceId` ✅ đã merged (LX5). `FeedScreen` param `spaceId` và `FeedController.filterSpaceId` vẫn cần leader gate change — ThienPDM thêm trước khi Space dev start T4+5 (#135).
+- **Shade slider color storage:** Step 3 color picker cho phép chỉnh sắc độ → `colorHex` sẽ lưu hex của màu sau khi điều chỉnh (không phải preset gốc). Client cần đảm bảo convert slider value → hex string trước khi gọi CF `createSpace`.
+
+---
+
+## Changelog
+
+| Ngày | Thay đổi | Tác giả |
+|---|---|---|
+| 2026-05-23 | Tạo spec ban đầu | ThienPDM |
+| 2026-05-27 | Cập nhật luồng tạo Space dựa trên Figma thực tế (5 frames): "Tiếp tục" button color `#39404180`; Step 2 là scrollable preset list; thêm bảng paired preset (iconEmoji + colorHex); Step 3 cơ chế 2 tab buttons + Gợi ý = color suggestions; color picker = preset + shade slider. Out-of-scope cập nhật. `emoji_picker_flutter` ✅ đã có. CF Option A: `onSpacePostCreated` merge vào `onPostCreated` qua helper `spacePostFanOut.ts`. Fix scope wording, data model, unit tests, risks. Contract table cập nhật đúng thực tế (routes ✅ đã wired, stubs ✅ đã có). Thêm `currentSpaceProvider` vào architecture. OQ5 resolved. | ThienPDM |

--- a/docs/specs/2026-05-23-widget-android.md
+++ b/docs/specs/2026-05-23-widget-android.md
@@ -10,7 +10,7 @@
 
 ## Goal
 
-Hiển thị ảnh mới nhất từ bạn bè trên home screen / lock screen Android dưới dạng AppWidget 2×2. Tap vào ảnh → mở Meep app tại post đó (deep link). Widget tự cập nhật khi có post mới.
+Hiển thị ảnh mới nhất từ bạn bè trên home screen Android dưới dạng AppWidget 2×2 bo góc. Widget gồm: ảnh full-frame, avatar tác giả + caption (style Note pill, dùng chung `app_note_pill` từ homefeed — KhoaLND), và badge đếm số ảnh mới chưa xem. Tap vào widget → mở Meep app tại post đó. Widget tự cập nhật khi có post mới.
 
 ---
 
@@ -26,7 +26,7 @@ Hiển thị ảnh mới nhất từ bạn bè trên home screen / lock screen A
 
 ### In-scope (M3)
 
-1. **AppWidget 2×2** — hiện 1 ảnh mới nhất từ feed (bạn bè + bản thân)
+1. **AppWidget 2×2** — hiện ảnh mới nhất từ feed bạn bè, fullscreen bo góc. Overlay: avatar tác giả + caption (bottom-left), unread count badge (top-right)
 2. **Tap deep link** — tap widget → mở Meep → navigate đến post đó
 3. **Auto-update** — WorkManager job chạy background, fetch ảnh mới, update widget
 4. **Widget setup flow** — trigger từ Settings → "Thêm tiện ích" → Android widget picker
@@ -37,8 +37,51 @@ Hiển thị ảnh mới nhất từ bạn bè trên home screen / lock screen A
 - Widget 4×2 hoặc size khác — post-MVP
 - Multiple photos / carousel widget — post-MVP
 - iOS WidgetKit — defer per ADR-0002
-- Widget hiện avatar friends (Settings OQ4 resolved: hiện ảnh, không phải avatars)
+- Widget hiện danh sách avatar nhiều bạn bè (friend group overview) — widget chỉ hiện avatar của 1 tác giả bài viết mới nhất
 - Glance API (Android 12+) — post-MVP
+
+---
+
+## Widget UI Content
+
+> Source of truth: screenshot Android thực tế từ Figma frame `693:2617`.
+
+### Layout
+
+```
+┌──────────────────────────┐
+│                     [9+] │  ← unread count badge (top-right)
+│                          │     • 1–9 : hiện số thực
+│   [ảnh bạn bè full]      │     • ≥10 : hiện "9+"
+│                          │     màu Turquoise/600 (#00C9E3), text trắng
+│  [avt]  caption text     │  ← bottom-left: avatar tròn + caption
+└──────────────────────────┘
+```
+
+### Elements
+
+| Element | Source data | Hiển thị |
+|---|---|---|
+| Ảnh background | `post.imageUrl` | Fullscreen, scaleType centerCrop |
+| Unread count badge | `count(feed where createdAt > lastViewedAt)` | Top-right, màu Turquoise/600 (`#00C9E3`) theo app theme, text trắng, "1"–"9" hoặc "9+" |
+| Avatar tác giả | `post.authorAvatarUrl` | Tròn, bottom-left |
+| Caption | `post.caption` + `post.captionType` | Note pill style — **dùng chung style `app_note_pill` từ homefeed (KhoaLND)**. Ẩn hoàn toàn khi `caption == null` |
+| Placeholder state | — | Meep logo + "Mở Meep để bắt đầu", hiện khi chưa login hoặc chưa có post |
+
+### Unread count logic
+
+- `lastViewedAt` = timestamp lúc user **mở app** từ bất kỳ đâu (AppLifecycleState.resumed → Flutter ghi vào SharedPreferences). Badge phản ánh số bài mới kể từ lần cuối dùng app.
+- WorkManager đọc `lastViewedAt` → query `/users/{uid}/feed` where `createdAt > lastViewedAt` → đếm số docs
+- Khi user tap widget → app navigate đến post đó (deep link). `lastViewedAt` sẽ được reset tự nhiên khi app resumed sau đó.
+- Badge ẩn khi `unreadCount == 0`
+
+### Caption style (RemoteViews replication)
+
+Style `app_note_pill.dart` (homefeed — KhoaLND) cần replicate trong RemoteViews:
+- Background: `#39404166` (semi-transparent dark), cornerRadius 30dp
+- Text: white, Nunito SemiBold 14sp
+- Padding: horizontal 12dp, vertical 6dp
+- Icon prefix theo `captionType` (emoji hoặc vector drawable): `text`→none, `location`→📍, `weather`→emoji thời tiết, `music`→♪, `star`→⭐, `time`→🕐, `streak`→🔥
 
 ---
 
@@ -48,7 +91,7 @@ Hiển thị ảnh mới nhất từ bạn bè trên home screen / lock screen A
 |---|---|---|
 | Widget confirm sheet (trong Settings) | `662:3341` | Bottom sheet "Thêm vào màn hình chờ?" |
 | Widget confirm variant | `678:2321` | Variant state |
-| Sau khi thêm widget | `693:2617` | Screenshot lock screen instructional UI |
+| Sau khi thêm widget | `693:2617` | Screenshot Android home screen thực tế với widget đang hiển thị — source of truth cho widget UI |
 | Widget on home screen | _(native Android — không có Figma)_ | Render bằng RemoteViews |
 
 ---
@@ -64,23 +107,32 @@ Settings sheet → tap "Thêm tiện ích"
         [Thêm] → requestPinAppWidget() (Android API)
              → Android system widget picker mở
              → User đặt widget lên home screen
-             → Không có callback thành công → hiện instructional screen 693:2617
+             → Không có callback thành công → hiện màn hình 693:2617 (screenshot home screen + widget) như hướng dẫn
         [Huỷ]  → đóng sheet
 ```
 
 ### Widget hiển thị ảnh
 
 ```
-WorkManager PeriodicWorkRequest (interval: 15 phút)
+WorkManager PeriodicWorkRequest (interval: 15 phút — Android đảm bảo chạy trong ~15–30 phút tuỳ Doze mode)
     → WidgetSyncWorker.doWork():
         (1) [H7-FIX] Lấy token: FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()
             Nếu currentUser == null → update widget với placeholder, return Result.success()
         (2) Lấy currentUid từ FirebaseAuth.currentUser.uid
         (3) Query Firestore (dùng fan-out subcollection, không dùng whereIn):
             /users/{currentUid}/feed ORDER BY createdAt DESC LIMIT 1
-            Sau đó fetch /posts/{feedDoc.postId} để lấy imageUrl
-        (4) Download ảnh → cache vào app's files directory (Glide)
-        (5) AppWidgetManager.updateAppWidget() với RemoteViews mới
+            Sau đó fetch /posts/{feedDoc.postId} để lấy imageUrl, authorAvatarUrl, caption, captionType
+        (4) Đọc widget_last_viewed_at từ SharedPreferences
+            Query /users/{currentUid}/feed WHERE createdAt > lastViewedAt → count() → unreadCount
+            ⚠️ count() là server-only, không có offline cache — nếu offline → fallback unreadCount = 0, không crash
+        (5) Download imageUrl + authorAvatarUrl → cache (Glide)
+            authorAvatarUrl → transform thành circular Bitmap
+        (6) AppWidgetManager.updateAppWidget() với RemoteViews:
+            - setImageViewBitmap(widget_photo, photoBitmap)
+            - setImageViewBitmap(widget_avatar, circularAvatarBitmap)
+            - setTextViewText(widget_caption, caption) + setViewVisibility(VISIBLE/GONE)
+            - setTextViewText(widget_count, formatCount(unreadCount)) + setViewVisibility(VISIBLE/GONE)
+            formatCount: 1–9 → số thực, ≥10 → "9+"
 ```
 
 ### Tap widget
@@ -101,9 +153,20 @@ User tap ảnh trong widget
 
 ### Stack
 
-- **Widget UI:** Android `AppWidgetProvider` (Kotlin) + `RemoteViews` — native Android, nằm trong `apps/widget/` hoặc `apps/mobile/android/`
+- **Widget UI:** Android `AppWidgetProvider` (Kotlin) + `RemoteViews` — native Android, nằm trong `apps/mobile/android/`
 - **Background sync:** `WorkManager` (AndroidX) — `PeriodicWorkRequest` 15 phút
-- **Data sharing Flutter ↔ Widget:** `SharedPreferences` (Android native) — Flutter plugin lưu **latest post display data** (`postId`, `imageUrl`, `authorName`) vào `shared_prefs` mà Kotlin đọc được. **KHÔNG lưu auth token** (xem H7 bên dưới).
+- **Data sharing Flutter ↔ Widget:** `SharedPreferences` (Android native) — Flutter plugin lưu **latest post display data** vào `shared_prefs` mà Kotlin đọc được. **KHÔNG lưu auth token** (xem H7 bên dưới).
+
+  Keys:
+  ```
+  widget_post_id            String  — postId, dùng cho deep link
+  widget_image_url          String  — URL ảnh background
+  widget_author_avatar_url  String  — URL avatar tác giả (tròn, bottom-left)
+  widget_caption            String? — caption text đã resolved (nullable — ẩn pill khi null)
+  widget_caption_type       String? — "text"|"location"|"weather"|"music"|"star"|"time"|"streak"
+  widget_last_viewed_at     Long    — millis timestamp lần cuối mở app (cho unread count)
+  ```
+  `authorName` **không lưu** — widget không hiện tên, avatar là visual identifier.
 - **[H7-FIX] Auth token trong Worker:** Firebase ID token hết hạn sau 1h — không thể lưu vào SharedPreferences rồi đọc lại. Worker phải gọi `FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()` để lấy token mới mỗi lần chạy (Firebase SDK tự refresh internally). Nếu `currentUser == null` → skip query, hiện placeholder.
 - **Image caching:** Glide (Kotlin side) — download + cache ảnh vào internal storage
 - **Deep link:** `MethodChannel` Flutter ↔ Android để truyền `postId` khi tap widget
@@ -115,6 +178,7 @@ apps/mobile/android/app/src/main/
 ├─ kotlin/.../
 │   ├─ MainActivity.kt          ← xử lý widget tap intent
 │   ├─ MeepWidget.kt            ← AppWidgetProvider
+│   ├─ WidgetDataStore.kt       ← helper đọc SharedPreferences
 │   └─ WidgetSyncWorker.kt      ← WorkManager worker
 └─ res/
     ├─ layout/meep_widget.xml   ← RemoteViews layout
@@ -125,21 +189,27 @@ apps/mobile/android/app/src/main/
 
 ```dart
 // Lưu data cho widget sau mỗi lần fetch feed
-class WidgetDataService {
-  static Future<void> updateWidgetData({
-    required String latestPostId,
-    required String latestImageUrl,
-    required String authorName,
-  }) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('widget_post_id', latestPostId);
-    await prefs.setString('widget_image_url', latestImageUrl);
-    await prefs.setString('widget_author_name', authorName);
-    // Trigger widget update via MethodChannel
-    await _channel.invokeMethod('updateWidget');
-  }
+abstract class WidgetDataService {
+  /// Gọi từ FeedController (KhoaLND) sau mỗi lần fetch feed mới.
+  /// caption + captionType: lấy từ post.caption / post.captionType (đã resolved string).
+  Future<void> updateWidgetData({
+    required String postId,
+    required String imageUrl,
+    required String authorAvatarUrl,
+    String? caption,       // null → pill ẩn trong widget
+    String? captionType,   // "text"|"location"|"weather"|"music"|"star"|"time"|"streak"
+  });
+
+  /// Gọi khi app vào foreground (AppLifecycleState.resumed).
+  /// Ghi widget_last_viewed_at = DateTime.now().millisecondsSinceEpoch.
+  Future<void> recordLastViewedAt();
+
+  /// Gọi khi logout → xóa tất cả widget_* keys → widget hiện placeholder.
+  Future<void> clearData();
 }
 ```
+
+**Cross-module:** `updateWidgetData()` được gọi từ `FeedController` (homefeed module — KhoaLND). Caption style (`app_note_pill`) do KhoaLND implement trong homefeed; Widget module replicate style trong RemoteViews XML.
 
 ---
 
@@ -149,17 +219,18 @@ class WidgetDataService {
 
 | Package | Lý do | Có sẵn? |
 |---|---|---|
-| `shared_preferences` | Share data Flutter ↔ Android widget | ❌ cần thêm (cũng dùng Profile notification toggle) |
-| `workmanager` | Trigger WorkManager từ Flutter (optional) | ❌ cần thêm hoặc dùng native only |
+| `shared_preferences` | Share data Flutter ↔ Android widget | ✅ đã có (`^2.3.3`) |
 
 ### Android (build.gradle)
 
-| Dependency | Lý do |
-|---|---|
-| `androidx.work:work-runtime-ktx` | WorkManager background sync |
-| `com.github.bumptech.glide:glide` | Image download + cache |
-| `com.google.firebase:firebase-firestore-ktx` | Query latest post từ Kotlin |
-| `com.google.firebase:firebase-auth-ktx` | Đọc auth token trong worker |
+| Dependency | Lý do | Có sẵn? |
+|---|---|---|
+| `androidx.work:work-runtime-ktx:2.9.1` | WorkManager background sync | ✅ đã có |
+| `com.github.bumptech.glide:glide` | Image download + cache + CircleCrop cho avatar | ❌ cần thêm |
+| `com.google.firebase:firebase-firestore-ktx:24.4.0+` | Query latest post + unread `count()` từ Kotlin — **min 24.4.0** (phiên bản đầu tiên có `Query.count()`) | ❌ cần thêm |
+| `com.google.firebase:firebase-auth-ktx` | Đọc auth token trong worker | ❌ cần thêm |
+
+> ⚠️ `count()` là server-side only — **không hoạt động offline**, không hỗ trợ realtime listener. Nếu query fail (offline/network) → badge fallback = 0, không crash (xem Worst path).
 
 ---
 
@@ -167,7 +238,7 @@ class WidgetDataService {
 
 - Widget chỉ đọc post data của user đang login — dùng Firebase Auth SDK trực tiếp trong WorkManager worker
 - **[H7] Auth token KHÔNG lưu SharedPreferences** — Worker gọi `FirebaseAuth.getInstance().currentUser?.getIdToken(false)?.await()` mỗi lần chạy. Firebase SDK tự refresh token nếu cần.
-- SharedPreferences chỉ lưu display data (postId, imageUrl, authorName) — không lưu credentials
+- SharedPreferences chỉ lưu display data (postId, imageUrl, authorAvatarUrl, caption, captionType, lastViewedAt) — không lưu credentials
 - Nếu `currentUser == null` (chưa login / logout) → worker skip update, widget hiện placeholder
 - Không lưu password hay sensitive credentials trong SharedPreferences
 
@@ -181,7 +252,11 @@ class WidgetDataService {
 |---|---|
 | `WidgetSyncWorker` không có token → return `Result.success()` (skip gracefully) | `WidgetSyncWorker` |
 | `WidgetSyncWorker` có token → fetch post + update widget | `WidgetSyncWorker` (mock Firestore) |
+| `WidgetSyncWorker` có token, `authorAvatarUrl == null` → Glide load null → không crash, hiện default avatar | `WidgetSyncWorker` |
+| `WidgetSyncWorker` có token, `count()` query fail (offline/permission) → badge = 0, widget vẫn update bình thường | `WidgetSyncWorker` |
 | `MeepWidget.onUpdate()` với valid RemoteViews → không crash | `MeepWidget` |
+| `authorAvatarUrl == null` → Glide fallback, không crash, widget vẫn render | `WidgetSyncWorker` |
+| `count()` query fail (offline/network) → unreadCount = 0, badge ẩn, widget update tiếp tục | `WidgetSyncWorker` |
 
 ### Manual smoke tests (device required)
 
@@ -189,7 +264,7 @@ class WidgetDataService {
 - [ ] Widget hiện ảnh mới nhất sau khi đăng ảnh từ app
 - [ ] Tap widget → app mở đúng post
 - [ ] Widget hiện placeholder khi logout
-- [ ] Widget tự update sau ≤ 15 phút khi bạn đăng ảnh mới
+- [ ] Widget tự update sau ≤ 15 phút khi bạn đăng ảnh mới (có thể trễ hơn do Doze mode)
 
 ---
 
@@ -197,14 +272,16 @@ class WidgetDataService {
 
 | Artifact | File | Status |
 |---|---|---|
-| `MeepWidget.kt` (AppWidgetProvider) | `android/app/src/main/kotlin/.../MeepWidget.kt` | ❌ |
-| `WidgetSyncWorker.kt` (WorkManager) | `android/app/src/main/kotlin/.../WidgetSyncWorker.kt` | ❌ |
-| `meep_widget.xml` (RemoteViews layout) | `android/app/src/main/res/layout/meep_widget.xml` | ❌ |
-| `meep_widget_info.xml` (AppWidget metadata) | `android/app/src/main/res/xml/meep_widget_info.xml` | ❌ |
-| `AndroidManifest.xml` — khai báo widget + WorkManager | `android/app/src/main/AndroidManifest.xml` | ❌ update |
-| `WidgetDataService` (Flutter) | `lib/features/widget/application/widget_data_service.dart` | ❌ |
+| `MeepWidget.kt` (AppWidgetProvider) | `android/app/src/main/kotlin/.../MeepWidget.kt` | ⏳ stub |
+| `WidgetDataStore.kt` (SharedPreferences helper) | `android/app/src/main/kotlin/.../WidgetDataStore.kt` | ❌ chưa có |
+| `WidgetSyncWorker.kt` (WorkManager) | `android/app/src/main/kotlin/.../WidgetSyncWorker.kt` | ⏳ stub |
+| `meep_widget.xml` (RemoteViews layout) | `android/app/src/main/res/layout/meep_widget.xml` | ⏳ stub — cần thêm widget_avatar, widget_caption pill, widget_count badge |
+| `meep_widget_info.xml` (AppWidget metadata) | `android/app/src/main/res/xml/meep_widget_info.xml` | ✅ |
+| `AndroidManifest.xml` — khai báo widget | `android/app/src/main/AndroidManifest.xml` | ✅ |
+| `WidgetDataService` (Flutter abstract) | `lib/features/widget/application/widget_data_service.dart` | ⏳ stub — cần update interface (avatar, caption, recordLastViewedAt) |
 | `MethodChannel` handler trong `MainActivity.kt` | `android/app/src/main/kotlin/.../MainActivity.kt` | ❌ update |
-| TODO markers trên mọi stub | — | ⏳ |
+
+> Mọi stub phải có TODO marker theo format `// TODO(W/T<n>/<DevName>): <mô tả>`
 
 ---
 
@@ -212,9 +289,13 @@ class WidgetDataService {
 
 | # | Câu hỏi | Status |
 |---|---|---|
-| OQ1 | Widget 2×2 hiện ảnh hay avatars? | **✅ Resolved:** hiện ảnh mới nhất (từ Settings spec OQ4) |
-| OQ2 | Update interval: 15 phút hay khác? | **15 phút** — minimum WorkManager interval. Có thể trigger thêm khi mở app |
-| OQ3 | Dùng `workmanager` Flutter plugin hay native WorkManager? | **Gợi ý: native WorkManager** — tránh thêm Flutter plugin, logic đơn giản đủ viết Kotlin |
+| OQ1 | Widget 2×2 hiện ảnh hay avatars? | **✅ Resolved 2026-05-27:** ảnh fullscreen + avatar tác giả overlay bottom-left + caption pill + unread count badge top-right |
+| OQ2 | Update interval: 15 phút hay khác? | **✅ Resolved:** 15 phút (schedule interval). Android thực tế có thể delay thêm do Doze mode — known limitation |
+| OQ3 | Dùng `workmanager` Flutter plugin hay native WorkManager? | **✅ Resolved:** native WorkManager (Kotlin) |
+| OQ4 | Widget hiện authorName hay không? | **✅ Resolved 2026-05-27:** không — avatar là visual identifier, không lưu authorName |
+| OQ5 | Caption có trong widget không? | **✅ Resolved 2026-05-27:** có. Style Note pill (reuse `app_note_pill` từ homefeed — KhoaLND). Ẩn khi `caption == null` |
+| OQ6 | Unread count format? | **✅ Resolved 2026-05-27:** 1–9 hiện số thực, ≥10 hiện "9+". Badge ẩn khi count = 0 |
+| OQ7 | `lastViewedAt` reset khi nào? | **✅ Resolved 2026-05-27:** AppLifecycleState.resumed. App tự navigate đến post mới nhất khi mở |
 
 ---
 
@@ -224,19 +305,33 @@ class WidgetDataService {
 |---|---|
 | Auth token hết hạn trong Worker | Worker skip update (`Result.success()`), widget hiện placeholder "Mở Meep để đăng nhập lại" |
 | Network fail trong Worker | Giữ ảnh Glide đã cache trước đó; không update timestamp; không crash |
-| OS defer Worker (Doze mode) | Widget hiện ảnh cũ (stale tối đa 15+ phút) — known limitation, document trong README |
+| OS defer Worker (Doze mode) | Widget hiện ảnh cũ (stale) — known limitation. Worker schedule 15 phút nhưng Android có thể defer; document trong README |
 | Deep link tap: post đã bị xóa | App mở, navigate đến Feed Home (fallback); toast "Khoảnh khắc này không còn tồn tại" |
 | SharedPreferences chưa có data (lần đầu / sau xóa cache) | Widget hiện placeholder Meep logo + "Mở Meep để bắt đầu" |
 | User logout khi widget đang cài | Flutter ghi `null` vào SharedPreferences → Worker next run detect no token → widget hiện placeholder ngay |
 | Feed rỗng (chưa có post nào) | Worker query trả empty → widget hiện placeholder, không crash |
 | Image download fail (Glide) | Widget giữ ảnh cached cũ (nếu có) hoặc hiện placeholder; không show broken image |
+| `authorAvatarUrl == null` (user chưa set avatar) | Glide load null → hiện default avatar placeholder (circle với icon người dùng); không crash |
+| Unread count query fail (network/permission) | Ẩn badge (fallback về 0), không block widget update; ảnh + caption vẫn hiện bình thường |
 | User thêm widget trước khi đăng nhập | Placeholder state, tự update khi app được mở và đăng nhập |
 | Nhiều widget instance trên home screen | Tất cả cùng hiện ảnh mới nhất — `AppWidgetManager.updateAppWidget(ids, views)` update all |
 
+---
+
+---
+
 ## Risks
 
-- **WorkManager 15 phút minimum:** Android không cho schedule dưới 15 phút. Widget có thể chậm tối đa 15 phút sau khi bạn đăng ảnh. Mitigation: trigger sync thêm khi user mở app (Flutter push FCM → update widget).
-- **Doze mode / battery optimization:** Android có thể defer WorkManager trên device tiết kiệm pin. Mitigation: document known limitation trong README.
-- **SharedPreferences race condition:** Flutter write + Kotlin read đồng thời → stale data. Mitigation: Kotlin luôn đọc fresh từ Firestore trong Worker, SharedPreferences chỉ là cache.
-- **Glide vs Coil:** nếu project đã có Coil trong Android deps → dùng Coil thay Glide để avoid duplicate image library.
-- **RemoteViews limitation:** không support tất cả Flutter widget — UI widget bị giới hạn bởi Android RemoteViews API. Design phải đơn giản (ImageView + TextView).
+- **WorkManager Doze mode delay:** Schedule 15 phút nhưng Android có thể defer khi device tiết kiệm pin. Mitigation: trigger sync bổ sung khi user mở app (`WorkManager.enqueueUniqueWork` one-time khi foreground) + document known limitation trong README.
+- **Glide circular bitmap:** Download 2 ảnh (photo + avatar) trong cùng Worker run. Glide cache giảm overhead. Avatar cần `CircleCrop` transform.
+- **Unread count stale:** Count tính tại thời điểm Worker chạy, không realtime. Acceptable — widget vốn không realtime.
+- **`app_note_pill` cross-module:** Style reference từ homefeed (KhoaLND). Nếu KhoaLND update style, Widget RemoteViews cần update tương ứng (manual sync — không có code share giữa Flutter và RemoteViews XML).
+
+---
+
+## Changelog
+
+| Ngày | Thay đổi | Tác giả |
+|---|---|---|
+| 2026-05-23 | Tạo spec ban đầu | ThienPDM |
+| 2026-05-27 | Cập nhật widget content dựa trên Figma thực tế (frame `693:2617`): thêm avatar tác giả (bottom-left), caption pill (style `app_note_pill` — KhoaLND), unread count badge (top-right, màu Turquoise/600, format 1–9/9+). Xác nhận không hiện authorName. Thêm `lastViewedAt` logic — reset mỗi lần mở app (Option A), navigate khi tap widget. WorkManager interval giữ 15 phút. Note Firebase Firestore `count()` min version 24.4.0 + offline limitation. Thêm `WidgetDataStore.kt` vào contract + file structure. Thêm 2 unit test case (avatarUrl null, count fail). Resolve OQ1–OQ7. | ThienPDM |


### PR DESCRIPTION
## Summary

- **Gate changes (contract):** `FeedController.build()` thêm `filterSpaceId String?`; `SpaceController.createSpace()` thêm `friendUids List<String>` — cả 2 là leader gate changes cho Space module
- **Spec Space:** cập nhật theo Figma thực tế (5 frames) — button colors, scrollable preset list, paired preset table, Step 3 mechanics, color picker = preset + shade slider, CF Option A (`spacePostFanOut` helper), `currentSpaceProvider` contract, `emoji_picker_flutter` config note, OQ5 resolved
- **Spec + Plan Widget:** cập nhật theo Figma và Android constraints
- **Plan Space:** contract table đúng thực tế, T3 ACs đầy đủ, T9 đổi thành helper, dependency graph fix

## Thay đổi files

| File | Loại |
|---|---|
| `apps/mobile/lib/features/feed/application/feed_controller.dart` | gate change — thêm `filterSpaceId` |
| `apps/mobile/lib/features/space/application/space_controller.dart` | gate change — thêm `friendUids` |
| `docs/specs/2026-05-23-space.md` | spec update theo Figma |
| `docs/specs/2026-05-23-widget-android.md` | spec update |
| `docs/plans/2026-05-23-space.md` | plan update |
| `docs/plans/2026-05-23-widget-android.md` | plan update |

## Test plan

- [x] `flutter analyze` clean (contract stubs không break build)
- [ ] Spec/plan review bởi leader trước khi merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)