### PR TITLE
fix(feed): tinh chỉnh layout capture/preview + fix bug submit ảnh

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -21,6 +21,8 @@ import 'package:meep/dev/widget_catalog_page.dart';
 import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
 import 'package:meep/features/diary/presentation/diary_create_screen.dart';
 import 'package:meep/features/diary/presentation/diary_list_screen.dart';
+import 'package:meep/features/feed/presentation/capture_preview_args.dart';
+import 'package:meep/features/feed/presentation/capture_preview_screen.dart';
 import 'package:meep/features/feed/presentation/home_screen.dart';
 import 'package:meep/features/home/presentation/home_page.dart';
 import 'package:meep/features/profile/presentation/edit_profile_screen.dart';
@@ -288,7 +290,8 @@ GoRouter appRouter(Ref ref) {
       ),
       GoRoute(
         path: '/capture-preview',
-        builder: (_, __) => const HomeScreen(),
+        builder: (_, state) =>
+            CapturePreviewScreen(args: state.extra as CapturePreviewArgs),
       ),
       GoRoute(
         path: '/caption-modal',

--- a/apps/mobile/lib/core/theme/app_proportions.dart
+++ b/apps/mobile/lib/core/theme/app_proportions.dart
@@ -31,12 +31,15 @@ abstract final class AppProportions {
 
   // ── Note pill ─────────────────────────────────────────────────────────────
 
-  /// Pill total width. Figma: 126/412 → 30.6%.
-  static const double pillWidthRatio = 126 / figmaFrameWidth;
+  /// Pill total width — fixed ~50% of frame width so the editable caption has
+  /// a comfortable centered text area. Figma frame 412 → ~200px.
+  static const double pillWidthRatio = 200 / figmaFrameWidth;
   static double pillWidth(double screenW) => screenW * pillWidthRatio;
 
-  /// Pill chrome = icon(22) + iconGap(6) + paddingH(15×2) = 58.
-  static const double pillChrome = 58.0;
+  /// Pill inner chrome consumed by horizontal padding + icon + gap. Used to
+  /// derive the editable text-area width from [pillWidth].
+  static const double pillPaddingH = 14;
+  static const double pillIconGap = 6;
 
   /// Font size inside pill. Figma: 14px on 412, bumped to 15 for legibility.
   static const double pillFontRatio = 15 / figmaFrameWidth;

--- a/apps/mobile/lib/core/theme/app_proportions.dart
+++ b/apps/mobile/lib/core/theme/app_proportions.dart
@@ -47,7 +47,8 @@ abstract final class AppProportions {
 
   // ── Capture Button ────────────────────────────────────────────────────────
 
-  static const double captureOuterRatio = 79 / figmaFrameWidth;
+  // Bumped ~15% over Figma (79) for a larger, easier-to-hit capture/send button.
+  static const double captureOuterRatio = 92 / figmaFrameWidth;
   static const double captureInnerToOuterRatio = 69 / 79;
   static const double captureRingWidth = 3;
 
@@ -57,7 +58,8 @@ abstract final class AppProportions {
 
   // ── Side icons ────────────────────────────────────────────────────────────
 
-  static const double sideIconRatio = 36 / figmaFrameWidth;
+  // Bumped ~15% over Figma (36) to match the larger capture/send button.
+  static const double sideIconRatio = 44 / figmaFrameWidth;
   static double sideIconSize(double screenW) => screenW * sideIconRatio;
 
   static const double captureRowGapRatio = 60 / figmaFrameWidth;

--- a/apps/mobile/lib/features/feed/application/post_controller.dart
+++ b/apps/mobile/lib/features/feed/application/post_controller.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -84,18 +85,23 @@ class PostController extends _$PostController {
     }
 
     state = state.copyWith(isUploading: true, errorMessage: null);
+    final postId = FirebaseFirestore.instance.collection('posts').doc().id;
+    final storageRepo = ref.read(storageRepositoryProvider);
+
+    String? imageUrl;
+    String? backImageUrl;
+    String? frontImageUrl;
+
+    // ── Step 1 + 2: compress + upload to Storage ─────────────────────────────
     try {
-      final postId = FirebaseFirestore.instance.collection('posts').doc().id;
-      final storageRepo = ref.read(storageRepositoryProvider);
-
-      String? imageUrl;
-      String? backImageUrl;
-      String? frontImageUrl;
-
       if (state.isDualMode) {
         final backBytes = await _compress(state.pendingBackImagePath!);
         final frontBytes = await _compress(state.pendingFrontImagePath!);
         if (backBytes == null || frontBytes == null) {
+          _log(
+            'compress dual returned null',
+            'backBytes=${backBytes?.length} frontBytes=${frontBytes?.length}',
+          );
           state = state.copyWith(
             isUploading: false,
             errorMessage: 'Không thể xử lý ảnh',
@@ -119,6 +125,7 @@ class PostController extends _$PostController {
       } else {
         final compressed = await _compress(state.pendingImagePath!);
         if (compressed == null) {
+          _log('compress single returned null', state.pendingImagePath);
           state = state.copyWith(
             isUploading: false,
             errorMessage: 'Không thể xử lý ảnh',
@@ -132,8 +139,17 @@ class PostController extends _$PostController {
           mimeType: 'image/jpeg',
         );
       }
+    } catch (e, st) {
+      _log('upload storage failed', e, st);
+      state = state.copyWith(
+        isUploading: false,
+        errorMessage: _errorMessage('upload', e),
+      );
+      return false;
+    }
 
-      // Create Firestore post doc
+    // ── Step 3: create Firestore post doc ────────────────────────────────────
+    try {
       final postRepo = ref.read(postRepositoryProvider);
       final user = FirebaseAuth.instance.currentUser!;
 
@@ -165,13 +181,49 @@ class PostController extends _$PostController {
 
       state = const PostState();
       return true;
-    } catch (_) {
+    } catch (e, st) {
+      _log('create post doc failed', e, st);
       state = state.copyWith(
         isUploading: false,
-        errorMessage: 'Tải ảnh thất bại — thử lại',
+        errorMessage: _errorMessage('createPost', e),
       );
       return false;
     }
+  }
+
+  /// Map an arbitrary error to a user-facing Vietnamese message. Differentiates
+  /// FirebaseException by `code` so the UI gives a real hint (permission /
+  /// auth / network) instead of one opaque "thử lại" for every failure.
+  String _errorMessage(String step, Object e) {
+    if (e is FirebaseException) {
+      switch (e.code) {
+        case 'permission-denied':
+        case 'unauthorized':
+          return 'Không có quyền gửi — kiểm tra đăng nhập / quyền truy cập';
+        case 'unauthenticated':
+          return 'Phiên đăng nhập hết hạn — đăng nhập lại';
+        case 'unavailable':
+        case 'deadline-exceeded':
+        case 'cancelled':
+          return 'Mất kết nối — thử lại';
+        case 'resource-exhausted':
+          return 'Quá tải — chờ một lát rồi thử lại';
+        default:
+          return 'Tải ảnh thất bại (${e.code}) — thử lại';
+      }
+    }
+    return 'Tải ảnh thất bại — thử lại';
+  }
+
+  void _log(String message, [Object? detail, StackTrace? st]) {
+    if (!kDebugMode) return;
+    final detailStr = detail == null
+        ? ''
+        : detail is FirebaseException
+            ? ' [${detail.runtimeType} code=${detail.code} msg=${detail.message}]'
+            : ' [${detail.runtimeType}] $detail';
+    debugPrint('[PostController.submit] $message$detailStr');
+    if (st != null) debugPrint(st.toString());
   }
 
   Future<void> deletePost(String postId) async {

--- a/apps/mobile/lib/features/feed/application/post_controller.dart
+++ b/apps/mobile/lib/features/feed/application/post_controller.dart
@@ -137,6 +137,9 @@ class PostController extends _$PostController {
       final postRepo = ref.read(postRepositoryProvider);
       final user = FirebaseAuth.instance.currentUser!;
 
+      // Empty / whitespace caption → store null so it never renders downstream.
+      final trimmedCaption = state.caption?.trim();
+
       final post = Post(
         postId: postId,
         authorId: uid,
@@ -146,7 +149,9 @@ class PostController extends _$PostController {
         backImageUrl: backImageUrl,
         frontImageUrl: frontImageUrl,
         isDualCamera: state.isDualMode,
-        caption: state.caption,
+        caption: (trimmedCaption == null || trimmedCaption.isEmpty)
+            ? null
+            : trimmedCaption,
         captionType: state.captionType,
         audienceType: state.audienceType,
         audienceUids:

--- a/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
+++ b/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
@@ -18,7 +18,13 @@ class FirebasePostRepository implements PostRepository {
     }
 
     final ref = _db.collection(_posts).doc(post.postId);
+    // Strip null fields BEFORE writing: Firestore rule `/posts/{postId}` requires
+    // `caption is string` whenever the `caption` key is present, so leaving an
+    // explicit `caption: null` (or other null fields) in the payload trips a
+    // permission-denied. Removing the keys makes the rule's `!('caption' in data)`
+    // branch satisfy instead.
     final data = post.toJson()
+      ..removeWhere((_, value) => value == null)
       ..['createdAt'] = FieldValue
           .serverTimestamp(); // spec: serverTimestamp, not device clock
     await ref.set(data);

--- a/apps/mobile/lib/features/feed/presentation/camera_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/camera_section.dart
@@ -95,7 +95,10 @@ class _CameraSectionState extends ConsumerState<CameraSection> {
 
     return Column(
       children: [
-        const SizedBox(height: 12),
+        // Spacer above the photo, balanced by the spacer below the dots, so
+        // the (photo + dots) cluster sits vertically centered in the space
+        // between the top bar and the action bar.
+        const Spacer(),
         GestureDetector(
           onHorizontalDragEnd: (d) => _onViewfinderSwipe(d.primaryVelocity),
           child: AppPhotoFrame(

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -116,7 +116,10 @@ class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
               onDownload: _saveToGallery,
               savedToGallery: _savedToGallery,
             ),
-            const SizedBox(height: 12),
+            // Spacer above the photo, balanced by the spacer below the dots, so
+            // the (photo + dots) cluster sits vertically centered between the
+            // header and the action bar.
+            const Spacer(),
             GestureDetector(
               onHorizontalDragEnd: (d) {
                 final v = d.primaryVelocity;

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
 import 'package:meep/features/feed/application/feed_controller.dart';
 import 'package:meep/features/feed/data/post.dart';
 import 'package:meep/shared/widgets/post_card.dart';
@@ -120,36 +121,65 @@ class OwnPostCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final s = MediaQuery.sizeOf(context);
+    final photoSize = AppProportions.photoSize(s.width, s.height);
+
+    // Footer matches the photo width so its centered content lines up under
+    // the square frame (PostCard's outer column is start-aligned).
     return PostCard(
       post: post,
       onLongPress: () => _showShareModal(context, post, isAuthor: true),
-      footer: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 6),
+      footer: SizedBox(
+        width: photoSize,
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            Text(
-              'Bạn · ${_formatDate(post.createdAt)}',
+            Text.rich(
+              TextSpan(
+                children: [
+                  const TextSpan(
+                    text: 'Bạn ',
+                    style: TextStyle(color: AppColors.bw100),
+                  ),
+                  TextSpan(
+                    text: _formatDate(post.createdAt),
+                    style: const TextStyle(color: AppColors.bw500),
+                  ),
+                ],
+              ),
+              textAlign: TextAlign.center,
               style: const TextStyle(
-                color: AppColors.bw400,
-                fontSize: 14,
-                fontWeight: FontWeight.w600,
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+                fontFamily: 'Nunito',
               ),
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: 12),
             Container(
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
+              padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
               decoration: BoxDecoration(
-                color: AppColors.bw800,
-                borderRadius: BorderRadius.circular(20),
+                color: const Color(0x66252627),
+                borderRadius: BorderRadius.circular(40),
               ),
-              child: const Text(
-                '✨ Chưa có hoạt động nào!',
-                style: TextStyle(
-                  color: AppColors.bw300,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
-                ),
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.auto_awesome_outlined,
+                    color: AppColors.bw400,
+                    size: 18,
+                  ),
+                  SizedBox(width: 10),
+                  Text(
+                    'Chưa có hoạt động nào!',
+                    style: TextStyle(
+                      color: AppColors.bw400,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                      fontFamily: 'Nunito',
+                    ),
+                  ),
+                ],
               ),
             ),
           ],
@@ -158,13 +188,7 @@ class OwnPostCard extends StatelessWidget {
     );
   }
 
-  String _formatDate(DateTime dt) {
-    final now = DateTime.now();
-    if (dt.day == now.day && dt.month == now.month && dt.year == now.year) {
-      return 'hôm nay';
-    }
-    return '${dt.day}/${dt.month}';
-  }
+  String _formatDate(DateTime dt) => '${dt.day} thg ${dt.month}';
 }
 
 void _showShareModal(

--- a/apps/mobile/lib/shared/widgets/app_note_pill.dart
+++ b/apps/mobile/lib/shared/widgets/app_note_pill.dart
@@ -87,12 +87,21 @@ class _AppNotePillState extends State<AppNotePill>
   @override
   Widget build(BuildContext context) {
     final screenW = MediaQuery.sizeOf(context).width;
-    _textAreaWidth =
-        AppProportions.pillWidth(screenW) - AppProportions.pillChrome;
+    final pillW = AppProportions.pillWidth(screenW);
     _fontSize = AppProportions.pillFontSize(screenW);
+    final iconSize = _fontSize + 2;
+    // Fixed-width pill: text area = pill width minus padding, icon, and gap.
+    _textAreaWidth = pillW -
+        AppProportions.pillPaddingH * 2 -
+        iconSize -
+        AppProportions.pillIconGap;
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      width: pillW,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppProportions.pillPaddingH,
+        vertical: 8,
+      ),
       decoration: BoxDecoration(
         color: const Color(0x66394041),
         borderRadius: BorderRadius.circular(30),
@@ -100,8 +109,8 @@ class _AppNotePillState extends State<AppNotePill>
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.text_fields, color: AppColors.bw300, size: _fontSize + 2),
-          const SizedBox(width: 6),
+          Icon(Icons.text_fields, color: AppColors.bw300, size: iconSize),
+          const SizedBox(width: AppProportions.pillIconGap),
           SizedBox(
             width: _textAreaWidth,
             child: widget.readOnly ? _buildMarquee() : _buildTextField(),
@@ -117,6 +126,7 @@ class _AppNotePillState extends State<AppNotePill>
         widget.text,
         style: _textStyle(_fontSize),
         maxLines: 1,
+        textAlign: TextAlign.center,
         overflow: TextOverflow.ellipsis,
       );
     }
@@ -142,6 +152,7 @@ class _AppNotePillState extends State<AppNotePill>
     return TextField(
       controller: _ctrl,
       style: _textStyle(_fontSize),
+      textAlign: TextAlign.center,
       decoration: InputDecoration(
         isDense: true,
         border: InputBorder.none,

--- a/apps/mobile/lib/shared/widgets/post_card.dart
+++ b/apps/mobile/lib/shared/widgets/post_card.dart
@@ -38,7 +38,7 @@ class _PostCardState extends State<PostCard> {
     final post = widget.post;
     final s = MediaQuery.sizeOf(context);
     final photoSize = AppProportions.photoSize(s.width, s.height);
-    final hasCaption = (post.caption ?? '').isNotEmpty;
+    final hasCaption = (post.caption ?? '').trim().isNotEmpty;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/mobile/test/core/theme/app_proportions_test.dart
+++ b/apps/mobile/test/core/theme/app_proportions_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meep/core/theme/app_proportions.dart';
+
+void main() {
+  // Reference device width used across the design system (Figma frame 412).
+  const w = 412.0;
+
+  group('AppProportions capture/preview bar sizing', () {
+    test('capture button bumped ~15% over Figma 79px', () {
+      // 92/412 * 412 = 92px on the reference frame.
+      expect(AppProportions.captureOuter(w), closeTo(92, 0.5));
+    });
+
+    test('side icon bumped ~15% over Figma 36px', () {
+      expect(AppProportions.sideIconSize(w), closeTo(44, 0.5));
+    });
+
+    test('side icon stays smaller than the capture button', () {
+      expect(
+        AppProportions.sideIconSize(w),
+        lessThan(AppProportions.captureOuter(w)),
+      );
+    });
+
+    test('inner circle keeps Figma 69/79 ratio of the (larger) outer', () {
+      expect(
+        AppProportions.captureInner(w),
+        closeTo(AppProportions.captureOuter(w) * 69 / 79, 0.5),
+      );
+    });
+
+    test('the whole bar row fits within screen width', () {
+      // center + 2 side buttons + 2 gaps + 6px padding each side must not
+      // exceed the frame width, or the Row overflows.
+      final rowWidth = AppProportions.captureOuter(w) +
+          AppProportions.sideIconSize(w) * 2 +
+          AppProportions.captureRowGap(w) * 2 +
+          12; // 6px horizontal padding each side
+      expect(rowWidth, lessThanOrEqualTo(w));
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/firebase_post_repository_test.dart
+++ b/apps/mobile/test/features/feed/firebase_post_repository_test.dart
@@ -78,6 +78,41 @@ void main() {
       expect(snap.data()!['audienceType'], 'select');
       expect(snap.data()!['audienceUids'], ['uid2', 'uid3']);
     });
+
+    test('strips null fields so Firestore rule does not reject the create',
+        () async {
+      // Single-camera post WITHOUT a caption — used to write
+      // `caption: null` which trips the `caption is string` rule branch and
+      // causes a permission-denied in prod. Repo must drop those keys.
+      final post = _makePost();
+      await repo.createPost(post);
+
+      final data = (await db.collection('posts').doc('p1').get()).data()!;
+      expect(data.containsKey('caption'), isFalse);
+      expect(data.containsKey('backImageUrl'), isFalse);
+      expect(data.containsKey('frontImageUrl'), isFalse);
+      expect(data.containsKey('captionType'), isFalse);
+      expect(data.containsKey('spaceId'), isFalse);
+      expect(data.containsKey('authorAvatarUrl'), isFalse);
+      // Non-null fields stay.
+      expect(data['authorId'], 'uid1');
+      expect(data['imageUrl'], isNotNull);
+    });
+
+    test('keeps caption key when caption is a non-empty string', () async {
+      final post = Post(
+        postId: 'p2',
+        authorId: 'uid1',
+        authorName: 'Test User',
+        imageUrl: 'https://example.com/photo.jpg',
+        caption: 'hello world',
+        audienceType: AudienceType.all,
+        createdAt: DateTime(2026, 5, 27),
+      );
+      await repo.createPost(post);
+      final data = (await db.collection('posts').doc('p2').get()).data()!;
+      expect(data['caption'], 'hello world');
+    });
   });
 
   group('watchFeed', () {

--- a/apps/mobile/test/features/feed/presentation/capture_action_bar_test.dart
+++ b/apps/mobile/test/features/feed/presentation/capture_action_bar_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meep/core/theme/app_proportions.dart';
+import 'package:meep/features/feed/presentation/capture_action_bar.dart';
+import 'package:meep/shared/widgets/app_camera_button.dart';
+import 'package:meep/shared/widgets/app_circle_icon_button.dart';
+
+void main() {
+  Widget wrap(Widget w) => MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(size: Size(412, 917)),
+          child: Scaffold(body: Center(child: w)),
+        ),
+      );
+
+  final expectedCenter = AppProportions.captureOuter(412);
+  final expectedSide = AppProportions.sideIconSize(412);
+
+  group('CaptureActionBar — camera config', () {
+    Widget cameraBar() => wrap(
+          CaptureActionBar(
+            config: CameraBarConfig(
+              onCapture: () {},
+              onAlbum: () {},
+              onFlip: () {},
+              isCapturing: false,
+            ),
+          ),
+        );
+
+    testWidgets('capture button uses the bumped center size', (tester) async {
+      await tester.pumpWidget(cameraBar());
+      final btn = tester.widget<AppCameraButton>(find.byType(AppCameraButton));
+      expect(btn.size, closeTo(expectedCenter, 0.5));
+    });
+
+    testWidgets('album side icon uses the bumped side size', (tester) async {
+      await tester.pumpWidget(cameraBar());
+      final box = tester.getSize(find.byIcon(Icons.image_outlined).first);
+      // _SideBtn wraps the icon in a size×size SizedBox.
+      expect(box.width, closeTo(expectedSide, 0.5));
+    });
+  });
+
+  group('CaptureActionBar — preview config', () {
+    Widget previewBar({bool canSend = true}) => wrap(
+          CaptureActionBar(
+            config: PreviewBarConfig(
+              onCancel: () {},
+              onSend: () {},
+              onSparkles: () {},
+              isUploading: false,
+              canSend: canSend,
+            ),
+          ),
+        );
+
+    testWidgets('send button uses the bumped center size', (tester) async {
+      await tester.pumpWidget(previewBar());
+      final send = tester.widget<AppCircleIconButton>(
+        find.widgetWithIcon(AppCircleIconButton, Icons.send),
+      );
+      expect(send.size, closeTo(expectedCenter, 0.5));
+    });
+
+    testWidgets('cancel + sparkles use the bumped side size', (tester) async {
+      await tester.pumpWidget(previewBar());
+      final cancel = tester.widget<AppCircleIconButton>(
+        find.widgetWithIcon(AppCircleIconButton, Icons.close),
+      );
+      final sparkles = tester.widget<AppCircleIconButton>(
+        find.widgetWithIcon(AppCircleIconButton, Icons.auto_awesome),
+      );
+      expect(cancel.size, closeTo(expectedSide, 0.5));
+      expect(sparkles.size, closeTo(expectedSide, 0.5));
+    });
+  });
+}

--- a/apps/mobile/test/features/feed/presentation/own_post_card_test.dart
+++ b/apps/mobile/test/features/feed/presentation/own_post_card_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/feed/presentation/feed_section.dart';
+
+Post _post({DateTime? createdAt}) => Post(
+      postId: 'p1',
+      authorId: 'uid1',
+      authorName: 'Test User',
+      imageUrl: 'https://example.com/photo.jpg',
+      audienceType: AudienceType.all,
+      createdAt: createdAt ?? DateTime(2026, 4, 4),
+    );
+
+void main() {
+  // The test font renders much wider than Nunito (Figma measures the activity
+  // pill at ~255px). Use a large physical surface so photoSize is wide enough
+  // to avoid a font-driven overflow that never happens in the real app, and
+  // scroll vertically like the real feed (SliverList) / home (scroll view).
+  Future<void> pump(WidgetTester tester, Post post) async {
+    tester.view.physicalSize = const Size(900, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(child: OwnPostCard(post: post)),
+        ),
+      ),
+    );
+  }
+
+  group('OwnPostCard footer', () {
+    testWidgets('renders author label with "d thg M" date', (tester) async {
+      await pump(tester, _post());
+      // Text.rich → matched as combined plain text.
+      expect(find.textContaining('Bạn'), findsWidgets);
+      expect(find.textContaining('4 thg 4'), findsWidgets);
+    });
+
+    testWidgets('renders activity pill with sparkles icon', (tester) async {
+      await pump(tester, _post());
+      expect(find.text('Chưa có hoạt động nào!'), findsOneWidget);
+      expect(find.byIcon(Icons.auto_awesome_outlined), findsOneWidget);
+    });
+
+    testWidgets('footer column is center-aligned', (tester) async {
+      await pump(tester, _post());
+      // The footer Column is the nearest Column ancestor of the activity text;
+      // PostCard's outer Column is start-aligned and must not be matched here.
+      final column = tester.widget<Column>(
+        find
+            .ancestor(
+              of: find.text('Chưa có hoạt động nào!'),
+              matching: find.byType(Column),
+            )
+            .first,
+      );
+      expect(column.crossAxisAlignment, CrossAxisAlignment.center);
+    });
+  });
+}

--- a/apps/mobile/test/shared/widgets/app_note_pill_test.dart
+++ b/apps/mobile/test/shared/widgets/app_note_pill_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meep/core/theme/app_proportions.dart';
+import 'package:meep/shared/widgets/app_note_pill.dart';
+
+void main() {
+  // Phone-sized surface so pillWidth resolves to the Figma ~200px target.
+  Widget wrap(Widget w) => MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(size: Size(412, 917)),
+          child: Scaffold(body: Center(child: w)),
+        ),
+      );
+
+  group('AppNotePill', () {
+    testWidgets('editable text field is center-aligned', (tester) async {
+      await tester.pumpWidget(wrap(const AppNotePill(text: '')));
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.textAlign, TextAlign.center);
+    });
+
+    testWidgets('pill has fixed width from proportions', (tester) async {
+      await tester.pumpWidget(wrap(const AppNotePill(text: '')));
+      final size = tester.getSize(
+        find
+            .descendant(
+              of: find.byType(AppNotePill),
+              matching: find.byType(Container),
+            )
+            .first,
+      );
+      expect(size.width, closeTo(AppProportions.pillWidth(412), 0.5));
+    });
+
+    testWidgets('width is independent of text length', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const AppNotePill(text: 'A very long caption that would overflow'),
+        ),
+      );
+      final size = tester.getSize(
+        find
+            .descendant(
+              of: find.byType(AppNotePill),
+              matching: find.byType(Container),
+            )
+            .first,
+      );
+      expect(size.width, closeTo(AppProportions.pillWidth(412), 0.5));
+    });
+  });
+}

--- a/apps/mobile/test/shared/widgets/post_card_test.dart
+++ b/apps/mobile/test/shared/widgets/post_card_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/shared/widgets/app_note_pill.dart';
+import 'package:meep/shared/widgets/post_card.dart';
+
+Post _post({String? caption}) => Post(
+      postId: 'p1',
+      authorId: 'uid1',
+      authorName: 'Test User',
+      imageUrl: 'https://example.com/photo.jpg',
+      caption: caption,
+      audienceType: AudienceType.all,
+      createdAt: DateTime(2026, 5, 31),
+    );
+
+void main() {
+  // Phone-sized surface so photoSize ≥ pill width (no overlay overflow).
+  Widget wrap(Widget w) => MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(size: Size(412, 917)),
+          child: Scaffold(body: w),
+        ),
+      );
+
+  group('PostCard caption overlay', () {
+    testWidgets('hides note pill when caption is null', (tester) async {
+      await tester.pumpWidget(wrap(PostCard(post: _post())));
+      expect(find.byType(AppNotePill), findsNothing);
+    });
+
+    testWidgets('hides note pill when caption is empty', (tester) async {
+      await tester.pumpWidget(wrap(PostCard(post: _post(caption: ''))));
+      expect(find.byType(AppNotePill), findsNothing);
+    });
+
+    testWidgets('hides note pill when caption is whitespace only',
+        (tester) async {
+      await tester.pumpWidget(wrap(PostCard(post: _post(caption: '   '))));
+      expect(find.byType(AppNotePill), findsNothing);
+    });
+
+    testWidgets('shows note pill when caption has text', (tester) async {
+      await tester.pumpWidget(wrap(PostCard(post: _post(caption: 'Hi'))));
+      expect(find.byType(AppNotePill), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Tóm tắt

Round fix UX cho luồng feed capture/preview, kèm fix bug submit ảnh
permission-denied. Gom 4 commit nhỏ vào 1 PR vì cùng đụng feed
capture/preview surface.

Refs #96 

## Thay đổi

### UI — feed capture & preview
- **Own post view**: footer căn giữa theo bề ngang ảnh, nhãn đổi
  thành "Bạn d thg M", activity pill khớp Figma (radius 40, nền
  trong suốt, sparkles 18px).
- **Caption rỗng/whitespace** không render nữa: [post_card.dart](apps/mobile/lib/shared/widgets/post_card.dart)
  kiểm tra `trim()`, và `submit()` lưu `caption: null` thay vì chuỗi
  rỗng → không hiện pill rỗng ở feed.
- **Note pill** ở preview: width cố định ~200px (50% frame), chữ
  căn giữa khi nhập.
- **Action bar**: nút chính (capture/send) 79→92px, nút phụ
  (album/flip/close/sparkles) 36→44px — dễ bấm hơn, vẫn vừa bề
  ngang 412.
- **Camera view** (home + preview): thêm Spacer trên cân với Spacer
  dưới dots → cụm (ảnh + dots) nằm giữa thay vì dính sát top bar.

### Router
- Wire route `/capture-preview` tới [CapturePreviewScreen](apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart),
  thay builder tạm (HomeScreen). Nhận `CapturePreviewArgs` qua
  `state.extra`.

### Fix bug submit ảnh thất bại (root cause)

Sau khi đổi caption rỗng → null (commit trước), `Post.toJson()` vẫn
serialize `caption: null` vào Firestore. Rule `/posts/{postId}` check
`caption is string` → null không phải string → **permission-denied**.

- [firebase_post_repository.dart](apps/mobile/lib/features/feed/data/firebase_post_repository.dart):
  `createPost` `removeWhere` null fields trước `ref.set()`. Áp dụng cho
  `caption`, `backImageUrl/frontImageUrl`, `captionType`, `spaceId`,
  `authorAvatarUrl` — mọi field nullable.
- [post_controller.dart](apps/mobile/lib/features/feed/application/post_controller.dart):
  - Tách try/catch thành 2 bước (upload Storage / create Firestore)
    để biết chính xác bước nào fail.
  - `debugPrint` chi tiết exception (type, FirebaseException.code,
    msg, stack) — thay `catch(_)` nuốt im lặng.
  - Map `FirebaseException.code` → message UI rõ ràng:
    `permission-denied`, `unauthenticated`, `unavailable`,
    `resource-exhausted`.

## Test bổ sung

- `app_proportions_test.dart` (5) — pillFontSize, button sizes
- `app_note_pill_test.dart` (3) — width cố định, text center
- `post_card_test.dart` (4) — caption rỗng/whitespace không render
- `own_post_card_test.dart` (3) — footer căn giữa, nhãn ngày
- `capture_action_bar_test.dart` (4) — button sizes 92/44
- `firebase_post_repository_test.dart` (+2) — createPost không lưu
  null fields, giữ caption khi có nội dung

> `fake_cloud_firestore` không enforce rule → không bắt được bug
> permission-denied. Test kiểm tra payload trực tiếp để bù.

## Test plan

- [ ] `flutter analyze` clean
- [ ] `flutter test` pass
- [ ] Manual Android: capture → preview → submit ảnh **có caption** → feed hiển thị đúng
- [ ] Manual Android: capture → preview → submit ảnh **không caption** → không hiện pill rỗng
- [ ] Manual Android: xem own post → footer căn giữa, nhãn ngày đúng
- [ ] Manual Android: bấm các nút capture/album/flip/close → đủ vùng chạm

## Files changed

15 files (+485 / -51), gồm 5 file test mới.