### PR TITLE
docs(profile): cập nhật spec theo thực tế Code/Figma

### DIFF
--- a/docs/plans/2026-05-23-profile.md
+++ b/docs/plans/2026-05-23-profile.md
@@ -113,7 +113,7 @@ Cross-module imports: `FriendSheet` từ **friend**, `AppTaskbar` từ **shared*
 
 Files:
 - `lib/features/profile/presentation/widgets/photo_grid.dart` — 3-column grid, lazy load, cursor-paginated 9/batch, `PostRepository.getPostsByAuthor(currentUid)`
-- `lib/features/profile/presentation/photo_detail_screen.dart` — full impl (Figma `660:1940`): swipe carousel + Note + Tag + thumbnail strip
+- `lib/features/profile/presentation/photo_detail_screen.dart` — full impl (Figma `660:1940`): swipe carousel + caption overlay + giờ đăng + thumbnail strip
 - `test/features/profile/photo_detail_screen_test.dart` — widget tests: swipe trái → ảnh cũ hơn, swipe phải → ảnh mới hơn, swipe quá giới hạn → bounce
 
 Acceptance criteria:

--- a/docs/plans/2026-05-23-profile.md
+++ b/docs/plans/2026-05-23-profile.md
@@ -19,6 +19,7 @@
 | `lib/features/profile/presentation/photo_detail_screen.dart` | widget stub | |
 | `lib/features/profile/presentation/avatar_picker_sheet.dart` | widget stub | |
 | `lib/shared/widgets/share_profile_sheet.dart` | **shared widget** — leader own | Dùng chung Profile + Settings |
