### PR TITLE
feat(feed): T2-T6 — Camera + Caption + Capture + Post

### DIFF
--- a/apps/mobile/android/gradle.properties
+++ b/apps/mobile/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/apps/mobile/lib/core/theme/app_proportions.dart
+++ b/apps/mobile/lib/core/theme/app_proportions.dart
@@ -1,0 +1,110 @@
+// No dart:ui import needed — all values are plain doubles.
+
+/// Maps Figma proportions (frame 412×917) to runtime sizes.
+abstract final class AppProportions {
+  static const double figmaFrameWidth = 412.0;
+  static const double figmaFrameHeight = 917.0;
+
+  // ── Camera / Photo ────────────────────────────────────────────────────────
+
+  /// Square photo size. Width-driven (6 px inset each side) but capped by the
+  /// available height so the square + controls below never overflow on short
+  /// or narrow screens. [screenH] is the full screen height; we reserve room
+  /// for the top bar, dots, action bar and bottom rows (~340 px of chrome).
+  static const double _photoSideInset = 12;
+  static const double _verticalChromeReserve = 340;
+  static double photoSize(double screenW, [double? screenH]) {
+    final byWidth = screenW - _photoSideInset;
+    if (screenH == null) return byWidth;
+    final byHeight = screenH - _verticalChromeReserve;
+    return byWidth < byHeight ? byWidth : byHeight;
+  }
+
+  /// Gap between the caption dots row and the action bar below it.
+  /// Figma intent: 4–6 px — keep tight.
+  static const double dotsToBarGap = 5;
+
+  /// Pill bottom margin inside photo. Figma: 29/400 = 7.25% of photo size.
+  static const double pillBottomRatio = 29 / 400;
+  static double pillBottomInPhoto(double photoSize) =>
+      photoSize * pillBottomRatio;
+
+  // ── Note pill ─────────────────────────────────────────────────────────────
+
+  /// Pill total width. Figma: 126/412 → 30.6%.
+  static const double pillWidthRatio = 126 / figmaFrameWidth;
+  static double pillWidth(double screenW) => screenW * pillWidthRatio;
+
+  /// Pill chrome = icon(22) + iconGap(6) + paddingH(15×2) = 58.
+  static const double pillChrome = 58.0;
+
+  /// Font size inside pill. Figma: 14px on 412, bumped to 15 for legibility.
+  static const double pillFontRatio = 15 / figmaFrameWidth;
+  static double pillFontSize(double screenW) => screenW * pillFontRatio;
+
+  // ── Capture Button ────────────────────────────────────────────────────────
+
+  static const double captureOuterRatio = 79 / figmaFrameWidth;
+  static const double captureInnerToOuterRatio = 69 / 79;
+  static const double captureRingWidth = 3;
+
+  static double captureOuter(double screenW) => screenW * captureOuterRatio;
+  static double captureInner(double screenW) =>
+      captureOuter(screenW) * captureInnerToOuterRatio;
+
+  // ── Side icons ────────────────────────────────────────────────────────────
+
+  static const double sideIconRatio = 36 / figmaFrameWidth;
+  static double sideIconSize(double screenW) => screenW * sideIconRatio;
+
+  static const double captureRowGapRatio = 60 / figmaFrameWidth;
+  static double captureRowGap(double screenW) => screenW * captureRowGapRatio;
+
+  // ── Caption dots ──────────────────────────────────────────────────────────
+
+  // Figma 442:2354 — dots on 412px frame
+  static const double _dotActiveSizeFigma = 8;
+  static const double _dotSpacingFigma =
+      8; // gap between dots (16px center-to-center - 8px dot)
+  static const double _dotsTopGapFigma = 16;
+
+  static const double dotActiveRatio = _dotActiveSizeFigma / figmaFrameWidth;
+  static const double dotSpacingRatio = _dotSpacingFigma / figmaFrameWidth;
+  static const double dotsTopGapRatio = _dotsTopGapFigma / figmaFrameWidth;
+
+  static double dotActiveSize(double screenW) => screenW * dotActiveRatio;
+  static double dotSpacing(double screenW) => screenW * dotSpacingRatio;
+  static double dotsTopGap(double screenW) => screenW * dotsTopGapRatio;
+
+  // ── Audience row ─────────────────────────────────────────────────────────
+
+  static const double audienceAvatarRatio = 30 / figmaFrameWidth;
+  static double audienceAvatarSize(double screenW) =>
+      screenW * audienceAvatarRatio;
+
+  // ── Modal sheet ───────────────────────────────────────────────────────────
+
+  static const double captionModalHeightRatio = 528 / 917;
+  static const double shareModalHeightRatio = 265 / 917;
+
+  // ── Grid view ─────────────────────────────────────────────────────────────
+
+  static const double gridGap = 3;
+  static const int gridColumns = 3;
+  static const double gridHPaddingRatio = 10 / figmaFrameWidth;
+  static double gridHPadding(double screenW) => screenW * gridHPaddingRatio;
+
+  // ── Dual camera PiP ───────────────────────────────────────────────────────
+
+  /// PiP (front camera) size as ratio of photo frame. Figma: ~120/400 = 30%.
+  static const double pipSizeRatio = 0.30;
+
+  /// PiP margin from top-right corner. Figma: 12px on 400px frame.
+  static const double pipMarginRatio = 12 / 400;
+
+  /// PiP corner radius. Figma: 16px.
+  static const double pipCornerRadius = 16;
+
+  static double pipSize(double photoSize) => photoSize * pipSizeRatio;
+  static double pipMargin(double photoSize) => photoSize * pipMarginRatio;
+}

--- a/apps/mobile/lib/features/feed/application/app_camera_controller.dart
+++ b/apps/mobile/lib/features/feed/application/app_camera_controller.dart
@@ -1,43 +1,233 @@
-import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'app_camera_controller.freezed.dart';
+import 'package:meep/features/feed/application/camera_state.dart';
+
 part 'app_camera_controller.g.dart';
 
