### PR TITLE
feat(feed): T1 — Data layer (Post repository + Storage repository)

### DIFF
--- a/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
+++ b/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/feed/data/post_repository.dart';
+
+class FirebasePostRepository implements PostRepository {
+  FirebasePostRepository(this._db);
+
+  final FirebaseFirestore _db;
+
+  static const _posts = 'posts';
+
+  @override
+  Future<Post> createPost(Post post) async {
+    if (post.audienceType == AudienceType.select && post.audienceUids.isEmpty) {
+      throw ArgumentError('select audience requires at least one uid');
+    }
+
+    final ref = _db.collection(_posts).doc(post.postId);
+    final data = post.toJson()
+      ..['createdAt'] = FieldValue
+          .serverTimestamp(); // spec: serverTimestamp, not device clock
+    await ref.set(data);
+    return post;
+  }
+
+  @override
+  Stream<List<Post>> watchFeed(String uid) {
+    // Direct-read approach: separate queries for own posts + each friend's posts,
+    // then merge streams. Works with Firestore Rules that check resource.data.authorId.
+    return _getFriendUids(uid).asStream().asyncExpand((friendUids) {
+      final authorIds = [uid, ...friendUids];
+
+      if (authorIds.isEmpty) {
+        return Stream.value(<Post>[]);
+      }
+
+      // Query each author separately, then merge + sort client-side.
+      // Firestore Rules allow read when resource.data.authorId matches or isFriend().
+      final streams = authorIds.take(30).map((authorId) {
+        return _db
+            .collection(_posts)
+            .where('authorId', isEqualTo: authorId)
+            .orderBy('createdAt', descending: true)
+            .limit(10)
+            .snapshots()
+            .map((snap) =>
+                snap.docs.map((doc) => Post.fromJson(doc.data())).toList(),);
+      }).toList();
+
+      // Merge all streams, flatten, sort by createdAt desc, take top 10.
+      return _mergeStreams(streams).map((allPosts) {
+        allPosts.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        return allPosts.take(10).toList();
+      });
+    });
+  }
+
+  /// Merge multiple streams of `List<Post>` into one stream of flattened `List<Post>`.
+  Stream<List<Post>> _mergeStreams(List<Stream<List<Post>>> streams) async* {
+    if (streams.isEmpty) {
+      yield [];
+      return;
+    }
+
+    final latestValues = List<List<Post>?>.filled(streams.length, null);
+    final controller = StreamController<List<Post>>();
+    final subscriptions = <StreamSubscription<List<Post>>>[];
+
+    for (var i = 0; i < streams.length; i++) {
+      subscriptions.add(
+        streams[i].listen(
+          (posts) {
+            latestValues[i] = posts;
+            // Emit only after all streams have emitted at least once.
+            if (latestValues.every((v) => v != null)) {
+              final merged = latestValues
+                  .whereType<List<Post>>()
+                  .expand((list) => list)
+                  .toList();
+              controller.add(merged);
+            }
+          },
+          onError: controller.addError,
+        ),
+      );
+    }
+
+    yield* controller.stream;
+
+    await Future.wait(subscriptions.map((s) => s.cancel()));
+    await controller.close();
+  }
+
+  /// Fetch friend UIDs from /friendships where members contains [uid].
+  /// Does NOT use FriendRepository (which is stub UnimplementedError).
+  Future<List<String>> _getFriendUids(String uid) async {
+    final snap = await _db
+        .collection('friendships')
+        .where('members', arrayContains: uid)
+        .get();
+
+    return snap.docs.expand((doc) {
+      final members = doc.data()['members'] as List<dynamic>? ?? [];
+      return members.cast<String>().where((m) => m != uid);
+    }).toList();
+  }
+
+  @override
+  Future<void> deletePost(String postId) async {
+    await _db.collection(_posts).doc(postId).delete();
+    // Storage cleanup is handled by CF onPostDeleted
+  }
+
+  @override
+  Future<List<Post>> getPostsByAuthor(String authorId) async {
+    final snap = await _db
+        .collection(_posts)
+        .where('authorId', isEqualTo: authorId)
+        .orderBy('createdAt', descending: true)
+        .get();
+    return snap.docs.map((d) => Post.fromJson(d.data())).toList();
+  }
+}

