### PR TITLE
docs(diary): sync spec with Figma actual values

### DIFF
--- a/docs/specs/2026-05-23-diary.md
+++ b/docs/specs/2026-05-23-diary.md
@@ -53,16 +53,16 @@ Cho phép user viết nhật ký cá nhân theo dạng blog: chọn ảnh mood l
 
 ## Màn hình & Figma IDs
 
-| Màn hình | Figma ID | Ghi chú |
-|---|---|---|
-| Empty state | `656:1945` | "Bạn chưa có nhật ký nào" + [+] FAB |
-| Danh sách Nhật ký | `656:1831` | Grid Diary Mood cards + search icon |
-| Tạo - Nhật ký | `656:1953` | Ảnh mood overlay "Hôm nay bạn thế nào?" |
-| Canvas - Nhật ký | `658:6070` | Editor: cover photo + text + toolbar |
-| Viết nhật ký | `667:11520` | Canvas + GBoard keyboard visible |
-| Tìm kiếm Nhật ký | `712:4356` | Search input → result cards |
-| Cập nhật quyền | `718:4643` | Privacy: Riêng tư / Công khai + [Xong] |
-| Chọn kiểu text | `724:2975` | Text style picker trong canvas |
+| Màn hình | Figma ID | Figma Name | Ghi chú |
+|---|---|---|---|
+| Empty state | `656:1945` | Empty state - Nhật ký | "Bạn chưa có nhật ký nào" + [+] FAB |
+| Danh sách Nhật ký | `656:1831` | Danh sách Nhật ký | Grid Diary Mood cards + search icon |
+| Tạo - Nhật ký | `656:1953` | Tạo - Nhật ký | Ảnh mood overlay "Hôm nay bạn thế nào?" |
+| Canvas - Nhật ký | `658:6070` | Canvas - Nhật ký | Editor: cover photo + text + toolbar |
+| Viết nhật ký | `667:11520` | Viết nhật ký | Canvas + GBoard keyboard visible |
+| Tìm kiếm Nhật ký | `712:4356` | Tìm kiếm Nhật ký | Search input → result cards |
+| Privacy Sheet | `718:4643` | Privacy Sheet - Nhật ký | Bottom sheet: Riêng tư / Công khai + [Xong] |
+| Text Style Picker | `724:2975` | Text style picker - Nhật ký | Bottom sheet: Normal / Heading / Sub-heading / Quote |
 
 ---
 