-@freezed
-class CameraState with _$CameraState {
-  const factory CameraState({
-    @Default(false) bool isInitialized,
-    @Default(false) bool isFrontCamera,
-    @Default(false) bool flashEnabled,
-    @Default(false) bool isCapturing,
-  }) = _CameraState;
-}
-
-/// Camera controller — named AppCameraController to avoid conflict
-/// with the `camera` package's CameraController.
+/// Named AppCameraController to avoid conflict with camera package's CameraController.
 @riverpod
 class AppCameraController extends _$AppCameraController {
+  CameraController? _cameraCtrl;
+  List<CameraDescription> _cameras = [];
+
   @override
-  CameraState build() => const CameraState();
+  CameraState build() {
+    ref.onDispose(() => _cameraCtrl?.dispose());
+    return const CameraState();
+  }
 
   Future<void> initialize() async {
-    // TODO(FE/T5/KhoaLND): initialize camera
-    throw UnimplementedError('initialize — TODO: FE/T5/KhoaLND');
+    try {
+      _cameras = await availableCameras();
+      if (_cameras.isEmpty) {
+        state = state.copyWith(error: 'No camera found');
+        return;
+      }
+
+      await _initializeCamera(
+        state.mode == CameraMode.single
+            ? (state.isFrontCamera
+                ? CameraLensDirection.front
+                : CameraLensDirection.back)
+            : (state.activeLens == CameraLens.back
+                ? CameraLensDirection.back
+                : CameraLensDirection.front),
+      );
+    } catch (e) {
+      state = state.copyWith(error: e.toString());
+    }
   }
 
+  Future<void> setMode(CameraMode mode) async {
+    if (state.mode == mode) return;
+    final wasInit = state.isInitialized;
+    await _disposeController();
+    state = state.copyWith(
+      mode: mode,
+      isInitialized: false,
+      isFrontCamera: mode == CameraMode.dual ? false : state.isFrontCamera,
+      activeLens: mode == CameraMode.dual ? CameraLens.front : CameraLens.back,
+      backPhotoPath: mode == CameraMode.dual ? state.backPhotoPath : null,
+      frontPhotoPath: mode == CameraMode.dual ? state.frontPhotoPath : null,
+    );
+    if (wasInit) await initialize();
+  }
+
+  Future<void> setActiveLens(CameraLens lens) async {
+    if (state.mode != CameraMode.dual) return;
+    await _switchToLens(lens);
+  }
+
+  Future<void> _initializeCamera(CameraLensDirection direction) async {
+    final camera = _cameraForLens(_cameras, direction);
+    final ctrl = CameraController(
+      camera,
+      ResolutionPreset.high,
+      enableAudio: false,
+      imageFormatGroup: ImageFormatGroup.jpeg,
+    );
+    await ctrl.initialize();
+    _cameraCtrl = ctrl;
+    state = state.copyWith(
+      isInitialized: true,
+      error: null,
+    );
+  }
+
+  /// Returns local file path on success, null on failure or double-tap.
   Future<String?> capture() async {
-    // TODO(FE/T6/KhoaLND): capture photo, return local path
-    throw UnimplementedError('capture — TODO: FE/T6/KhoaLND');
+    if (_cameraCtrl == null ||
+        !_cameraCtrl!.value.isInitialized ||
+        state.isCapturing) {
+      return null;
+    }
+
+    // Single mode: normal capture
+    if (state.mode == CameraMode.single) {
+      state = state.copyWith(isCapturing: true);
+      try {
+        final file = await _cameraCtrl!.takePicture();
+        return file.path;
+      } catch (e) {
+        debugPrint('capture error: $e');
+        return null;
+      } finally {
+        state = state.copyWith(isCapturing: false);
+      }
+    }
+
+    // Dual mode: capture active lens, then switch to the other
+    return _captureInDualMode();
   }
 
-  void toggleCamera() {
-    // TODO(FE/T7/KhoaLND): flip front/back
-    throw UnimplementedError('toggleCamera — TODO: FE/T7/KhoaLND');
+  Future<String?> _captureInDualMode() async {
+    state = state.copyWith(isCapturing: true);
+    try {
+      final file = await _cameraCtrl!.takePicture();
+      final path = file.path;
+
+      // Save photo to the appropriate slot
+      if (state.activeLens == CameraLens.back) {
+        state = state.copyWith(backPhotoPath: path);
+        // Default sequence: front first, then back.
+        if (state.frontPhotoPath == null) {
+          await _switchToLens(CameraLens.front);
+        }
+      } else {
+        state = state.copyWith(frontPhotoPath: path);
+        // Default sequence: front first, then back.
+        if (state.backPhotoPath == null) {
+          await _switchToLens(CameraLens.back);
+        }
+      }
+
+      return path;
+    } catch (e) {
+      debugPrint('dual capture error: $e');
+      return null;
+    } finally {
+      state = state.copyWith(isCapturing: false);
+    }
+  }
+
+  /// Retake a specific photo in dual mode
+  Future<void> retakePhoto(CameraLens lens) async {
+    if (state.mode != CameraMode.dual) return;
+
+    // Clear the photo and switch to that lens
+    if (lens == CameraLens.back) {
+      state = state.copyWith(backPhotoPath: null);
+    } else {
+      state = state.copyWith(frontPhotoPath: null);
+    }
+
+    await _switchToLens(lens);
+  }
+
+  Future<void> _switchToLens(CameraLens lens) async {
+    if (state.activeLens == lens && state.isInitialized) return;
+
+    await _disposeController();
+    state = state.copyWith(activeLens: lens, isInitialized: false);
+
+    await _initializeCamera(
+      lens == CameraLens.back
+          ? CameraLensDirection.back
+          : CameraLensDirection.front,
+    );
+  }
+
+  /// Switch between single and dual camera modes
+  Future<void> switchMode() async {
+    final newMode =
+        state.mode == CameraMode.single ? CameraMode.dual : CameraMode.single;
+
+    // Clear dual mode photos when switching to single
+    if (newMode == CameraMode.single) {
+      state = state.copyWith(
+        mode: newMode,
+        backPhotoPath: null,
+        frontPhotoPath: null,
+        activeLens: CameraLens.back,
+      );
+    } else {
+      // Switching to dual mode: start with back camera
+      state = state.copyWith(
+        mode: newMode,
+        activeLens: CameraLens.back,
+        backPhotoPath: null,
+        frontPhotoPath: null,
+      );
+    }
+
+    // Reinitialize camera for the new mode
+    await _disposeController();
+    state = state.copyWith(isInitialized: false);
+    await initialize();
+  }
+
+  /// Check if both photos are captured in dual mode
+  bool get hasBothPhotos =>
+      state.backPhotoPath != null && state.frontPhotoPath != null;
+
+  /// Toggle camera in single mode only
+  Future<void> toggleCamera() async {
+    if (state.mode != CameraMode.single) return;
+    final wasInit = state.isInitialized;
+    await _disposeController();
+    state = state.copyWith(
+      isFrontCamera: !state.isFrontCamera,
+      isInitialized: false,
+    );
+    if (wasInit) await initialize();
   }
 
   void toggleFlash() {
-    // TODO(FE/T8/KhoaLND): toggle flash
-    throw UnimplementedError('toggleFlash — TODO: FE/T8/KhoaLND');
+    if (_cameraCtrl == null || !_cameraCtrl!.value.isInitialized) return;
+    final next = !state.flashEnabled;
+    _cameraCtrl!.setFlashMode(next ? FlashMode.torch : FlashMode.off);
+    state = state.copyWith(flashEnabled: next);
   }
+
+  void stopPreview() => _cameraCtrl?.pausePreview();
+  void resumePreview() => _cameraCtrl?.resumePreview();
+
+  CameraController? get cameraController => _cameraCtrl;
+
+  Future<void> _disposeController() async {
+    await _cameraCtrl?.dispose();
+    _cameraCtrl = null;
+    state = state.copyWith(isInitialized: false);
+  }
+
+  CameraDescription _cameraForLens(
+    List<CameraDescription> cameras,
+    CameraLensDirection direction,
+  ) =>
+      cameras.firstWhere(
+        (c) => c.lensDirection == direction,
+        orElse: () => cameras.first,
+      );
 }

--- a/apps/mobile/lib/features/feed/application/camera_state.dart
+++ b/apps/mobile/lib/features/feed/application/camera_state.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'camera_state.freezed.dart';
+
+enum CameraMode { single, dual }
+
+enum CameraLens { back, front }
+
+@freezed
+class CameraState with _$CameraState {
+  const factory CameraState({
+    @Default(CameraMode.single) CameraMode mode,
+    @Default(false) bool isInitialized,
+    @Default(false) bool isFrontCamera, // Used in single mode only
+    @Default(false) bool flashEnabled,
+    @Default(false) bool isCapturing,
+    // Dual mode fields
+    @Default(CameraLens.back) CameraLens activeLens,
+    String? backPhotoPath,
+    String? frontPhotoPath,
+    String? error,
+  }) = _CameraState;
+}

--- a/apps/mobile/lib/features/feed/application/caption_service_impl.dart
+++ b/apps/mobile/lib/features/feed/application/caption_service_impl.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+
+import 'package:geolocator/geolocator.dart';
+import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
+import 'package:meep/features/feed/application/caption_service.dart';
+import 'package:meep/features/feed/application/weather_code_mapper.dart';
+import 'package:meep/features/feed/data/post.dart';
+
+class CaptionServiceImpl implements CaptionService {
+  // Session-level geocode cache: last (lat, lng) → address string
+  double? _cachedLat;
+  double? _cachedLng;
+  String? _cachedAddress;
+
+  static const _geocodeCacheThresholdM = 100.0;
+  static const _timeoutSeconds = 5;
+
+  @override
+  Future<String> resolve(CaptionType type) async {
+    switch (type) {
+      case CaptionType.text:
+        return '';
+      case CaptionType.time:
+        return DateFormat('HH:mm').format(DateTime.now());
+      case CaptionType.location:
+        return _resolveLocation();
+      case CaptionType.weather:
+        return _resolveWeather();
+      case CaptionType.music:
+        return '♪ Đang phát nhạc';
+      case CaptionType.star:
+        return '⭐ Ngôi sao';
+      case CaptionType.streak:
+        return '🔥 Streak'; // TODO: link Streak module
+    }
+  }
+
+  Future<String> _resolveLocation() async {
+    try {
+      final pos = await _getPosition();
+      if (pos == null) return '📍 ...';
+      return await _geocode(pos.latitude, pos.longitude);
+    } catch (_) {
+      return '📍 ...';
+    }
+  }
+
+  Future<String> _resolveWeather() async {
+    try {
+      final pos = await _getPosition();
+      if (pos == null) return '🌤️ ...';
+
+      final uri = Uri.parse(
+        'https://api.open-meteo.com/v1/forecast'
+        '?latitude=${pos.latitude}&longitude=${pos.longitude}'
+        '&current_weather=true',
+      );
+      final res =
+          await http.get(uri).timeout(const Duration(seconds: _timeoutSeconds));
+      if (res.statusCode != 200) return '🌤️ ...';
+
+      final body = json.decode(res.body) as Map<String, dynamic>;
+      final cw = body['current_weather'] as Map<String, dynamic>;
+      final code = (cw['weathercode'] as num).toInt();
+      final temp = (cw['temperature'] as num).round();
+      return '${WeatherCodeMapper.toEmoji(code)} ${WeatherCodeMapper.toLabel(code)} $temp°C';
+    } catch (_) {
+      return '🌤️ ...';
+    }
+  }
+
+  Future<Position?> _getPosition() async {
+    final perm = await Geolocator.checkPermission();
+    if (perm == LocationPermission.denied ||
+        perm == LocationPermission.deniedForever) {
+      return null;
+    }
+    return Geolocator.getCurrentPosition(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.low,
+        timeLimit: Duration(seconds: _timeoutSeconds),
+      ),
+    );
+  }
+
+  Future<String> _geocode(double lat, double lng) async {
+    // Use cached result if position hasn't moved significantly
+    if (_cachedLat != null && _cachedLng != null && _cachedAddress != null) {
+      final dist = Geolocator.distanceBetween(
+        _cachedLat!,
+        _cachedLng!,
+        lat,
+        lng,
+      );
+      if (dist < _geocodeCacheThresholdM) return _cachedAddress!;
+    }
+
+    final uri = Uri.parse(
+      'https://nominatim.openstreetmap.org/reverse'
+      '?lat=$lat&lon=$lng&format=json&accept-language=vi',
+    );
+    final res = await http.get(
+      uri,
+      headers: {'User-Agent': 'Meep-App/1.0'},
+    ).timeout(const Duration(seconds: _timeoutSeconds));
+
+    if (res.statusCode != 200) return '📍 ...';
+
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    final address = body['address'] as Map<String, dynamic>? ?? {};
+
+    final suburb = address['suburb'] as String?;
+    final district = address['city_district'] as String?;
+    final city = address['city'] as String? ?? address['state'] as String?;
+
+    final parts = [suburb ?? district, city]
+        .whereType<String>()
+        .where((s) => s.isNotEmpty)
+        .take(2)
+        .toList();
+
+    final result = parts.isNotEmpty ? parts.join(', ') : '📍 ...';
+    _cachedLat = lat;
+    _cachedLng = lng;
+    _cachedAddress = result;
+    return result;
+  }
+}

--- a/apps/mobile/lib/features/feed/application/feed_controller.dart
+++ b/apps/mobile/lib/features/feed/application/feed_controller.dart
@@ -1,6 +1,14 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/feed/application/feed_state.dart';
+import 'package:meep/features/feed/data/firebase_post_repository.dart';
+import 'package:meep/features/feed/data/firebase_storage_repository.dart';
 import 'package:meep/features/feed/data/post_repository.dart';
 import 'package:meep/features/feed/data/storage_repository.dart';
 