--- a/apps/mobile/lib/features/feed/data/firebase_storage_repository.dart
+++ b/apps/mobile/lib/features/feed/data/firebase_storage_repository.dart
@@ -1,0 +1,42 @@
+import 'dart:typed_data';
+
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:meep/features/feed/data/storage_repository.dart';
+
+class FirebaseStorageRepository implements StorageRepository {
+  FirebaseStorageRepository(this._storage);
+
+  final FirebaseStorage _storage;
+
+  static const _maxBytes = 5 * 1024 * 1024; // 5 MB
+
+  @override
+  Future<String> uploadImage({
+    required String uid,
+    required String postId,
+    required List<int> bytes,
+    required String mimeType,
+    String fileName = 'photo.jpg',
+  }) async {
+    if (bytes.length > _maxBytes) {
+      throw ArgumentError(
+        'Image exceeds 5 MB limit (${bytes.length} bytes)',
+      );
+    }
+
+    final ref = _storage.ref('posts/$uid/$postId/$fileName');
+    final metadata = SettableMetadata(contentType: mimeType);
+    await ref.putData(Uint8List.fromList(bytes), metadata);
+    return ref.getDownloadURL();
+  }
+
+  @override
+  Future<void> deleteImage(String storagePath) async {
+    try {
+      await _storage.ref(storagePath).delete();
+    } on FirebaseException catch (e) {
+      // object-not-found is acceptable (CF may have deleted first)
+      if (e.code != 'object-not-found') rethrow;
+    }
+  }
+}