@@ -379,7 +379,7 @@ SingleChildScrollView(
 | Code key | Tên hiển thị | Node Figma | Loại shape | Figma size | Flutter impl |
 |---|---|---|---|---|---|
 | `happy` | Vui vẻ | `658:4065` | RECTANGLE | 51×51px | `BorderRadius.circular(38.5)` ≈ circle |
-| `bored` | Chán nản | `658:4069` | RECTANGLE | 45×45px | `BorderRadius.circular(10)` (scale: ~27px ở 120px) |
+| `bored` | Chán nản | `658:4069` | RECTANGLE | 45×45px | `BorderRadius.circular(21)` (scale từ 45px picker → 120px card) |
 | `tired` | Mệt mỏi | `658:4072` | **VECTOR** | 56×50px | `CustomClipper` — export SVG path từ Figma |
 | `shy` | Ngại ngùng | `658:4110` | **VECTOR** | 60×47.5px | `CustomClipper` — export SVG path từ Figma |
 | `sad` | Buồn bã | `658:4174` | **VECTOR** | 48×45px | `CustomClipper` — export SVG path từ Figma |

--- a/docs/specs/2026-05-23-diary.md
+++ b/docs/specs/2026-05-23-diary.md
@@ -56,13 +56,17 @@ Cho phép user viết nhật ký cá nhân theo dạng blog: chọn ảnh mood l
 | Màn hình | Figma ID | Figma Name | Ghi chú |
 |---|---|---|---|
 | Empty state | `656:1945` | Empty state - Nhật ký | "Bạn chưa có nhật ký nào" + [+] FAB |
-| Danh sách Nhật ký | `656:1831` | Danh sách Nhật ký | Grid Diary Mood cards + search icon |
+| Danh sách Nhật ký | `656:1831` | Danh sách Nhật ký - Grid Card View | Grid 2 columns cards + filter bar + toggle icon |
+| Danh sách Nhật ký - List View | `769:5917` | Danh sách Nhật ký - List Card View | List 1 column cards + filter bar + toggle icon |
 | Tạo - Nhật ký | `656:1953` | Tạo - Nhật ký | Ảnh mood overlay "Hôm nay bạn thế nào?" |
 | Canvas - Nhật ký | `658:6070` | Canvas - Nhật ký | Editor: cover photo + text + toolbar |
 | Viết nhật ký | `667:11520` | Viết nhật ký | Canvas + GBoard keyboard visible |
 | Tìm kiếm Nhật ký | `712:4356` | Tìm kiếm Nhật ký | Search input → result cards |
 | Privacy Sheet | `718:4643` | Privacy Sheet - Nhật ký | Bottom sheet: Riêng tư / Công khai + [Xong] |
-| Text Style Picker | `724:2975` | Text style picker - Nhật ký | Bottom sheet: Normal / Heading / Sub-heading / Quote |
+| Text Style Picker | `724:2975` | Text style picker - Nhật ký | Bottom sheet: Size dropdown + Bold/Italic/Underline/Strikethrough |
+| Xem nhật ký | `769:4634` | Chọn một nhật ký đã viết - Nhật ký | Canvas read mode + ellipsis menu |
+| Menu nhật ký | `769:5255` | Menu nhật ký đã viết - Nhật ký | Bottom sheet: Chỉnh sửa / Xóa / Chia sẻ |
+| Xóa nhật ký Dialog | `769:5575` | Xóa nhật ký - Nhật ký | Confirmation dialog: Lưu / Xoá |
 
 ---
 
@@ -93,13 +97,19 @@ Bottom taskbar → tap [book-heart] icon (thứ 2 từ trái)
 
 ```
 Topbar: [🔍 search] | "Nhật ký" | [Avatar]
-Body:   Grid các "Diary Mood" card:
-        [Circular cover photo 79x79] + date label "22 th 5" bên dưới
+Body:   
+  Filter bar: [Tất cả] text + [grid-3x2 / grip-horizontal] toggle icon
+  Grid các "Diary Mood" card (Grid mode):
+        [Circular cover photo 120×120] + title + date label "22 th 5" bên dưới
+  List các "Diary Mood" card (List mode):
+        [Horizontal layout: image 54×53 + title + date]
 FAB [+] (bottom-center, Turquoise)
 
 → tap một card → Xem nhật ký (Canvas read mode)
 → tap [🔍] → Tìm kiếm Nhật ký
 → tap [+] → Tạo nhật ký
+→ tap [grid-3x2] icon → switch to List view (icon đổi thành grip-horizontal)
+→ tap [grip-horizontal] icon → switch to Grid view (icon đổi thành grid-3x2)
 ```
 
 ---
@@ -109,16 +119,16 @@ FAB [+] (bottom-center, Turquoise)
 ```
 Overlay slide up trên Diary list:
     Title: "Hôm nay bạn thế nào?"
-    Body: ảnh gần nhất từ gallery hiển thị trong 5 mood frames (hàng ngang scroll):
-        - Vui vẻ   (happy)      ← icon image + frame PNG riêng
-        - Chán nản  (bored)      ← icon image + frame PNG riêng
-        - Mệt mỏi  (tired)      ← icon image + frame PNG riêng
-        - Buồn bã   (sad)        ← icon image + frame PNG riêng
-        - Ngại ngùng (shy)       ← icon image + frame PNG riêng
+    Body: 5 mood frames xếp theo vòng cung (arc layout):
+        - Vui vẻ   (happy)      ← top center
+        - Chán nản  (bored)      ← right
+        - Mệt mỏi  (tired)      ← bottom right
+        - Ngại ngùng (shy)       ← left
+        - Buồn bã   (sad)        ← bottom left
     [X] đóng overlay (button tối, bottom-center)
 
-→ tap 1 mood → ảnh đó + frame template tương ứng trở thành cover → mở Canvas editor
-→ Canvas: user tự gõ mood caption (placeholder: "Hôm nay bạn thế nào?")
+→ tap 1 mood → chọn moodTemplate → mở Canvas editor
+→ Canvas: user chọn ảnh cover + gõ mood caption (placeholder: "Hôm nay bạn thế nào?")
 ```
 
 > **Frame template = 2 layer:**
@@ -148,11 +158,19 @@ Body:
     [Text cursor "|" — gõ nội dung]
     [Chèn ảnh inline — giống blog]
 
-Bottom toolbar (keyboard bar):
+Content toolbar (above keyboard):
+    [image-plus] — chèn ảnh inline
+    [type] — chọn text style (Normal/Heading/Sub-heading/Quote)
+    [text-align-center] — text alignment (left/center/right)
+    [smile-plus] — chèn emoji/sticker
+
+Keyboard toolbar (GBoard bar):
     [←] [sticker — disabled] [GIF — disabled] [clipboard] [settings] [more] [mic]
 
-→ tap text area → GBoard keyboard hiện + bottom toolbar
-→ tap [text style button trong toolbar] → Chọn kiểu text sheet
+→ tap text area → GBoard keyboard hiện + Content toolbar + Keyboard toolbar
+→ tap [type] trong Content toolbar → Chọn kiểu text sheet
+→ tap [text-align-center] trong Content toolbar → toggle alignment (left/center/right)
+→ tap [image-plus] trong Content toolbar → chọn ảnh → chèn inline với Polaroid frame
 → tap [🔒 lock] → Privacy sheet (Cập nhật quyền)
 → tap [✓ check] → lưu entry + navigate về Danh sách
 → tap [←] back (create mode) → DiscardChangesDialog:
@@ -168,10 +186,17 @@ Bottom toolbar (keyboard bar):
 
 ```
 Canvas + keyboard đang visible
-→ tap text style icon trong toolbar
-    → Bottom sheet hoặc inline picker slide up:
-        Text styles: Normal | Heading | Sub-heading | Quote | ...
-    → Chọn style → apply cho đoạn text đang chọn
+→ tap [type] icon trong Content toolbar
+    → Text style picker toolbar slide up (above keyboard):
+        [X] close
+        [Size dropdown] — 4 sizes:
+            Size 1 (Large)   — Heading (H1)
+            Size 2 (Big)     — Sub-heading (H2)
+            Size 3 (Medium)  — Normal body text (default)
+            Size 4 (Small)   — Quote/caption
+        [Bold] [Italic] [Underline] [Strikethrough] — text formatting
+    → Chọn size → apply cho đoạn text đang chọn
+    → Tap formatting icon → toggle on/off (selected = Info/200 background)
     → keyboard vẫn visible
 ```
 
@@ -214,10 +239,12 @@ Canvas → tap [✓ check]
 ```
 Danh sách → tap [🔍]
     → Search screen:
-        Input field + cursor "|"
+        Input field + cursor "|" + [X] clear button + [list-filter] icon
         → gõ → filter real-time theo text content
+        → tap [X] → clear input
+        → tap [list-filter] → Filter sheet (lọc theo mood và thời gian)
         → "N kết quả"
-        → Result cards: [keyword highlight] + [date full: "22 tháng 5 năm 2026"]
+        → Result cards: [image 54×53px circular] + [keyword highlight] + [date full: "22 tháng 5 năm 2026"]
     → tap result → Xem nhật ký
 ```
 
@@ -228,13 +255,46 @@ Danh sách → tap [🔍]
 ### Xem nhật ký (read mode)
 
 ```
-Tap card từ Danh sách → Canvas read mode:
-    Topbar: [←] | date | [lock/unlock icon] [✏️ edit?]
-    Body: render các content blocks (text + images)
+Tap card từ Danh sách → Canvas read mode (Figma `769:4634`):
+    Topbar: [←] | "22 tháng 5" | [...] ellipsis menu
+    Body: render các content blocks (text + Polaroid images)
     → tap [←] → về Danh sách
+    → tap [...] → Menu nhật ký sheet
 ```
 
-> Edit mode cho phép sửa nội dung và đổi privacy. Tap [✏️] hoặc re-open từ Danh sách.
+---
+
+### Menu nhật ký
+
+```
+Canvas read mode → tap [...] ellipsis
+    → Bottom sheet (Figma `769:5255`):
+        [pencil icon] Chỉnh sửa
+        [trash-2 icon] Xóa nhật ký
+        [share icon] Chia sẻ
+        [Xong] button
+    → tap [Chỉnh sửa] → chuyển sang Canvas edit mode
+    → tap [Xóa nhật ký] → Xóa nhật ký Dialog
+    → tap [Chia sẻ] → native share sheet (share text + images)
+    → tap [Xong] → đóng sheet
+```
+
+---
+
+### Xóa nhật ký
+
+```
+Menu nhật ký → tap [Xóa nhật ký]
+    → Confirmation dialog (Figma `769:5575`):
+        Title: "Xóa nhật ký của bạn?"
+        Message: "Nhật ký sẽ bị xóa hoàn toàn khỏi danh sách nhật ký hiện tại của bạn"
+        [Lưu] button (BW/200 background)
+        [Xoá] button (Error/800 text, BW/200 background)
+    → tap [Lưu] → dismiss dialog, không xóa
+    → tap [Xoá] → xóa entry khỏi Firestore + navigate về Danh sách
+```
+
+> Xóa entry cần xóa cả images trên Storage: cover image + inline images.
 
 ---
 
@@ -425,8 +485,14 @@ Total height: ~182px (image 120px + gap 9px + text area 53px)
 ```
 Screen bg: #050f10
 Content container: 333px wide, padding-x: 39px
-Grid: 2 columns, horizontal gap: 32px, vertical gap: 32px
-Card: DiaryMoodCard 150.5px wide
+Filter bar: "Tất cả" (Nunito SemiBold 16px, #8d999b) + toggle icon (grid-3x2 / grip-horizontal)
+Grid mode: 2 columns, horizontal gap: 32px, vertical gap: 32px
+  Card: DiaryMoodCard 150.5px wide, image 120×120px
+List mode (Figma `769:5917`): 1 column, vertical gap: 12px
+  Card: Horizontal layout, 382px wide, height 85px, cornerRadius 30
+    - Image: 65×66px circular (left, margin 20px)
+    - Title: Nunito Bold 18px, #f9fcfc
+    - Date: Nunito Regular 12px, #8d999b
 FAB: 60×60 Turquoise/500, cornerRadius 30, centered, y=725 (above taskbar)
 Topbar: search icon (left) + "Nhật ký" (Nunito Bold 18px, center) + avatar 40×40 (right)
 ```


### PR DESCRIPTION
## Summary
Cập nhật spec Nhật ký để khớp với Figma actual values sau khi designer (HanDHG) đã finalize design.

## Changes
### Updated Screens
- **Danh sách Nhật ký (Grid)**: Image size 79×79 → 120×120, thêm filter bar + Grid/List toggle icon
- **Danh sách Nhật ký (List)**: Thêm List View layout mới (Figma ID: 769:5917)
- **Tạo - Nhật ký**: Layout horizontal scroll → arc layout, clarify mood selection flow
- **Canvas - Nhật ký**: Thêm Content toolbar (image-plus, type, text-align-center, smile-plus)
- **Tìm kiếm Nhật ký**: Thêm filter icon, clear button, image size 54×53px
- **Text Style Picker**: Clarify Size dropdown (4 sizes: Large/Big/Medium/Small) + text formatting (Bold/Italic/Underline/Strikethrough)

### New Screens
- **Xem nhật ký (read mode)** (769:4634): Canvas với ellipsis menu
- **Menu nhật ký** (769:5255): Bottom sheet với Chỉnh sửa / Xóa / Chia sẻ
- **Xóa nhật ký Dialog** (769:5575): Confirmation dialog

## Verification
✅ Tất cả changes đã được verify với Figma frames
✅ 12 frames đã được check và cập nhật đầy đủ

## Related
- Figma file: [Meep Design](https://www.figma.com/design/...)
- Spec file: `docs/specs/2026-05-23-diary.md`

cc @manhthien2005