### PR TITLE
feat(chat): implement InboxScreen, ChatScreen 1-1, GroupChatScreen + UI polish

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -15,6 +15,7 @@ import 'package:meep/features/auth/presentation/signup/signup_name_page.dart';
 import 'package:meep/features/auth/presentation/signup/signup_password_page.dart';
 import 'package:meep/features/auth/presentation/signup/signup_username_page.dart';
 import 'package:meep/features/chat/presentation/chat_screen.dart';
+import 'package:meep/features/chat/presentation/group_chat_screen.dart';
 import 'package:meep/features/chat/presentation/inbox_screen.dart';
 import 'package:meep/dev/widget_catalog_page.dart';
 import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
@@ -57,6 +58,15 @@ String? authRedirect({
 
   // Password reset deep link: bypass toàn bộ auth guard
   if (location == '/login/reset-password' || location.startsWith('/__/auth/')) {
+    return null;
+  }
+
+  // DEV(C/#142): cho phép test luồng Chat FE không cần login (bypass cả 2 chiều
+  // — uid null không bị đá về /intro, uid có không bị đá về /home). Bỏ khi auth
+  // wire xong + có home-shell điều hướng Inbox sau đăng nhập.
+  if (location.startsWith('/inbox') ||
+      location.startsWith('/chat') ||
+      location.startsWith('/group-chat')) {
     return null;
   }
 
@@ -305,6 +315,12 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/chat/:conversationId',
         builder: (_, state) => ChatScreen(
+          conversationId: state.pathParameters['conversationId'] ?? '',
+        ),
+      ),
+      GoRoute(
+        path: '/group-chat/:conversationId',
+        builder: (_, state) => GroupChatScreen(
           conversationId: state.pathParameters['conversationId'] ?? '',
         ),
       ),

--- a/apps/mobile/lib/core/theme/app_text_styles.dart
+++ b/apps/mobile/lib/core/theme/app_text_styles.dart
@@ -37,6 +37,14 @@ abstract final class AppTextStyles {
     height: 18 / 14,
   );
 
+  // text-base — 18px
+  static const baseBold = TextStyle(
+    fontFamily: _family,
+    fontSize: 18,
+    fontWeight: FontWeight.w700,
+    height: 24 / 18,
+  );
+
   // text-md — 16px
   static const mdRegular = TextStyle(
     fontFamily: _family,

--- a/apps/mobile/lib/core/theme/hex_color.dart
+++ b/apps/mobile/lib/core/theme/hex_color.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Parse hex color string ("#RRGGBB" hoặc "RRGGBB") → [Color].
+///
+/// Trả về [fallback] nếu chuỗi không hợp lệ (sai độ dài / ký tự lạ) thay vì
+/// throw — tránh crash UI khi colorHex từ nguồn ngoài (Firestore, custom)
+/// bị malformed.
+Color hexToColor(String hex, {Color fallback = const Color(0xFF656C6D)}) {
+  var cleaned = hex.trim();
+  if (cleaned.startsWith('#')) cleaned = cleaned.substring(1);
+  if (cleaned.length != 6) return fallback;
+  final value = int.tryParse(cleaned, radix: 16);
+  if (value == null) return fallback;
+  return Color(0xFF000000 | value);
+}

--- a/apps/mobile/lib/dev/widget_catalog_page.dart
+++ b/apps/mobile/lib/dev/widget_catalog_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_spacing.dart';
@@ -19,6 +20,15 @@ class WidgetCatalogPage extends StatefulWidget {
 
 class _WidgetCatalogPageState extends State<WidgetCatalogPage> {
   TaskbarTab _activeTab = TaskbarTab.home;
+
+  /// DEV: tab Tin nhắn mở Inbox để test luồng Chat. Các tab khác chỉ đổi active.
+  void _onTab(TaskbarTab tab) {
+    if (tab == TaskbarTab.chat) {
+      context.push('/inbox');
+      return;
+    }
+    setState(() => _activeTab = tab);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -117,7 +127,7 @@ class _WidgetCatalogPageState extends State<WidgetCatalogPage> {
                   activeTab: _activeTab,
                   variant: TaskbarVariant.floating,
                   chatBadgeCount: 2,
-                  onTabSelected: (tab) => setState(() => _activeTab = tab),
+                  onTabSelected: _onTab,
                 ),
               ],
             ),
@@ -150,7 +160,7 @@ class _WidgetCatalogPageState extends State<WidgetCatalogPage> {
                 AppTaskbar(
                   activeTab: _activeTab,
                   variant: TaskbarVariant.embedded,
-                  onTabSelected: (tab) => setState(() => _activeTab = tab),
+                  onTabSelected: _onTab,
                 ),
               ],
             ),

--- a/apps/mobile/lib/features/chat/application/chat_controller.dart
+++ b/apps/mobile/lib/features/chat/application/chat_controller.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/chat/data/conversation_repository.dart';
 
 part 'chat_controller.g.dart';
@@ -12,25 +14,65 @@ ConversationRepository conversationRepository(Ref ref) =>
       'wire FirestoreConversationRepository in main.dart (TODO: C/T1/TBD)',
     );
 
+/// Drives message sending. UI watches this for in-flight/error feedback;
+/// the message list itself comes from `messagesProvider` (a StreamProvider),
+/// so this controller only owns the transient send status.
 @riverpod
 class ChatController extends _$ChatController {
   @override
-  void build() {}
+  ChatSendStatus build() => const ChatSendStatus();
 
   Future<void> sendMessage({
     required String conversationId,
     required String text,
   }) async {
-    // TODO(C/T2/TBD): implement sendMessage
-    throw UnimplementedError('sendMessage — TODO: C/T2/TBD');
+    state = const ChatSendStatus(isSending: true);
+    try {
+      await ref.read(conversationRepositoryProvider).sendMessage(
+            conversationId: conversationId,
+            senderId: ref.read(currentChatUidProvider),
+            text: text,
+          );
+      state = const ChatSendStatus();
+    } catch (e) {
+      state = ChatSendStatus(errorMessage: AppError.fromUnknown(e).message);
+    }
   }
 
-  Future<void> sendMessageFromFeed({
+  /// Reply to a feed post — get/create the 1-1 conversation then send.
+  /// Returns the conversation id so the caller can navigate to the thread.
+  Future<String?> sendMessageFromFeed({
     required String postId,
     required String authorId,
     required String text,
   }) async {
-    // TODO(C/T3/TBD): get/create conversation then send message
-    throw UnimplementedError('sendMessageFromFeed — TODO: C/T3/TBD');
+    state = const ChatSendStatus(isSending: true);
+    try {
+      final repo = ref.read(conversationRepositoryProvider);
+      final conversation = await repo.getOrCreateConversation(
+        uid: ref.read(currentChatUidProvider),
+        otherUid: authorId,
+      );
+      await repo.sendMessage(
+        conversationId: conversation.conversationId,
+        senderId: ref.read(currentChatUidProvider),
+        text: text,
+      );
+      state = const ChatSendStatus();
+      return conversation.conversationId;
+    } catch (e) {
+      state = ChatSendStatus(errorMessage: AppError.fromUnknown(e).message);
+      return null;
+    }
   }
+
+  void clearError() => state = const ChatSendStatus();
+}
+
+/// Transient send status for the chat input bar.
+class ChatSendStatus {
+  const ChatSendStatus({this.isSending = false, this.errorMessage});
+
+  final bool isSending;
+  final String? errorMessage;
 }

--- a/apps/mobile/lib/features/chat/application/chat_providers.dart
+++ b/apps/mobile/lib/features/chat/application/chat_providers.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/chat/data/chat_seed_data.dart';
+import 'package:meep/features/chat/data/conversation.dart';
+import 'package:meep/features/chat/application/chat_controller.dart';
+import 'package:meep/features/chat/data/message.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/space/data/space.dart';
+import 'package:meep/features/space/data/space_member.dart';
+
+part 'chat_providers.g.dart';
+
+/// Current logged-in uid for the Chat module.
+///
+/// FE-first round returns a mock uid (matches [ChatSeed.currentUid]).
+/// TODO(C/wire): read from `currentUidProvider` (auth) once integrated.
+@riverpod
+String currentChatUid(Ref ref) => ChatSeed.currentUid;
+
+/// Live conversations for the inbox, sorted by lastMessageAt DESC.
+@riverpod
+Stream<List<Conversation>> conversations(Ref ref) {
+  final uid = ref.watch(currentChatUidProvider);
+  return ref.watch(conversationRepositoryProvider).watchConversations(uid);
+}
+
+/// Per-conversation message-window limit. Increase to load older messages
+/// (re-subscribes `messages` with a larger limit). See [ConversationRepository].
+@riverpod
+class MessageLimit extends _$MessageLimit {
+  @override
+  int build(String conversationId) => 50;
+
+  void loadMore() => state += 50;
+}
+
+/// Live messages for [conversationId], chronological ASC, windowed by limit.
+@riverpod
+Stream<List<Message>> messages(Ref ref, String conversationId) {
+  final limit = ref.watch(messageLimitProvider(conversationId));
+  return ref
+      .watch(conversationRepositoryProvider)
+      .watchMessages(conversationId, limit: limit);
+}
+
+/// Unread counts per conversation — NOT in [Conversation] model yet
+/// (contract-pending, see plan). FE renders the inbox badge from this.
+/// TODO(C/wire): derive from `lastReadAt` once the field lands on the model.
+@riverpod
+Map<String, int> unreadCounts(Ref ref) => ChatSeed.seedUnreadCounts();
+
+/// User profiles keyed by uid, for resolving 1-1 conversation display info.
+/// TODO(C/wire): replace seed lookup with `userRepository` reads.
+@riverpod
+Map<String, UserProfile> chatUserProfiles(Ref ref) => ChatSeed.usersByUid;
+
+/// The single demo space backing group chat.
+/// TODO(C/wire): replace with `spaceRepository.watchSpace(spaceId)`.
+@riverpod
+Space chatSpace(Ref ref, String spaceId) => ChatSeed.seedSpace();
+
+/// Members of the demo space.
+/// TODO(C/wire): replace with `spaceRepository.watchMembers(spaceId)`.
+@riverpod
+List<SpaceMember> chatSpaceMembers(Ref ref, String spaceId) =>
+    ChatSeed.seedMembers();
+
+/// The post that a 1-1 conversation was started from (quoted photo header).
+/// Returns null when the conversation has no originating post.
+/// TODO(C/wire): replace with `postRepository.getPost(quotedPostId)`.
+@riverpod
+Post? chatQuotedPost(Ref ref, String? quotedPostId) {
+  if (quotedPostId == null) return null;
+  final post = ChatSeed.quotedPost();
+  return post.postId == quotedPostId ? post : null;
+}

--- a/apps/mobile/lib/features/chat/data/chat_seed_data.dart
+++ b/apps/mobile/lib/features/chat/data/chat_seed_data.dart
@@ -1,0 +1,186 @@
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/chat/data/conversation.dart';
+import 'package:meep/features/chat/data/message.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/space/data/space.dart';
+import 'package:meep/features/space/data/space_member.dart';
+
+/// Seed data for [FakeConversationRepository] — FE-first round (#142).
+///
+/// Hardcoded demo content so the Chat UI can be built and reviewed before the
+/// Firebase backend (Friend #88 / Settings #115 / Space) is wired. Replaced by
+/// real Firestore reads via `FirebaseConversationRepository` later.
+///
+/// `DateTime.now()` is intentional here — seed timestamps are relative to app
+/// launch so the inbox ordering and "x phút trước" labels look natural in demo.
+abstract final class ChatSeed {
+  /// Current logged-in user (mock). Matches `'current-uid-mock'` used by
+  /// `friend_select_step` so cross-screen demo data lines up.
+  static const currentUid = 'current-uid-mock';
+
+  static final _now = DateTime.now();
+
+  // --- Users -------------------------------------------------------------
+
+  static final me = UserProfile(
+    uid: currentUid,
+    email: 'me@meep.app',
+    displayName: 'Bạn',
+    username: 'me',
+    createdAt: _now,
+    updatedAt: _now,
+  );
+
+  static final talaki = UserProfile(
+    uid: 'uid-talaki',
+    email: 'talaki@meep.app',
+    displayName: 'Talaki',
+    username: 'talaki',
+    avatarUrl: 'https://i.pravatar.cc/150?img=12',
+    createdAt: _now,
+    updatedAt: _now,
+  );
+
+  static final minh = UserProfile(
+    uid: 'uid-minh',
+    email: 'minh@meep.app',
+    displayName: 'Minh Anh',
+    username: 'minhanh',
+    avatarUrl: 'https://i.pravatar.cc/150?img=32',
+    createdAt: _now,
+    updatedAt: _now,
+  );
+
+  static final linh = UserProfile(
+    uid: 'uid-linh',
+    email: 'linh@meep.app',
+    displayName: 'Linh',
+    username: 'linh',
+    avatarUrl: 'https://i.pravatar.cc/150?img=45',
+    createdAt: _now,
+    updatedAt: _now,
+  );
+
+  /// Lookup by uid for tiles / bubbles / member lists.
+  static Map<String, UserProfile> get usersByUid => {
+        for (final u in [me, talaki, minh, linh]) u.uid: u,
+      };
+
+  // --- Conversation IDs --------------------------------------------------
+
+  static const convTalaki = 'conv-talaki'; // 1-1 with messages + unread
+  static const convMinh = 'conv-minh'; // 1-1 empty (empty-thread state)
+  static const convGroup = 'conv-group'; // space group chat
+
+  static const groupSpaceId = 'space-fun';
+
+  // --- Messages ----------------------------------------------------------
+
+  /// Initial messages per conversation. `convMinh` intentionally absent →
+  /// empty thread (`769:3019`).
+  static Map<String, List<Message>> seedMessages() => {
+        convTalaki: [
+          Message(
+            messageId: 'm1',
+            senderId: talaki.uid,
+            text: 'Ảnh đẹp quá, chụp ở đâu vậy?',
+            createdAt: _now.subtract(const Duration(minutes: 30)),
+          ),
+          Message(
+            messageId: 'm2',
+            senderId: me.uid,
+            text: 'Đà Lạt đó, cuối tuần đi không?',
+            createdAt: _now.subtract(const Duration(minutes: 25)),
+          ),
+          Message(
+            messageId: 'm3',
+            senderId: talaki.uid,
+            text: 'Đi chứ!',
+            createdAt: _now.subtract(const Duration(minutes: 2)),
+          ),
+        ],
+        convGroup: [
+          Message(
+            messageId: 'g1',
+            senderId: minh.uid,
+            text: 'Mọi người rảnh tối nay không?',
+            createdAt: _now.subtract(const Duration(hours: 1)),
+          ),
+          Message(
+            messageId: 'g2',
+            senderId: linh.uid,
+            text: 'Có nha',
+            createdAt: _now.subtract(const Duration(minutes: 50)),
+          ),
+        ],
+      };
+
+  // --- Conversations -----------------------------------------------------
+
+  static List<Conversation> seedConversations() => [
+        Conversation(
+          conversationId: convTalaki,
+          type: ConversationType.direct,
+          participantIds: [me.uid, talaki.uid],
+          quotedPostId: 'post-dalat',
+          lastMessage: 'Đi chứ!',
+          lastMessageAt: _now.subtract(const Duration(minutes: 2)),
+          lastSenderId: talaki.uid,
+          createdAt: _now.subtract(const Duration(days: 1)),
+        ),
+        Conversation(
+          conversationId: convMinh,
+          type: ConversationType.direct,
+          participantIds: [me.uid, minh.uid],
+          lastMessageAt: _now.subtract(const Duration(minutes: 10)),
+          createdAt: _now.subtract(const Duration(minutes: 10)),
+        ),
+        Conversation(
+          conversationId: convGroup,
+          type: ConversationType.space,
+          participantIds: [me.uid, minh.uid, linh.uid],
+          spaceId: groupSpaceId,
+          lastMessage: 'Có nha',
+          lastMessageAt: _now.subtract(const Duration(minutes: 50)),
+          lastSenderId: linh.uid,
+          createdAt: _now.subtract(const Duration(days: 3)),
+        ),
+      ];
+
+  /// Unread counts per conversation — NOT in [Conversation] model yet
+  /// (contract-pending, see plan). FE renders badge from this map.
+  static Map<String, int> seedUnreadCounts() => {convTalaki: 1};
+
+  // --- Quoted post (1-1 reply origin) ------------------------------------
+
+  /// The post that started [convTalaki] — shown as the quoted photo at the top
+  /// of the thread (`564:6942` + caption `564:6961`).
+  static Post quotedPost() => Post(
+        postId: 'post-dalat',
+        authorId: me.uid,
+        authorName: me.displayName,
+        imageUrl: 'https://picsum.photos/seed/dalat/600',
+        caption: 'Feeling toasty!',
+        audienceType: AudienceType.all,
+        createdAt: _now.subtract(const Duration(days: 1)),
+      );
+
+  // --- Space (group chat) ------------------------------------------------
+
+  static Space seedSpace() => Space(
+        spaceId: groupSpaceId,
+        name: 'Hội bạn thân',
+        iconEmoji: '🎉',
+        colorHex: '#00DEEE',
+        creatorId: me.uid,
+        memberCount: 3,
+        memberIds: [me.uid, minh.uid, linh.uid],
+        createdAt: _now.subtract(const Duration(days: 3)),
+      );
+
+  static List<SpaceMember> seedMembers() => [
+        SpaceMember(role: SpaceRole.creator, uid: me.uid, joinedAt: _now),
+        SpaceMember(role: SpaceRole.member, uid: minh.uid, joinedAt: _now),
+        SpaceMember(role: SpaceRole.member, uid: linh.uid, joinedAt: _now),
+      ];
+}

--- a/apps/mobile/lib/features/chat/data/conversation_repository.dart
+++ b/apps/mobile/lib/features/chat/data/conversation_repository.dart
@@ -21,6 +21,14 @@ abstract class ConversationRepository {
     required String text,
   });
 
-  /// Stream of messages for [conversationId], chronological ASC.
-  Stream<List<Message>> watchMessages(String conversationId);
+  /// Stream of the most recent [limit] messages for [conversationId],
+  /// ordered chronological ASC (oldest first) for display.
+  ///
+  /// Impl: query `orderBy('createdAt', descending: true).limit(limit)` to take
+  /// the newest [limit] messages, then reverse client-side to ASC.
+  /// To load older messages, re-subscribe with a larger [limit] (50 → 100 → …).
+  Stream<List<Message>> watchMessages(
+    String conversationId, {
+    int limit = 50,
+  });
 }

--- a/apps/mobile/lib/features/chat/data/fake_conversation_repository.dart
+++ b/apps/mobile/lib/features/chat/data/fake_conversation_repository.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/core/utils/pair_id.dart';
+import 'package:meep/features/chat/data/chat_seed_data.dart';
+import 'package:meep/features/chat/data/conversation.dart';
+import 'package:meep/features/chat/data/conversation_repository.dart';
+import 'package:meep/features/chat/data/message.dart';
+
+/// In-memory [ConversationRepository] for the FE-first round (#142).
+///
+/// Holds seed conversations + messages in memory and re-emits the full list on
+/// every mutation through broadcast controllers. No Firestore. Swap for
+/// `FirebaseConversationRepository` via provider override once the backend is
+/// wired (see plan §wire-point).
+class FakeConversationRepository implements ConversationRepository {
+  FakeConversationRepository() {
+    _conversations = ChatSeed.seedConversations();
+    _messages = ChatSeed.seedMessages();
+  }
+
+  /// Max message length — mirrors `Message.text` "Max 500 chars." contract.
+  static const _maxTextLength = 500;
+
+  late List<Conversation> _conversations;
+  late Map<String, List<Message>> _messages;
+
+  final _conversationsCtrl = StreamController<List<Conversation>>.broadcast();
+
+  /// One message controller per conversation, created on first watch.
+  final _messageCtrls = <String, StreamController<List<Message>>>{};
+
+  // --- Reads -------------------------------------------------------------
+
+  @override
+  Stream<List<Conversation>> watchConversations(String uid) async* {
+    // Emit current snapshot on listen (broadcast controllers don't replay),
+    // then forward live updates.
+    yield _sortedFor(uid, _conversations);
+    yield* _conversationsCtrl.stream.map((list) => _sortedFor(uid, list));
+  }
+
+  @override
+  Stream<List<Message>> watchMessages(
+    String conversationId, {
+    int limit = 50,
+  }) async* {
+    // Long-lived controller, reused across re-subscriptions and closed in
+    // [dispose]; not closed per-listen by design.
+    // ignore: close_sinks
+    final ctrl = _messageCtrls.putIfAbsent(
+      conversationId,
+      () => StreamController<List<Message>>.broadcast(),
+    );
+    yield _windowed(_messagesOf(conversationId), limit);
+    yield* ctrl.stream.map((list) => _windowed(list, limit));
+  }
+
+  // --- Writes ------------------------------------------------------------
+
+  @override
+  Future<Conversation> getOrCreateConversation({
+    required String uid,
+    required String otherUid,
+  }) async {
+    final existing = _conversations.where(
+      (c) =>
+          c.type == ConversationType.direct &&
+          c.participantIds.contains(uid) &&
+          c.participantIds.contains(otherUid),
+    );
+    if (existing.isNotEmpty) return existing.first;
+
+    final now = DateTime.now();
+    final created = Conversation(
+      conversationId: pairIdOf(uid, otherUid),
+      type: ConversationType.direct,
+      participantIds: [uid, otherUid],
+      lastMessageAt: now,
+      createdAt: now,
+    );
+    _conversations = [..._conversations, created];
+    _conversationsCtrl.add(_conversations);
+    return created;
+  }
+
+  @override
+  Future<void> sendMessage({
+    required String conversationId,
+    required String senderId,
+    required String text,
+  }) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) {
+      throw const ValidationError(message: 'Tin nhắn không được để trống');
+    }
+    if (trimmed.length > _maxTextLength) {
+      throw const ValidationError(
+        message: 'Tin nhắn tối đa $_maxTextLength ký tự',
+      );
+    }
+    final idx = _conversations.indexWhere(
+      (c) => c.conversationId == conversationId,
+    );
+    if (idx == -1) throw NotFoundError('Conversation');
+
+    final now = DateTime.now();
+    final msg = Message(
+      messageId: 'm-${now.microsecondsSinceEpoch}',
+      senderId: senderId,
+      text: trimmed,
+      createdAt: now,
+    );
+
+    _messages = {
+      ..._messages,
+      conversationId: [..._messagesOf(conversationId), msg],
+    };
+    _conversations = [..._conversations]..[idx] = _conversations[idx].copyWith(
+        lastMessage: trimmed,
+        lastMessageAt: now,
+        lastSenderId: senderId,
+      );
+
+    _messageCtrls[conversationId]?.add(_messagesOf(conversationId));
+    _conversationsCtrl.add(_conversations);
+  }
+
+  // --- Helpers -----------------------------------------------------------
+
+  List<Message> _messagesOf(String id) => _messages[id] ?? const [];
+
+  List<Conversation> _sortedFor(String uid, List<Conversation> list) {
+    final mine = list.where((c) => c.participantIds.contains(uid)).toList()
+      ..sort((a, b) => b.lastMessageAt.compareTo(a.lastMessageAt));
+    return mine;
+  }
+
+  /// Newest [limit] messages, returned chronological ASC (oldest first).
+  List<Message> _windowed(List<Message> all, int limit) {
+    if (all.length <= limit) return List.unmodifiable(all);
+    return List.unmodifiable(all.sublist(all.length - limit));
+  }
+
+  /// Release controllers — call from provider `onDispose`.
+  void dispose() {
+    _conversationsCtrl.close();
+    for (final c in _messageCtrls.values) {
+      c.close();
+    }
+  }
+}