--- a/apps/mobile/lib/features/feed/data/post.dart
+++ b/apps/mobile/lib/features/feed/data/post.dart
@@ -10,12 +10,21 @@ enum AudienceType { all, select }
 
 @freezed
 class Post with _$Post {
+  const Post._();
+
   const factory Post({
     required String postId,
     required String authorId,
     required String authorName,
     String? authorAvatarUrl,
-    required String imageUrl,
+
+    /// Single camera mode: imageUrl is set, backImageUrl/frontImageUrl are null.
+    /// Dual camera mode: backImageUrl/frontImageUrl are set, imageUrl is null.
+    String? imageUrl,
+    String? backImageUrl,
+    String? frontImageUrl,
+    @Default(false) bool isDualCamera,
+
     String? caption,
     CaptionType? captionType,
     required AudienceType audienceType,
@@ -28,6 +37,11 @@ class Post with _$Post {
   }) = _Post;
 
   factory Post.fromJson(Map<String, dynamic> json) => _$PostFromJson(json);
+
+  /// Representative image for single-image contexts (grid thumbnail, share).
+  /// Single mode → imageUrl. Dual mode → back lens (the "scene" photo).
+  String get coverImageUrl =>
+      imageUrl ?? backImageUrl ?? frontImageUrl ?? '';
 }
 
 class TimestampConverter implements JsonConverter<DateTime, Object> {

--- a/apps/mobile/lib/features/feed/data/storage_repository.dart
+++ b/apps/mobile/lib/features/feed/data/storage_repository.dart
@@ -1,10 +1,15 @@
 abstract class StorageRepository {
   /// Upload image bytes and return the download URL.
+  ///
+  /// [fileName] selects the object name under the post folder.
+  /// Single mode uses the default `photo.jpg`; dual mode passes
+  /// `back.jpg` / `front.jpg` to store both lenses under one postId.
   Future<String> uploadImage({
     required String uid,
     required String postId,
     required List<int> bytes,
     required String mimeType,
+    String fileName,
   });
 
   /// Delete image at [storagePath].

--- a/apps/mobile/test/features/feed/firebase_post_repository_test.dart
+++ b/apps/mobile/test/features/feed/firebase_post_repository_test.dart
@@ -1,0 +1,129 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/feed/data/firebase_post_repository.dart';
+import 'package:meep/features/feed/data/post.dart';
+
+Post _makePost({
+  String postId = 'p1',
+  String authorId = 'uid1',
+  AudienceType audience = AudienceType.all,
+  List<String> uids = const [],
+}) =>
+    Post(
+      postId: postId,
+      authorId: authorId,
+      authorName: 'Test User',
+      imageUrl: 'https://example.com/photo.jpg',
+      audienceType: audience,
+      audienceUids: uids,
+      createdAt: DateTime(2026, 5, 27),
+    );
+
+void main() {
+  late FakeFirebaseFirestore db;
+  late FirebasePostRepository repo;
+
+  setUp(() {
+    db = FakeFirebaseFirestore();
+    repo = FirebasePostRepository(db);
+  });
+
+  group('createPost', () {
+    test('writes doc with correct fields', () async {
+      final post = _makePost();
+      await repo.createPost(post);
+
+      final snap = await db.collection('posts').doc('p1').get();
+      expect(snap.exists, isTrue);
+      expect(snap.data()!['authorId'], 'uid1');
+      expect(snap.data()!['audienceType'], 'all');
+    });
+
+    test('persists dual camera lenses + flag', () async {
+      final post = Post(
+        postId: 'dual1',
+        authorId: 'uid1',
+        authorName: 'Test User',
+        backImageUrl: 'https://example.com/back.jpg',
+        frontImageUrl: 'https://example.com/front.jpg',
+        isDualCamera: true,
+        audienceType: AudienceType.all,
+        createdAt: DateTime(2026, 5, 31),
+      );
+      await repo.createPost(post);
+
+      final snap = await db.collection('posts').doc('dual1').get();
+      expect(snap.data()!['isDualCamera'], isTrue);
+      expect(snap.data()!['backImageUrl'], 'https://example.com/back.jpg');
+      expect(snap.data()!['frontImageUrl'], 'https://example.com/front.jpg');
+      expect(snap.data()!['imageUrl'], isNull);
+    });
+
+    test('select audience with empty uids throws ArgumentError', () async {
+      final post = _makePost(audience: AudienceType.select, uids: []);
+      await expectLater(
+        () => repo.createPost(post),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('select audience with uids succeeds', () async {
+      final post = _makePost(
+        audience: AudienceType.select,
+        uids: ['uid2', 'uid3'],
+      );
+      await repo.createPost(post);
+
+      final snap = await db.collection('posts').doc('p1').get();
+      expect(snap.data()!['audienceType'], 'select');
+      expect(snap.data()!['audienceUids'], ['uid2', 'uid3']);
+    });
+  });
+
+  group('watchFeed', () {
+    test('returns own posts + friend posts ordered by createdAt', () async {
+      // Seed /posts docs
+      final p1 = _makePost(postId: 'p1', authorId: 'uid1');
+      final p2 = _makePost(postId: 'p2', authorId: 'uid2');
+      final p3 = _makePost(postId: 'p3', authorId: 'uid3');
+      await db.collection('posts').doc('p1').set(p1.toJson());
+      await db.collection('posts').doc('p2').set(p2.toJson());
+      await db.collection('posts').doc('p3').set(p3.toJson());
+
+      // Seed /friendships — uid1 is friends with uid2 (not uid3)
+      await db.collection('friendships').doc('uid1_uid2').set({
+        'members': ['uid1', 'uid2'],
+        'createdAt': DateTime(2026, 5, 1),
+      });
+
+      final posts = await repo.watchFeed('uid1').first;
+      expect(posts.map((p) => p.postId), containsAll(['p1', 'p2']));
+      expect(posts.map((p) => p.postId), isNot(contains('p3')));
+    });
+
+    test('returns empty list when no friends and no own posts', () async {
+      final posts = await repo.watchFeed('uid1').first;
+      expect(posts, isEmpty);
+    });
+  });
+
+  group('deletePost', () {
+    test('removes post doc', () async {
+      await db.collection('posts').doc('p1').set(_makePost().toJson());
+      await repo.deletePost('p1');
+      final snap = await db.collection('posts').doc('p1').get();
+      expect(snap.exists, isFalse);
+    });
+  });
+
+  group('getPostsByAuthor', () {
+    test('returns only posts by given author', () async {
+      await db.collection('posts').doc('p1').set(_makePost(postId: 'p1', authorId: 'uid1').toJson());
+      await db.collection('posts').doc('p2').set(_makePost(postId: 'p2', authorId: 'uid2').toJson());
+
+      final posts = await repo.getPostsByAuthor('uid1');
+      expect(posts.length, 1);
+      expect(posts.first.authorId, 'uid1');
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/post_test.dart
+++ b/apps/mobile/test/features/feed/post_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/feed/data/post.dart';
+
+Post _single({String imageUrl = 'https://example.com/photo.jpg'}) => Post(
+      postId: 'p1',
+      authorId: 'uid1',
+      authorName: 'Test User',
+      imageUrl: imageUrl,
+      audienceType: AudienceType.all,
+      createdAt: DateTime(2026, 5, 31),
+    );
+
+Post _dual({
+  String back = 'https://example.com/back.jpg',
+  String front = 'https://example.com/front.jpg',
+}) =>
+    Post(
+      postId: 'p2',
+      authorId: 'uid1',
+      authorName: 'Test User',
+      backImageUrl: back,
+      frontImageUrl: front,
+      isDualCamera: true,
+      audienceType: AudienceType.all,
+      createdAt: DateTime(2026, 5, 31),
+    );
+
+void main() {
+  group('isDualCamera default', () {
+    test('single post defaults isDualCamera to false', () {
+      expect(_single().isDualCamera, isFalse);
+    });
+  });
+
+  group('coverImageUrl', () {
+    test('single mode returns imageUrl', () {
+      expect(_single().coverImageUrl, 'https://example.com/photo.jpg');
+    });
+
+    test('dual mode returns back lens as cover', () {
+      expect(_dual().coverImageUrl, 'https://example.com/back.jpg');
+    });
+
+    test('falls back to front when only front present', () {
+      final post = Post(
+        postId: 'p3',
+        authorId: 'uid1',
+        authorName: 'Test User',
+        frontImageUrl: 'https://example.com/front.jpg',
+        isDualCamera: true,
+        audienceType: AudienceType.all,
+        createdAt: DateTime(2026, 5, 31),
+      );
+      expect(post.coverImageUrl, 'https://example.com/front.jpg');
+    });
+
+    test('returns empty string when no image present', () {
+      final post = Post(
+        postId: 'p4',
+        authorId: 'uid1',
+        authorName: 'Test User',
+        audienceType: AudienceType.all,
+        createdAt: DateTime(2026, 5, 31),
+      );
+      expect(post.coverImageUrl, '');
+    });
+  });
+
+  group('json round-trip', () {
+    test('dual post serializes both lenses and isDualCamera flag', () {
+      final json = _dual().toJson();
+      expect(json['backImageUrl'], 'https://example.com/back.jpg');
+      expect(json['frontImageUrl'], 'https://example.com/front.jpg');
+      expect(json['isDualCamera'], isTrue);
+      expect(json['imageUrl'], isNull);
+      // coverImageUrl is a getter, must not leak into serialized data.
+      expect(json.containsKey('coverImageUrl'), isFalse);
+    });
+
+    test('dual post survives fromJson(toJson())', () {
+      final restored = Post.fromJson(_dual().toJson());
+      expect(restored.isDualCamera, isTrue);
+      expect(restored.backImageUrl, 'https://example.com/back.jpg');
+      expect(restored.frontImageUrl, 'https://example.com/front.jpg');
+      expect(restored.imageUrl, isNull);
+    });
+
+    test('single post survives fromJson(toJson())', () {
+      final restored = Post.fromJson(_single().toJson());
+      expect(restored.isDualCamera, isFalse);
+      expect(restored.imageUrl, 'https://example.com/photo.jpg');
+      expect(restored.backImageUrl, isNull);
+      expect(restored.frontImageUrl, isNull);
+    });
+
+    test('legacy doc without dual fields defaults isDualCamera false', () {
+      // Simulates posts created before dual camera shipped.
+      final restored = Post.fromJson({
+        'postId': 'legacy',
+        'authorId': 'uid1',
+        'authorName': 'Test User',
+        'imageUrl': 'https://example.com/old.jpg',
+        'audienceType': 'all',
+        'audienceUids': <String>[],
+        'createdAt': '2026-05-01T00:00:00.000',
+      });
+      expect(restored.isDualCamera, isFalse);
+      expect(restored.coverImageUrl, 'https://example.com/old.jpg');
+    });
+  });
+}


### PR DESCRIPTION
## Issue

Refs #94 (T1)

## Thay đổi

### Data Layer
- `Post` model với freezed + json_serializable
  - Fields: postId, authorId, authorName, authorAvatarUrl, imageUrl, caption, captionType, audienceType, audienceUids, spaceId, createdAt
- `PostRepository` abstract interface
  - create(), read(), update(), delete(), watchUserPosts()
- `FirebasePostRepository`: CRUD operations cho `/posts/{postId}` collection
- `StorageRepository` abstract interface
  - uploadImage(), deleteImage()
- `FirebaseStorageRepository`: Upload/delete ảnh lên Cloud Storage
  - Path: `/posts/{uid}/{postId}/photo.jpg`
  - Validation: max 5MB

### Tests
- `post_test.dart`: Post model serialization tests
- `firebase_post_repository_test.dart`: Repository unit tests với fake_cloud_firestore
- Storage upload/delete tests

## Checklist

- [x] Models + interfaces defined
- [x] Firebase implementations
- [x] Unit tests pass
- [x] `flutter analyze` clean