### PR TITLE
chore(profile,settings): gate contracts — isSearchable, FriendProfileScreen, AppTaskbar, unblockUser

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -23,6 +23,7 @@ import 'package:meep/features/feed/presentation/home_screen.dart';
 import 'package:meep/features/home/presentation/home_page.dart';
 import 'package:meep/features/profile/presentation/edit_profile_screen.dart';
 import 'package:meep/features/profile/presentation/photo_detail_screen.dart';
+import 'package:meep/features/profile/presentation/friend_profile_screen.dart';
 import 'package:meep/features/profile/presentation/profile_screen.dart';
 import 'package:meep/features/space/presentation/space_context_bottom_sheet.dart';
 import 'package:meep/features/space/presentation/space_create_sheet.dart';
@@ -297,7 +298,7 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/friend-profile/:uid',
         builder: (_, state) =>
-            ProfileScreen(uid: state.pathParameters['uid'] ?? ''),
+            FriendProfileScreen(uid: state.pathParameters['uid'] ?? ''),
       ),
       GoRoute(path: '/inbox', builder: (_, __) => const InboxScreen()),
       GoRoute(

--- a/apps/mobile/lib/features/auth/data/user_profile.dart
+++ b/apps/mobile/lib/features/auth/data/user_profile.dart
@@ -25,6 +25,10 @@ class UserProfile with _$UserProfile {
     @Default(0) int postCount,
     @Default(0) int friendCount,
     @Default(0) int spaceCount,
+
+    /// Allow other users to find this account by username search.
+    /// Default true. Toggled in Settings > Quyền riêng tư và dữ liệu.
+    @Default(true) bool isSearchable,
     @TimestampConverter() required DateTime createdAt,
     @TimestampConverter() required DateTime updatedAt,
   }) = _UserProfile;

--- a/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+// TODO(P/T7/HanDHG): implement FriendProfileScreen per Figma — friend's profile view
+// Shows: avatar + stats (postCount + friendCount only; spaceCount hidden) + bio + photo grid
+// Photo grid: only posts shared with the current viewer (audienceType == 'all' OR
+//   audienceType == 'select' && audienceUids.contains(currentUid))
+// No Edit / Share buttons — read-only. "Xoá bạn" navigates to FriendSheet.
+class FriendProfileScreen extends StatelessWidget {
+  const FriendProfileScreen({super.key, required this.uid});
+
+  /// UID of the friend whose profile is being viewed.
+  final String uid;
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+}