--- a/apps/mobile/lib/features/chat/presentation/chat_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/chat_screen.dart
@@ -1,11 +1,184 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// TODO(C/T5/TBD): implement ChatScreen per Figma — 1-1 direct chat
-class ChatScreen extends StatelessWidget {
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/chat/application/chat_controller.dart';
+import 'package:meep/features/chat/application/chat_providers.dart';
+import 'package:meep/features/chat/data/conversation.dart';
+import 'package:meep/features/chat/presentation/chat_thread_view.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_avatar.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_confirm_dialogs.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_input_bar.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_menu_sheet.dart';
+
+/// 1-1 direct chat thread. Figma `564:6934` (+ empty `769:3019`).
+class ChatScreen extends ConsumerWidget {
   const ChatScreen({super.key, required this.conversationId});
 
   final String conversationId;
 
   @override
-  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+  Widget build(BuildContext context, WidgetRef ref) {
+    final conversationsAsync = ref.watch(conversationsProvider);
+    final conversation = conversationsAsync.valueOrNull
+        ?.where((c) => c.conversationId == conversationId)
+        .firstOrNull;
+
+    final myUid = ref.watch(currentChatUidProvider);
+    final profiles = ref.watch(chatUserProfilesProvider);
+    final peer = _resolvePeer(conversation, myUid, profiles);
+
+    final messagesAsync = ref.watch(messagesProvider(conversationId));
+    final sendStatus = ref.watch(chatControllerProvider);
+    final quotedPost =
+        ref.watch(chatQuotedPostProvider(conversation?.quotedPostId));
+
+    // No composer for a brand-new conversation with no shared Meep: the only way
+    // to start is by replying to a Meep (Figma `769:3019` has no input bar).
+    final hasMessages = messagesAsync.valueOrNull?.isNotEmpty ?? false;
+    final canCompose = hasMessages || quotedPost != null;
+
+    return Scaffold(
+      backgroundColor: AppColors.bw900,
+      body: SafeArea(
+        child: Column(
+          children: [
+            _ChatHeader(
+              title: peer?.displayName ?? 'Trò chuyện',
+              avatarUrl: peer?.avatarUrl,
+              onMenu: () =>
+                  _onMenu(context, ref, peer?.displayName ?? 'người này'),
+            ),
+            Expanded(
+              child: messagesAsync.when(
+                loading: () => const Center(
+                  child: CircularProgressIndicator(
+                    color: AppColors.turquoise500,
+                  ),
+                ),
+                error: (_, __) => const Center(
+                  child: Text('Không tải được tin nhắn.'),
+                ),
+                data: (messages) => ChatThreadView(
+                  messages: messages,
+                  myUid: myUid,
+                  peerAvatarUrl: peer?.avatarUrl,
+                  quotedPostId: conversation?.quotedPostId,
+                  peerName: peer?.displayName ?? '',
+                ),
+              ),
+            ),
+            if (canCompose)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+                child: ChatInputBar(
+                  isSending: sendStatus.isSending,
+                  onSend: (text) => ref
+                      .read(chatControllerProvider.notifier)
+                      .sendMessage(conversationId: conversationId, text: text),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  UserProfile? _resolvePeer(
+    Conversation? conversation,
+    String myUid,
+    Map<String, UserProfile> profiles,
+  ) {
+    if (conversation == null) return null;
+    final otherUid =
+        conversation.participantIds.where((id) => id != myUid).firstOrNull;
+    return otherUid == null ? null : profiles[otherUid];
+  }
+
+  Future<void> _onMenu(BuildContext context, WidgetRef ref, String name) async {
+    final action = await showSettingMenu<ChatMenuAction>(context, const [
+      SettingMenuItem(
+        icon: Icons.person_remove_outlined,
+        label: 'Xóa bạn',
+        value: ChatMenuAction.unfriend,
+      ),
+      SettingMenuItem(
+        icon: Icons.block,
+        label: 'Chặn',
+        value: ChatMenuAction.block,
+        isDestructive: true,
+      ),
+    ]);
+    if (action == null || !context.mounted) return;
+
+    switch (action) {
+      case ChatMenuAction.unfriend:
+        final confirmed = await showUnfriendDialog(context, name);
+        if (confirmed) {
+          // TODO(C/wire): ref.read(friendControllerProvider.notifier).unfriend(uid)
+        }
+      case ChatMenuAction.block:
+        final confirmed = await showBlockSheet(context, name);
+        if (confirmed) {
+          // TODO(C/wire): ref.read(settingsControllerProvider.notifier).blockUser(uid)
+        }
+    }
+  }
+}
+
+/// Overflow-menu actions for a 1-1 chat.
+enum ChatMenuAction { unfriend, block }
+
+class _ChatHeader extends StatelessWidget {
+  const _ChatHeader({
+    required this.title,
+    required this.onMenu,
+    this.avatarUrl,
+  });
+
+  final String title;
+  final VoidCallback onMenu;
+  final String? avatarUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 12),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () => Navigator.maybePop(context),
+            child: const Icon(
+              Icons.chevron_left,
+              size: 28,
+              color: AppColors.bw100,
+            ),
+          ),
+          Expanded(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                ChatAvatar(imageUrl: avatarUrl, size: 30),
+                const SizedBox(width: 10),
+                Flexible(
+                  child: Text(
+                    title,
+                    style: AppTextStyles.baseBold,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          GestureDetector(
+            onTap: onMenu,
+            child:
+                const Icon(Icons.more_horiz, size: 24, color: AppColors.bw100),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/apps/mobile/lib/features/chat/presentation/chat_thread_view.dart
+++ b/apps/mobile/lib/features/chat/presentation/chat_thread_view.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/chat/application/chat_providers.dart';
+import 'package:meep/features/chat/data/message.dart';
+import 'package:meep/features/chat/presentation/chat_time_format.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_avatar.dart';
+import 'package:meep/features/chat/presentation/widgets/message_bubble.dart';
+import 'package:meep/features/chat/presentation/widgets/quoted_photo_block.dart';
+
+/// Scrollable message list for a thread (shared by 1-1 + group).
+///
+/// Shows the originating quoted photo at the top when [quotedPostId] resolves,
+/// the empty-thread CTA (`769:3019`) when there are no messages, otherwise the
+/// chronological bubble list. Auto-scrolls to the newest message on open, when
+/// a message is added, and as the keyboard opens (Messenger-style).
+class ChatThreadView extends ConsumerStatefulWidget {
+  const ChatThreadView({
+    super.key,
+    required this.messages,
+    required this.myUid,
+    required this.peerName,
+    this.peerAvatarUrl,
+    this.quotedPostId,
+  });
+
+  final List<Message> messages;
+  final String myUid;
+  final String peerName;
+  final String? peerAvatarUrl;
+  final String? quotedPostId;
+
+  @override
+  ConsumerState<ChatThreadView> createState() => _ChatThreadViewState();
+}
+
+class _ChatThreadViewState extends ConsumerState<ChatThreadView>
+    with WidgetsBindingObserver {
+  final _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _jumpToBottom());
+  }
+
+  @override
+  void didUpdateWidget(ChatThreadView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.messages.length != oldWidget.messages.length) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _jumpToBottom());
+    }
+  }
+
+  // Keyboard open/close changes the bottom inset over several frames; pin the
+  // list to the newest message so the composer never covers it.
+  @override
+  void didChangeMetrics() {
+    WidgetsBinding.instance.addPostFrameCallback((_) => _jumpToBottom());
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _jumpToBottom() {
+    if (!_scrollController.hasClients) return;
+    _scrollController.animateTo(
+      _scrollController.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final quoted = ref.watch(chatQuotedPostProvider(widget.quotedPostId));
+
+    if (widget.messages.isEmpty && quoted == null) {
+      return _EmptyThread(
+        peerName: widget.peerName,
+        peerAvatarUrl: widget.peerAvatarUrl,
+      );
+    }
+
+    return ListView(
+      controller: _scrollController,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+      children: [
+        if (quoted != null)
+          QuotedPhotoBlock(
+            imageUrl: quoted.imageUrl,
+            caption: quoted.caption,
+            createdAt: quoted.createdAt,
+          ),
+        for (var i = 0; i < widget.messages.length; i++) ...[
+          if (_showSeparatorBefore(i))
+            _TimeSeparator(time: widget.messages[i].createdAt),
+          MessageBubble(
+            text: widget.messages[i].text,
+            isMine: widget.messages[i].senderId == widget.myUid,
+            avatarUrl: widget.peerAvatarUrl,
+          ),
+        ],
+      ],
+    );
+  }
+
+  // First message always carries a separator; later ones only when the gap
+  // from the previous message reaches [threadSeparatorGap] (1 hour).
+  bool _showSeparatorBefore(int i) {
+    if (i == 0) return true;
+    final gap = widget.messages[i].createdAt
+        .difference(widget.messages[i - 1].createdAt);
+    return gap >= threadSeparatorGap;
+  }
+}
+
+class _TimeSeparator extends StatelessWidget {
+  const _TimeSeparator({required this.time});
+
+  final DateTime time;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Center(
+        child: Text(
+          formatThreadSeparator(time),
+          style: AppTextStyles.xsSemiBold.copyWith(color: AppColors.bw500),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyThread extends StatelessWidget {
+  const _EmptyThread({required this.peerName, this.peerAvatarUrl});
+
+  final String peerName;
+  final String? peerAvatarUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 40),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ChatAvatar(
+              imageUrl: peerAvatarUrl,
+              size: 95,
+              ringColor: AppColors.bw600,
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'Bắt đầu cuộc hội thoại!',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.lgBold.copyWith(color: AppColors.bw100),
+            ),
+            const SizedBox(height: 13),
+            Text(
+              'Trả lời một Meep của $peerName để bắt đầu trò chuyện',
+              textAlign: TextAlign.center,
+              // text-base/SemiBold (18 w600) — override weight off baseBold.
+              style: AppTextStyles.baseBold.copyWith(
+                fontWeight: FontWeight.w600,
+                color: AppColors.bw600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/chat/presentation/chat_time_format.dart
+++ b/apps/mobile/lib/features/chat/presentation/chat_time_format.dart
@@ -1,0 +1,39 @@
+/// Timestamp formatting for chat surfaces (inbox preview + thread header).
+///
+/// Vietnamese, matches Figma: recent → "Vừa xong" / "x phút" / "x giờ",
+/// older → "DD thg M".
+library;
+
+String formatInboxTimestamp(DateTime time, {DateTime? now}) {
+  final ref = now ?? DateTime.now();
+  final diff = ref.difference(time);
+
+  if (diff.inMinutes < 1) return 'Vừa xong';
+  if (diff.inMinutes < 60) return '${diff.inMinutes} phút';
+  if (diff.inHours < 24 && ref.day == time.day) return '${diff.inHours} giờ';
+  return '${time.day} thg ${time.month}';
+}
+
+/// Full date + time for the quoted-photo block header, e.g. "11 thg 4 lúc 14:30".
+String formatQuotedPhotoTimestamp(DateTime time) {
+  final hh = time.hour.toString().padLeft(2, '0');
+  final mm = time.minute.toString().padLeft(2, '0');
+  return '${time.day} thg ${time.month} lúc $hh:$mm';
+}
+
+/// Gap between two consecutive messages above which a centered time separator
+/// is shown in the thread (Messenger/iMessage convention).
+const threadSeparatorGap = Duration(hours: 1);
+
+/// Centered time separator shown between message clusters in a thread.
+///
+/// Same day → "HH:mm"; older → "DD thg M lúc HH:mm".
+String formatThreadSeparator(DateTime time, {DateTime? now}) {
+  final ref = now ?? DateTime.now();
+  final hh = time.hour.toString().padLeft(2, '0');
+  final mm = time.minute.toString().padLeft(2, '0');
+  final sameDay =
+      ref.year == time.year && ref.month == time.month && ref.day == time.day;
+  if (sameDay) return '$hh:$mm';
+  return '${time.day} thg ${time.month} lúc $hh:$mm';
+}

--- a/apps/mobile/lib/features/chat/presentation/group_chat_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/group_chat_screen.dart
@@ -1,11 +1,172 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// TODO(C/T6/TBD): implement GroupChatScreen per Figma — Space group chat
-class GroupChatScreen extends StatelessWidget {
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/chat/application/chat_controller.dart';
+import 'package:meep/features/chat/application/chat_providers.dart';
+import 'package:meep/features/chat/presentation/chat_thread_view.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_avatar.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_confirm_dialogs.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_input_bar.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_menu_sheet.dart';
+import 'package:meep/features/chat/presentation/widgets/space_members_sheet.dart';
+
+/// Space group chat thread. Figma `564:8603` (+ menu `564:8733`).
+class GroupChatScreen extends ConsumerWidget {
   const GroupChatScreen({super.key, required this.conversationId});
 
   final String conversationId;
 
   @override
-  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+  Widget build(BuildContext context, WidgetRef ref) {
+    final conversation = ref
+        .watch(conversationsProvider)
+        .valueOrNull
+        ?.where((c) => c.conversationId == conversationId)
+        .firstOrNull;
+    final spaceId = conversation?.spaceId ?? '';
+    final space = ref.watch(chatSpaceProvider(spaceId));
+
+    final myUid = ref.watch(currentChatUidProvider);
+    final messagesAsync = ref.watch(messagesProvider(conversationId));
+    final sendStatus = ref.watch(chatControllerProvider);
+
+    return Scaffold(
+      backgroundColor: AppColors.bw900,
+      body: SafeArea(
+        child: Column(
+          children: [
+            _GroupHeader(
+              title: space.name,
+              emoji: space.iconEmoji,
+              colorHex: space.colorHex,
+              onMenu: () => _onMenu(context, ref, spaceId),
+            ),
+            Expanded(
+              child: messagesAsync.when(
+                loading: () => const Center(
+                  child: CircularProgressIndicator(
+                    color: AppColors.turquoise500,
+                  ),
+                ),
+                error: (_, __) =>
+                    const Center(child: Text('Không tải được tin nhắn.')),
+                data: (messages) => ChatThreadView(
+                  messages: messages,
+                  myUid: myUid,
+                  peerName: space.name,
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+              child: ChatInputBar(
+                isSending: sendStatus.isSending,
+                onSend: (text) => ref
+                    .read(chatControllerProvider.notifier)
+                    .sendMessage(conversationId: conversationId, text: text),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _onMenu(
+    BuildContext context,
+    WidgetRef ref,
+    String spaceId,
+  ) async {
+    final action = await showSettingMenu<GroupMenuAction>(context, const [
+      SettingMenuItem(
+        icon: Icons.palette_outlined,
+        label: 'Chỉnh sửa theme',
+        value: GroupMenuAction.editTheme,
+      ),
+      SettingMenuItem(
+        icon: Icons.group_outlined,
+        label: 'Xem thành viên',
+        value: GroupMenuAction.viewMembers,
+      ),
+      SettingMenuItem(
+        icon: Icons.logout,
+        label: 'Rời khỏi Space',
+        value: GroupMenuAction.leaveSpace,
+        isDestructive: true,
+      ),
+    ]);
+    if (action == null || !context.mounted) return;
+
+    switch (action) {
+      case GroupMenuAction.editTheme:
+        // TODO(C/wire): open Space theme editor (Space module).
+        break;
+      case GroupMenuAction.viewMembers:
+        await SpaceMembersSheet.show(context, spaceId);
+      case GroupMenuAction.leaveSpace:
+        final confirmed = await showLeaveSpaceDialog(context);
+        if (confirmed) {
+          // TODO(C/wire): ref.read(spaceControllerProvider.notifier).leaveSpace(spaceId)
+        }
+    }
+  }
+}
+
+/// Overflow-menu actions for a Space group chat.
+enum GroupMenuAction { editTheme, viewMembers, leaveSpace }
+
+class _GroupHeader extends StatelessWidget {
+  const _GroupHeader({
+    required this.title,
+    required this.emoji,
+    required this.colorHex,
+    required this.onMenu,
+  });
+
+  final String title;
+  final String emoji;
+  final String colorHex;
+  final VoidCallback onMenu;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 12),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () => Navigator.maybePop(context),
+            child: const Icon(
+              Icons.chevron_left,
+              size: 28,
+              color: AppColors.bw100,
+            ),
+          ),
+          Expanded(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                SpaceAvatar(emoji: emoji, colorHex: colorHex, size: 30),
+                const SizedBox(width: 10),
+                Flexible(
+                  child: Text(
+                    title,
+                    style: AppTextStyles.baseBold,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          GestureDetector(
+            onTap: onMenu,
+            child:
+                const Icon(Icons.more_horiz, size: 24, color: AppColors.bw100),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
@@ -1,9 +1,168 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-// TODO(C/T4/TBD): implement InboxScreen per Figma
-class InboxScreen extends StatelessWidget {
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/chat/application/chat_providers.dart';
+import 'package:meep/features/chat/data/conversation.dart';
+import 'package:meep/features/chat/presentation/widgets/conversation_tile.dart';
+import 'package:meep/shared/widgets/app_taskbar.dart';
+
+/// Inbox — list of all conversations (1-1 + group), newest first.
+/// Figma `269:942`. Tapping a row opens the matching chat thread.
+class InboxScreen extends ConsumerWidget {
   const InboxScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+  Widget build(BuildContext context, WidgetRef ref) {
+    final conversationsAsync = ref.watch(conversationsProvider);
+
+    return Scaffold(
+      backgroundColor: AppColors.bw900,
+      body: SafeArea(
+        child: Stack(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Column(
+                children: [
+                  const _InboxTopbar(),
+                  const SizedBox(height: 24),
+                  Expanded(
+                    child: conversationsAsync.when(
+                      loading: () => const Center(
+                        child: CircularProgressIndicator(
+                          color: AppColors.turquoise500,
+                        ),
+                      ),
+                      error: (_, __) => const _InboxMessage(
+                        text: 'Không tải được tin nhắn. Thử lại sau nhé.',
+                      ),
+                      data: (conversations) => conversations.isEmpty
+                          ? const _InboxMessage(
+                              text:
+                                  'Chưa có tin nhắn nào — reply một ảnh để bắt đầu',
+                            )
+                          : _ConversationList(conversations: conversations),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: AppTaskbar(
+                  activeTab: TaskbarTab.chat,
+                  chatBadgeCount: 2,
+                  onTabSelected: (tab) {
+                    if (tab != TaskbarTab.chat) Navigator.maybePop(context);
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Topbar: centered title + trailing avatar slot.
+/// TODO(C/HanDHG): thay bằng shared home-feed topbar khi Khoa implement.
+class _InboxTopbar extends StatelessWidget {
+  const _InboxTopbar();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Row(
+        children: [
+          const SizedBox(width: 40),
+          const Expanded(
+            child: Text(
+              'Tin nhắn',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.baseBold,
+            ),
+          ),
+          Container(
+            width: 40,
+            height: 40,
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              color: AppColors.bw700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConversationList extends ConsumerWidget {
+  const _ConversationList({required this.conversations});
+
+  final List<Conversation> conversations;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profiles = ref.watch(chatUserProfilesProvider);
+    final unread = ref.watch(unreadCountsProvider);
+    final myUid = ref.watch(currentChatUidProvider);
+
+    return ListView.builder(
+      padding: const EdgeInsets.only(bottom: 90),
+      itemCount: conversations.length,
+      itemBuilder: (context, index) {
+        final conv = conversations[index];
+        final isUnread = (unread[conv.conversationId] ?? 0) > 0;
+
+        if (conv.type == ConversationType.space) {
+          final space = ref.watch(chatSpaceProvider(conv.spaceId ?? ''));
+          return ConversationTile.group(
+            spaceName: space.name,
+            emoji: space.iconEmoji,
+            colorHex: space.colorHex,
+            conversation: conv,
+            isUnread: isUnread,
+            onTap: () => context.push('/group-chat/${conv.conversationId}'),
+          );
+        }
+
+        final otherUid = conv.participantIds.firstWhere(
+          (id) => id != myUid,
+          orElse: () => myUid,
+        );
+        final other = profiles[otherUid];
+        return ConversationTile.direct(
+          displayName: other?.displayName ?? 'Người dùng',
+          avatarUrl: other?.avatarUrl,
+          conversation: conv,
+          isUnread: isUnread,
+          onTap: () => context.push('/chat/${conv.conversationId}'),
+        );
+      },
+    );
+  }
+}
+
+class _InboxMessage extends StatelessWidget {
+  const _InboxMessage({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        text,
+        textAlign: TextAlign.center,
+        style: AppTextStyles.smMedium.copyWith(color: AppColors.bw500),
+      ),
+    );
+  }
 }

--- a/apps/mobile/lib/features/chat/presentation/widgets/chat_avatar.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/chat_avatar.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/core/theme/hex_color.dart';
+
+/// Ring thickness around inbox avatars (Figma "Ellipse 29").
+const double _kRingWidth = 2;
+
+/// Gap between the ring and the avatar image (Figma shows the dark bg between
+/// the turquoise ring and the photo).
+const double _kRingGap = 2;
+
+/// Circular avatar used across chat surfaces (inbox tile, bubbles, members).
+///
+/// [ringColor] draws the Figma "Ellipse 29" ring with a small gap to the photo:
+/// turquoise = unread, bw700 = read. Pass null (default) for a plain avatar with
+/// no ring — used in the chat header where Figma shows a borderless circle.
+class ChatAvatar extends StatelessWidget {
+  const ChatAvatar({super.key, this.imageUrl, this.size = 50, this.ringColor});
+
+  final String? imageUrl;
+  final double size;
+  final Color? ringColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final inset = ringColor != null ? (_kRingWidth + _kRingGap) : 0.0;
+    final inner = size - inset * 2;
+    final avatar = ClipOval(
+      child: SizedBox(
+        width: inner,
+        height: inner,
+        child: (imageUrl != null && imageUrl!.isNotEmpty)
+            ? Image.network(
+                imageUrl!,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) =>
+                    const ColoredBox(color: AppColors.bw600),
+              )
+            : const ColoredBox(color: AppColors.bw600),
+      ),
+    );
+
+    if (ringColor == null) return avatar;
+
+    // Ring (outer) → dark gap → avatar: two nested circles create the gap.
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(shape: BoxShape.circle, color: ringColor),
+      padding: const EdgeInsets.all(_kRingWidth),
+      child: Container(
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          color: AppColors.bw900,
+        ),
+        padding: const EdgeInsets.all(_kRingGap),
+        child: avatar,
+      ),
+    );
+  }
+}
+
+/// Avatar showing a Space's emoji on its themed color (group conversations).
+/// [ringColor] behaves like [ChatAvatar.ringColor].
+class SpaceAvatar extends StatelessWidget {
+  const SpaceAvatar({
+    super.key,
+    required this.emoji,
+    required this.colorHex,
+    this.size = 50,
+    this.ringColor,
+  });
+
+  final String emoji;
+  final String colorHex;
+  final double size;
+  final Color? ringColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final inset = ringColor != null ? (_kRingWidth + _kRingGap) : 0.0;
+    final inner = size - inset * 2;
+    final disc = Container(
+      width: inner,
+      height: inner,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: hexToColor(colorHex),
+      ),
+      alignment: Alignment.center,
+      child: Text(emoji, style: AppTextStyles.mdBold),
+    );
+
+    if (ringColor == null) return disc;
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(shape: BoxShape.circle, color: ringColor),
+      padding: const EdgeInsets.all(_kRingWidth),
+      child: Container(
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          color: AppColors.bw900,
+        ),
+        padding: const EdgeInsets.all(_kRingGap),
+        child: disc,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/chat/presentation/widgets/chat_confirm_dialogs.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/chat_confirm_dialogs.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/shared/widgets/app_bottom_sheet.dart';
+import 'package:meep/shared/widgets/app_confirm_dialog.dart';
+
+/// "Xóa bạn" (unfriend) confirm popup. Figma `564:7131` — buttons Huỷ / Xoá.
+Future<bool> showUnfriendDialog(BuildContext context, String name) {
+  return showAppConfirmDialog(
+    context,
+    title: 'Xóa $name khỏi Meep của bạn?',
+    body: 'Các bạn sẽ không còn có thể gửi ảnh cho nhau trên Meep. '
+        'Lịch sử của bạn sẽ có thể phục hồi nếu các bạn thêm lại nhau.',
+    cancelLabel: 'Huỷ',
+    confirmLabel: 'Xoá',
+  );
+}
+
+/// "Rời khỏi Space" confirm popup. Figma `564:9063` — buttons Hủy / Rời khỏi.
+Future<bool> showLeaveSpaceDialog(BuildContext context) {
+  return showAppConfirmDialog(
+    context,
+    title: 'Rời khỏi Space của bạn?',
+    body: 'Cuộc trò chuyện sẽ được lưu trữ và bạn sẽ không còn có thể nhận '
+        'được tin nhắn nào của bạn bè trên Space.',
+    cancelLabel: 'Hủy',
+    confirmLabel: 'Rời khỏi',
+  );
+}
+
+/// "Chặn" (block) confirm — Figma `564:7080` is a BOTTOM SHEET (AppBottomSheet),
+/// primary "Chặn" button on turquoise, secondary "Bỏ qua" on bw700.
+Future<bool> showBlockSheet(BuildContext context, String name) async {
+  final result = await showModalBottomSheet<bool>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    builder: (_) => AppBottomSheet(
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(39, 24, 39, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.block, size: 28, color: AppColors.bw100),
+              const SizedBox(height: 20),
+              Text(
+                'Chặn $name?',
+                textAlign: TextAlign.center,
+                style: AppTextStyles.baseBold.copyWith(color: AppColors.bw100),
+              ),
+              const SizedBox(height: 14),
+              Text(
+                'Họ sẽ không thể nhắn tin cho bạn, xem các khoảnh khắc của bạn '
+                'hoặc gửi lời mời kết bạn. Hai người vẫn có thể được thêm vào '
+                'cùng một nhóm, nhưng sẽ không thể xem tin nhắn hoặc khoảnh '
+                'khắc của nhau.',
+                textAlign: TextAlign.center,
+                style: AppTextStyles.smMedium.copyWith(color: AppColors.bw100),
+              ),
+              const SizedBox(height: 14),
+              Text(
+                'Họ sẽ không được thông báo rằng mình đã bị chặn',
+                textAlign: TextAlign.center,
+                style: AppTextStyles.smMedium.copyWith(color: AppColors.bw100),
+              ),
+              const SizedBox(height: 24),
+              _SheetButton(
+                label: 'Chặn',
+                background: AppColors.turquoise600,
+                textColor: AppColors.turquoise900,
+                onTap: () => Navigator.pop(context, true),
+              ),
+              const SizedBox(height: 12),
+              _SheetButton(
+                label: 'Bỏ qua',
+                background: AppColors.bw700,
+                textColor: AppColors.bw100,
+                onTap: () => Navigator.pop(context, false),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+  return result ?? false;
+}
+
+class _SheetButton extends StatelessWidget {
+  const _SheetButton({
+    required this.label,
+    required this.background,
+    required this.textColor,
+    required this.onTap,
+  });
+
+  final String label;
+  final Color background;
+  final Color textColor;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: label,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(vertical: 18),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(30),
+          ),
+          child: Text(
+            label,
+            style: AppTextStyles.mdBold.copyWith(color: textColor),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/chat/presentation/widgets/chat_input_bar.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/chat_input_bar.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+
+/// Chat composer with two states (Figma `564:6935` ActText):
+///  - blurred: placeholder + 3 quick-send emoji + emoji-picker icon
+///  - focused: text field + emoji-picker icon + send button (quick-send hidden)
+///
+/// Quick-send emoji send immediately; the send button sends the typed text.
+class ChatInputBar extends StatefulWidget {
+  const ChatInputBar({
+    super.key,
+    required this.onSend,
+    this.isSending = false,
+    this.quickEmojis = const ['🩵', '🤣', '🥰'],
+  });
+
+  final void Function(String text) onSend;
+  final bool isSending;
+  final List<String> quickEmojis;
+
+  @override
+  State<ChatInputBar> createState() => _ChatInputBarState();
+}
+
+class _ChatInputBarState extends State<ChatInputBar> {
+  final _controller = TextEditingController();
+  final _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(_onFocusChange);
+    _controller.addListener(_onTextChange);
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChange);
+    _focusNode.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onFocusChange() => setState(() {});
+  void _onTextChange() => setState(() {});
+
+  bool get _isExpanded => _focusNode.hasFocus || _controller.text.isNotEmpty;
+  bool get _canSend => _controller.text.trim().isNotEmpty && !widget.isSending;
+
+  void _submit() {
+    if (!_canSend) return;
+    widget.onSend(_controller.text.trim());
+    _controller.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 15),
+      decoration: BoxDecoration(
+        color: const Color(0x66252627),
+        borderRadius: BorderRadius.circular(30),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _controller,
+              focusNode: _focusNode,
+              style: AppTextStyles.mdRegular.copyWith(color: AppColors.bw100),
+              cursorColor: AppColors.turquoise500,
+              maxLines: 4,
+              minLines: 1,
+              textInputAction: TextInputAction.send,
+              onSubmitted: (_) => _submit(),
+              decoration: InputDecoration(
+                isDense: true,
+                border: InputBorder.none,
+                hintText: 'Gửi tin nhắn...',
+                hintStyle:
+                    AppTextStyles.mdRegular.copyWith(color: AppColors.bw400),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          if (_isExpanded) ..._expandedActions() else ..._collapsedActions(),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _collapsedActions() => [
+        for (final emoji in widget.quickEmojis)
+          Padding(
+            padding: const EdgeInsets.only(left: 4),
+            child: GestureDetector(
+              onTap: widget.isSending ? null : () => widget.onSend(emoji),
+              // No fontFamily: let the platform emoji font render the glyph.
+              // Forcing Nunito drops newer emoji (e.g. 🩵 U+1FA75) to tofu.
+              child: Text(emoji, style: const TextStyle(fontSize: 24)),
+            ),
+          ),
+        const SizedBox(width: 4),
+        const Icon(
+          Icons.add_reaction_outlined,
+          size: 24,
+          color: AppColors.bw100,
+        ),
+      ];
+
+  List<Widget> _expandedActions() => [
+        const Icon(
+          Icons.add_reaction_outlined,
+          size: 24,
+          color: AppColors.bw100,
+        ),
+        const SizedBox(width: 8),
+        GestureDetector(
+          onTap: _submit,
+          child: Icon(
+            Icons.send_rounded,
+            size: 24,
+            color: _canSend ? AppColors.turquoise500 : AppColors.bw500,
+          ),
+        ),
+      ];
+}

--- a/apps/mobile/lib/features/chat/presentation/widgets/chat_menu_sheet.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/chat_menu_sheet.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+
+/// A single row inside a [SettingMenuCard]: icon + label, optionally destructive
+/// (red icon + text, Figma `Error/800`).
+class SettingMenuItem {
+  const SettingMenuItem({
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.isDestructive = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final Object value;
+  final bool isDestructive;
+}
+
+/// Floating "Setting" popup anchored to the top-right (under the ⋯ button),
+/// Figma `564:7079` / `564:8779`: bw800 fill, radius 30, hairline bw600 border,
+/// rows of md/Regular(16) with a divider between groups. Returns the tapped
+/// item's value, or null when dismissed.
+Future<T?> showSettingMenu<T>(
+  BuildContext context,
+  List<SettingMenuItem> items,
+) {
+  return showDialog<T>(
+    context: context,
+    barrierColor: Colors.transparent,
+    builder: (_) => Stack(
+      children: [
+        Positioned(
+          top: 64,
+          right: 20,
+          child: Material(
+            color: Colors.transparent,
+            child: _SettingMenuCard(items: items),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+class _SettingMenuCard extends StatelessWidget {
+  const _SettingMenuCard({required this.items});
+
+  final List<SettingMenuItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.bw800,
+        borderRadius: BorderRadius.circular(30),
+        border: Border.all(color: AppColors.bw600),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (var i = 0; i < items.length; i++) _MenuRow(item: items[i]),
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuRow extends StatelessWidget {
+  const _MenuRow({required this.item});
+
+  final SettingMenuItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = item.isDestructive ? AppColors.error800 : AppColors.bw100;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => Navigator.pop(context, item.value),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(item.icon, size: 18, color: color),
+          const SizedBox(width: 10),
+          Text(
+            item.label,
+            style: AppTextStyles.mdRegular.copyWith(color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/chat/presentation/widgets/conversation_tile.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/conversation_tile.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/chat/data/conversation.dart';
+import 'package:meep/features/chat/presentation/chat_time_format.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_avatar.dart';
+
+/// One row in the inbox list — 1-1 or group conversation.
+///
+/// Unread conversations render name/preview in a brighter tone (bw100/bw300)
+/// per Figma; read ones dim to bw300/bw500.
+class ConversationTile extends StatelessWidget {
+  const ConversationTile({
+    super.key,
+    required this.title,
+    required this.preview,
+    required this.timestamp,
+    required this.onTap,
+    this.avatarUrl,
+    this.spaceEmoji,
+    this.spaceColorHex,
+    this.isUnread = false,
+  });
+
+  /// Build a tile for a direct (1-1) conversation.
+  factory ConversationTile.direct({
+    required String displayName,
+    String? avatarUrl,
+    required Conversation conversation,
+    required bool isUnread,
+    required VoidCallback onTap,
+  }) {
+    return ConversationTile(
+      title: displayName,
+      avatarUrl: avatarUrl,
+      preview: conversation.lastMessage,
+      timestamp: formatInboxTimestamp(conversation.lastMessageAt),
+      isUnread: isUnread,
+      onTap: onTap,
+    );
+  }
+
+  /// Build a tile for a space (group) conversation.
+  factory ConversationTile.group({
+    required String spaceName,
+    required String emoji,
+    required String colorHex,
+    required Conversation conversation,
+    required bool isUnread,
+    required VoidCallback onTap,
+  }) {
+    return ConversationTile(
+      title: spaceName,
+      spaceEmoji: emoji,
+      spaceColorHex: colorHex,
+      preview: conversation.lastMessage,
+      timestamp: formatInboxTimestamp(conversation.lastMessageAt),
+      isUnread: isUnread,
+      onTap: onTap,
+    );
+  }
+
+  final String title;
+  final String preview;
+  final String timestamp;
+  final VoidCallback onTap;
+  final String? avatarUrl;
+  final String? spaceEmoji;
+  final String? spaceColorHex;
+  final bool isUnread;
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = isUnread ? AppColors.bw100 : AppColors.bw300;
+    final previewColor = isUnread ? AppColors.bw100 : AppColors.bw500;
+    final timeColor = isUnread ? AppColors.bw300 : AppColors.bw500;
+    final ringColor = isUnread ? AppColors.turquoise500 : AppColors.bw700;
+    final isGroup = spaceEmoji != null && spaceColorHex != null;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            if (isGroup)
+              SpaceAvatar(
+                emoji: spaceEmoji!,
+                colorHex: spaceColorHex!,
+                ringColor: ringColor,
+              )
+            else
+              ChatAvatar(imageUrl: avatarUrl, ringColor: ringColor),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          title,
+                          style:
+                              AppTextStyles.mdBold.copyWith(color: titleColor),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        timestamp,
+                        style:
+                            AppTextStyles.xsSemiBold.copyWith(color: timeColor),
+                      ),
+                    ],
+                  ),
+                  if (preview.isNotEmpty)
+                    Text(
+                      preview,
+                      style: AppTextStyles.xsSemiBold
+                          .copyWith(color: previewColor),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            const Icon(
+              Icons.chevron_right,
+              size: 20,
+              color: AppColors.bw500,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/chat/presentation/widgets/message_bubble.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/message_bubble.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_avatar.dart';
+
+/// A single chat message bubble.
+///
+/// Mine (right): light bw200 fill, dark text, no avatar.
+/// Theirs (left): translucent dark fill, light text, avatar leading.
+/// Figma `564:6945` (theirs) / `564:6947` (mine).
+class MessageBubble extends StatelessWidget {
+  const MessageBubble({
+    super.key,
+    required this.text,
+    required this.isMine,
+    this.avatarUrl,
+  });
+
+  final String text;
+  final bool isMine;
+  final String? avatarUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final bubble = Container(
+      constraints: const BoxConstraints(maxWidth: 260),
+      padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
+      decoration: BoxDecoration(
+        color: isMine ? AppColors.bw200 : const Color(0x6E585754),
+        borderRadius: BorderRadius.circular(40),
+      ),
+      child: Text(
+        text,
+        style: AppTextStyles.smSemiBold.copyWith(
+          color: isMine ? AppColors.turquoise900 : AppColors.bw100,
+        ),
+      ),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment:
+            isMine ? MainAxisAlignment.end : MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          if (!isMine) ...[
+            ChatAvatar(imageUrl: avatarUrl, size: 40),
+            const SizedBox(width: 6),
+          ],
+          Flexible(child: bubble),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/chat/presentation/widgets/quoted_photo_block.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/quoted_photo_block.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/chat/presentation/chat_time_format.dart';
+
+/// The originating post shown at the top of a 1-1 thread that started from a
+/// feed reply — square photo + caption pill + timestamp. Figma `564:6942`.
+class QuotedPhotoBlock extends StatelessWidget {
+  const QuotedPhotoBlock({
+    super.key,
+    required this.imageUrl,
+    required this.createdAt,
+    this.caption,
+  });
+
+  final String imageUrl;
+  final DateTime createdAt;
+  final String? caption;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          formatQuotedPhotoTimestamp(createdAt),
+          style: AppTextStyles.xsSemiBold.copyWith(color: AppColors.bw500),
+        ),
+        const SizedBox(height: 18),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            clipBehavior: Clip.none,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(50),
+                child: Image.network(
+                  imageUrl,
+                  width: 301,
+                  height: 301,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, __, ___) => Container(
+                    width: 301,
+                    height: 301,
+                    color: AppColors.bw700,
+                  ),
+                ),
+              ),
+              if (caption != null && caption!.isNotEmpty)
+                Positioned(
+                  bottom: 15,
+                  child: _CaptionPill(caption: caption!),
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 30),
+      ],
+    );
+  }
+}
+
+class _CaptionPill extends StatelessWidget {
+  const _CaptionPill({required this.caption});
+
+  final String caption;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 8),
+      decoration: BoxDecoration(
+        color: const Color(0x66394041),
+        borderRadius: BorderRadius.circular(30),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.text_fields, size: 18, color: AppColors.bw100),
+          const SizedBox(width: 6),
+          Text(
+            caption,
+            style: AppTextStyles.smSemiBold.copyWith(color: AppColors.bw100),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/chat/presentation/widgets/space_members_sheet.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/space_members_sheet.dart
@@ -1,11 +1,106 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// TODO(C/T7/TBD): implement SpaceMembersSheet per Figma
-class SpaceMembersSheet extends StatelessWidget {
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/chat/application/chat_providers.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_avatar.dart';
+import 'package:meep/shared/widgets/app_bottom_sheet.dart';
+
+/// Bottom sheet listing the members of a Space. Figma `564:8865`.
+/// The current user appears first, labelled "Bạn".
+class SpaceMembersSheet extends ConsumerWidget {
   const SpaceMembersSheet({super.key, required this.spaceId});
 
   final String spaceId;
 
+  /// Shows the members sheet for [spaceId].
+  static Future<void> show(BuildContext context, String spaceId) {
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => SpaceMembersSheet(spaceId: spaceId),
+    );
+  }
+
   @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final members = ref.watch(chatSpaceMembersProvider(spaceId));
+    final profiles = ref.watch(chatUserProfilesProvider);
+    final myUid = ref.watch(currentChatUidProvider);
+
+    // Tall sheet (~75% screen) per Figma `564:8865`, not a half-height sheet.
+    return SizedBox(
+      height: MediaQuery.sizeOf(context).height * 0.75,
+      child: AppBottomSheet(
+        child: SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Text(
+                    'Thành viên Space',
+                    style:
+                        AppTextStyles.baseBold.copyWith(color: AppColors.bw100),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  'Mọi người (${members.length})',
+                  style:
+                      AppTextStyles.xsSemiBold.copyWith(color: AppColors.bw500),
+                ),
+                const SizedBox(height: 8),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: members.length,
+                    itemBuilder: (context, index) {
+                      final member = members[index];
+                      final profile = profiles[member.uid];
+                      final isMe = member.uid == myUid;
+                      return _MemberRow(
+                        name: isMe
+                            ? 'Bạn'
+                            : (profile?.displayName ?? 'Thành viên'),
+                        avatarUrl: profile?.avatarUrl,
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MemberRow extends StatelessWidget {
+  const _MemberRow({required this.name, this.avatarUrl});
+
+  final String name;
+  final String? avatarUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          ChatAvatar(imageUrl: avatarUrl, size: 44),
+          const SizedBox(width: 14),
+          Text(
+            name,
+            style: AppTextStyles.mdBold.copyWith(color: AppColors.bw100),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -15,6 +15,8 @@ import 'package:meep/features/auth/application/sign_up_controller.dart';
 import 'package:meep/features/auth/data/firebase_auth_repository.dart';
 import 'package:meep/features/auth/data/firebase_user_repository.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/chat/application/chat_controller.dart';
+import 'package:meep/features/chat/data/fake_conversation_repository.dart';
 import 'package:meep/firebase_options.dart';
 
 void main() async {
@@ -39,6 +41,10 @@ void main() async {
         userRepositoryProvider.overrideWithValue(
           FirebaseUserRepository(firestore: FirebaseFirestore.instance),
         ),
+        // TODO(C/wire): swap for FirestoreConversationRepository once the chat
+        // backend (Friend #88 / Settings #115 / Space) is wired. FE-first only.
+        conversationRepositoryProvider
+            .overrideWithValue(FakeConversationRepository()),
       ],
       child: const MeepApp(),
     ),

--- a/apps/mobile/lib/shared/widgets/app_bottom_sheet.dart
+++ b/apps/mobile/lib/shared/widgets/app_bottom_sheet.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:meep/core/theme/app_colors.dart';
+
+/// Shared bottom sheet container với handle bar + rounded top corners.
+/// Dùng cho tất cả bottom sheets trong app.
+class AppBottomSheet extends StatelessWidget {
+  const AppBottomSheet({
+    super.key,
+    required this.child,
+    this.backgroundColor = AppColors.bw800,
+  });
+
+  final Widget child;
+  final Color backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(50)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Handle bar
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: Container(
+              width: 55,
+              height: 8,
+              decoration: BoxDecoration(
+                color: AppColors.bw700,
+                borderRadius: BorderRadius.circular(6.5),
+              ),
+            ),
+          ),
+          // Content
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/shared/widgets/app_confirm_dialog.dart
+++ b/apps/mobile/lib/shared/widgets/app_confirm_dialog.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+
+/// Floating confirm modal (Popup) for destructive actions.
+///
+/// Figma pattern: bw800 fill, radius 30, hairline border, left-aligned
+/// title/body, two pill buttons on bw700 where the destructive label is red.
+///
+/// Used by: unfriend `564:7131`, leave-space `564:9063`.
+///
+/// Returns `true` if confirmed, `false` if cancelled or dismissed.
+Future<bool> showAppConfirmDialog(
+  BuildContext context, {
+  required String title,
+  required String body,
+  required String cancelLabel,
+  required String confirmLabel,
+}) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (_) => Dialog(
+      backgroundColor: AppColors.bw800,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 64),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(30),
+        side: BorderSide(color: AppColors.bw600.withValues(alpha: 0.5)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 25, vertical: 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: AppTextStyles.mdSemiBold.copyWith(color: AppColors.bw100),
+            ),
+            const SizedBox(height: 10),
+            Text(
+              body,
+              style: AppTextStyles.smRegular.copyWith(color: AppColors.bw400),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: _ConfirmDialogButton(
+                    label: cancelLabel,
+                    textColor: AppColors.bw100,
+                    onTap: () => Navigator.pop(context, false),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _ConfirmDialogButton(
+                    label: confirmLabel,
+                    textColor: AppColors.error800,
+                    onTap: () => Navigator.pop(context, true),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  return result ?? false;
+}
+
+class _ConfirmDialogButton extends StatelessWidget {
+  const _ConfirmDialogButton({
+    required this.label,
+    required this.textColor,
+    required this.onTap,
+  });
+
+  final String label;
+  final Color textColor;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: label,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 15),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: AppColors.bw700,
+            borderRadius: BorderRadius.circular(30),
+          ),
+          child: Text(
+            label,
+            style: AppTextStyles.smSemiBold.copyWith(color: textColor),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/core/router/app_router_test.dart
+++ b/apps/mobile/test/core/router/app_router_test.dart
@@ -291,5 +291,45 @@ void main() {
         '/home',
       );
     });
+
+    // ── DEV(C/#142): chat routes bypass auth both ways ───────
+    test('uid null + /inbox → null (stay, dev bypass)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: null,
+          profileExists: null,
+          needsProfile: false,
+          location: '/inbox',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid + profile + /chat/:id → null (stay, not /home)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          location: '/chat/conv-1',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid null + /group-chat/:id → null (stay, dev bypass)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: null,
+          profileExists: null,
+          needsProfile: false,
+          location: '/group-chat/conv-1',
+        ),
+        isNull,
+      );
+    });
   });
 }

--- a/apps/mobile/test/features/chat/application/chat_controller_test.dart
+++ b/apps/mobile/test/features/chat/application/chat_controller_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:meep/features/chat/application/chat_controller.dart';
+import 'package:meep/features/chat/data/chat_seed_data.dart';
+import 'package:meep/features/chat/data/fake_conversation_repository.dart';
+
+void main() {
+  late ProviderContainer container;
+  late FakeConversationRepository repo;
+
+  setUp(() {
+    repo = FakeConversationRepository();
+    container = ProviderContainer(
+      overrides: [
+        conversationRepositoryProvider.overrideWithValue(repo),
+      ],
+    );
+  });
+  tearDown(() {
+    container.dispose();
+    repo.dispose();
+  });
+
+  ChatController controller() =>
+      container.read(chatControllerProvider.notifier);
+
+  group('sendMessage', () {
+    test('happy path resets status (no error, not sending)', () async {
+      await controller().sendMessage(
+        conversationId: ChatSeed.convTalaki,
+        text: 'Xin chào',
+      );
+
+      final status = container.read(chatControllerProvider);
+      expect(status.isSending, isFalse);
+      expect(status.errorMessage, isNull);
+    });
+
+    test('empty text surfaces ValidationError message in state', () async {
+      await controller().sendMessage(
+        conversationId: ChatSeed.convTalaki,
+        text: '   ',
+      );
+
+      final status = container.read(chatControllerProvider);
+      expect(status.isSending, isFalse);
+      expect(status.errorMessage, isNotNull);
+    });
+
+    test('unknown conversation surfaces error in state', () async {
+      await controller().sendMessage(
+        conversationId: 'does-not-exist',
+        text: 'hi',
+      );
+      expect(container.read(chatControllerProvider).errorMessage, isNotNull);
+    });
+
+    test('clearError resets the error', () async {
+      await controller().sendMessage(
+        conversationId: 'does-not-exist',
+        text: 'hi',
+      );
+      controller().clearError();
+      expect(container.read(chatControllerProvider).errorMessage, isNull);
+    });
+  });
+
+  group('sendMessageFromFeed', () {
+    test('creates conversation + sends, returns conversation id', () async {
+      final id = await controller().sendMessageFromFeed(
+        postId: 'post-x',
+        authorId: 'uid-new-author',
+        text: 'Trả lời từ feed',
+      );
+
+      expect(id, isNotNull);
+      final msgs = await repo.watchMessages(id!).first;
+      expect(msgs.single.text, 'Trả lời từ feed');
+    });
+
+    test('reuses existing conversation for known author', () async {
+      final id = await controller().sendMessageFromFeed(
+        postId: 'post-y',
+        authorId: 'uid-talaki',
+        text: 'reply',
+      );
+      expect(id, ChatSeed.convTalaki);
+    });
+
+    test('returns null and sets error on validation failure', () async {
+      final id = await controller().sendMessageFromFeed(
+        postId: 'post-z',
+        authorId: 'uid-talaki',
+        text: '',
+      );
+      expect(id, isNull);
+      expect(container.read(chatControllerProvider).errorMessage, isNotNull);
+    });
+  });
+}

--- a/apps/mobile/test/features/chat/data/fake_conversation_repository_test.dart
+++ b/apps/mobile/test/features/chat/data/fake_conversation_repository_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/chat/data/chat_seed_data.dart';
+import 'package:meep/features/chat/data/fake_conversation_repository.dart';
+
+void main() {
+  late FakeConversationRepository repo;
+
+  setUp(() => repo = FakeConversationRepository());
+  tearDown(() => repo.dispose());
+
+  group('watchConversations', () {
+    test('emits seeded conversations sorted by lastMessageAt DESC', () async {
+      final list = await repo.watchConversations(ChatSeed.currentUid).first;
+
+      expect(list.length, 3);
+      // convTalaki (2 min ago) is most recent → first.
+      expect(list.first.conversationId, ChatSeed.convTalaki);
+      for (var i = 0; i < list.length - 1; i++) {
+        expect(
+          list[i].lastMessageAt.isAfter(list[i + 1].lastMessageAt) ||
+              list[i].lastMessageAt == list[i + 1].lastMessageAt,
+          isTrue,
+        );
+      }
+    });
+
+    test('only returns conversations the uid participates in', () async {
+      final list = await repo.watchConversations('stranger-uid').first;
+      expect(list, isEmpty);
+    });
+  });
+
+  group('watchMessages', () {
+    test('returns chronological ASC (oldest first)', () async {
+      final msgs = await repo.watchMessages(ChatSeed.convTalaki).first;
+
+      expect(msgs.length, 3);
+      for (var i = 0; i < msgs.length - 1; i++) {
+        expect(msgs[i].createdAt.isBefore(msgs[i + 1].createdAt), isTrue);
+      }
+    });
+
+    test('empty conversation yields empty list (empty-thread state)', () async {
+      final msgs = await repo.watchMessages(ChatSeed.convMinh).first;
+      expect(msgs, isEmpty);
+    });
+
+    test('respects limit — returns newest N', () async {
+      final msgs =
+          await repo.watchMessages(ChatSeed.convTalaki, limit: 2).first;
+
+      expect(msgs.length, 2);
+      // Newest 2 of 3 → drops the oldest ('m1').
+      expect(msgs.map((m) => m.messageId), ['m2', 'm3']);
+    });
+  });
+
+  group('sendMessage', () {
+    test('appends message and re-emits on the stream', () async {
+      final emissions = <int>[];
+      final sub = repo
+          .watchMessages(ChatSeed.convTalaki)
+          .listen((m) => emissions.add(m.length));
+
+      // Let the subscription attach + receive the initial snapshot before
+      // sending (mirrors StreamProvider: UI is subscribed before send is tapped).
+      await Future<void>.delayed(Duration.zero);
+      expect(emissions, [3]);
+
+      await repo.sendMessage(
+        conversationId: ChatSeed.convTalaki,
+        senderId: ChatSeed.currentUid,
+        text: 'Tin mới',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emissions, [3, 4]);
+      await sub.cancel();
+    });
+
+    test('updates conversation lastMessage + reorders inbox', () async {
+      await repo.sendMessage(
+        conversationId: ChatSeed.convGroup,
+        senderId: ChatSeed.currentUid,
+        text: 'Bump group lên đầu',
+      );
+      final list = await repo.watchConversations(ChatSeed.currentUid).first;
+
+      expect(list.first.conversationId, ChatSeed.convGroup);
+      expect(list.first.lastMessage, 'Bump group lên đầu');
+      expect(list.first.lastSenderId, ChatSeed.currentUid);
+    });
+
+    test('trims whitespace before storing', () async {
+      await repo.sendMessage(
+        conversationId: ChatSeed.convMinh,
+        senderId: ChatSeed.currentUid,
+        text: '  hi  ',
+      );
+      final msgs = await repo.watchMessages(ChatSeed.convMinh).first;
+      expect(msgs.single.text, 'hi');
+    });
+
+    test('throws ValidationError on empty/whitespace text', () async {
+      expect(
+        () => repo.sendMessage(
+          conversationId: ChatSeed.convTalaki,
+          senderId: ChatSeed.currentUid,
+          text: '   ',
+        ),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+
+    test('throws ValidationError when text exceeds 500 chars', () async {
+      expect(
+        () => repo.sendMessage(
+          conversationId: ChatSeed.convTalaki,
+          senderId: ChatSeed.currentUid,
+          text: 'a' * 501,
+        ),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+
+    test('throws NotFoundError for unknown conversation', () async {
+      expect(
+        () => repo.sendMessage(
+          conversationId: 'nope',
+          senderId: ChatSeed.currentUid,
+          text: 'hi',
+        ),
+        throwsA(isA<NotFoundError>()),
+      );
+    });
+  });
+
+  group('getOrCreateConversation', () {
+    test('returns existing direct conversation (idempotent)', () async {
+      final c = await repo.getOrCreateConversation(
+        uid: ChatSeed.currentUid,
+        otherUid: 'uid-talaki',
+      );
+      expect(c.conversationId, ChatSeed.convTalaki);
+    });
+
+    test('creates a new empty conversation when none exists', () async {
+      final c = await repo.getOrCreateConversation(
+        uid: ChatSeed.currentUid,
+        otherUid: 'uid-new-friend',
+      );
+      expect(c.type.name, 'direct');
+      expect(
+        c.participantIds,
+        containsAll([ChatSeed.currentUid, 'uid-new-friend']),
+      );
+
+      final list = await repo.watchConversations(ChatSeed.currentUid).first;
+      expect(list.any((x) => x.conversationId == c.conversationId), isTrue);
+    });
+  });
+}

--- a/apps/mobile/test/features/chat/presentation/chat_time_format_test.dart
+++ b/apps/mobile/test/features/chat/presentation/chat_time_format_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/chat/presentation/chat_time_format.dart';
+
+void main() {
+  group('formatThreadSeparator', () {
+    final now = DateTime(2026, 5, 30, 14, 30);
+
+    test('same day → HH:mm', () {
+      final time = DateTime(2026, 5, 30, 9, 5);
+      expect(formatThreadSeparator(time, now: now), '09:05');
+    });
+
+    test('pads single-digit hour and minute', () {
+      final time = DateTime(2026, 5, 30, 8, 7);
+      expect(formatThreadSeparator(time, now: now), '08:07');
+    });
+
+    test('different day → DD thg M lúc HH:mm', () {
+      final time = DateTime(2026, 4, 11, 14, 30);
+      expect(formatThreadSeparator(time, now: now), '11 thg 4 lúc 14:30');
+    });
+
+    test('different year still uses day/month form', () {
+      final time = DateTime(2025, 12, 31, 23, 59);
+      expect(formatThreadSeparator(time, now: now), '31 thg 12 lúc 23:59');
+    });
+  });
+
+  group('threadSeparatorGap', () {
+    test('is 1 hour', () {
+      expect(threadSeparatorGap, const Duration(hours: 1));
+    });
+
+    test('gap below threshold does not trigger (boundary 59m)', () {
+      const gap = Duration(minutes: 59);
+      expect(gap >= threadSeparatorGap, isFalse);
+    });
+
+    test('gap at threshold triggers (boundary 60m)', () {
+      const gap = Duration(minutes: 60);
+      expect(gap >= threadSeparatorGap, isTrue);
+    });
+  });
+}

--- a/apps/mobile/test/features/chat/presentation/chat_widgets_test.dart
+++ b/apps/mobile/test/features/chat/presentation/chat_widgets_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/chat/presentation/widgets/chat_input_bar.dart';
+import 'package:meep/features/chat/presentation/widgets/message_bubble.dart';
+
+void main() {
+  group('MessageBubble', () {
+    testWidgets('mine: no avatar, aligned end', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MessageBubble(text: 'Hi', isMine: true, avatarUrl: 'x'),
+          ),
+        ),
+      );
+
+      expect(find.text('Hi'), findsOneWidget);
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.mainAxisAlignment, MainAxisAlignment.end);
+    });
+
+    testWidgets('theirs: shows avatar, aligned start', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MessageBubble(text: 'Yo', isMine: false),
+          ),
+        ),
+      );
+
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.mainAxisAlignment, MainAxisAlignment.start);
+    });
+  });
+
+  group('ChatInputBar 2-state', () {
+    testWidgets('blurred shows quick-send emoji, no send icon', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ChatInputBar(onSend: (_) {})),
+        ),
+      );
+
+      expect(find.text('🩵'), findsOneWidget);
+      expect(find.text('🤣'), findsOneWidget);
+      expect(find.byIcon(Icons.send_rounded), findsNothing);
+    });
+
+    testWidgets('typing hides quick-send and reveals send', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ChatInputBar(onSend: (_) {})),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'xin chào');
+      await tester.pump();
+
+      expect(find.text('🩵'), findsNothing);
+      expect(find.byIcon(Icons.send_rounded), findsOneWidget);
+    });
+
+    testWidgets('quick-send emoji fires onSend immediately', (tester) async {
+      final sent = <String>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ChatInputBar(onSend: sent.add)),
+        ),
+      );
+
+      await tester.tap(find.text('🥰'));
+      await tester.pump();
+
+      expect(sent, ['🥰']);
+    });
+
+    testWidgets('send button submits trimmed text and clears', (tester) async {
+      final sent = <String>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: ChatInputBar(onSend: sent.add)),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), '  hello  ');
+      await tester.pump();
+      await tester.tap(find.byIcon(Icons.send_rounded));
+      await tester.pump();
+
+      expect(sent, ['hello']);
+      expect(find.text('  hello  '), findsNothing);
+    });
+  });
+}

--- a/apps/mobile/test/features/chat/presentation/inbox_screen_test.dart
+++ b/apps/mobile/test/features/chat/presentation/inbox_screen_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/chat/application/chat_controller.dart';
+import 'package:meep/features/chat/data/conversation.dart';
+import 'package:meep/features/chat/data/conversation_repository.dart';
+import 'package:meep/features/chat/data/fake_conversation_repository.dart';
+import 'package:meep/features/chat/presentation/inbox_screen.dart';
+import 'package:meep/features/chat/presentation/widgets/conversation_tile.dart';
+
+/// Repository that always emits an empty conversation list.
+class _EmptyRepo extends FakeConversationRepository {
+  @override
+  Stream<List<Conversation>> watchConversations(String uid) async* {
+    yield const [];
+  }
+}
+
+void main() {
+  Widget wrap(ConversationRepository repo) => ProviderScope(
+        overrides: [conversationRepositoryProvider.overrideWithValue(repo)],
+        child: const MaterialApp(home: InboxScreen()),
+      );
+
+  testWidgets('renders title and seeded conversation tiles', (tester) async {
+    await tester.pumpWidget(wrap(FakeConversationRepository()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tin nhắn'), findsOneWidget);
+    // 3 seeded conversations → 3 tiles.
+    expect(find.byType(ConversationTile), findsNWidgets(3));
+  });
+
+  testWidgets('shows 1-1 name and group name', (tester) async {
+    await tester.pumpWidget(wrap(FakeConversationRepository()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Talaki'), findsOneWidget); // direct
+    expect(find.text('Hội bạn thân'), findsOneWidget); // group/space
+  });
+
+  testWidgets('empty state shows Vietnamese CTA', (tester) async {
+    await tester.pumpWidget(wrap(_EmptyRepo()));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Chưa có tin nhắn nào'),
+      findsOneWidget,
+    );
+    expect(find.byType(ConversationTile), findsNothing);
+  });
+}

--- a/apps/mobile/test/features/chat/presentation/space_members_sheet_test.dart
+++ b/apps/mobile/test/features/chat/presentation/space_members_sheet_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/chat/presentation/widgets/space_members_sheet.dart';
+
+void main() {
+  Widget wrap(Widget child) => ProviderScope(
+        child: MaterialApp(home: Scaffold(body: child)),
+      );
+
+  testWidgets('lists members with count and labels current user "Bạn"',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(const SpaceMembersSheet(spaceId: 'space-fun')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Thành viên Space'), findsOneWidget);
+    // 3 seeded members.
+    expect(find.text('Mọi người (3)'), findsOneWidget);
+    // Current user shows as "Bạn", not their displayName.
+    expect(find.text('Bạn'), findsOneWidget);
+    // Other members by displayName.
+    expect(find.text('Minh Anh'), findsOneWidget);
+    expect(find.text('Linh'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #144
Closes #145

## Tóm tắt
- T3+4: InboxScreen + ChatScreen 1-1 (#144)
- T5+6: GroupChatScreen + SpaceMembersSheet + menu (#145)
- 37/37 tests passed
- flutter analyze clean

## Files changed
- 32 files, 2779 insertions
- Inbox: list conversations, search, unread badge
- Chat 1-1: messages, input, reactions, image preview
- Group chat: members sheet, leave/mute menu
- Shared: MessageBubble, ChatInput, ImagePreviewSheet

## Can test
- Review code
- Test thuc te tren emulator/device