+| `lib/shared/widgets/app_taskbar.dart` | **shared widget** — **CHƯA CÓ, cần leader assign owner** | Bottom nav bar dùng chung Feed / Profile / Diary / Chat / Streak — xem OQ8 |
 | `lib/core/router/app_router.dart` | update | Routes `/profile`, `/profile/edit`, `/profile/photo/:postId`, `/friend-profile/:uid` |
 | `firebase/storage.rules` | update | Rules cho `avatars/{uid}/` — read: authed; write: owner + ≤5MB + image/* |
 
@@ -95,8 +96,10 @@ Acceptance criteria:
 - [ ] Avatar: avatar url → `CachedNetworkImage`; null → initials placeholder
 - [ ] 2 action buttons: [Chỉnh sửa] → `EditProfileScreen`, [Chia sẻ trang cá nhân] → `ShareProfileSheet`
 - [ ] Tab bar: Photos (active) + Diary (empty state M2)
+- [ ] Username hiển thị KHÔNG có "@" prefix (khác với EditProfile — xem T5)
+- [ ] `AppTaskbar` consume từ shared widget — KHÔNG tự tạo (pending OQ8)
 
-Cross-module imports: `FriendSheet` từ **friend**
+Cross-module imports: `FriendSheet` từ **friend**, `AppTaskbar` từ **shared** (pending owner)
 
 ---
 **T4 · feat(profile): PhotoGrid tab + PhotoDetailScreen (swipe)**
@@ -114,11 +117,15 @@ Files:
 - `test/features/profile/photo_detail_screen_test.dart` — widget tests: swipe trái → ảnh cũ hơn, swipe phải → ảnh mới hơn, swipe quá giới hạn → bounce
 
 Acceptance criteria:
-- [ ] PhotoGrid: 3-column, lazy load, 9 posts/batch cursor-paginated (createdAt DESC)
+- [ ] PhotoGrid: 3-column (gap 3px, bo góc 20px), hiển thị TẤT CẢ ảnh của user, load lazy 9/batch cursor-paginated, sắp xếp mới → cũ (createdAt DESC)
 - [ ] Tap ảnh → `PhotoDetailScreen` với `initialIndex`
 - [ ] Swipe trái = ảnh cũ hơn (createdAt nhỏ hơn); swipe phải = ảnh mới hơn
 - [ ] Swipe đến ảnh đầu/cuối → bounce animation, không crash
-- [ ] Thumbnail strip: ảnh đang xem = enlarged + outline turquoise `#00DEEE`
+- [ ] PhotoDetail topbar: [X close] [Ngày D tháng M / YYYY — Vietnamese format] [share icon]
+- [ ] Caption hiển thị dạng pill trắng CHỒNG TRÊN ảnh (không phải text dưới ảnh)
+- [ ] Thời gian đăng hiển thị riêng bên dưới ảnh (ví dụ "17:03")
+- [ ] Thumbnail strip: ảnh đang xem = viền teal `#00DEEE`
+- [ ] Ảnh kề 2 bên peek ra ngoài (PageView behavior)
 - [ ] Share icon trong PhotoDetail topbar → `ShareModal` (từ Feed module)
 
 Cross-module imports: `PostRepository` từ **home-camera-feed**, `ShareModal` từ **home-camera-feed**
@@ -142,8 +149,11 @@ Files:
 - `lib/features/profile/presentation/widgets/notification_toggle.dart` — toggle switch lưu vào `SharedPreferences`
 
 Acceptance criteria:
+- [ ] Screen header: "Chỉnh sửa trang cá nhân" + back button
+- [ ] Section label "Thông tin cá nhân" hiển thị phía trên danh sách
+- [ ] "Chỉnh sửa ảnh đại diện" là link màu teal — không phải nút bấm thông thường
 - [ ] `displayName` change: validate không rỗng, min 2 ký tự → update
-- [ ] `username` change: `isUsernameAvailable()` check → inline error nếu taken; dùng Firestore transaction (race condition)
+- [ ] `username` change: hint text hiển thị "@{username}" (UI decoration, không lưu "@" vào data); `isUsernameAvailable()` check → inline error nếu taken; dùng Firestore transaction (race condition)
 - [ ] `bio`: max 150 chars, optional (trống OK), hint "Tiểu sử của bạn hiển thị với bạn bè của bạn."
 - [ ] Email update: `reauthenticateWithCredential()` required → nếu Google user → dùng GoogleAuthProvider (không hiện password field)
 - [ ] `requires-recent-login` error → re-auth dialog inline, KHÔNG show generic error
@@ -168,8 +178,10 @@ Files:
 Acceptance criteria:
 - [ ] "Chọn từ thư viện" → `image_picker.pickImage(source: gallery)` → compress → `updateAvatar()`
 - [ ] "Chụp ảnh" → `image_picker.pickImage(source: camera)` → compress → `updateAvatar()`
-- [ ] "Gỡ ảnh hiện tại" → `removeAvatar()` → avatar hiện initials placeholder; nút ẩn/disabled khi `avatarUrl == null`
+- [ ] "Gỡ ảnh hiện tại" hiển thị màu đỏ (destructive); ẩn/disabled khi `avatarUrl == null`
+- [ ] Sheet có footnote: "Ảnh hồ sơ của bạn sẽ được hiển thị cho tất cả bạn bè của bạn."
 - [ ] `ShareProfileSheet` (shared) hiện từ [Chia sẻ trang cá nhân] + từ Settings — cùng component
+- [ ] ShareProfileSheet chỉ có 2 options: Gửi qua Messenger + Sao chép liên kết (không có Instagram)
 
 Cross-module imports: `ShareProfileSheet` từ **shared widgets** (leader own)
 
@@ -190,7 +202,8 @@ Acceptance criteria:
 - [ ] Chỉ accessible khi đã là bạn bè (`isFriend` check ở tầng routing hoặc controller)
 - [ ] Hiện: avatar + stats (postCount + friendCount, KHÔNG hiện Space) + bio + grid ảnh (read-only)
 - [ ] KHÔNG có nút Edit / Chia sẻ — chỉ có nút "Xoá bạn" (mở FriendSheet)
-- [ ] Grid ảnh của người đó: dùng `PostRepository.getPostsByAuthor(friendUid)` — chỉ posts có trong feed của mình
+- [ ] Grid ảnh: CHỈ hiển thị ảnh được chia sẻ với người đang xem — không phải toàn bộ ảnh của chủ profile
+- [ ] Query: phụ thuộc data model OQ5 (pending ThienPDM) — tạm thời stub, chờ confirm `Post.recipientIds` hay equivalent
 
 Cross-module imports: `FriendSheet` từ **friend**, `PostRepository` từ **home-camera-feed**
 
@@ -254,6 +267,13 @@ contracts Part 1 → T1 → T9 (chạy sớm sau T1 done)
 
 ## PART 4 — Open questions
 
-Tất cả đã resolved trong spec (`docs/specs/2026-05-22-profile.md`). None blocking.
+Xem đầy đủ tại `docs/specs/2026-05-22-profile.md` §Open questions.
+
+| OQ | Blocking | Tóm tắt |
+|---|---|---|
+| OQ5 | **T7** | Post visibility model — `Post.recipientIds` hay query khác? |
+| OQ6 | **T6** | ShareProfileSheet URL: `meep.cam` (Figma) hay `meep://profile/` (spec Q3)? |
+| OQ7 | **T4** | Photo detail "Tag" — chỉ timestamp hay có tag tên người? |
+| OQ8 | **T3, T7, T8** | `AppTaskbar` chưa có owner — ThienPDM cần assign trước khi các task này complete |
 
 > **Note M2 vs M3:** T8 (Diary tab) bao gồm cả M2 stub và M3 implementation. M2 deploy trước (empty state), M3 update sau khi Diary module implement xong.

--- a/docs/specs/2026-05-22-profile.md
+++ b/docs/specs/2026-05-22-profile.md
@@ -30,7 +30,7 @@ Cho phép user xem trang cá nhân của mình (stats + avatar + bio + grid ản
 - Là user, tôi muốn xem trang cá nhân với số liệu (Khoảnh khắc, Bạn bè, Space), avatar, username và bio.
 - Là user, tôi muốn chỉnh sửa họ tên, username, ngày sinh, số điện thoại, email và giới tính.
 - Là user, tôi muốn thay đổi hoặc xoá ảnh đại diện.
-- Là user, tôi muốn chia sẻ trang cá nhân của mình qua link / Messenger / Instagram.
+- Là user, tôi muốn chia sẻ trang cá nhân của mình qua link / Messenger.
 - Là user, tôi muốn xem lại tất cả ảnh mình đã đăng theo dạng lưới, và tap vào để xem chi tiết.
 
 ---
@@ -43,7 +43,7 @@ Cho phép user xem trang cá nhân của mình (stats + avatar + bio + grid ản
 | Profile_Diary tab | `573:3213` | Cùng layout nhưng tab Diary active — M2: hiện empty state |
 | Edit profile (form) | `573:2968` | Danh sách settings options dạng list |
 | Avatar picker sheet | `573:3561` (bottom sheet) | Chọn thư viện / Chụp ảnh / Gỡ ảnh |
-| Share profile sheet | `573:3648` (overlay) | Link + Messenger + Instagram |
+| Share profile sheet | `573:3648` (overlay) | Link + Messenger |
 | Photo detail | `660:1940` | Ảnh full + caption Note + Tag + thumbnail strip |
 
 ---
@@ -55,7 +55,7 @@ Cho phép user xem trang cá nhân của mình (stats + avatar + bio + grid ản
 1. **Profile main screen** — stats, avatar, username, bio, grid ảnh (tab Photos active)
 2. **Edit profile** — họ tên, username, ngày sinh, số điện thoại, email, giới tính, thông báo toggle
 3. **Avatar edit** — bottom sheet: Chọn từ thư viện / Chụp ảnh / Gỡ ảnh hiện tại
-4. **Share profile** — bottom sheet: deep link copy / Messenger / Instagram DM / Instagram post
+4. **Share profile** — bottom sheet: deep link copy / Messenger
 5. **Photo detail** — xem ảnh full, caption, timestamp, thumbnail strip (swipe)
 6. **Diary tab** — hiện icon + empty state "Tính năng sắp ra mắt" (disabled, chờ M3)
 7. **Friend profile screen** — xem profile của bạn bè (chỉ khi đã là friend); navigate từ Friend search result
@@ -82,6 +82,8 @@ Taskbar → tap icon User (active)
         ├─ [Chỉnh sửa] → Edit profile screen
         ├─ [Chia sẻ trang cá nhân] → Share profile bottom sheet
         ├─ Tab [grid-3x3] (default) → Photos grid
+        │   Hiển thị TẤT CẢ ảnh user đã đăng từ lúc tạo tài khoản, sắp xếp mới → cũ (createdAt desc)
+        │   Load lazy, cursor-paginated 9 ảnh/batch — KHÔNG giới hạn tổng số ảnh hiển thị
         ├─ Tab [book-heart] → Diary tab (empty state M2)
         └─ Tap ảnh trong grid → Photo detail
 ```
@@ -91,12 +93,15 @@ Taskbar → tap icon User (active)
 ```
 Profile → [Chỉnh sửa]
     → Edit profile screen (list settings)
-        ├─ Tap "Chỉnh sửa ảnh đại diện" → Avatar picker sheet
+        Section header: "Thông tin cá nhân"
+        ├─ Tap "Chỉnh sửa ảnh đại diện" (link màu teal) → Avatar picker sheet
         │   ├─ "Chọn từ thư viện" → image_picker → crop/upload
         │   ├─ "Chụp ảnh" → camera → crop/upload
-        │   └─ "Gỡ ảnh hiện tại" → xoá avatarUrl → null
+        │   └─ "Gỡ ảnh hiện tại" (màu đỏ — destructive) → xoá avatarUrl → null
+        │       Footnote: "Ảnh hồ sơ của bạn sẽ được hiển thị cho tất cả bạn bè của bạn."
         ├─ Tap "Chỉnh sửa họ tên" → inline edit / bottom input sheet
         ├─ Tap "Chỉnh sửa tên người dùng" → inline edit, uniqueness check
+        │   Hint text hiển thị "@{username}" (có "@" prefix là UI decoration, không lưu vào data)
         ├─ Tap "Chỉnh sửa ngày sinh" → date picker sheet (DD/MM/YYYY)
         ├─ Tap "Cập nhật số điện thoại" → phone input sheet
         ├─ Tap "Cập nhật địa chỉ email" → email input + re-auth flow
@@ -141,6 +146,8 @@ Friend search result → user card (exact match)
                 ├─ Hiện: avatar + stats (chỉ K.khắc + Bạn bè chung; Space ẩn hoặc 0)
                 ├─ Bio (nếu có)
                 └─ Grid ảnh của người đó (chỉ read, không edit)
+                    CHỈ hiển thị ảnh được chia sẻ với người đang xem — không phải toàn bộ ảnh của chủ profile
+                    (xem OQ5 — cần xác nhận data model post visibility)
 ```
 
 > **Không có** nút Edit / Chia sẻ trên FriendProfileScreen — chỉ hiện nút "Xoá bạn" (mở Friend sheet).
@@ -152,12 +159,13 @@ Friend search result → user card (exact match)
 ```
 Profile grid → tap ảnh
     → Photo detail screen:
-        ├─ Topbar: [X close] [Date + Year] [share icon]
-        ├─ Ảnh full (swipe trái = ảnh cũ hơn, swipe phải = ảnh mới hơn)
-        │   Tất cả ảnh của bản thân, sắp xếp createdAt desc
-        ├─ Note caption (nếu có)
-        ├─ Tag (tên + thời gian)
-        └─ Thumbnail strip (cuộn ngang, ảnh đang xem = active/enlarged)
+        ├─ Topbar: [X close] [Ngày D tháng M / YYYY (Vietnamese format)] [share icon]
+        ├─ Ảnh full — swipe trái = ảnh cũ hơn, swipe phải = ảnh mới hơn
+        │   Tất cả ảnh của bản thân, sắp xếp createdAt desc (mới → cũ)
+        │   Ảnh kề 2 bên peek ra ngoài (PageView behavior)
+        ├─ Caption — overlay pill trắng CHỒng trên ảnh (không phải text bên dưới)
+        ├─ Thời gian đăng — hiển thị riêng bên dưới ảnh (ví dụ: "17:03")
+        └─ Thumbnail strip (cuộn ngang, ảnh đang xem = viền teal #00DEEE)
 ```
 
 ---
@@ -260,12 +268,13 @@ abstract class ProfileRepository {
 Presentation                    Application                   Data
 ─────────────────────────       ──────────────────────        ────────────────────────
 ProfileScreen                   ProfileController             ProfileRepository (abstract)
- ├─ ProfileHeader                ├─ ProfileState               FirebaseProfileRepository
- ├─ ProfileStats                 ├─ loadProfile()
- ├─ ProfileActionButtons         ├─ updateField()
- ├─ ProfileTabBar                ├─ updateAvatar()
- ├─ PhotoGrid (tab 1)            ├─ removeAvatar()
- └─ DiaryTabEmpty (tab 2)        └─ shareProfile()
+ ├─ AppTaskbar (shared)          ├─ ProfileState               FirebaseProfileRepository
+ ├─ ProfileHeader                ├─ loadProfile()
+ ├─ ProfileStats                 ├─ updateField()
+ ├─ ProfileActionButtons         ├─ updateAvatar()
+ ├─ ProfileTabBar                ├─ removeAvatar()
+ ├─ PhotoGrid (tab 1)            └─ shareProfile()
+ └─ DiaryTabEmpty (tab 2)
 EditProfileScreen
  ├─ AvatarEditSection
  └─ ProfileSettingsList
@@ -273,6 +282,8 @@ AvatarPickerSheet
 ShareProfileSheet
 PhotoDetailScreen
 ```
+
+> **[SHARED WIDGET — PENDING OWNER]** `AppTaskbar` (`lib/shared/widgets/app_taskbar.dart`) xuất hiện trong ProfileScreen và tất cả màn hình chính (Feed, Diary, Chat, Streak). File **chưa tồn tại** trong codebase. Cần leader (ThienPDM) define contract + assign owner trước khi bất kỳ module nào implement. Profile module **không tự tạo** Taskbar — chỉ consume.
 
 ---
 
@@ -384,13 +395,14 @@ match /avatars/{uid}/{filename} {
 ## Acceptance criteria
 
 - [ ] Profile screen hiển thị đúng stats (Khoảnh khắc = số posts, Bạn bè = friendCount, Space = spaceCount)
-- [ ] Grid ảnh load lazy, cursor-paginated 9 ảnh/batch (sắp xếp createdAt desc)
+- [ ] Grid ảnh hiển thị TẤT CẢ ảnh từ lúc tạo tài khoản, sắp xếp mới → cũ (createdAt desc), load lazy cursor-paginated 9 ảnh/batch
 - [ ] Edit profile: save thành công → Firestore updated + UI reflected
 - [ ] Avatar upload: chọn từ gallery → compress < 5MB → upload → avatarUrl updated
 - [ ] Avatar remove: tap "Gỡ ảnh" → avatarUrl = null → avatar hiện initials placeholder
 - [ ] Username change: uniqueness check + inline error nếu đã bị lấy
 - [ ] Email change: re-auth dialog → thành công → Firebase Auth email updated
-- [ ] Share profile: copy link → clipboard toast; share Messenger/Instagram → intent fired
+- [ ] Share profile: copy link → clipboard toast; Gửi qua Messenger → Android share intent
+- [ ] FriendProfileScreen: grid ảnh chỉ hiển thị ảnh được chia sẻ với người đang xem (pending OQ5)
 - [ ] Photo detail: swipe trái → ảnh cũ hơn, swipe phải → ảnh mới hơn (tất cả ảnh bản thân, mới → cũ)
 - [ ] Diary tab: hiện empty state, không crash
 - [ ] Bio: nhập ≤ 150 chars, hint text hiển thị đúng, empty OK
@@ -425,6 +437,7 @@ match /avatars/{uid}/{filename} {
 - **Stats count denormalization:** `friendCount` từ Friend module, `spaceCount` chưa có (Space module M3) → **hiện `0`** cho Space count M2, cập nhật khi Space module xong.
 - **Diary tab M2:** hiện empty state nhưng tab icon phải vẫn tap được (không bị disabled/grayed out hoàn toàn) để không confuse user.
 - **`user-round-plus` button:** đã confirm xoá khỏi UI — designer cần update Figma.
+- **Post visibility (OQ5):** Nếu Post không có `recipientIds` field → FriendProfileScreen không thể lọc đúng ảnh được chia sẻ. Cần clarify trước khi T7 bắt đầu.
 
 ---
 
@@ -436,3 +449,7 @@ match /avatars/{uid}/{filename} {
 | OQ2 | Bio field có trong Profile screen không? Figma không thấy field bio riêng trong Edit | **✅ Resolved** — Anh đã thêm "Tiểu sử" vào Edit profile (node `719:2722`). Field `bio` optional, hint: *"Tiểu sử của bạn hiển thị với bạn bè của bạn."* |
 | OQ3 | `spaceCount` M2 hiện 0 hay ẩn hẳn? | **✅ Resolved** — Hiện số `0` cho đến khi Space module (M3) đi vào hoạt động |
 | OQ4 | Photo detail swipe đi qua ảnh nào? | **✅ Resolved** — Tất cả ảnh bản thân, swipe trái = cũ hơn (mới → cũ, sắp theo `createdAt` desc) |
+| OQ5 | **[BLOCKING T7]** Post visibility model cho FriendProfileScreen: khi A xem profile B, grid ảnh của B chỉ hiện ảnh chia sẻ với A hay tất cả ảnh B đã đăng? Nếu chỉ hiện ảnh chia sẻ với A → Post model cần field `recipientIds: List<String>` — cần anh Thiên chốt data model trước khi implement T7 | **⏳ Pending — cần leader confirm** |
+| OQ6 | **[BLOCKING T6]** ShareProfileSheet URL: Figma hiển thị `meep.cam/{username}` nhưng Q3 đã resolve là `meep://profile/{username}`. Dùng cái nào? Domain `meep.cam` chưa có DNS thật → link bấm sẽ không mở được trên máy thật | **⏳ Pending — cần leader confirm** |
+| OQ7 | Photo detail — "Tag" là gì? Figma chỉ thấy timestamp "17:03", không thấy tag tên người. Có tính năng tag người vào ảnh không? | **⏳ Pending** |
+| OQ8 | **[BLOCKING tất cả màn hình chính]** `AppTaskbar` (`lib/shared/widgets/app_taskbar.dart`) là shared widget dùng chung Feed / Profile / Diary / Chat / Streak nhưng **chưa có file trong codebase và chưa có owner**. Cần ThienPDM: (1) define contract + Figma node ID cho Taskbar, (2) assign owner implement, (3) confirm Profile module chỉ consume không tự tạo. Nếu chưa có Taskbar → ProfileScreen không thể hoàn chỉnh UI. | **⏳ Pending — cần ThienPDM confirm** |

--- a/docs/specs/2026-05-22-profile.md
+++ b/docs/specs/2026-05-22-profile.md
@@ -44,7 +44,7 @@ Cho phép user xem trang cá nhân của mình (stats + avatar + bio + grid ản
 | Edit profile (form) | `573:2968` | Danh sách settings options dạng list |
 | Avatar picker sheet | `573:3561` (bottom sheet) | Chọn thư viện / Chụp ảnh / Gỡ ảnh |
 | Share profile sheet | `573:3648` (overlay) | Link + Messenger |
-| Photo detail | `660:1940` | Ảnh full + caption Note + Tag + thumbnail strip |
+| Photo detail | `660:1940` | Ảnh full + caption overlay + giờ đăng + thumbnail strip |
 
 ---
 
@@ -452,5 +452,5 @@ match /avatars/{uid}/{filename} {
 | OQ4 | Photo detail swipe đi qua ảnh nào? | **✅ Resolved** — Tất cả ảnh bản thân, swipe trái = cũ hơn (mới → cũ, sắp theo `createdAt` desc) |
 | OQ5 | **[BLOCKING T7]** Post visibility model cho FriendProfileScreen: khi A xem profile B, grid ảnh của B chỉ hiện ảnh chia sẻ với A hay tất cả ảnh B đã đăng? Nếu chỉ hiện ảnh chia sẻ với A → Post model cần field `recipientIds: List<String>` — cần anh Thiên chốt data model trước khi implement T7 | **⏳ Pending — cần leader confirm** |
 | OQ6 | **[BLOCKING T6]** ShareProfileSheet URL: Figma hiển thị `meep.cam/{username}` nhưng Q3 đã resolve là `meep://profile/{username}`. Dùng cái nào? Domain `meep.cam` chưa có DNS thật → link bấm sẽ không mở được trên máy thật | **⏳ Pending — cần leader confirm** |
-| OQ7 | Photo detail — "Tag" là gì? Figma chỉ thấy timestamp "17:03", không thấy tag tên người. Có tính năng tag người vào ảnh không? | **⏳ Pending** |
+| OQ7 | Photo detail — "Tag" là gì? Figma chỉ thấy timestamp "17:03", không thấy tag tên người. Có tính năng tag người vào ảnh không? | **✅ Resolved** — Chỉ hiện giờ đăng, không có tag tên người |
 | OQ8 | **[BLOCKING tất cả màn hình chính]** `AppTaskbar` (`lib/shared/widgets/app_taskbar.dart`) là shared widget dùng chung Feed / Profile / Diary / Chat / Streak nhưng **chưa có file trong codebase và chưa có owner**. Cần ThienPDM: (1) define contract + Figma node ID cho Taskbar, (2) assign owner implement, (3) confirm Profile module chỉ consume không tự tạo. Nếu chưa có Taskbar → ProfileScreen không thể hoàn chỉnh UI. | **⏳ Pending — cần ThienPDM confirm** |

--- a/docs/specs/2026-05-22-profile.md
+++ b/docs/specs/2026-05-22-profile.md
@@ -40,7 +40,7 @@ Cho phép user xem trang cá nhân của mình (stats + avatar + bio + grid ản
 | Frame | Figma ID | Mô tả |
 |---|---|---|
 | Profile main | `269:1941` | Avatar + stats + username + bio + 2 action buttons + tab bar + grid ảnh |
-| Profile_Diary tab | `573:3213` | Cùng layout nhưng tab Diary active — M2: hiện empty state |
+| Profile_Diary tab | `573:3213` | Cùng layout nhưng tab Diary active — M2: hiện mock diary content |
 | Edit profile (form) | `573:2968` | Danh sách settings options dạng list |
 | Avatar picker sheet | `573:3561` (bottom sheet) | Chọn thư viện / Chụp ảnh / Gỡ ảnh |
 | Share profile sheet | `573:3648` (overlay) | Link + Messenger |
@@ -57,7 +57,7 @@ Cho phép user xem trang cá nhân của mình (stats + avatar + bio + grid ản
 3. **Avatar edit** — bottom sheet: Chọn từ thư viện / Chụp ảnh / Gỡ ảnh hiện tại
 4. **Share profile** — bottom sheet: deep link copy / Messenger
 5. **Photo detail** — xem ảnh full, caption, timestamp, thumbnail strip (swipe)
-6. **Diary tab** — tab bấm được; hiển thị các Diary entry **public** của user (từ Diary module)
+6. **Diary tab** — tab bấm được; hiển thị mock diary content (M2); toggle grid/list là tính năng M3
 7. **Friend profile screen** — xem profile của bạn bè (chỉ khi đã là friend); navigate từ Friend search result
 
 ### Out-of-scope
@@ -84,7 +84,7 @@ Taskbar → tap icon User (active)
         ├─ Tab [grid-3x3] (default) → Photos grid
         │   Hiển thị TẤT CẢ ảnh user đã đăng từ lúc tạo tài khoản, sắp xếp mới → cũ (createdAt desc)
         │   Load lazy, cursor-paginated 9 ảnh/batch — KHÔNG giới hạn tổng số ảnh hiển thị
-        ├─ Tab [book-heart] → Diary tab — hiển thị Diary entry public của user (empty tự nhiên nếu chưa có)
+        ├─ Tab [book-heart] → Diary tab — hiển thị mock diary content (M2); toggle grid/list là tính năng M3
         └─ Tap ảnh trong grid → Photo detail
 ```
 
@@ -106,7 +106,9 @@ Profile → [Chỉnh sửa]
         ├─ Tap "Cập nhật số điện thoại" → phone input sheet
         ├─ Tap "Cập nhật địa chỉ email" → email input + re-auth flow
         ├─ Tap "Chỉnh sửa giới tính" → bottom sheet options (Nam / Nữ / Khác)
-        ├─ Tap "Tiểu sử" → text input sheet (multiline, max 150 chars, hint: "Tiểu sử của bạn hiển thị với bạn bè của bạn.")
+        ├─ Tap "Tiểu sử" → text input sheet (multiline, max 150 chars)
+        │   Info icon (ⓘ) bên cạnh label → tap hiện inline tooltip: "Tiểu sử của bạn sẽ hiển thị với bạn bè của bạn. Phần giới thiệu bản thân được giới hạn tối đa 150 chữ."
+        │   (Figma Frame 3 — tooltip inline trong EditProfileScreen, không phải hint ở bottom sheet)
         └─ "Thông báo" toggle → bật/tắt FCM notifications (local preference)
 ```
 
@@ -150,7 +152,7 @@ Friend search result → user card (exact match)
                     (xem OQ5 — cần xác nhận data model post visibility)
 ```
 
-> **Không có** nút Edit / Chia sẻ trên FriendProfileScreen — chỉ hiện nút "Xoá bạn" (mở Friend sheet).
+> **Không có** nút Edit trên FriendProfileScreen — hiện 2 nút: **[Nhắn tin]** (navigate to chat) và **[Chia sẻ trang cá nhân]** (mở ShareProfileSheet với title "Chia sẻ liên kết của bạn bè").
 
 ---
 
@@ -164,7 +166,7 @@ Profile grid → tap ảnh
         │   Tất cả ảnh của bản thân, sắp xếp createdAt desc (mới → cũ)
         │   Ảnh kề 2 bên peek ra ngoài (PageView behavior)
         ├─ Caption — overlay pill trắng CHỒng trên ảnh (không phải text bên dưới)
-        ├─ Thời gian đăng — hiển thị riêng bên dưới ảnh (ví dụ: "17:03")
+        ├─ Thời gian đăng — hiển thị riêng bên dưới ảnh (ví dụ: "17:03") — chỉ giờ, không kèm tên người dùng
         └─ Thumbnail strip (cuộn ngang, ảnh đang xem = viền teal #00DEEE)
 ```
 

--- a/docs/specs/2026-05-22-profile.md
+++ b/docs/specs/2026-05-22-profile.md
@@ -14,7 +14,7 @@
 | Q1 | `dateOfBirth` + `phoneNumber` + `gender` có bắt buộc không? | **Optional** — user có thể bỏ qua |
 | Q2 | Email update có flow re-auth không? | **Có** — Firebase yêu cầu re-auth |
 | Q3 | `meep.cam` domain thật hay placeholder? | **Placeholder** — dùng deep link `meep://profile/{username}` |
-| Q4 | Diary tab trong Profile hiện M2 không? | **Chờ M3** — hiện tab icon nhưng empty state + disable |
+| Q4 | Diary tab trong Profile hiện M2 không? | **Có** — tab bấm được; hiện các Diary entry public của user. Nếu chưa có entry nào → empty tự nhiên (không có placeholder "Tính năng sắp ra mắt") |
 | Q5 | "user-round-plus" button làm gì? | **Bỏ** — xóa khỏi UI |
 
 ---
@@ -57,7 +57,7 @@ Cho phép user xem trang cá nhân của mình (stats + avatar + bio + grid ản
 3. **Avatar edit** — bottom sheet: Chọn từ thư viện / Chụp ảnh / Gỡ ảnh hiện tại
 4. **Share profile** — bottom sheet: deep link copy / Messenger
 5. **Photo detail** — xem ảnh full, caption, timestamp, thumbnail strip (swipe)
-6. **Diary tab** — hiện icon + empty state "Tính năng sắp ra mắt" (disabled, chờ M3)
+6. **Diary tab** — tab bấm được; hiển thị các Diary entry **public** của user (từ Diary module)
 7. **Friend profile screen** — xem profile của bạn bè (chỉ khi đã là friend); navigate từ Friend search result
 
 ### Out-of-scope
@@ -84,7 +84,7 @@ Taskbar → tap icon User (active)
         ├─ Tab [grid-3x3] (default) → Photos grid
         │   Hiển thị TẤT CẢ ảnh user đã đăng từ lúc tạo tài khoản, sắp xếp mới → cũ (createdAt desc)
         │   Load lazy, cursor-paginated 9 ảnh/batch — KHÔNG giới hạn tổng số ảnh hiển thị
-        ├─ Tab [book-heart] → Diary tab (empty state M2)
+        ├─ Tab [book-heart] → Diary tab — hiển thị Diary entry public của user (empty tự nhiên nếu chưa có)
         └─ Tap ảnh trong grid → Photo detail
 ```
 
@@ -143,7 +143,7 @@ Friend search result → user card (exact match)
     └─ Trường hợp B: đã là bạn bè
         └─ Hiện card: [avatar] [displayName] [@username] [Nút "Trang cá nhân"]
             └─ Tap card hoặc nút → navigate → FriendProfileScreen
-                ├─ Hiện: avatar + stats (chỉ K.khắc + Bạn bè chung; Space ẩn hoặc 0)
+                ├─ Hiện: avatar + stats (chỉ K.khắc + Bạn bè; Space ẩn hoặc 0)
                 ├─ Bio (nếu có)
                 └─ Grid ảnh của người đó (chỉ read, không edit)
                     CHỈ hiển thị ảnh được chia sẻ với người đang xem — không phải toàn bộ ảnh của chủ profile
@@ -332,16 +332,17 @@ match /avatars/{uid}/{filename} {
 
 | Artifact | File | Status |
 |---|---|---|
-| `UserProfile` freezed model (update: thêm 3 fields) | `lib/features/auth/data/user_profile.dart` | ❌ update needed |
-| `ProfileRepository` abstract | `lib/features/profile/data/profile_repository.dart` | ❌ |
-| `ProfileController` stub + `ProfileState` | `lib/features/profile/application/profile_controller.dart` | ❌ |
-| `ProfileScreen` stub | `lib/features/profile/presentation/profile_screen.dart` | ❌ |
-| `EditProfileScreen` stub | `lib/features/profile/presentation/edit_profile_screen.dart` | ❌ |
-| `PhotoDetailScreen` stub | `lib/features/profile/presentation/photo_detail_screen.dart` | ❌ |
-| `AvatarPickerSheet` stub | `lib/features/profile/presentation/avatar_picker_sheet.dart` | ❌ |
-| `ShareProfileSheet` stub | `lib/shared/widgets/share_profile_sheet.dart` — **shared**, leader own (Profile + Settings dùng chung) | ❌ |
-| Routes: `/profile`, `/profile/edit`, `/profile/photo/:postId` | `lib/core/router/app_router.dart` | ❌ |
-| Storage rules: `avatars/{uid}/` | `firebase/storage.rules` | ❌ |
+| `UserProfile` freezed model (update: thêm 7 fields) | `lib/features/auth/data/user_profile.dart` | ✅ LX9 |
+| `ProfileRepository` abstract | `lib/features/profile/data/profile_repository.dart` | ✅ LX9 |
+| `ProfileController` stub + `ProfileState` | `lib/features/profile/application/profile_controller.dart` | ✅ LX9 |
+| `ProfileScreen` stub | `lib/features/profile/presentation/profile_screen.dart` | ✅ LX9 |
+| `EditProfileScreen` stub | `lib/features/profile/presentation/edit_profile_screen.dart` | ✅ LX9 |
+| `PhotoDetailScreen` stub | `lib/features/profile/presentation/photo_detail_screen.dart` | ✅ LX9 |
+| `AvatarPickerSheet` stub | `lib/features/profile/presentation/avatar_picker_sheet.dart` | ✅ LX9 |
+| `FriendProfileScreen` stub | `lib/features/profile/presentation/friend_profile_screen.dart` | ❌ **Chưa có — cần leader tạo** |
+| `ShareProfileSheet` stub | `lib/shared/widgets/share_profile_sheet.dart` — **shared**, leader own | ✅ LX3 |
+| Routes: `/profile`, `/profile/edit`, `/profile/photo/:postId`, `/friend-profile/:uid` | `lib/core/router/app_router.dart` | ✅ LX9 |
+| Storage rules: `avatars/{uid}/` | `firebase/storage.rules` | ✅ LX-RULES |
 | TODO markers | — | ⏳ |
 
 ---
@@ -435,7 +436,7 @@ match /avatars/{uid}/{filename} {
 - **Username change race condition:** 2 user đổi sang cùng username → cần transaction. Reuse logic từ Auth module (`/usernames/{username}` doc).
 - **Email re-auth UX:** Firebase `requires-recent-login` error phải được handle gracefully — nếu session cũ > 5 phút → hiện dialog re-auth.
 - **Stats count denormalization:** `friendCount` từ Friend module, `spaceCount` chưa có (Space module M3) → **hiện `0`** cho Space count M2, cập nhật khi Space module xong.
-- **Diary tab M2:** hiện empty state nhưng tab icon phải vẫn tap được (không bị disabled/grayed out hoàn toàn) để không confuse user.
+- **Diary tab:** hiển thị Diary entry public — phụ thuộc Diary module implement `DiaryRepository.getPublicEntries(uid)`. Nếu Diary module chưa done → tab render empty tự nhiên, không crash.
 - **`user-round-plus` button:** đã confirm xoá khỏi UI — designer cần update Figma.
 - **Post visibility (OQ5):** Nếu Post không có `recipientIds` field → FriendProfileScreen không thể lọc đúng ảnh được chia sẻ. Cần clarify trước khi T7 bắt đầu.
 


### PR DESCRIPTION
## Summary

- Share options: chỉ Messenger + copy (bỏ Instagram)
- FriendProfileScreen: nút Nhắn tin + Chia sẻ (không phải Xoá bạn)
- Diary tab M2: mock diary content thay vì empty state; note toggle grid/list là M3
- Tooltip Tiểu sử: text đúng theo Figma Frame 3 + mô tả info icon inline
- Photo detail: Tag chỉ hiển thị giờ (17:03), không kèm tên người dùng

## Test plan

- [ ] Đọc lại `docs/specs/2026-05-22-profile.md` — verify 7 điểm đã khớp với Code/Figma thực tế

🤖 Generated with [Claude Code](https://claude.com/claude-code)