--- a/apps/mobile/lib/shared/widgets/app_taskbar.dart
+++ b/apps/mobile/lib/shared/widgets/app_taskbar.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Bottom navigation taskbar — shared across Feed, Profile, Diary, Chat, Streak.
+///
+/// Owner: ThienPDM (leader-owned shared widget).
+/// Figma: OQ8 — node ID TBD, pending designer confirmation.
+///
+/// Contract:
+///   - [activeTab] — which tab is currently highlighted.
+///   - [onTabSelected] — called when user taps a tab; caller handles navigation.
+///   - Height: 64px logical pixels (48px touch target + 8px top/bottom padding).
+///   - Background: Theme surface. No elevation shadow per Figma.
+///
+// TODO(OQ8/ThienPDM): confirm Figma node ID for AppTaskbar with HanDHG/NganTNK
+// TODO(T3/TBD): implement AppTaskbar per Figma once node ID confirmed
+enum TaskbarTab { feed, profile, diary, chat, streak }
+
+class AppTaskbar extends StatelessWidget {
+  const AppTaskbar({
+    super.key,
+    required this.activeTab,
+    required this.onTabSelected,
+  });
+
+  final TaskbarTab activeTab;
+  final ValueChanged<TaskbarTab> onTabSelected;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/docs/specs/2026-05-22-profile.md
+++ b/docs/specs/2026-05-22-profile.md
@@ -146,8 +146,10 @@ Friend search result → user card (exact match)
                 ├─ Hiện: avatar + stats (chỉ K.khắc + Bạn bè; Space ẩn hoặc 0)
                 ├─ Bio (nếu có)
                 └─ Grid ảnh của người đó (chỉ read, không edit)
-                    CHỈ hiển thị ảnh được chia sẻ với người đang xem — không phải toàn bộ ảnh của chủ profile
-                    (xem OQ5 — cần xác nhận data model post visibility)
+                    CHỈ hiển thị ảnh được chia sẻ với người đang xem:
+                    - audienceType == 'all' (all-friends post), HOẶC
+                    - audienceType == 'select' && audienceUids.contains(currentUid)
+                    Dùng field có sẵn trong Post model — KHÔNG thêm recipientIds mới.
 ```
 
 > **Không có** nút Edit / Chia sẻ trên FriendProfileScreen — chỉ hiện nút "Xoá bạn" (mở Friend sheet).
@@ -339,7 +341,7 @@ match /avatars/{uid}/{filename} {
 | `EditProfileScreen` stub | `lib/features/profile/presentation/edit_profile_screen.dart` | ✅ LX9 |
 | `PhotoDetailScreen` stub | `lib/features/profile/presentation/photo_detail_screen.dart` | ✅ LX9 |
 | `AvatarPickerSheet` stub | `lib/features/profile/presentation/avatar_picker_sheet.dart` | ✅ LX9 |
-| `FriendProfileScreen` stub | `lib/features/profile/presentation/friend_profile_screen.dart` | ❌ **Chưa có — cần leader tạo** |
+| `FriendProfileScreen` stub | `lib/features/profile/presentation/friend_profile_screen.dart` | ✅ LX-GATE |
 | `ShareProfileSheet` stub | `lib/shared/widgets/share_profile_sheet.dart` — **shared**, leader own | ✅ LX3 |
 | Routes: `/profile`, `/profile/edit`, `/profile/photo/:postId`, `/friend-profile/:uid` | `lib/core/router/app_router.dart` | ✅ LX9 |
 | Storage rules: `avatars/{uid}/` | `firebase/storage.rules` | ✅ LX-RULES |
@@ -403,7 +405,7 @@ match /avatars/{uid}/{filename} {
 - [ ] Username change: uniqueness check + inline error nếu đã bị lấy
 - [ ] Email change: re-auth dialog → thành công → Firebase Auth email updated
 - [ ] Share profile: copy link → clipboard toast; Gửi qua Messenger → Android share intent
-- [ ] FriendProfileScreen: grid ảnh chỉ hiển thị ảnh được chia sẻ với người đang xem (pending OQ5)
+- [ ] FriendProfileScreen: grid ảnh chỉ hiển thị ảnh được chia sẻ với người đang xem (`audienceType == 'all'` OR `audienceType == 'select' && audienceUids.contains(currentUid)`)
 - [ ] Photo detail: swipe trái → ảnh cũ hơn, swipe phải → ảnh mới hơn (tất cả ảnh bản thân, mới → cũ)
 - [ ] Diary tab: hiện empty state, không crash
 - [ ] Bio: nhập ≤ 150 chars, hint text hiển thị đúng, empty OK
@@ -438,7 +440,7 @@ match /avatars/{uid}/{filename} {
 - **Stats count denormalization:** `friendCount` từ Friend module, `spaceCount` chưa có (Space module M3) → **hiện `0`** cho Space count M2, cập nhật khi Space module xong.
 - **Diary tab:** hiển thị Diary entry public — phụ thuộc Diary module implement `DiaryRepository.getPublicEntries(uid)`. Nếu Diary module chưa done → tab render empty tự nhiên, không crash.
 - **`user-round-plus` button:** đã confirm xoá khỏi UI — designer cần update Figma.
-- **Post visibility (OQ5):** Nếu Post không có `recipientIds` field → FriendProfileScreen không thể lọc đúng ảnh được chia sẻ. Cần clarify trước khi T7 bắt đầu.
+- **Post visibility:** FriendProfileScreen filter bằng `audienceType` + `audienceUids` đã có trong `Post` model. Không cần field mới.
 
 ---
 
@@ -450,7 +452,7 @@ match /avatars/{uid}/{filename} {
 | OQ2 | Bio field có trong Profile screen không? Figma không thấy field bio riêng trong Edit | **✅ Resolved** — Anh đã thêm "Tiểu sử" vào Edit profile (node `719:2722`). Field `bio` optional, hint: *"Tiểu sử của bạn hiển thị với bạn bè của bạn."* |
 | OQ3 | `spaceCount` M2 hiện 0 hay ẩn hẳn? | **✅ Resolved** — Hiện số `0` cho đến khi Space module (M3) đi vào hoạt động |
 | OQ4 | Photo detail swipe đi qua ảnh nào? | **✅ Resolved** — Tất cả ảnh bản thân, swipe trái = cũ hơn (mới → cũ, sắp theo `createdAt` desc) |
-| OQ5 | **[BLOCKING T7]** Post visibility model cho FriendProfileScreen: khi A xem profile B, grid ảnh của B chỉ hiện ảnh chia sẻ với A hay tất cả ảnh B đã đăng? Nếu chỉ hiện ảnh chia sẻ với A → Post model cần field `recipientIds: List<String>` — cần anh Thiên chốt data model trước khi implement T7 | **⏳ Pending — cần leader confirm** |
-| OQ6 | **[BLOCKING T6]** ShareProfileSheet URL: Figma hiển thị `meep.cam/{username}` nhưng Q3 đã resolve là `meep://profile/{username}`. Dùng cái nào? Domain `meep.cam` chưa có DNS thật → link bấm sẽ không mở được trên máy thật | **⏳ Pending — cần leader confirm** |
+| OQ5 | **[BLOCKING T7]** Post visibility model cho FriendProfileScreen: khi A xem profile B, grid ảnh của B chỉ hiện ảnh chia sẻ với A hay tất cả ảnh B đã đăng? Nếu chỉ hiện ảnh chia sẻ với A → Post model cần field `recipientIds: List<String>` — cần anh Thiên chốt data model trước khi implement T7 | **✅ Resolved (2026-05-28, ThienPDM):** Dùng `audienceType` + `audienceUids` đã có trong `Post` model. Filter: `audienceType == 'all'` OR (`audienceType == 'select'` AND `audienceUids.contains(currentUid)`). KHÔNG thêm `recipientIds`. |
+| OQ6 | **[BLOCKING T6]** ShareProfileSheet URL: Figma hiển thị `meep.cam/{username}` nhưng Q3 đã resolve là `meep://profile/{username}`. Dùng cái nào? Domain `meep.cam` chưa có DNS thật → link bấm sẽ không mở được trên máy thật | **✅ Resolved (2026-05-28, ThienPDM):** Dùng `AppConfig.shareBaseUrl` (`meep://profile`). Khi có HTTP domain thật thì đổi 1 chỗ trong `AppConfig`. Consistent với Settings OQH4. |
 | OQ7 | Photo detail — "Tag" là gì? Figma chỉ thấy timestamp "17:03", không thấy tag tên người. Có tính năng tag người vào ảnh không? | **✅ Resolved** — Chỉ hiện giờ đăng, không có tag tên người |
-| OQ8 | **[BLOCKING tất cả màn hình chính]** `AppTaskbar` (`lib/shared/widgets/app_taskbar.dart`) là shared widget dùng chung Feed / Profile / Diary / Chat / Streak nhưng **chưa có file trong codebase và chưa có owner**. Cần ThienPDM: (1) define contract + Figma node ID cho Taskbar, (2) assign owner implement, (3) confirm Profile module chỉ consume không tự tạo. Nếu chưa có Taskbar → ProfileScreen không thể hoàn chỉnh UI. | **⏳ Pending — cần ThienPDM confirm** |
+| OQ8 | **[BLOCKING tất cả màn hình chính]** `AppTaskbar` (`lib/shared/widgets/app_taskbar.dart`) là shared widget dùng chung Feed / Profile / Diary / Chat / Streak nhưng **chưa có file trong codebase và chưa có owner**. Cần ThienPDM: (1) define contract + Figma node ID cho Taskbar, (2) assign owner implement, (3) confirm Profile module chỉ consume không tự tạo. Nếu chưa có Taskbar → ProfileScreen không thể hoàn chỉnh UI. | **✅ Resolved (2026-05-28, ThienPDM):** Stub tạo tại `lib/shared/widgets/app_taskbar.dart`. Owner: ThienPDM. Contract: `TaskbarTab` enum + `onTabSelected` callback. Figma node ID pending confirm với designer. Module owners chỉ consume, không tự tạo. |

--- a/docs/specs/2026-05-23-settings.md
+++ b/docs/specs/2026-05-23-settings.md
@@ -196,7 +196,7 @@ Settings sheet → tap "Tài khoản đã chặn"
         → user bị xoá khỏi danh sách ngay lập tức
 ```
 
-> **Unblock + unfriend là atomic:** cần CF hoặc Firestore batch — xem OQ5 bên dưới.
+> **Unblock + unfriend là atomic:** dùng CF `unblockUser` (Admin SDK batch). Resolved OQ5 — 2026-05-28.
 
 ---
 
@@ -339,12 +339,10 @@ blockId = "{blockerUid}_{blockedUid}"   ← KHÔNG sorted, giữ direction
 ### `/users/{uid}` — thêm field `isSearchable`
 
 ```
-isSearchable: bool (default: true)
+isSearchable: bool (default: true)   ← ✅ Added to UserProfile freezed model (2026-05-28)
 ```
 
 Block list lấy từ `/blocks` collection query `where('blockerUid', isEqualTo: currentUid)`.
-
-> **⚠️ [OQ5] Cần ThienPDM confirm:** thêm `isSearchable: bool` vào freezed model `UserProfile` và contract `/users/{uid}`. Friend search query phải filter `where('isSearchable', isEqualTo: true)` trước khi trả kết quả.
 
 ---
 
@@ -397,9 +395,8 @@ match /blocks/{blockId} {
   // Chỉ blocker tạo (qua Cloud Function blockUser — không cho client trực tiếp)
   // Nếu dùng CF: rules chặn client write, CF dùng Admin SDK bypass rules
   allow create: if false;  // CF Admin SDK bypasses
-  // Chỉ blocker unblock (client trực tiếp OK vì chỉ xoá doc của mình)
-  allow delete: if isAuthed()
-    && resource.data.blockerUid == request.auth.uid;
+  // Chỉ CF Admin SDK unblock (atomic với unfriend) — client không write trực tiếp
+  allow delete: if false;  // CF Admin SDK bypasses — resolved OQ5
   allow update: if false;
 }
 ```
@@ -519,43 +516,11 @@ function isBlocked(uid) {
 | `ShareProfileSheet` stub | `lib/shared/widgets/share_profile_sheet.dart` — **shared component**, leader own | ⬅️ Shared |
 | `PhotoActionSheet` stub | `lib/features/home/presentation/photo_action_sheet.dart` | ❌ (home-camera-feed module) |
 | Firestore rules `/blocks` | `firestore.rules` | ❌ |
-| Cloud Function `blockUser` stub | `firebase/functions/src/index.ts` | ❌ |
-| Cloud Function `deleteAccount` stub | `firebase/functions/src/index.ts` | ❌ |
+| Cloud Function `blockUser` stub | `firebase/functions/src/index.ts` | ✅ |
+| Cloud Function `unblockUser` stub | `firebase/functions/src/index.ts` | ✅ LX-GATE |
+| Cloud Function `deleteAccount` stub | `firebase/functions/src/index.ts` | ✅ |
 | `isBlocked()` rule helper | `firestore.rules` | ❌ |
 | TODO markers trên mọi stub | — | ⏳ |
-
----
-
-## ⚠️ Pending — Cần ThienPDM quyết định
-
-> Ghi chú ngày 2026-05-28 (NganTNK). Hai vấn đề dưới đây block implement T1 và T4 — cần leader resolve trước khi NganTNK code phần liên quan.
-
-### [OQ5] Unblock + unfriend — client writes hay CF atomic?
-
-**Bối cảnh:** Luồng unblock mới (2026-05-28) yêu cầu tap [Bỏ chặn] phải đồng thời:
-1. Xoá `/blocks/{me}_{targetUid}`
-2. Xoá `/friendships/{pairId}` nếu tồn tại
-
-**Vấn đề:** Hiện tại `BlockRepository.unblockUser()` là client delete trực tiếp (Firestore rules `allow delete` cho blocker). Nếu cần atomic với unfriend thì phải dùng CF `unblockUser`.
-
-**Hai hướng:**
-- **A — CF `unblockUser`:** atomic, nhất quán với `blockUser`. Cần thêm CF stub + đổi Firestore rules `allow delete: if false`. Tốn thêm ~1 ngày.
-- **B — 2 client writes sequential:** đơn giản hơn, nhưng nếu write 2 fail thì partial state (block xoá nhưng friendship còn). Acceptable cho MVP?
-
-**Quyết định cần:** A hay B? Nếu A → ThienPDM cần thêm CF stub `unblockUser` vào contract và đổi Firestore rules.
-
----
-
-### [OQ6] Field `isSearchable` trong `UserProfile` freezed model
-
-**Bối cảnh:** Luồng Quyền riêng tư mới (2026-05-28) có toggle cho phép/tắt tìm kiếm bằng username. Cần field `isSearchable: bool` trong `/users/{uid}`.
-
-**Vấn đề:** Field này chưa có trong freezed model `UserProfile` hiện tại. NganTNK không được tự thêm field vào model của leader (Strict gate rule).
-
-**Việc cần ThienPDM làm:**
-1. Thêm `isSearchable: bool` (default `true`) vào `UserProfile` freezed model.
-2. Thêm field vào Firestore `/users/{uid}` schema.
-3. Thông báo cho module Friend: search query phải filter `where('isSearchable', isEqualTo: true)`.
 
 ---
 
@@ -567,8 +532,8 @@ function isBlocked(uid) {
 | OQ2 | Re-auth UX khi xoá tài khoản | UX | ✅ **Resolved:** inline trong `DeleteAccountDialog` step 2 |
 | OQ3 | "Quyền riêng tư và dữ liệu" — static hay có action? | Scope | 🔄 **Revised (2026-05-28, NganTNK):** không còn static — có toggle `isSearchable` |
 | OQ4 | Widget 2x2 hiện avatars hay ảnh? | Widget contract | ✅ **Resolved:** deferred to Widget module spec |
-| OQ5 | Unblock + unfriend — client 2 writes hay CF atomic? | Architecture | ⏳ **Cần ThienPDM confirm:** unblock hiện là client delete, nhưng cần đồng thời xoá friendship → nên dùng CF `unblockUser` để atomic, hoặc chấp nhận 2 client writes sequential? |
-| OQ6 | `isSearchable` field trong `UserProfile` freezed model | Contract | ⏳ **Cần ThienPDM thêm:** field `isSearchable: bool` vào `/users/{uid}` + freezed model. Friend search module phải filter theo field này. |
+| OQ5 | Unblock + unfriend — client 2 writes hay CF atomic? | Architecture | ✅ **Resolved (2026-05-28, ThienPDM):** CF `unblockUser` (hướng A). Atomic batch: xoá `/blocks/{me}_{targetUid}` + xoá `/friendships/{pairId}` nếu tồn tại. Firestore rules `/blocks` giữ `allow delete: if false` — chỉ CF Admin SDK. Stub `unblockUser` đã thêm vào `firebase/functions/src/index.ts`. |
+| OQ6 | `isSearchable` field trong `UserProfile` freezed model | Contract | ✅ **Resolved (2026-05-28, ThienPDM):** Thêm `@Default(true) bool isSearchable` vào `UserProfile`. Friend search query phải filter `where('isSearchable', isEqualTo: true)`. Default `true` để existing users không bị ẩn. |
 | OQH1 | Block trigger & menu options | UX | ✅ **Resolved:** `PhotoActionSheet` — Chia sẻ / Messenger / Instagram / Tin nhắn / Báo cáo (stub) / Chặn / Lưu / Xoá |
 | OQH2 | Navigation sau khi block | UX | ✅ **Resolved:** modal đổi sang [Đã chặn!] → tap [Bỏ qua] → về feed (blocked posts hidden) |
 | OQH3 | SpaceQuickRow trước M3 | UX | 🔄 **Revised (2026-05-28, NganTNK):** không dùng toast — navigate thẳng vào Space module (Sửa/Tạo) |

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -166,7 +166,7 @@ service cloud.firestore {
         request.auth.uid == resource.data.blockerUid ||
         request.auth.uid == resource.data.blockedUid
       );
-      allow create, update, delete: if false; // CF blockUser only
+      allow create, update, delete: if false; // CF blockUser / unblockUser (Admin SDK) only
     }
 
     // ===== /spaces/{spaceId} =====

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -119,6 +119,21 @@ export const blockUser = onCall((request) => {
 });
 
 /**
+ * Unblock a user: delete /blocks doc + delete /friendships/{pairId} if exists.
+ * Atomic via Admin SDK batch — client cannot write /blocks directly.
+ *
+ * TODO(SE/impl):
+ *   - verify caller != target
+ *   - delete /blocks/{blockerUid}_{targetUid} if exists
+ *   - delete /friendships/{pairId} if exists
+ */
+export const unblockUser = onCall((request) => {
+  if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
+  // TODO(SE/impl): see comment above.
+  return { ok: true };
+});
+
+/**
  * Delete account: re-authenticate, then cascade-delete all user data.
  *
  * TODO(SE/impl):


### PR DESCRIPTION
## Tóm tắt

Gate contracts cho Profile + Settings module — resolve tất cả OQ blocking trước khi dev implement.

- `UserProfile`: thêm `isSearchable: bool` (`@Default(true)`) — Settings toggle quyền riêng tư; Friend search filter theo field này
- `FriendProfileScreen`: tạo stub + sửa route `/friend-profile/:uid` (trước đây trỏ sai sang `ProfileScreen`)
- `AppTaskbar`: tạo stub shared widget với `TaskbarTab` enum + `onTabSelected` contract; owner ThienPDM; unblock T3/T7/T8
- CF `unblockUser`: thêm stub atomic (Admin SDK batch) — xoá `/blocks` + `/friendships` trong 1 transaction; consistent với `blockUser`
- Firestore rules `/blocks`: cập nhật comment rõ `blockUser` + `unblockUser`
- Profile spec: resolve OQ5 (post visibility dùng `audienceType`/`audienceUids` có sẵn, không thêm `recipientIds`), OQ6 (`AppConfig.shareBaseUrl`), OQ8 (AppTaskbar owner + stub)
- Settings spec: resolve OQ5 (CF `unblockUser` atomic), OQ6 (`isSearchable` field); xoá section Pending

## Quyết định đã chốt

| OQ | Quyết định |
|---|---|
| Profile OQ5 | Dùng `audienceType` + `audienceUids` đã có trong `Post` — KHÔNG thêm `recipientIds` |
| Profile OQ6 | `AppConfig.shareBaseUrl = 'meep://profile'` — consistent với Settings OQH4 |
| Profile OQ8 | `AppTaskbar` owner: ThienPDM; stub tại `lib/shared/widgets/app_taskbar.dart` |
| Settings OQ5 | CF `unblockUser` atomic (hướng A) — Firestore rules giữ `allow delete: if false` |
| Settings OQ6 | `isSearchable: bool` thêm vào `UserProfile` freezed model, default `true` |

## Test plan

- [x] `flutter analyze` — no issues
- [x] `dart format` — no changes
- [x] ESLint CF — no issues
- [x] Pre-commit hooks pass
- [ ] Friend search query cần filter `where('isSearchable', isEqualTo: true)` — notify KhoaLND (Friend module)
- [ ] AppTaskbar Figma node ID cần confirm với HanDHG/NganTNK trước khi implement

🤖 Generated with [Claude Code](https://claude.ai/claude-code)