### PR TITLE
feat(friend): implement T1 data layer #89

### DIFF
--- a/apps/mobile/lib/features/friend/application/friend_controller.dart
+++ b/apps/mobile/lib/features/friend/application/friend_controller.dart
@@ -1,9 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/friend/application/friend_state.dart';
 import 'package:meep/features/friend/data/friend_repository.dart';
-import 'package:meep/features/friend/data/friend_request.dart';
 import 'package:meep/features/friend/data/friend_request_repository.dart';
 
 part 'friend_controller.g.dart';
@@ -11,51 +10,58 @@ part 'friend_controller.g.dart';
 @Riverpod(keepAlive: true)
 FriendRepository friendRepository(Ref ref) => throw UnimplementedError(
       'friendRepositoryProvider must be overridden — '
-      'wire FirestoreFriendRepository in main.dart (TODO: F/T1/KhoaLND)',
+      'wire FirestoreFriendRepository in main.dart (TODO: F/T1/ThienPDM)',
     );
 
 @Riverpod(keepAlive: true)
 FriendRequestRepository friendRequestRepository(Ref ref) =>
     throw UnimplementedError(
       'friendRequestRepositoryProvider must be overridden — '
-      'wire FirestoreFriendRequestRepository in main.dart (TODO: F/T1/KhoaLND)',
+      'wire FirestoreFriendRequestRepository in main.dart (TODO: F/T1/ThienPDM)',
     );
 
 @riverpod
 class FriendController extends _$FriendController {
   @override
-  Future<List<UserProfile>> build(String uid) async {
-    // TODO(F/T2/KhoaLND): implement watchFriends stream
-    throw UnimplementedError('FriendController.build — TODO: F/T2/KhoaLND');
+  FriendState build(String uid) {
+    // TODO(F/T2/ThienPDM): implement watchFriends stream + watchPendingRequests
+    // Listen to both streams and merge into FriendState
+    return const FriendState();
   }
 
-  Future<void> searchUsers(String query) async {
-    // TODO(F/T3/KhoaLND): implement user search
-    throw UnimplementedError('searchUsers — TODO: F/T3/KhoaLND');
+  Future<void> searchUser(String query) async {
+    // TODO(F/T2/ThienPDM): implement user search with 500ms debounce
+    // Call friendRepository.searchUser(query.toLowerCase())
+    // Update state.searchResult + state.searchQuery
+    throw UnimplementedError('searchUser — TODO: F/T2/ThienPDM');
   }
 
-  Future<void> sendRequest(String receiverUid) async {
-    // TODO(F/T4/KhoaLND): implement sendFriendRequest
-    throw UnimplementedError('sendRequest — TODO: F/T4/KhoaLND');
+  Future<void> sendFriendRequest(String receiverUid) async {
+    // TODO(F/T2/ThienPDM): implement sendFriendRequest
+    // Call friendRequestRepository.sendFriendRequest
+    throw UnimplementedError('sendFriendRequest — TODO: F/T2/ThienPDM');
   }
 
-  Future<void> cancelRequest(String requestId) async {
-    // TODO(F/T5/KhoaLND): implement cancelFriendRequest
-    throw UnimplementedError('cancelRequest — TODO: F/T5/KhoaLND');
+  Future<void> acceptFriendRequest(String requestId) async {
+    // TODO(F/T2/ThienPDM): implement acceptFriendRequest
+    // Call friendRequestRepository.acceptFriendRequest (calls CF)
+    // Handle error "max 20 friends" → set state.errorMessage
+    throw UnimplementedError('acceptFriendRequest — TODO: F/T2/ThienPDM');
   }
 
-  Future<void> declineRequest(String requestId) async {
-    // TODO(F/T6/KhoaLND): implement declineFriendRequest
-    throw UnimplementedError('declineRequest — TODO: F/T6/KhoaLND');
+  Future<void> cancelFriendRequest(String requestId) async {
+    // TODO(F/T2/ThienPDM): implement cancelFriendRequest
+    throw UnimplementedError('cancelFriendRequest — TODO: F/T2/ThienPDM');
   }
 
-  Future<void> unfriend(String friendUid) async {
-    // TODO(F/T7/KhoaLND): implement unfriend
-    throw UnimplementedError('unfriend — TODO: F/T7/KhoaLND');
+  Future<void> declineFriendRequest(String requestId) async {
+    // TODO(F/T2/ThienPDM): implement declineFriendRequest
+    throw UnimplementedError('declineFriendRequest — TODO: F/T2/ThienPDM');
   }
 
-  Future<List<FriendRequest>> watchPendingRequests() async {
-    // TODO(F/T8/KhoaLND): implement watchPendingRequests
-    throw UnimplementedError('watchPendingRequests — TODO: F/T8/KhoaLND');
+  Future<void> unfriend(String pairId) async {
+    // TODO(F/T2/ThienPDM): implement unfriend with optimistic update
+    // Remove friend from state.friends immediately, then call repo
+    throw UnimplementedError('unfriend — TODO: F/T2/ThienPDM');
   }
 }

--- a/apps/mobile/lib/features/friend/application/friend_state.dart
+++ b/apps/mobile/lib/features/friend/application/friend_state.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/friend/data/friend_request.dart';
+
+part 'friend_state.freezed.dart';
+
+@freezed
+class FriendState with _$FriendState {
+  const factory FriendState({
+    @Default([]) List<UserProfile> friends,
+    @Default([]) List<FriendRequest> pendingRequests,
+    UserProfile? searchResult,
+    @Default('') String searchQuery,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+  }) = _FriendState;
+}

--- a/apps/mobile/lib/features/friend/data/firebase_friend_repository.dart
+++ b/apps/mobile/lib/features/friend/data/firebase_friend_repository.dart
@@ -1,0 +1,78 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/friend/data/friend_repository.dart';
+import 'package:meep/features/friend/data/friendship.dart';
+
+class FirebaseFriendRepository implements FriendRepository {
+  FirebaseFriendRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  @override
+  Future<UserProfile?> searchUser(String username) async {
+    final query = username.toLowerCase().trim();
+    if (query.isEmpty) return null;
+
+    final snapshot = await _firestore
+        .collection('users')
+        .where('username', isEqualTo: query)
+        .limit(1)
+        .get();
+
+    if (snapshot.docs.isEmpty) return null;
+
+    return UserProfile.fromJson(snapshot.docs.first.data());
+  }
+
+  @override
+  Stream<List<UserProfile>> watchFriends(String uid) {
+    return _firestore
+        .collection('friendships')
+        .where('members', arrayContains: uid)
+        .snapshots()
+        .asyncMap((snapshot) async {
+      if (snapshot.docs.isEmpty) return <UserProfile>[];
+
+      // Extract friend UIDs
+      final friendUids = <String>[];
+      for (final doc in snapshot.docs) {
+        final friendship = Friendship.fromJson(doc.data());
+        final friendUid = friendship.uid1 == uid ? friendship.uid2 : friendship.uid1;
+        friendUids.add(friendUid);
+      }
+
+      // Batch fetch user profiles
+      if (friendUids.isEmpty) return <UserProfile>[];
+
+      final userDocs = await Future.wait(
+        friendUids.map((fuid) => _firestore.collection('users').doc(fuid).get()),
+      );
+
+      return userDocs
+          .where((doc) => doc.exists)
+          .map((doc) => UserProfile.fromJson(doc.data()!))
+          .toList();
+    });
+  }
+
+  @override
+  Future<List<String>> getFriendUids(String uid) async {
+    final snapshot = await _firestore
+        .collection('friendships')
+        .where('members', arrayContains: uid)
+        .get();
+
+    if (snapshot.docs.isEmpty) return [];
+
+    return snapshot.docs.map((doc) {
+      final friendship = Friendship.fromJson(doc.data());
+      return friendship.uid1 == uid ? friendship.uid2 : friendship.uid1;
+    }).toList();
+  }
+
+  @override
+  Future<void> unfriend(String pairId) async {
+    await _firestore.collection('friendships').doc(pairId).delete();
+  }
+}

--- a/apps/mobile/lib/features/friend/data/firebase_friend_request_repository.dart
+++ b/apps/mobile/lib/features/friend/data/firebase_friend_request_repository.dart
@@ -1,0 +1,72 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+import 'package:meep/features/friend/data/friend_request.dart';
+import 'package:meep/features/friend/data/friend_request_repository.dart';
+
+class FirebaseFriendRequestRepository implements FriendRequestRepository {
+  FirebaseFriendRequestRepository(this._firestore, this._functions);
+
+  final FirebaseFirestore _firestore;
+  final FirebaseFunctions _functions;
+
+  @override
+  Stream<List<FriendRequest>> watchPendingRequests(String receiverUid) {
+    return _firestore
+        .collection('friend_requests')
+        .where('receiverId', isEqualTo: receiverUid)
+        .where('status', isEqualTo: 'pending')
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snapshot) {
+      return snapshot.docs
+          .map(
+            (doc) => FriendRequest.fromJson({
+              ...doc.data(),
+              'requestId': doc.id,
+            }),
+          )
+          .toList();
+    });
+  }
+
+  @override
+  Future<void> sendFriendRequest({
+    required String senderUid,
+    required String receiverUid,
+  }) async {
+    if (senderUid == receiverUid) {
+      throw Exception('Cannot send friend request to yourself');
+    }
+
+    await _firestore.collection('friend_requests').add({
+      'senderId': senderUid,
+      'receiverId': receiverUid,
+      'status': 'pending',
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  @override
+  Future<void> acceptFriendRequest(String requestId) async {
+    final callable = _functions.httpsCallable('acceptFriendRequest');
+    await callable.call<Map<String, dynamic>>({'requestId': requestId});
+  }
+
+  @override
+  Future<void> cancelFriendRequest(String requestId) async {
+    await _firestore.collection('friend_requests').doc(requestId).update({
+      'status': 'cancelled',
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  @override
+  Future<void> declineFriendRequest(String requestId) async {
+    await _firestore.collection('friend_requests').doc(requestId).update({
+      'status': 'declined',
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+}

--- a/apps/mobile/lib/features/friend/data/friend_repository.dart
+++ b/apps/mobile/lib/features/friend/data/friend_repository.dart
@@ -1,8 +1,9 @@
 import 'package:meep/features/auth/data/user_profile.dart';
 
 abstract class FriendRepository {
-  /// Search users by display name or username prefix. Max 20 results.
-  Future<List<UserProfile>> searchUser(String query);
+  /// Search user by exact username match (case-insensitive).
+  /// Returns the user if found, null otherwise.
+  Future<UserProfile?> searchUser(String username);
 
   /// Stream of current user's accepted friends.
   Stream<List<UserProfile>> watchFriends(String uid);
@@ -10,6 +11,7 @@ abstract class FriendRepository {
   /// Returns UIDs of all friends — used for feed filtering.
   Future<List<String>> getFriendUids(String uid);
 
-  /// Remove an existing friendship. Bidirectional.
-  Future<void> unfriend({required String uid, required String friendUid});
+  /// Remove an existing friendship by pairId. Bidirectional.
+  /// Use [pairIdOf] to compute the pairId from two UIDs.
+  Future<void> unfriend(String pairId);
 }

--- a/apps/mobile/lib/features/friend/data/friend_request_repository.dart
+++ b/apps/mobile/lib/features/friend/data/friend_request_repository.dart
@@ -10,6 +10,11 @@ abstract class FriendRequestRepository {
     required String receiverUid,
   });
 
+  /// Accept a friend request via Cloud Function.
+  /// Creates friendship + conversation + increments friendCount.
+  /// Throws if sender or receiver already has 20 friends.
+  Future<void> acceptFriendRequest(String requestId);
+
   /// Cancel a sent friend request.
   Future<void> cancelFriendRequest(String requestId);
 

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   firebase_core: ^3.6.0
   firebase_auth: ^5.3.1
   cloud_firestore: ^5.4.4
+  cloud_functions: ^5.1.3
   firebase_storage: ^12.3.4
   firebase_messaging: ^15.1.3
   firebase_crashlytics: ^4.1.3

--- a/apps/mobile/test/features/friend/firebase_friend_repository_test.dart
+++ b/apps/mobile/test/features/friend/firebase_friend_repository_test.dart
@@ -1,0 +1,197 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meep/core/utils/pair_id.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/friend/data/firebase_friend_repository.dart';
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late FirebaseFriendRepository repository;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    repository = FirebaseFriendRepository(firestore);
+  });
+
+  group('searchUser', () {
+    test('returns user when exact username match (case-insensitive)', () async {
+      // Arrange
+      await firestore.collection('users').doc('uid1').set({
+        'uid': 'uid1',
+        'email': 'thien@meep.app',
+        'displayName': 'Thien PDM',
+        'username': 'thienpdm',
+        'createdAt': Timestamp.now(),
+        'updatedAt': Timestamp.now(),
+      });
+
+      // Act
+      final result = await repository.searchUser('ThienPDM');
+
+      // Assert
+      expect(result, isNotNull);
+      expect(result!.uid, 'uid1');
+      expect(result.username, 'thienpdm');
+    });
+
+    test('returns null when username not found', () async {
+      // Act
+      final result = await repository.searchUser('notexist');
+
+      // Assert
+      expect(result, isNull);
+    });
+
+    test('returns null when query is empty', () async {
+      // Act
+      final result = await repository.searchUser('');
+
+      // Assert
+      expect(result, isNull);
+    });
+
+    test('trims whitespace before search', () async {
+      // Arrange
+      await firestore.collection('users').doc('uid1').set({
+        'uid': 'uid1',
+        'email': 'thien@meep.app',
+        'displayName': 'Thien PDM',
+        'username': 'thienpdm',
+        'createdAt': Timestamp.now(),
+        'updatedAt': Timestamp.now(),
+      });
+
+      // Act
+      final result = await repository.searchUser('  ThienPDM  ');
+
+      // Assert
+      expect(result, isNotNull);
+      expect(result!.username, 'thienpdm');
+    });
+  });
+
+  group('getFriendUids', () {
+    test('returns friend UIDs using arrayContains query', () async {
+      // Arrange
+      const uid = 'user1';
+      final pairId1 = pairIdOf(uid, 'friend1');
+      final pairId2 = pairIdOf(uid, 'friend2');
+
+      await firestore.collection('friendships').doc(pairId1).set({
+        'uid1': uid.compareTo('friend1') < 0 ? uid : 'friend1',
+        'uid2': uid.compareTo('friend1') < 0 ? 'friend1' : uid,
+        'members': [uid, 'friend1'],
+        'createdAt': Timestamp.now(),
+      });
+
+      await firestore.collection('friendships').doc(pairId2).set({
+        'uid1': uid.compareTo('friend2') < 0 ? uid : 'friend2',
+        'uid2': uid.compareTo('friend2') < 0 ? 'friend2' : uid,
+        'members': [uid, 'friend2'],
+        'createdAt': Timestamp.now(),
+      });
+
+      // Act
+      final result = await repository.getFriendUids(uid);
+
+      // Assert
+      expect(result, hasLength(2));
+      expect(result, containsAll(['friend1', 'friend2']));
+    });
+
+    test('returns empty list when no friends', () async {
+      // Act
+      final result = await repository.getFriendUids('user1');
+
+      // Assert
+      expect(result, isEmpty);
+    });
+  });
+
+  group('unfriend', () {
+    test('deletes friendship document by pairId', () async {
+      // Arrange
+      const pairId = 'uid1_uid2';
+      await firestore.collection('friendships').doc(pairId).set({
+        'uid1': 'uid1',
+        'uid2': 'uid2',
+        'members': ['uid1', 'uid2'],
+        'createdAt': Timestamp.now(),
+      });
+
+      // Act
+      await repository.unfriend(pairId);
+
+      // Assert
+      final doc = await firestore.collection('friendships').doc(pairId).get();
+      expect(doc.exists, isFalse);
+    });
+  });
+
+  group('pairIdOf', () {
+    test('returns same ID regardless of order', () {
+      // Act
+      final id1 = pairIdOf('alice', 'bob');
+      final id2 = pairIdOf('bob', 'alice');
+
+      // Assert
+      expect(id1, id2);
+      expect(id1, 'alice_bob'); // alice < bob lexicographically
+    });
+
+    test('handles identical UIDs', () {
+      // Act
+      final id = pairIdOf('alice', 'alice');
+
+      // Assert
+      expect(id, 'alice_alice');
+    });
+  });
+
+  group('watchFriends', () {
+    test('streams friend profiles', () async {
+      // Arrange
+      const uid = 'user1';
+      final pairId = pairIdOf(uid, 'friend1');
+
+      await firestore.collection('friendships').doc(pairId).set({
+        'uid1': uid.compareTo('friend1') < 0 ? uid : 'friend1',
+        'uid2': uid.compareTo('friend1') < 0 ? 'friend1' : uid,
+        'members': [uid, 'friend1'],
+        'createdAt': Timestamp.now(),
+      });
+
+      await firestore.collection('users').doc('friend1').set({
+        'uid': 'friend1',
+        'email': 'friend@meep.app',
+        'displayName': 'Friend One',
+        'username': 'friend1',
+        'createdAt': Timestamp.now(),
+        'updatedAt': Timestamp.now(),
+      });
+
+      // Act
+      final stream = repository.watchFriends(uid);
+
+      // Assert
+      await expectLater(
+        stream,
+        emits(
+          predicate<List<UserProfile>>((list) {
+            return list.length == 1 && list.first.uid == 'friend1';
+          }),
+        ),
+      );
+    });
+
+    test('returns empty list when no friends', () async {
+      // Act
+      final stream = repository.watchFriends('user1');
+
+      // Assert
+      await expectLater(stream, emits(isEmpty));
+    });
+  });
+}

--- a/apps/mobile/test/features/friend/firebase_friend_request_repository_test.dart
+++ b/apps/mobile/test/features/friend/firebase_friend_request_repository_test.dart
@@ -1,0 +1,145 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/features/friend/data/firebase_friend_request_repository.dart';
+import 'package:meep/features/friend/data/friend_request.dart';
+
+class MockFirebaseFunctions extends Mock implements FirebaseFunctions {}
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late MockFirebaseFunctions functions;
+  late FirebaseFriendRequestRepository repository;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    functions = MockFirebaseFunctions();
+    repository = FirebaseFriendRequestRepository(firestore, functions);
+  });
+
+  group('watchPendingRequests', () {
+    test('streams pending requests for receiver', () async {
+      // Arrange
+      const receiverUid = 'user1';
+      await firestore.collection('friend_requests').add({
+        'senderId': 'sender1',
+        'receiverId': receiverUid,
+        'status': 'pending',
+        'createdAt': Timestamp.now(),
+        'updatedAt': Timestamp.now(),
+      });
+
+      await firestore.collection('friend_requests').add({
+        'senderId': 'sender2',
+        'receiverId': receiverUid,
+        'status': 'pending',
+        'createdAt': Timestamp.now(),
+        'updatedAt': Timestamp.now(),
+      });
+
+      // Add accepted request (should not appear)
+      await firestore.collection('friend_requests').add({
+        'senderId': 'sender3',
+        'receiverId': receiverUid,
+        'status': 'accepted',
+        'createdAt': Timestamp.now(),
+        'updatedAt': Timestamp.now(),
+      });
+
+      // Act
+      final stream = repository.watchPendingRequests(receiverUid);
+
+      // Assert
+      await expectLater(
+        stream,
+        emits(
+          predicate<List<FriendRequest>>((list) {
+            return list.length == 2 &&
+                list.every((req) => req.status == FriendRequestStatus.pending);
+          }),
+        ),
+      );
+    });
+
+    test('returns empty list when no pending requests', () async {
+      // Act
+      final stream = repository.watchPendingRequests('user1');
+
+      // Assert
+      await expectLater(stream, emits(isEmpty));
+    });
+  });
+
+  group('sendFriendRequest', () {
+    test('creates friend request document', () async {
+      // Act
+      await repository.sendFriendRequest(
+        senderUid: 'user1',
+        receiverUid: 'user2',
+      );
+
+      // Assert
+      final snapshot = await firestore.collection('friend_requests').get();
+      expect(snapshot.docs, hasLength(1));
+
+      final data = snapshot.docs.first.data();
+      expect(data['senderId'], 'user1');
+      expect(data['receiverId'], 'user2');
+      expect(data['status'], 'pending');
+    });
+
+    test('throws when sending request to self', () async {
+      // Act & Assert
+      expect(
+        () => repository.sendFriendRequest(
+          senderUid: 'user1',
+          receiverUid: 'user1',
+        ),
+        throwsException,
+      );
+    });
+  });
+
+  group('cancelFriendRequest', () {
+    test('updates request status to cancelled', () async {
+      // Arrange
+      final docRef = await firestore.collection('friend_requests').add({
+        'senderId': 'user1',
+        'receiverId': 'user2',
+        'status': 'pending',
+        'createdAt': Timestamp.now(),
+        'updatedAt': Timestamp.now(),
+      });
+
+      // Act
+      await repository.cancelFriendRequest(docRef.id);
+
+      // Assert
+      final doc = await firestore.collection('friend_requests').doc(docRef.id).get();
+      expect(doc.data()!['status'], 'cancelled');
+    });
+  });
+
+  group('declineFriendRequest', () {
+    test('updates request status to declined', () async {
+      // Arrange
+      final docRef = await firestore.collection('friend_requests').add({
+        'senderId': 'user1',
+        'receiverId': 'user2',
+        'status': 'pending',
+        'createdAt': Timestamp.now(),
+        'updatedAt': Timestamp.now(),
+      });
+
+      // Act
+      await repository.declineFriendRequest(docRef.id);
+
+      // Assert
+      final doc = await firestore.collection('friend_requests').doc(docRef.id).get();
+      expect(doc.data()!['status'], 'declined');
+    });
+  });
+}

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -75,29 +75,48 @@ export const onPostCreated = onDocumentCreated(
 /**
  * Accept a pending friend request and create the friendship doc.
  *
- * TODO(F/impl):
- *   - verify request exists + status == 'pending'
- *   - verify request.auth.uid == receiverId
- *   - create /friendships/{pairId} doc
- *   - update request status to 'accepted'
- *   - send FCM notification to sender
+ * TODO(F/T5/ThienPDM):
+ *   1. Verify request exists + status == 'pending' + request.auth.uid == receiverId
+ *   2. Check sender.friendCount < 20 AND receiver.friendCount < 20
+ *      → throw FAILED_PRECONDITION if either >= 20
+ *   3. Firestore batch (1 commit, atomic):
+ *      a. Create /friendships/{pairId} (uid1, uid2, members, createdAt)
+ *      b. Create /conversations/{pairId} (type='direct', participantIds=[uid1,uid2])
+ *      c. Update /friend_requests/{requestId}.status = 'accepted'
+ *      d. FieldValue.increment(1) friendCount for both sender and receiver
+ *   4. Send FCM notification to sender
+ *   5. Return { success: true, pairId: string }
+ *
+ * Note: conversationId == pairId (sorted uid1_uid2) — consistent with friendship docId.
+ * Idempotent: if A→B and B→A send requests simultaneously, detect and create 1 friendship only.
  */
 export const acceptFriendRequest = onCall((request) => {
   if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
-  // TODO(F/impl): see comment above.
+  // TODO(F/T5/ThienPDM): see comment above.
   return { ok: true };
 });
 
 /**
  * Clean up friend-related data when a friendship is deleted.
  *
- * TODO(F/impl):
- *   - remove each member from the other's cached friend list
+ * TODO(F/T6/ThienPDM):
+ *   1. Decrement friendCount for uid1 and uid2 using FieldValue.increment(-1)
+ *      → use transaction for idempotency
+ *   2. Update /conversations/{pairId}.status = 'unfriended' if conversation exists
+ *      → do NOT crash if conversation doesn't exist
+ *   3. Batch delete cross-feed entries:
+ *      - Delete /users/{uid1}/feed/{postId} WHERE authorId == uid2 AND spaceId == null
+ *      - Delete /users/{uid2}/feed/{postId} WHERE authorId == uid1 AND spaceId == null
+ *   4. Preserve Space posts (spaceId != null) — do NOT delete from feed
+ *
+ * Note: This CF owns feed cleanup (Home/Camera/Feed module concern).
+ * Home/Camera/Feed module does NOT create a separate CF for this cleanup.
+ * CF must be idempotent: re-running after partial failure produces same final state.
  */
 export const onFriendshipDeleted = onDocumentDeleted(
   { document: 'friendships/{pairId}', region: 'asia-southeast1' },
   (_event) => {
-    // TODO(F/impl): see comment above.
+    // TODO(F/T6/ThienPDM): see comment above.
   },
 );
 


### PR DESCRIPTION
## Mô tả

Implement T1 — Data layer cho Friend module:
- FirebaseFriendRepository: searchUser, watchFriends, getFriendUids, unfriend
- FirebaseFriendRequestRepository: watchPendingRequests, sendFriendRequest, acceptFriendRequest, cancelFriendRequest, declineFriendRequest

## Thay đổi chính

**FirebaseFriendRepository:**
- `searchUser`: exact match username (case-insensitive), trả `UserProfile?`
- `watchFriends`: stream friends qua arrayContains query + batch fetch profiles
- `getFriendUids`: lấy list friend UIDs cho feed filtering
- `unfriend`: xóa `/friendships/{pairId}`

**FirebaseFriendRequestRepository:**
- `watchPendingRequests`: stream pending requests cho receiver
- `sendFriendRequest`: tạo friend_request doc, validate không tự gửi
- `acceptFriendRequest`: gọi CF acceptFriendRequest
- `cancelFriendRequest`: update status = cancelled
- `declineFriendRequest`: update status = declined

**Tests:**
- 11 test cases FirebaseFriendRepository
- 6 test cases FirebaseFriendRequestRepository
- Dùng fake_cloud_firestore + mocktail

**Dependencies:**
- Thêm cloud_functions ^5.1.3 cho CF callable

## Checklist

- [x] Tests pass (17/17)
- [x] Lint clean (flutter analyze)
- [x] Self-review qua /review
- [x] Khớp spec docs/specs/2026-05-22-friend.md
- [x] Khớp plan docs/plans/2026-05-23-friend.md T1 acceptance criteria

## Liên quan

Closes #89