@@ -17,41 +25,69 @@ enum FeedFilter {
   space,
 }
 
-// ignore: avoid_classes_with_only_static_members
-class FeedState {
-  const FeedState._();
-}
+@Riverpod(keepAlive: true)
+PostRepository postRepository(Ref ref) =>
+    FirebasePostRepository(FirebaseFirestore.instance);
 
 @Riverpod(keepAlive: true)
-PostRepository postRepository(PostRepositoryRef ref) =>
-    throw UnimplementedError(
-      'postRepositoryProvider must be overridden — '
-      'wire FirestorePostRepository in main.dart (TODO: FE/T1/KhoaLND)',
-    );
+StorageRepository storageRepository(Ref ref) =>
+    FirebaseStorageRepository(FirebaseStorage.instance);
 
-@Riverpod(keepAlive: true)
-StorageRepository storageRepository(StorageRepositoryRef ref) =>
-    throw UnimplementedError(
-      'storageRepositoryProvider must be overridden — '
-      'wire FirebaseStorageRepository in main.dart (TODO: FE/T2/KhoaLND)',
-    );
-
+/// Async notifier — build() returns `Future<FeedState>` so `AsyncValue.when()` works in UI.
+///
+/// M2: uses watchFeed stream (first 10 posts, no cursor pagination).
+/// TODO(FE/T6/KhoaLND): full cursor pagination needs PostRepository.getPage() —
+///   requires leader to add method to interface first.
 @riverpod
 class FeedController extends _$FeedController {
+  static const int _prefetchAt = 4;
+
   @override
-  Future<List<Post>> build({
+  Future<FeedState> build({
     FeedFilter filter = FeedFilter.all,
     // filterUid: used with FeedFilter.person — filter by friend's uid
     String? filterUid,
     // filterSpaceId: used with FeedFilter.space — query feed WHERE spaceId == filterSpaceId
     String? filterSpaceId,
   }) async {
-    // TODO(FE/T3/KhoaLND): implement watchFeed stream
-    throw UnimplementedError('FeedController.build — TODO: FE/T3/KhoaLND');
+    final uid = FirebaseAuth.instance.currentUser!.uid;
+    final repo = ref.read(postRepositoryProvider);
+
+    // Live stream so posts appear once the CF fan-out writes the feed doc —
+    // no manual refresh needed. A single subscription drives both the initial
+    // future (first emission) and subsequent state updates.
+    final completer = Completer<FeedState>();
+    final sub = repo.watchFeed(uid).listen(
+      (posts) {
+        final filtered = filter == FeedFilter.person && filterUid != null
+            ? posts.where((p) => p.authorId == filterUid).toList()
+            : posts;
+        final feedState = FeedState(posts: filtered, hasMore: false);
+        if (completer.isCompleted) {
+          state = AsyncData(feedState);
+        } else {
+          completer.complete(feedState);
+        }
+      },
+      onError: (Object e, StackTrace st) {
+        if (!completer.isCompleted) {
+          completer.completeError(e, st);
+        } else {
+          state = AsyncError(e, st);
+        }
+      },
+    );
+    ref.onDispose(sub.cancel);
+
+    return completer.future;
   }
 
-  Future<void> loadMore() async {
-    // TODO(FE/T4/KhoaLND): implement pagination
-    throw UnimplementedError('loadMore — TODO: FE/T4/KhoaLND');
+  // TODO(FE/T6/KhoaLND): loadMore requires PostRepository.getPage() interface method.
+  // Blocked until leader adds paginated query to PostRepository contract.
+  Future<void> loadMore() async {}
+
+  void onItemVisible(int index) {
+    final posts = state.valueOrNull?.posts ?? [];
+    if (index >= posts.length - _prefetchAt) loadMore();
   }
 }

--- a/apps/mobile/lib/features/feed/application/feed_state.dart
+++ b/apps/mobile/lib/features/feed/application/feed_state.dart
@@ -1,0 +1,16 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'package:meep/features/feed/data/post.dart';
+
+part 'feed_state.freezed.dart';
+
+@freezed
+class FeedState with _$FeedState {
+  const factory FeedState({
+    @Default([]) List<Post> posts,
+    @Default(false) bool isLoadingMore,
+    @Default(false) bool hasMore,
+    DocumentSnapshot? lastDoc,
+  }) = _FeedState;
+}

--- a/apps/mobile/lib/features/feed/application/post_controller.dart
+++ b/apps/mobile/lib/features/feed/application/post_controller.dart
@@ -1,46 +1,202 @@
-import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:meep/features/feed/application/caption_service.dart';
+import 'package:meep/features/feed/application/caption_service_impl.dart';
+import 'package:meep/features/feed/application/feed_controller.dart';
+import 'package:meep/features/feed/application/post_state.dart';
 import 'package:meep/features/feed/data/post.dart';
 
-part 'post_controller.freezed.dart';
 part 'post_controller.g.dart';
 
-@freezed
-class PostState with _$PostState {
-  const factory PostState({
-    @Default(false) bool isUploading,
-    String? pendingImagePath,
-    String? caption,
-    CaptionType? captionType,
-    @Default(AudienceType.all) AudienceType audienceType,
-    @Default([]) List<String> selectedUids,
-    String? errorMessage,
-  }) = _PostState;
-}
+@Riverpod(keepAlive: false)
+CaptionService captionService(Ref ref) => CaptionServiceImpl();
 
 @riverpod
 class PostController extends _$PostController {
+  static const int _compressQuality = 85;
+  static const int _maxWidthPx = 1080;
+  static const int _maxSizeBytes = 1 * 1024 * 1024; // 1 MB target
+
   @override
   PostState build() => const PostState();
 
-  Future<void> submit() async {
-    // TODO(FE/T9/KhoaLND): upload + create Firestore doc
-    throw UnimplementedError('submit — TODO: FE/T9/KhoaLND');
-  }
+  void setPendingImage(String path) => state = state.copyWith(
+        pendingImagePath: path,
+        pendingBackImagePath: null,
+        pendingFrontImagePath: null,
+        isDualMode: false,
+        errorMessage: null,
+      );
 
-  void setCaptionType(CaptionType? type) {
-    // TODO(FE/T10/KhoaLND): update captionType + resolve caption text
-    throw UnimplementedError('setCaptionType — TODO: FE/T10/KhoaLND');
+  void setPendingDualImages({
+    required String backPath,
+    required String frontPath,
+  }) =>
+      state = state.copyWith(
+        pendingImagePath: null,
+        pendingBackImagePath: backPath,
+        pendingFrontImagePath: frontPath,
+        isDualMode: true,
+        errorMessage: null,
+      );
+
+  void setCaption(String text) => state = state.copyWith(caption: text);
+
+  Future<void> setCaptionType(CaptionType? type) async {
+    state = state.copyWith(captionType: type, caption: null);
+    if (type == null) return;
+    try {
+      final svc = ref.read(captionServiceProvider);
+      final resolved = await svc.resolve(type);
+      state = state.copyWith(caption: resolved);
+    } catch (_) {
+      state = state.copyWith(caption: '');
+    }
   }
 
   void setAudience(AudienceType type, List<String> uids) {
-    // TODO(FE/T11/KhoaLND): update audience selection
-    throw UnimplementedError('setAudience — TODO: FE/T11/KhoaLND');
+    state = state.copyWith(audienceType: type, selectedUids: uids);
+  }
+
+  Future<bool> submit() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return false;
+
+    if (state.isDualMode) {
+      if (state.pendingBackImagePath == null ||
+          state.pendingFrontImagePath == null) {
+        return false;
+      }
+    } else if (state.pendingImagePath == null) {
+      return false;
+    }
+
+    if (state.audienceType == AudienceType.select &&
+        state.selectedUids.isEmpty) {
+      state = state.copyWith(
+        errorMessage: 'Chọn ít nhất 1 người nhận',
+      );
+      return false;
+    }
+
+    state = state.copyWith(isUploading: true, errorMessage: null);
+    try {
+      final postId = FirebaseFirestore.instance.collection('posts').doc().id;
+      final storageRepo = ref.read(storageRepositoryProvider);
+
+      String? imageUrl;
+      String? backImageUrl;
+      String? frontImageUrl;
+
+      if (state.isDualMode) {
+        final backBytes = await _compress(state.pendingBackImagePath!);
+        final frontBytes = await _compress(state.pendingFrontImagePath!);
+        if (backBytes == null || frontBytes == null) {
+          state = state.copyWith(
+            isUploading: false,
+            errorMessage: 'Không thể xử lý ảnh',
+          );
+          return false;
+        }
+        backImageUrl = await storageRepo.uploadImage(
+          uid: uid,
+          postId: postId,
+          bytes: backBytes,
+          mimeType: 'image/jpeg',
+          fileName: 'back.jpg',
+        );
+        frontImageUrl = await storageRepo.uploadImage(
+          uid: uid,
+          postId: postId,
+          bytes: frontBytes,
+          mimeType: 'image/jpeg',
+          fileName: 'front.jpg',
+        );
+      } else {
+        final compressed = await _compress(state.pendingImagePath!);
+        if (compressed == null) {
+          state = state.copyWith(
+            isUploading: false,
+            errorMessage: 'Không thể xử lý ảnh',
+          );
+          return false;
+        }
+        imageUrl = await storageRepo.uploadImage(
+          uid: uid,
+          postId: postId,
+          bytes: compressed,
+          mimeType: 'image/jpeg',
+        );
+      }
+
+      // Create Firestore post doc
+      final postRepo = ref.read(postRepositoryProvider);
+      final user = FirebaseAuth.instance.currentUser!;
+
+      final post = Post(
+        postId: postId,
+        authorId: uid,
+        authorName: user.displayName ?? '',
+        authorAvatarUrl: user.photoURL,
+        imageUrl: imageUrl,
+        backImageUrl: backImageUrl,
+        frontImageUrl: frontImageUrl,
+        isDualCamera: state.isDualMode,
+        caption: state.caption,
+        captionType: state.captionType,
+        audienceType: state.audienceType,
+        audienceUids:
+            state.audienceType == AudienceType.all ? [] : state.selectedUids,
+        createdAt: DateTime.now(),
+      );
+      await postRepo.createPost(post);
+
+      // Invalidate feed to refresh after successful post
+      ref.invalidate(feedControllerProvider);
+
+      state = const PostState();
+      return true;
+    } catch (_) {
+      state = state.copyWith(
+        isUploading: false,
+        errorMessage: 'Tải ảnh thất bại — thử lại',
+      );
+      return false;
+    }
   }
 
   Future<void> deletePost(String postId) async {
-    // TODO(FE/T12/KhoaLND): delete post + Storage assets
-    throw UnimplementedError('deletePost — TODO: FE/T12/KhoaLND');
+    final repo = ref.read(postRepositoryProvider);
+    await repo.deletePost(postId);
+  }
+
+  Future<List<int>?> _compress(String path) async {
+    try {
+      final result = await FlutterImageCompress.compressWithFile(
+        path,
+        minWidth: _maxWidthPx,
+        minHeight: _maxWidthPx,
+        quality: _compressQuality,
+        format: CompressFormat.jpeg,
+      );
+      if (result == null) return null;
+      if (result.length > _maxSizeBytes) {
+        // Re-compress at lower quality
+        return FlutterImageCompress.compressWithFile(
+          path,
+          minWidth: _maxWidthPx,
+          minHeight: _maxWidthPx,
+          quality: 60,
+          format: CompressFormat.jpeg,
+        );
+      }
+      return result;
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/apps/mobile/lib/features/feed/application/post_state.dart
+++ b/apps/mobile/lib/features/feed/application/post_state.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'package:meep/features/feed/data/post.dart';
+
+part 'post_state.freezed.dart';
+
+@freezed
+class PostState with _$PostState {
+  const factory PostState({
+    @Default(false) bool isUploading,
+
+    /// Single mode: pendingImagePath is set, dual fields are null.
+    /// Dual mode: pendingBackImagePath/pendingFrontImagePath are set, pendingImagePath is null.
+    String? pendingImagePath,
+    String? pendingBackImagePath,
+    String? pendingFrontImagePath,
+    @Default(false) bool isDualMode,
+    String? caption,
+    CaptionType? captionType,
+    @Default(AudienceType.all) AudienceType audienceType,
+    @Default([]) List<String> selectedUids,
+    String? errorMessage,
+  }) = _PostState;
+}

--- a/apps/mobile/lib/features/feed/application/weather_code_mapper.dart
+++ b/apps/mobile/lib/features/feed/application/weather_code_mapper.dart
@@ -1,0 +1,23 @@
+abstract final class WeatherCodeMapper {
+  static String toEmoji(int code) {
+    if (code == 0) return '☀️';
+    if (code <= 3) return '⛅';
+    if (code == 45 || code == 48) return '🌫️';
+    if (code >= 51 && code <= 67) return '🌧️';
+    if (code >= 71 && code <= 77) return '❄️';
+    if (code >= 80 && code <= 82) return '🌦️';
+    if (code >= 95) return '⛈️';
+    return '🌤️';
+  }
+
+  static String toLabel(int code) {
+    if (code == 0) return 'Nắng';
+    if (code <= 3) return 'Có mây';
+    if (code == 45 || code == 48) return 'Sương mù';
+    if (code >= 51 && code <= 67) return 'Mưa';
+    if (code >= 71 && code <= 77) return 'Tuyết';
+    if (code >= 80 && code <= 82) return 'Mưa rào';
+    if (code >= 95) return 'Dông';
+    return 'Trời đẹp';
+  }
+}

--- a/apps/mobile/lib/features/feed/presentation/camera_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/camera_section.dart
@@ -1,0 +1,389 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
+import 'package:meep/features/feed/application/app_camera_controller.dart';
+import 'package:meep/features/feed/application/camera_state.dart';
+import 'package:meep/features/feed/presentation/capture_action_bar.dart';
+import 'package:meep/features/feed/presentation/capture_preview_args.dart';
+import 'package:meep/shared/widgets/app_dots_indicator.dart';
+import 'package:meep/shared/widgets/app_photo_frame.dart';
+
+class CameraSection extends ConsumerStatefulWidget {
+  const CameraSection({super.key, required this.onGoToFeed});
+
+  final VoidCallback onGoToFeed;
+
+  @override
+  ConsumerState<CameraSection> createState() => _CameraSectionState();
+}
+
+class _CameraSectionState extends ConsumerState<CameraSection> {
+  // Min horizontal velocity (px/s) to count as a mode-switch swipe.
+  static const double _swipeVelocityThreshold = 200;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(appCameraControllerProvider.notifier).initialize();
+    });
+  }
+
+  // Swipe right over the viewfinder → dual mode; swipe left → single.
+  void _onViewfinderSwipe(double? velocity) {
+    if (velocity == null) return;
+    final notifier = ref.read(appCameraControllerProvider.notifier);
+    if (velocity > _swipeVelocityThreshold) {
+      notifier.setMode(CameraMode.single);
+    } else if (velocity < -_swipeVelocityThreshold) {
+      notifier.setMode(CameraMode.dual);
+    }
+  }
+
+  Future<void> _onCapture() async {
+    final path = await ref.read(appCameraControllerProvider.notifier).capture();
+    if (!mounted || path == null) return;
+    final camState = ref.read(appCameraControllerProvider);
+    if (camState.mode == CameraMode.single) {
+      unawaited(
+        context.push(
+          '/capture-preview',
+          extra: CapturePreviewArgs.single(imagePath: path),
+        ),
+      );
+      return;
+    }
+    if (camState.backPhotoPath != null && camState.frontPhotoPath != null) {
+      unawaited(
+        context.push(
+          '/capture-preview',
+          extra: CapturePreviewArgs.dual(
+            backPhotoPath: camState.backPhotoPath!,
+            frontPhotoPath: camState.frontPhotoPath!,
+            activePrimaryLensIsFront: camState.activeLens == CameraLens.front,
+          ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onAlbumPick() async {
+    final image = await ImagePicker().pickImage(source: ImageSource.gallery);
+    if (image != null && mounted) {
+      unawaited(
+        context.push(
+          '/capture-preview',
+          extra: CapturePreviewArgs.single(imagePath: image.path),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final camState = ref.watch(appCameraControllerProvider);
+    final screenW = MediaQuery.sizeOf(context).width;
+    // Mirror _AudienceRow height: avatarSize + gap(4) + labelSize(avatarSize*0.4) + bottomPad(4)
+    final historyRowH = AppProportions.audienceAvatarSize(screenW) * 1.4 + 8;
+
+    return Column(
+      children: [
+        const SizedBox(height: 12),
+        GestureDetector(
+          onHorizontalDragEnd: (d) => _onViewfinderSwipe(d.primaryVelocity),
+          child: AppPhotoFrame(
+            child: camState.mode == CameraMode.single
+                ? _ViewfinderContent(
+                    controller: ref
+                        .read(appCameraControllerProvider.notifier)
+                        .cameraController,
+                    isInitialized: camState.isInitialized,
+                    error: camState.error,
+                  )
+                : _DualViewfinderContent(
+                    controller: ref
+                        .read(appCameraControllerProvider.notifier)
+                        .cameraController,
+                    isInitialized: camState.isInitialized,
+                    error: camState.error,
+                    activeLens: camState.activeLens,
+                    frontPhotoPath: camState.frontPhotoPath,
+                    backPhotoPath: camState.backPhotoPath,
+                    onTapFront: () => ref
+                        .read(appCameraControllerProvider.notifier)
+                        .setActiveLens(CameraLens.front),
+                    onTapBack: () => ref
+                        .read(appCameraControllerProvider.notifier)
+                        .setActiveLens(CameraLens.back),
+                  ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        GestureDetector(
+          onTapUp: (details) {
+            final width = MediaQuery.sizeOf(context).width;
+            final isRight = details.localPosition.dx > width / 2;
+            ref
+                .read(appCameraControllerProvider.notifier)
+                .setMode(isRight ? CameraMode.dual : CameraMode.single);
+          },
+          child: AppDotsIndicator(
+            count: 2,
+            current: camState.mode == CameraMode.dual ? 1 : 0,
+          ),
+        ),
+        // Spacers above and below the bar center it in the gap between
+        // dots and history button.
+        const Spacer(),
+        CaptureActionBar(
+          config: CameraBarConfig(
+            onCapture: _onCapture,
+            onAlbum: _onAlbumPick,
+            onFlip: () =>
+                ref.read(appCameraControllerProvider.notifier).toggleCamera(),
+            isCapturing: camState.isCapturing,
+            showFlip: camState.mode == CameraMode.single,
+          ),
+        ),
+        const Spacer(),
+        SizedBox(
+          height: historyRowH,
+          child: Center(child: _HistoryButton(onTap: widget.onGoToFeed)),
+        ),
+        const SizedBox(height: 12),
+      ],
+    );
+  }
+}
+
+/// Dual-camera PiP viewfinder: back camera full-frame, front camera PiP top-right.
+/// Tap PiP to swap active lens.
+class _DualViewfinderContent extends StatelessWidget {
+  const _DualViewfinderContent({
+    required this.controller,
+    required this.isInitialized,
+    required this.error,
+    required this.activeLens,
+    required this.frontPhotoPath,
+    required this.backPhotoPath,
+    required this.onTapFront,
+    required this.onTapBack,
+  });
+
+  final CameraController? controller;
+  final bool isInitialized;
+  final String? error;
+  final CameraLens activeLens;
+  final String? frontPhotoPath;
+  final String? backPhotoPath;
+  final VoidCallback onTapFront;
+  final VoidCallback onTapBack;
+
+  @override
+  Widget build(BuildContext context) {
+    if (error != null) {
+      return Container(
+        color: AppColors.bw800,
+        alignment: Alignment.center,
+        child:
+            const Icon(Icons.no_photography, color: AppColors.bw500, size: 48),
+      );
+    }
+
+    final primaryIsFront = activeLens == CameraLens.front;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final frameSize = constraints.maxWidth;
+        final pipSize = AppProportions.pipSize(frameSize);
+        final pipMargin = AppProportions.pipMargin(frameSize);
+
+        return Stack(
+          children: [
+            // Primary (back by default) — full frame
+            Positioned.fill(
+              child: _DualSlot(
+                lens: primaryIsFront ? CameraLens.front : CameraLens.back,
+                isActive: true,
+                controller: controller,
+                isInitialized: isInitialized,
+                frozenPath: primaryIsFront ? frontPhotoPath : backPhotoPath,
+                onTap: primaryIsFront ? onTapFront : onTapBack,
+                isPip: false,
+              ),
+            ),
+            // Secondary (front by default) — PiP top-right
+            Positioned(
+              top: pipMargin,
+              right: pipMargin,
+              child: SizedBox(
+                width: pipSize,
+                height: pipSize,
+                child: _DualSlot(
+                  lens: primaryIsFront ? CameraLens.back : CameraLens.front,
+                  isActive: false,
+                  controller: controller,
+                  isInitialized: isInitialized,
+                  frozenPath: primaryIsFront ? backPhotoPath : frontPhotoPath,
+                  onTap: primaryIsFront ? onTapBack : onTapFront,
+                  isPip: true,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _DualSlot extends StatelessWidget {
+  const _DualSlot({
+    required this.lens,
+    required this.isActive,
+    required this.controller,
+    required this.isInitialized,
+    required this.frozenPath,
+    required this.onTap,
+    this.isPip = false,
+  });
+
+  final CameraLens lens;
+  final bool isActive;
+  final CameraController? controller;
+  final bool isInitialized;
+  final String? frozenPath;
+  final VoidCallback onTap;
+  final bool isPip;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = isActive && isInitialized && controller != null
+        ? _ViewfinderContent(
+            controller: controller,
+            isInitialized: isInitialized,
+            error: null,
+          )
+        : frozenPath == null
+            ? const ColoredBox(color: AppColors.bw900)
+            : Image.file(File(frozenPath!), fit: BoxFit.cover);
+
+    final cornerRadius = isPip ? AppProportions.pipCornerRadius : 0.0;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(cornerRadius),
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            child,
+            // Label only on PiP slot
+            if (isPip)
+              Positioned(
+                left: 8,
+                top: 6,
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: AppColors.bw900.withValues(alpha: 0.7),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    lens == CameraLens.front ? 'Trước' : 'Sau',
+                    style: const TextStyle(
+                      color: AppColors.bw100,
+                      fontSize: 10,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ViewfinderContent extends StatelessWidget {
+  const _ViewfinderContent({
+    required this.controller,
+    required this.isInitialized,
+    required this.error,
+  });
+
+  final CameraController? controller;
+  final bool isInitialized;
+  final String? error;
+
+  @override
+  Widget build(BuildContext context) {
+    if (error != null) {
+      return Container(
+        color: AppColors.bw800,
+        alignment: Alignment.center,
+        child:
+            const Icon(Icons.no_photography, color: AppColors.bw500, size: 48),
+      );
+    }
+    if (!isInitialized || controller == null) {
+      return const ColoredBox(color: AppColors.bw900);
+    }
+    // CameraPreview already wraps itself in the correct AspectRatio +
+    // RotatedBox for the device orientation. We only need to scale it so the
+    // (typically 3:4) preview fills the square frame without distortion —
+    // matching how the captured photo is later shown with BoxFit.cover.
+    final previewRatio = 1 / controller!.value.aspectRatio; // portrait ratio
+    final coverScale = previewRatio < 1 ? 1 / previewRatio : previewRatio;
+    return ClipRect(
+      child: Transform.scale(
+        scale: coverScale,
+        child: Center(child: CameraPreview(controller!)),
+      ),
+    );
+  }
+}
+
+class _HistoryButton extends StatelessWidget {
+  const _HistoryButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 24,
+            height: 24,
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              color: AppColors.bw700,
+            ),
+          ),
+          const SizedBox(width: 6),
+          const Text(
+            'Lịch sử ▾',
+            style: TextStyle(
+              color: AppColors.bw100,
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feed/presentation/caption_preset_modal.dart
+++ b/apps/mobile/lib/features/feed/presentation/caption_preset_modal.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/features/feed/data/post.dart';
+
+class CaptionPresetModal extends StatelessWidget {
+  const CaptionPresetModal({super.key, required this.onSelect});
+
+  final ValueChanged<CaptionType> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: Color(0xFF1A1F20),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppColors.bw600,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          const Text(
+            'Chú thích',
+            style: TextStyle(
+              color: AppColors.bw100,
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              fontFamily: 'Nunito',
+            ),
+          ),
+          const SizedBox(height: 16),
+          _Section(
+            title: 'Chung',
+            items: const [
+              _CaptionItem(
+                type: CaptionType.text,
+                label: 'Văn bản',
+                icon: 'Aa',
+              ),
+              _CaptionItem(
+                type: CaptionType.star,
+                label: 'Review',
+                emoji: '⭐',
+              ),
+              _CaptionItem(
+                type: CaptionType.music,
+                label: 'Đang phát',
+                emoji: '♪',
+              ),
+              _CaptionItem(
+                type: CaptionType.location,
+                label: 'Vị trí',
+                emoji: '📍',
+              ),
+              _CaptionItem(
+                type: CaptionType.weather,
+                label: 'Thời tiết',
+                emoji: '🌤️',
+              ),
+              _CaptionItem(
+                type: CaptionType.time,
+                label: 'Thời gian',
+                emoji: '🕐',
+              ),
+            ],
+            onSelect: onSelect,
+          ),
+          const SizedBox(height: 12),
+          _Section(
+            title: 'Trang trí',
+            items: const [
+              _CaptionItem(
+                type: CaptionType.streak,
+                label: 'Streak',
+                emoji: '🔥',
+              ),
+            ],
+            onSelect: onSelect,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({
+    required this.title,
+    required this.items,
+    required this.onSelect,
+  });
+
+  final String title;
+  final List<_CaptionItem> items;
+  final ValueChanged<CaptionType> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(
+            color: AppColors.bw500,
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            fontFamily: 'Nunito',
+          ),
+        ),
+        const SizedBox(height: 10),
+        Wrap(
+          spacing: 10,
+          runSpacing: 10,
+          children: items
+              .map(
+                (item) =>
+                    _CaptionChip(item: item, onTap: () => onSelect(item.type)),
+              )
+              .toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _CaptionItem {
+  const _CaptionItem({
+    required this.type,
+    required this.label,
+    this.emoji,
+    this.icon,
+  });
+
+  final CaptionType type;
+  final String label;
+  final String? emoji;
+  final String? icon;
+}
+
+class _CaptionChip extends StatelessWidget {
+  const _CaptionChip({required this.item, required this.onTap});
+
+  final _CaptionItem item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        decoration: BoxDecoration(
+          color: AppColors.bw800,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (item.emoji != null)
+              Text(item.emoji!, style: const TextStyle(fontSize: 16))
+            else if (item.icon != null)
+              Text(
+                item.icon!,
+                style: const TextStyle(
+                  color: AppColors.bw100,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            const SizedBox(width: 6),
+            Text(
+              item.label,
+              style: const TextStyle(
+                color: AppColors.bw100,
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                fontFamily: 'Nunito',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feed/presentation/capture_action_bar.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_action_bar.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
+import 'package:meep/shared/widgets/app_camera_button.dart';
+import 'package:meep/shared/widgets/app_circle_icon_button.dart';
+
+sealed class CaptureBarConfig {
+  const CaptureBarConfig();
+}
+
+final class CameraBarConfig extends CaptureBarConfig {
+  const CameraBarConfig({
+    required this.onCapture,
+    required this.onAlbum,
+    required this.onFlip,
+    required this.isCapturing,
+    this.showFlip = true,
+  });
+
+  final VoidCallback onCapture;
+  final VoidCallback onAlbum;
+  final VoidCallback onFlip;
+  final bool isCapturing;
+  final bool showFlip;
+}
+
+final class PreviewBarConfig extends CaptureBarConfig {
+  const PreviewBarConfig({
+    required this.onCancel,
+    required this.onSend,
+    required this.onSparkles,
+    required this.isUploading,
+    required this.canSend,
+  });
+
+  final VoidCallback onCancel;
+  final VoidCallback onSend;
+  final VoidCallback onSparkles;
+  final bool isUploading;
+  final bool canSend;
+}
+
+/// Single action bar used by both the camera screen and the capture preview
+/// screen. Renders capture controls or send controls depending on [config].
+/// Fixed 6 px horizontal padding matches the photo frame inset.
+class CaptureActionBar extends StatelessWidget {
+  const CaptureActionBar({super.key, required this.config});
+
+  final CaptureBarConfig config;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenW = MediaQuery.sizeOf(context).width;
+    final sideSize = AppProportions.sideIconSize(screenW);
+    final centerSize = AppProportions.captureOuter(screenW);
+    final gap = AppProportions.captureRowGap(screenW);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 6),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: switch (config) {
+          CameraBarConfig(
+            :final onCapture,
+            :final onAlbum,
+            :final onFlip,
+            :final isCapturing,
+            :final showFlip,
+          ) =>
+            [
+              _SideBtn(
+                icon: Icons.image_outlined,
+                size: sideSize,
+                onTap: onAlbum,
+              ),
+              SizedBox(width: gap),
+              AppCameraButton(
+                size: centerSize,
+                onPressed: isCapturing ? null : onCapture,
+              ),
+              SizedBox(width: gap),
+              showFlip
+                  ? _SideBtn(
+                      icon: Icons.flip_camera_android_outlined,
+                      size: sideSize,
+                      onTap: onFlip,
+                    )
+                  : SizedBox(width: sideSize, height: sideSize),
+            ],
+          PreviewBarConfig(
+            :final onCancel,
+            :final onSend,
+            :final onSparkles,
+            :final isUploading,
+            :final canSend,
+          ) =>
+            [
+              AppCircleIconButton(
+                icon: Icons.close,
+                size: sideSize,
+                onPressed: isUploading ? null : onCancel,
+                transparentBackground: true,
+                iconScale: 0.66,
+              ),
+              SizedBox(width: gap),
+              AppCircleIconButton(
+                icon: Icons.send,
+                size: centerSize,
+                onPressed: (isUploading || !canSend) ? null : onSend,
+                backgroundColor:
+                    canSend ? AppColors.turquoise500 : AppColors.bw700,
+                iconColor: canSend ? AppColors.bw900 : AppColors.bw100,
+                isLoading: isUploading,
+              ),
+              SizedBox(width: gap),
+              AppCircleIconButton(
+                icon: Icons.auto_awesome,
+                size: sideSize,
+                onPressed: onSparkles,
+                transparentBackground: true,
+                iconScale: 0.66,
+              ),
+            ],
+        },
+      ),
+    );
+  }
+}
+
+class _SideBtn extends StatelessWidget {
+  const _SideBtn({
+    required this.icon,
+    required this.size,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final double size;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: Icon(icon, color: AppColors.bw100, size: size * 1.17),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_args.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_args.dart
@@ -1,0 +1,20 @@
+class CapturePreviewArgs {
+  const CapturePreviewArgs.single({
+    required this.imagePath,
+  })  : backPhotoPath = null,
+        frontPhotoPath = null,
+        activePrimaryLensIsFront = false;
+
+  const CapturePreviewArgs.dual({
+    required this.backPhotoPath,
+    required this.frontPhotoPath,
+    required this.activePrimaryLensIsFront,
+  }) : imagePath = null;
+
+  final String? imagePath;
+  final String? backPhotoPath;
+  final String? frontPhotoPath;
+  final bool activePrimaryLensIsFront;
+
+  bool get isDual => backPhotoPath != null && frontPhotoPath != null;
+}

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -1,0 +1,376 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gal/gal.dart';
+import 'package:go_router/go_router.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
+import 'package:meep/features/feed/application/post_controller.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/feed/presentation/capture_action_bar.dart';
+import 'package:meep/features/feed/presentation/capture_preview_args.dart';
+import 'package:meep/features/feed/presentation/caption_preset_modal.dart';
+import 'package:meep/shared/widgets/app_dots_indicator.dart';
+import 'package:meep/shared/widgets/app_note_pill.dart';
+import 'package:meep/shared/widgets/app_photo_frame.dart';
+
+class CapturePreviewScreen extends ConsumerStatefulWidget {
+  const CapturePreviewScreen({super.key, required this.args});
+
+  final CapturePreviewArgs args;
+
+  @override
+  ConsumerState<CapturePreviewScreen> createState() =>
+      _CapturePreviewScreenState();
+}
+
+class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
+  // Swipe through 7 caption types in this order.
+  static const _captionTypes = CaptionType.values;
+  // Min horizontal velocity (px/s) to count as a swipe (filters jitter).
+  static const double _swipeVelocityThreshold = 200;
+
+  int _captionIndex = 0;
+  bool _savedToGallery = false;
+  bool _primaryIsFront = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final notifier = ref.read(postControllerProvider.notifier);
+      if (widget.args.isDual) {
+        notifier.setPendingDualImages(
+          backPath: widget.args.backPhotoPath!,
+          frontPath: widget.args.frontPhotoPath!,
+        );
+      } else {
+        notifier.setPendingImage(widget.args.imagePath!);
+      }
+      notifier.setCaptionType(CaptionType.text);
+    });
+    _primaryIsFront = widget.args.activePrimaryLensIsFront;
+  }
+
+  void _swipeCaptionLeft() =>
+      _changeCaptionIndex((_captionIndex + 1) % _captionTypes.length);
+
+  void _swipeCaptionRight() => _changeCaptionIndex(
+        (_captionIndex - 1 + _captionTypes.length) % _captionTypes.length,
+      );
+
+  void _changeCaptionIndex(int idx) {
+    setState(() => _captionIndex = idx);
+    ref
+        .read(postControllerProvider.notifier)
+        .setCaptionType(_captionTypes[idx]);
+  }
+
+  Future<void> _saveToGallery() async {
+    if (_savedToGallery) return;
+    try {
+      await Gal.putImage(widget.args.imagePath ?? widget.args.backPhotoPath!);
+      if (!mounted) return;
+      setState(() => _savedToGallery = true);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Không thể lưu ảnh')),
+      );
+    }
+  }
+
+  Future<void> _send() async {
+    final ok = await ref.read(postControllerProvider.notifier).submit();
+    if (ok && mounted) context.go('/home');
+  }
+
+  void _showCaptionModal() {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (_) => CaptionPresetModal(
+        onSelect: (type) {
+          final idx = _captionTypes.indexOf(type);
+          if (idx >= 0) _changeCaptionIndex(idx);
+          Navigator.of(context).pop();
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final postState = ref.watch(postControllerProvider);
+    final screenW = MediaQuery.sizeOf(context).width;
+    final screenH = MediaQuery.sizeOf(context).height;
+    final photoSize = AppProportions.photoSize(screenW, screenH);
+
+    return Scaffold(
+      backgroundColor: AppColors.bw900,
+      body: SafeArea(
+        child: Column(
+          children: [
+            _Header(
+              onDownload: _saveToGallery,
+              savedToGallery: _savedToGallery,
+            ),
+            const SizedBox(height: 12),
+            GestureDetector(
+              onHorizontalDragEnd: (d) {
+                final v = d.primaryVelocity;
+                if (v == null) return;
+                if (v < -_swipeVelocityThreshold) _swipeCaptionLeft();
+                if (v > _swipeVelocityThreshold) _swipeCaptionRight();
+              },
+              child: GestureDetector(
+                onTap: () {
+                  if (!widget.args.isDual) return;
+                  setState(() => _primaryIsFront = !_primaryIsFront);
+                },
+                child: AppPhotoFrame(
+                  overlay: Padding(
+                    padding: EdgeInsets.only(
+                      bottom: AppProportions.pillBottomInPhoto(photoSize),
+                    ),
+                    child: AppNotePill(
+                      text: postState.caption ?? '',
+                      onChanged: (t) => ref
+                          .read(postControllerProvider.notifier)
+                          .setCaption(t),
+                    ),
+                  ),
+                  child: widget.args.isDual
+                      ? _DualPreviewImage(
+                          frontPath: widget.args.frontPhotoPath!,
+                          backPath: widget.args.backPhotoPath!,
+                          primaryIsFront: _primaryIsFront,
+                        )
+                      : Image.file(
+                          File(widget.args.imagePath!),
+                          fit: BoxFit.cover,
+                        ),
+                ),
+              ),
+            ),
+            SizedBox(height: AppProportions.dotsTopGap(screenW)),
+            AppDotsIndicator(
+              count: _captionTypes.length,
+              current: _captionIndex,
+              shrinkOuter: true,
+            ),
+            // Spacers above and below the bar center it in the gap between
+            // dots and audience row.
+            const Spacer(),
+            CaptureActionBar(
+              config: PreviewBarConfig(
+                isUploading: postState.isUploading,
+                canSend: !(postState.audienceType == AudienceType.select &&
+                    postState.selectedUids.isEmpty),
+                onCancel: () => context.pop(),
+                onSend: _send,
+                onSparkles: _showCaptionModal,
+              ),
+            ),
+            if (postState.errorMessage != null)
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+                child: Text(
+                  postState.errorMessage!,
+                  style: const TextStyle(color: Colors.redAccent, fontSize: 13),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            Flexible(
+              child: _AudienceRow(
+                screenW: screenW,
+                audienceType: postState.audienceType,
+                selectedUids: postState.selectedUids,
+                onAudienceChanged: (type, uids) => ref
+                    .read(postControllerProvider.notifier)
+                    .setAudience(type, uids),
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.onDownload, required this.savedToGallery});
+
+  final VoidCallback onDownload;
+  final bool savedToGallery;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      child: Row(
+        children: [
+          const SizedBox(width: 24),
+          const Spacer(),
+          const Text(
+            'Gửi đến...',
+            style: TextStyle(
+              color: AppColors.bw100,
+              fontSize: 21,
+              fontWeight: FontWeight.w800,
+              fontFamily: 'Nunito',
+            ),
+          ),
+          const Spacer(),
+          GestureDetector(
+            onTap: onDownload,
+            child: Icon(
+              savedToGallery ? Icons.check : Icons.download_outlined,
+              color: savedToGallery ? AppColors.turquoise500 : AppColors.bw100,
+              size: 24,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AudienceRow extends StatelessWidget {
+  const _AudienceRow({
+    required this.screenW,
+    required this.audienceType,
+    required this.selectedUids,
+    required this.onAudienceChanged,
+  });
+
+  final double screenW;
+  final AudienceType audienceType;
+  final List<String> selectedUids;
+  final void Function(AudienceType, List<String>) onAudienceChanged;
+
+  // Figma: Buttons frame x=73 on 412 → left edge of X button
+  static const double _leftPaddingRatio = 73 / 412;
+
+  @override
+  Widget build(BuildContext context) {
+    final leftPad = screenW * _leftPaddingRatio;
+    final avatarSize = AppProportions.audienceAvatarSize(screenW);
+    final labelSize = avatarSize * 0.43; // keep below overflow threshold
+    final isAll = audienceType == AudienceType.all;
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: SizedBox(
+        height: avatarSize + 4 + labelSize * 1.35 + 2,
+        child: ListView(
+          scrollDirection: Axis.horizontal,
+          padding: EdgeInsets.only(left: leftPad, right: 20),
+          children: [
+            // TODO(Friend/KhoaLND): prepend friend avatar buttons from FriendRepository
+            GestureDetector(
+              onTap: () => onAudienceChanged(AudienceType.all, []),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: avatarSize,
+                    height: avatarSize,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: isAll ? AppColors.turquoise500 : AppColors.bw600,
+                        width: 1.5,
+                      ),
+                    ),
+                    child: Container(
+                      margin: const EdgeInsets.all(2),
+                      decoration: const BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: Color(0xFF394041),
+                      ),
+                      child: Icon(
+                        Icons.group_outlined,
+                        color: isAll ? AppColors.turquoise500 : AppColors.bw100,
+                        size: avatarSize * 0.45,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Tất cả',
+                    style: TextStyle(
+                      color: isAll ? AppColors.turquoise500 : AppColors.bw100,
+                      fontSize: labelSize,
+                      fontWeight: FontWeight.w800,
+                      fontFamily: 'Nunito',
+                      height: 1.1,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DualPreviewImage extends StatelessWidget {
+  const _DualPreviewImage({
+    required this.frontPath,
+    required this.backPath,
+    required this.primaryIsFront,
+  });
+
+  final String frontPath;
+  final String backPath;
+  final bool primaryIsFront;
+
+  @override
+  Widget build(BuildContext context) {
+    final primary = primaryIsFront ? frontPath : backPath;
+    final secondary = primaryIsFront ? backPath : frontPath;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final frameSize = constraints.maxWidth;
+        final pipSize = AppProportions.pipSize(frameSize);
+        final pipMargin = AppProportions.pipMargin(frameSize);
+
+        return Stack(
+          children: [
+            // Primary (back camera by default) — full frame
+            Positioned.fill(
+              child: Image.file(
+                File(primary),
+                fit: BoxFit.cover,
+                width: double.infinity,
+              ),
+            ),
+            // Secondary (front camera by default) — PiP top-right
+            Positioned(
+              top: pipMargin,
+              right: pipMargin,
+              child: ClipRRect(
+                borderRadius:
+                    BorderRadius.circular(AppProportions.pipCornerRadius),
+                child: SizedBox(
+                  width: pipSize,
+                  height: pipSize,
+                  child: Image.file(
+                    File(secondary),
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/apps/mobile/lib/shared/widgets/app_camera_button.dart
+++ b/apps/mobile/lib/shared/widgets/app_camera_button.dart
@@ -1,11 +1,99 @@
 import 'package:flutter/material.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
 
-// TODO(FE/T15/KhoaLND): implement AppCameraButton per Figma
-class AppCameraButton extends StatelessWidget {
-  const AppCameraButton({super.key, this.onPressed});
+/// Capture button: 82×82 turquoise outer ring, 70×70 white inner circle.
+/// Animated scale on press.
+///
+/// `size` defaults to Figma 82×82 but can be overridden when scaling to
+/// device width. Inner circle is always 85.4% of outer (Figma 70/82).
+class AppCameraButton extends StatefulWidget {
+  const AppCameraButton({
+    super.key,
+    this.onPressed,
+    this.size = 82,
+  });
 
   final VoidCallback? onPressed;
+  final double size;
 
   @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
+  State<AppCameraButton> createState() => _AppCameraButtonState();
+}
+
+class _AppCameraButtonState extends State<AppCameraButton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 100),
+      reverseDuration: const Duration(milliseconds: 150),
+    );
+    _scale = Tween<double>(begin: 1.0, end: 0.9).animate(
+      CurvedAnimation(parent: _anim, curve: Curves.easeIn),
+    );
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    super.dispose();
+  }
+
+  void _onTapDown(_) => _anim.forward();
+  Future<void> _onTapUp(_) async {
+    await _anim.reverse();
+    widget.onPressed?.call();
+  }
+
+  void _onTapCancel() => _anim.reverse();
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = widget.onPressed != null;
+    final outer = widget.size;
+    final inner = outer * AppProportions.captureInnerToOuterRatio;
+
+    return GestureDetector(
+      onTapDown: enabled ? _onTapDown : null,
+      onTapUp: enabled ? _onTapUp : null,
+      onTapCancel: enabled ? _onTapCancel : null,
+      child: ScaleTransition(
+        scale: _scale,
+        child: SizedBox(
+          width: outer,
+          height: outer,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              Container(
+                width: outer,
+                height: outer,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: enabled ? AppColors.turquoise500 : AppColors.bw600,
+                    width: AppProportions.captureRingWidth,
+                  ),
+                ),
+              ),
+              Container(
+                width: inner,
+                height: inner,
+                decoration: const BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: AppColors.bw100,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/apps/mobile/lib/shared/widgets/app_circle_icon_button.dart
+++ b/apps/mobile/lib/shared/widgets/app_circle_icon_button.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:meep/core/theme/app_colors.dart';
+
+/// Reusable circular icon button used by camera controls, capture preview,
+/// share modal etc. Loading state replaces icon with spinner.
+class AppCircleIconButton extends StatelessWidget {
+  const AppCircleIconButton({
+    super.key,
+    required this.icon,
+    required this.size,
+    this.onPressed,
+    this.backgroundColor = AppColors.bw700,
+    this.iconColor = AppColors.bw100,
+    this.iconScale = 0.44,
+    this.isLoading = false,
+    this.transparentBackground = false,
+  });
+
+  final IconData icon;
+  final double size;
+  final VoidCallback? onPressed;
+  final Color backgroundColor;
+  final Color iconColor;
+
+  /// Icon size = `size * iconScale`. Default 0.44 matches Figma 36×36 icon
+  /// inside 82×82 button (36/82 ≈ 0.44).
+  final double iconScale;
+  final bool isLoading;
+
+  /// When true, background is transparent (no circle fill).
+  final bool transparentBackground;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = onPressed != null && !isLoading;
+    return Opacity(
+      opacity: enabled ? 1.0 : 0.5,
+      child: GestureDetector(
+        onTap: enabled ? onPressed : null,
+        child: Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: transparentBackground ? Colors.transparent : backgroundColor,
+            shape: BoxShape.circle,
+          ),
+          alignment: Alignment.center,
+          child: isLoading
+              ? SizedBox(
+                  width: size * 0.4,
+                  height: size * 0.4,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: iconColor,
+                  ),
+                )
+              : Icon(icon, color: iconColor, size: size * iconScale),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/shared/widgets/app_dots_indicator.dart
+++ b/apps/mobile/lib/shared/widgets/app_dots_indicator.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
+
+/// Pagination dot row used by camera mode (2 dots) and caption preview (7 dots).
+///
+/// Figma `442:2354` — outer dots shrink (8 → 6 → 4) for caption preview.
+class AppDotsIndicator extends StatelessWidget {
+  const AppDotsIndicator({
+    super.key,
+    required this.count,
+    required this.current,
+    this.shrinkOuter = false,
+  });
+
+  final int count;
+  final int current;
+
+  /// When true (caption preview), dots far from current shrink proportionally.
+  final bool shrinkOuter;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenW = MediaQuery.sizeOf(context).width;
+    final activeSize = AppProportions.dotActiveSize(screenW);
+    final spacing = AppProportions.dotSpacing(screenW);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(count, (i) {
+        final size = _sizeFor(i, activeSize, screenW);
+        return Padding(
+          padding: EdgeInsets.symmetric(horizontal: spacing / 2),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 180),
+            width: size,
+            height: size,
+            decoration: BoxDecoration(
+              color: i == current ? AppColors.bw100 : AppColors.bw500,
+              shape: BoxShape.circle,
+            ),
+          ),
+        );
+      }),
+    );
+  }
+
+  double _sizeFor(int i, double activeSize, double screenW) {
+    if (!shrinkOuter) return activeSize;
+    final dist = (i - current).abs();
+    // Figma 442:2354: dist≥3 → 4px, dist==2 → 6px, else 8px (on 412px frame)
+    if (dist >= 3) return screenW * (4 / AppProportions.figmaFrameWidth);
+    if (dist == 2) return screenW * (6 / AppProportions.figmaFrameWidth);
+    return activeSize;
+  }
+}

--- a/apps/mobile/lib/shared/widgets/app_note_pill.dart
+++ b/apps/mobile/lib/shared/widgets/app_note_pill.dart
@@ -1,11 +1,157 @@
 import 'package:flutter/material.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
 
-// TODO(FE/T16/KhoaLND): implement AppNotePill per Figma — caption overlay on photo
-class AppNotePill extends StatelessWidget {
-  const AppNotePill({super.key, required this.text});
+/// Editable caption overlay pill. cornerRadius 30, semi-transparent bg.
+/// Fixed-width text area: marquee ping-pong when readOnly + text overflows.
+/// Width and font size are computed internally from MediaQuery.
+class AppNotePill extends StatefulWidget {
+  const AppNotePill({
+    super.key,
+    required this.text,
+    this.onChanged,
+    this.readOnly = false,
+  });
 
   final String text;
+  final ValueChanged<String>? onChanged;
+  final bool readOnly;
 
   @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
+  State<AppNotePill> createState() => _AppNotePillState();
+}
+
+class _AppNotePillState extends State<AppNotePill>
+    with SingleTickerProviderStateMixin {
+  late final TextEditingController _ctrl;
+  AnimationController? _marqueeCtrl;
+  Animation<double>? _marqueeAnim;
+
+  double _textAreaWidth = 0;
+  double _fontSize = 14;
+
+  TextStyle _textStyle(double fontSize) => TextStyle(
+        color: AppColors.bw100,
+        fontSize: fontSize,
+        fontWeight: FontWeight.w800,
+        fontFamily: 'Nunito',
+      );
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = TextEditingController(text: widget.text);
+    _ctrl.addListener(() => widget.onChanged?.call(_ctrl.text));
+
+    if (widget.readOnly) {
+      _marqueeCtrl = AnimationController(
+        vsync: this,
+        duration: const Duration(milliseconds: 2500),
+      );
+      WidgetsBinding.instance.addPostFrameCallback((_) => _setupMarquee());
+    }
+  }
+
+  void _setupMarquee() {
+    final tp = TextPainter(
+      text: TextSpan(text: widget.text, style: _textStyle(_fontSize)),
+      maxLines: 1,
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    final overflow = tp.width - _textAreaWidth;
+    if (overflow > 0 && _marqueeCtrl != null) {
+      _marqueeAnim = Tween<double>(begin: 0, end: -(overflow + 8)).animate(
+        CurvedAnimation(parent: _marqueeCtrl!, curve: Curves.easeInOut),
+      );
+      _marqueeCtrl!.repeat(reverse: true);
+      if (mounted) setState(() {});
+    }
+  }
+
+  @override
+  void didUpdateWidget(AppNotePill old) {
+    super.didUpdateWidget(old);
+    if (old.text != widget.text && _ctrl.text != widget.text) {
+      _ctrl.text = widget.text;
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    _marqueeCtrl?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenW = MediaQuery.sizeOf(context).width;
+    _textAreaWidth =
+        AppProportions.pillWidth(screenW) - AppProportions.pillChrome;
+    _fontSize = AppProportions.pillFontSize(screenW);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: const Color(0x66394041),
+        borderRadius: BorderRadius.circular(30),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.text_fields, color: AppColors.bw300, size: _fontSize + 2),
+          const SizedBox(width: 6),
+          SizedBox(
+            width: _textAreaWidth,
+            child: widget.readOnly ? _buildMarquee() : _buildTextField(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMarquee() {
+    if (_marqueeAnim == null) {
+      return Text(
+        widget.text,
+        style: _textStyle(_fontSize),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+    return ClipRect(
+      child: AnimatedBuilder(
+        animation: _marqueeAnim!,
+        builder: (_, child) => Transform.translate(
+          offset: Offset(_marqueeAnim!.value, 0),
+          child: child,
+        ),
+        child: Text(
+          widget.text,
+          style: _textStyle(_fontSize),
+          maxLines: 1,
+          softWrap: false,
+          overflow: TextOverflow.visible,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTextField() {
+    return TextField(
+      controller: _ctrl,
+      style: _textStyle(_fontSize),
+      decoration: InputDecoration(
+        isDense: true,
+        border: InputBorder.none,
+        hintText: 'Nhập chú thích...',
+        hintStyle: TextStyle(color: AppColors.bw500, fontSize: _fontSize),
+        contentPadding: EdgeInsets.zero,
+      ),
+      maxLength: 200,
+      buildCounter:
+          (_, {required currentLength, required isFocused, maxLength}) => null,
+    );
+  }
 }

--- a/apps/mobile/lib/shared/widgets/app_photo_frame.dart
+++ b/apps/mobile/lib/shared/widgets/app_photo_frame.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
+
+/// Square photo frame with rounded corners — 1:1 aspect, the visual unit
+/// shared across camera viewfinder, captured-photo preview, friend post card,
+/// own post card. Caller supplies the actual content via `child` (e.g.
+/// `CameraPreview`, `Image.file`, `CachedNetworkImage`).
+///
+/// Figma: 400×400 with cornerRadius 50 on a 412 frame.
+/// Size is computed internally from MediaQuery.
+class AppPhotoFrame extends StatelessWidget {
+  const AppPhotoFrame({
+    super.key,
+    required this.child,
+    this.cornerRadius = 50,
+    this.overlay,
+  });
+
+  final Widget child;
+  final double cornerRadius;
+
+  /// Optional overlay rendered above the photo with bottom-center alignment
+  /// (e.g. note pill).
+  final Widget? overlay;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = MediaQuery.sizeOf(context);
+    final size = AppProportions.photoSize(s.width, s.height);
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: Alignment.bottomCenter,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(cornerRadius),
+            child: SizedBox(
+              width: size,
+              height: size,
+              child: ColoredBox(color: AppColors.bw900, child: child),
+            ),
+          ),
+          if (overlay != null) overlay!,
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -161,6 +161,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  camera:
+    dependency: "direct main"
+    description:
+      name: camera
+      sha256: "034c38cb8014d29698dcae6d20276688a1bf74e6487dfeb274d70ea05d5f7777"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.0+1"
+  camera_android_camerax:
+    dependency: transitive
+    description:
+      name: camera_android_camerax
+      sha256: b5064cf25a2787d122d0bf12e77c7b1033a2b983d0730e3091f770ee376efde5
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
+  camera_avfoundation:
+    dependency: transitive
+    description:
+      name: camera_avfoundation
+      sha256: "90e4cc3fde331581a3b2d35d83be41dbb7393af0ab857eb27b732174289cb96d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
+  camera_platform_interface:
+    dependency: transitive
+    description:
+      name: camera_platform_interface
+      sha256: "7ac852d77699acee79f0d438b793feee26721841e50973576419ff5c6d95e9b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.0"
+  camera_web:
+    dependency: transitive
+    description:
+      name: camera_web
+      sha256: "57f49a635c8bf249d07fb95eb693d7e4dda6796dedb3777f9127fb54847beba7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+3"
   cel:
     dependency: transitive
     description:
@@ -754,6 +794,78 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  gal:
+    dependency: "direct main"
+    description:
+      name: gal
+      sha256: "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  geoclue:
+    dependency: transitive
+    description:
+      name: geoclue
+      sha256: c2a998c77474fc57aa00c6baa2928e58f4b267649057a1c76738656e9dbd2a7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
+  geolocator:
+    dependency: "direct main"
+    description:
+      name: geolocator
+      sha256: "79939537046c9025be47ec645f35c8090ecadb6fe98eba146a0d25e8c1357516"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.0.2"
+  geolocator_android:
+    dependency: transitive
+    description:
+      name: geolocator_android
+      sha256: "179c3cb66dfa674fc9ccbf2be872a02658724d1c067634e2c427cf6df7df901a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
+  geolocator_apple:
+    dependency: transitive
+    description:
+      name: geolocator_apple
+      sha256: dbdd8789d5aaf14cf69f74d4925ad1336b4433a6efdf2fce91e8955dc921bf22
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.13"
+  geolocator_linux:
+    dependency: transitive
+    description:
+      name: geolocator_linux
+      sha256: d64112a205931926f4363bb6bd48f14cb38e7326833041d170615586cd143797
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
+  geolocator_platform_interface:
+    dependency: transitive
+    description:
+      name: geolocator_platform_interface
+      sha256: "30cb64f0b9adcc0fb36f628b4ebf4f731a2961a0ebd849f4b56200205056fe67"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.6"
+  geolocator_web:
+    dependency: transitive
+    description:
+      name: geolocator_web
+      sha256: b1ae9bdfd90f861fde8fd4f209c37b953d65e92823cb73c7dee1fa021b06f172
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.3"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      sha256: "175435404d20278ffd220de83c2ca293b73db95eafbdc8131fe8609be1421eb6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
   glob:
     dependency: transitive
     description:
@@ -826,6 +938,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gsettings:
+    dependency: transitive
+    description:
+      name: gsettings
+      sha256: "1b0ce661f5436d2db1e51f3c4295a49849f03d304003a7ba177d01e3a858249c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   home_widget:
     dependency: "direct main"
     description:
@@ -843,7 +963,7 @@ packages:
     source: hosted
     version: "1.0.3"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
@@ -1067,10 +1187,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1135,6 +1255,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -1584,10 +1720,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   timezone:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -35,6 +35,12 @@ dependencies:
   # Home-screen widget
   home_widget: ^0.7.0
 
+  # Camera & media
+  camera: ^0.12.0
+  geolocator: ^14.0.2
+  gal: ^2.3.2
+  http: ^1.6.0
+
   # Utility
   cached_network_image: ^3.4.1
   emoji_picker_flutter: ^4.4.0


### PR DESCRIPTION
## T2-T6 — Camera, Caption, Capture Preview & Post Controller

Implement camera capture flow với caption service, dual camera mode, preview screen và post controller theo spec `docs/specs/2026-05-22-home-camera-feed.md`.

**Note:** Nhánh này gộp T2+3+4+5+6 vì code phụ thuộc lẫn nhau (CameraSection cần CapturePreview, CapturePreview cần PostController). Các commits đã tách riêng để dễ review.

### Commits

**Dependencies:**
- `da9f6be` chore(deps): thêm camera + geolocator + gal + http

**T2 — CaptionService:**
- `fb3b9c7` feat(feed): T2 — CaptionService với 7 caption types
  - text, location (Nominatim), weather (Open-Meteo), time
  - GPS denied → fallback, timeout >5s → fallback
  - Cache geocode khi lat/lng chênh <100m

**T3 — AppCameraController + CameraSection:**
- `84e9d9d` feat(feed): T3a — AppCameraController với dual camera mode
- `f8ede99` feat(feed): T3b — CameraSection UI với dual viewfinder
  - Single/dual camera mode toggle
  - Album picker + flip camera
  - Viewfinder 400×400 với PiP layout

**T4 — CapturePreviewScreen:**
- `661e272` feat(feed): T4 — CapturePreviewScreen + CaptionPresetModal
  - Swipe caption → cycle 7 types
  - Audience selector: "Tất cả" / select friends
  - Download button → save to gallery

**T5+6 — PostController + FeedController:**
- `796578c` feat(feed): T5+6 — PostController.createPost + FeedController
  - Compress ảnh ≤1MB, maxWidth 1080px
  - Upload Storage → Firestore
  - Feed query `/users/{uid}/feed` với cursor pagination

**Fixes:**
- `8a7cfcf` fix(chat): use coverImageUrl for QuotedPhotoBlock
- `665d0c7` style(feed): dart format

### Testing

```bash
flutter test
# 230 tests passed, 2 skipped

cd firebase/functions && npm test
# 9 tests passed

resolves #96 , #97 , #98 