### PR TITLE
feat(space): T1+T2 — FirebaseSpaceRepository + SpaceController (#133)

### DIFF
--- a/apps/mobile/lib/features/chat/presentation/group_chat_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/group_chat_screen.dart
@@ -108,7 +108,8 @@ class GroupChatScreen extends ConsumerWidget {
       case GroupMenuAction.leaveSpace:
         final confirmed = await showLeaveSpaceDialog(context);
         if (confirmed) {
-          // TODO(C/wire): ref.read(spaceControllerProvider.notifier).leaveSpace(spaceId)
+          // TODO(C/wire): ref.read(spaceControllerProvider(uid).notifier).leaveSpace(spaceId)
+          //   — controller giờ là family, đọc uid từ currentUidProvider trước khi gọi.
         }
     }
   }

--- a/apps/mobile/lib/features/space/application/space_controller.dart
+++ b/apps/mobile/lib/features/space/application/space_controller.dart
@@ -1,7 +1,11 @@
-import 'package:freezed_annotation/freezed_annotation.dart';
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/space/data/space.dart';
 import 'package:meep/features/space/data/space_repository.dart';
 
@@ -13,43 +17,195 @@ class SpaceState with _$SpaceState {
   const factory SpaceState({
     @Default([]) List<Space> spaces,
     @Default(false) bool isLoading,
+    String? errorMessage,
   }) = _SpaceState;
 }
 
 @Riverpod(keepAlive: true)
 SpaceRepository spaceRepository(Ref ref) => throw UnimplementedError(
       'spaceRepositoryProvider must be overridden — '
-      'wire FirestoreSpaceRepository in main.dart (TODO: SP/T1/TBD)',
+      'wire FirebaseSpaceRepository in main.dart',
     );
 
+/// Family controller — instance per uid. Sheet/screen lấy uid từ
+/// [currentUidProvider] trước khi watch để đảm bảo signed-in.
 @riverpod
 class SpaceController extends _$SpaceController {
-  @override
-  SpaceState build() => const SpaceState();
+  StreamSubscription<List<Space>>? _spacesSub;
 
+  // Self-healing retry timer. Firestore snapshot streams terminate
+  // permanently on error (e.g. permission-denied during rules-deploy window).
+  // Without re-subscribing, the list stays broken for the whole app session
+  // và server-side fixes không surface đến khi full restart. Timer re-listen
+  // sau backoff để UI tự khôi phục.
+  Timer? _spacesRetry;
+  bool _disposed = false;
+
+  // Per-stream error flag. Chỉ clear errorMessage on recovery (error→success),
+  // không clear trên emission bình thường — tránh emission đầu tiên wipe error
+  // set bởi mutation (createSpace, leaveSpace, ...).
+  bool _spacesHadError = false;
+
+  static const _retryDelay = Duration(seconds: 3);
+
+  @override
+  SpaceState build(String uid) {
+    ref.onDispose(() {
+      _disposed = true;
+      _spacesSub?.cancel();
+      _spacesRetry?.cancel();
+    });
+    _listenSpaces(uid);
+    return const SpaceState();
+  }
+
+  void _listenSpaces(String uid) {
+    if (_disposed) return;
+    _spacesSub?.cancel();
+    _spacesSub = ref.read(spaceRepositoryProvider).watchMySpaces(uid).listen(
+      (spaces) {
+        final clearError = _spacesHadError;
+        _spacesHadError = false;
+        state = clearError
+            ? state.copyWith(spaces: spaces, errorMessage: null)
+            : state.copyWith(spaces: spaces);
+      },
+      onError: (Object _) {
+        _spacesHadError = true;
+        state = state.copyWith(
+          errorMessage: 'Không thể tải danh sách Space. Thử lại sau.',
+        );
+        _spacesRetry?.cancel();
+        _spacesRetry = Timer(_retryDelay, () => _listenSpaces(uid));
+      },
+    );
+  }
+
+  Space? _findSpace(String spaceId) {
+    for (final s in state.spaces) {
+      if (s.spaceId == spaceId) return s;
+    }
+    return null;
+  }
+
+  /// Validate + delegate `createSpace` CF. Server enforces server-side
+  /// invariants (member-count, creator-only, etc.) — client guards là
+  /// fail-fast UX, không phải security boundary.
   Future<void> createSpace({
     required String name,
     required String iconEmoji,
     required String colorHex,
-    // friendUids: list of friend uids to invite (max 9 — creator is auto-added, total ≤ 10)
     required List<String> friendUids,
   }) async {
-    // TODO(SP/T2/TBD): call createSpace CF
-    throw UnimplementedError('createSpace — TODO: SP/T2/TBD');
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) {
+      state = state.copyWith(errorMessage: 'Tên Space không được trống');
+      return;
+    }
+    if (trimmed.length > 30) {
+      state = state.copyWith(errorMessage: 'Tên Space tối đa 30 ký tự');
+      return;
+    }
+    if (friendUids.length > 9) {
+      state = state.copyWith(
+        errorMessage: 'Space tối đa 10 người (bao gồm bạn)',
+      );
+      return;
+    }
+
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      await ref.read(spaceRepositoryProvider).createSpace(
+            name: trimmed,
+            iconEmoji: iconEmoji,
+            colorHex: colorHex,
+            friendUids: friendUids,
+          );
+      state = state.copyWith(isLoading: false);
+    } catch (e) {
+      final err = AppError.fromUnknown(e, fallback: 'Không thể tạo Space');
+      state = state.copyWith(isLoading: false, errorMessage: err.message);
+    }
   }
 
   Future<void> leaveSpace(String spaceId) async {
-    // TODO(SP/T3/TBD): call leaveSpace CF
-    throw UnimplementedError('leaveSpace — TODO: SP/T3/TBD');
+    final currentUid = ref.read(currentUidProvider).valueOrNull;
+    if (currentUid == null) {
+      state = state.copyWith(errorMessage: 'Chưa đăng nhập');
+      return;
+    }
+
+    final space = _findSpace(spaceId);
+    if (space != null && space.creatorId == currentUid) {
+      state = state.copyWith(
+        errorMessage: 'Chọn người quản trị mới trước khi rời Space',
+      );
+      return;
+    }
+
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      await ref.read(spaceRepositoryProvider).leaveSpace(spaceId);
+      state = state.copyWith(isLoading: false);
+    } catch (e) {
+      final err = AppError.fromUnknown(e, fallback: 'Không thể rời Space');
+      state = state.copyWith(isLoading: false, errorMessage: err.message);
+    }
+  }
+
+  Future<void> deleteSpace(String spaceId) async {
+    final currentUid = ref.read(currentUidProvider).valueOrNull;
+    if (currentUid == null) {
+      state = state.copyWith(errorMessage: 'Chưa đăng nhập');
+      return;
+    }
+
+    final space = _findSpace(spaceId);
+    if (space != null && space.creatorId != currentUid) {
+      state = state.copyWith(
+        errorMessage: 'Chỉ creator mới có quyền xoá Space',
+      );
+      return;
+    }
+
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      await ref.read(spaceRepositoryProvider).deleteSpace(spaceId);
+      state = state.copyWith(isLoading: false);
+    } catch (e) {
+      final err = AppError.fromUnknown(e, fallback: 'Không thể xoá Space');
+      state = state.copyWith(isLoading: false, errorMessage: err.message);
+    }
   }
 
   Future<void> kickMember(String spaceId, String targetUid) async {
-    // TODO(SP/T4/TBD): call kickMember CF
-    throw UnimplementedError('kickMember — TODO: SP/T4/TBD');
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      await ref.read(spaceRepositoryProvider).kickMember(
+            spaceId: spaceId,
+            targetUid: targetUid,
+          );
+      state = state.copyWith(isLoading: false);
+    } catch (e) {
+      final err = AppError.fromUnknown(e, fallback: 'Không thể xoá thành viên');
+      state = state.copyWith(isLoading: false, errorMessage: err.message);
+    }
   }
 
   Future<void> transferOwnership(String spaceId, String newCreatorUid) async {
-    // TODO(SP/T5/TBD): call transferOwnership CF
-    throw UnimplementedError('transferOwnership — TODO: SP/T5/TBD');
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      await ref.read(spaceRepositoryProvider).transferOwnership(
+            spaceId: spaceId,
+            newCreatorUid: newCreatorUid,
+          );
+      state = state.copyWith(isLoading: false);
+    } catch (e) {
+      final err = AppError.fromUnknown(
+        e,
+        fallback: 'Không thể chuyển quyền quản trị',
+      );
+      state = state.copyWith(isLoading: false, errorMessage: err.message);
+    }
   }
 }

--- a/apps/mobile/lib/features/space/data/firebase_space_repository.dart
+++ b/apps/mobile/lib/features/space/data/firebase_space_repository.dart
@@ -17,9 +17,13 @@ class FirebaseSpaceRepository implements SpaceRepository {
 
   @override
   Stream<List<Space>> watchMySpaces(String uid) {
+    // orderBy createdAt desc — Space mới nhất lên đầu để Space list trong
+    // Profile/Camera context sheet có thứ tự ổn định (không bị Firestore
+    // default insertion order khiến UI nhảy).
     return _firestore
         .collection(_spacesCollection)
         .where('memberIds', arrayContains: uid)
+        .orderBy('createdAt', descending: true)
         .snapshots()
         .map((snapshot) {
       return snapshot.docs

--- a/apps/mobile/lib/features/space/data/firebase_space_repository.dart
+++ b/apps/mobile/lib/features/space/data/firebase_space_repository.dart
@@ -1,0 +1,163 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/space/data/space.dart';
+import 'package:meep/features/space/data/space_repository.dart';
+
+class FirebaseSpaceRepository implements SpaceRepository {
+  FirebaseSpaceRepository(this._firestore, this._functions);
+
+  final FirebaseFirestore _firestore;
+  final FirebaseFunctions _functions;
+
+  static const _spacesCollection = 'spaces';
+
+  // ===== Firestore reads =====
+
+  @override
+  Stream<List<Space>> watchMySpaces(String uid) {
+    return _firestore
+        .collection(_spacesCollection)
+        .where('memberIds', arrayContains: uid)
+        .snapshots()
+        .map((snapshot) {
+      return snapshot.docs
+          .map((doc) => Space.fromJson({...doc.data(), 'spaceId': doc.id}))
+          .where((space) => space.deletedAt == null)
+          .toList();
+    });
+  }
+
+  @override
+  Future<Space?> getSpace(String spaceId) async {
+    final doc =
+        await _firestore.collection(_spacesCollection).doc(spaceId).get();
+    if (!doc.exists) return null;
+
+    final space = Space.fromJson({...doc.data()!, 'spaceId': doc.id});
+    if (space.deletedAt != null) return null;
+    return space;
+  }
+
+  @override
+  Future<void> deleteSpace(String spaceId) async {
+    await _firestore.collection(_spacesCollection).doc(spaceId).update({
+      'deletedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  // ===== Cloud Function mutations =====
+
+  @override
+  Future<String> createSpace({
+    required String name,
+    required String iconEmoji,
+    required String colorHex,
+    required List<String> friendUids,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('createSpace');
+      final result = await callable.call<Map<Object?, Object?>>({
+        'name': name,
+        'iconEmoji': iconEmoji,
+        'colorHex': colorHex,
+        'friendUids': friendUids,
+      });
+      final spaceId = result.data['spaceId'];
+      if (spaceId is! String || spaceId.isEmpty) {
+        throw const UnexpectedError(
+          message: 'CF createSpace không trả về spaceId hợp lệ',
+        );
+      }
+      return spaceId;
+    } on FirebaseFunctionsException catch (e) {
+      throw _mapFunctionsException(e, 'tạo Space');
+    }
+  }
+
+  @override
+  Future<void> leaveSpace(String spaceId) async {
+    try {
+      final callable = _functions.httpsCallable('leaveSpace');
+      await callable.call<void>({'spaceId': spaceId});
+    } on FirebaseFunctionsException catch (e) {
+      throw _mapFunctionsException(e, 'rời Space');
+    }
+  }
+
+  @override
+  Future<void> kickMember({
+    required String spaceId,
+    required String targetUid,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('kickMember');
+      await callable.call<void>({
+        'spaceId': spaceId,
+        'targetUid': targetUid,
+      });
+    } on FirebaseFunctionsException catch (e) {
+      throw _mapFunctionsException(e, 'xoá thành viên');
+    }
+  }
+
+  @override
+  Future<void> transferOwnership({
+    required String spaceId,
+    required String newCreatorUid,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('transferOwnership');
+      await callable.call<void>({
+        'spaceId': spaceId,
+        'newCreatorUid': newCreatorUid,
+      });
+    } on FirebaseFunctionsException catch (e) {
+      throw _mapFunctionsException(e, 'chuyển quyền quản trị');
+    }
+  }
+
+  /// Map [FirebaseFunctionsException] sang [AppError] tương ứng.
+  ///
+  /// [action] là động từ tiếng Việt mô tả thao tác (vd "tạo Space",
+  /// "rời Space") — dùng cho fallback message khi server không trả message.
+  AppError _mapFunctionsException(
+    FirebaseFunctionsException e,
+    String action,
+  ) {
+    final serverMessage = e.message;
+    switch (e.code) {
+      case 'invalid-argument':
+      case 'failed-precondition':
+        return ValidationError(
+          message: serverMessage ?? 'Không thể $action: dữ liệu không hợp lệ',
+          code: e.code,
+          cause: e,
+        );
+      case 'permission-denied':
+        return ForbiddenError(action);
+      case 'not-found':
+        return NotFoundError(serverMessage ?? action);
+      case 'unauthenticated':
+        return UnauthenticatedError(
+          message: serverMessage ?? 'Cần đăng nhập để $action',
+          code: e.code,
+          cause: e,
+        );
+      case 'unavailable':
+      case 'deadline-exceeded':
+        return NetworkError(
+          message: serverMessage ?? 'Mất kết nối khi $action. Thử lại sau.',
+          code: e.code,
+          cause: e,
+        );
+      default:
+        return UnexpectedError(
+          message: serverMessage ?? 'Không thể $action. Thử lại sau.',
+          code: e.code,
+          cause: e,
+        );
+    }
+  }
+}

--- a/apps/mobile/lib/features/space/data/space_repository.dart
+++ b/apps/mobile/lib/features/space/data/space_repository.dart
@@ -1,12 +1,57 @@
 import 'package:meep/features/space/data/space.dart';
 
+/// Single source of truth cho mọi Space data ops — Firestore reads + CF mutations.
+///
+/// **Option A (#133):** repository wrap `httpsCallable` cho 4 CF mutations
+/// (`createSpace`, `leaveSpace`, `kickMember`, `transferOwnership`), parallel
+/// với [FriendRequestRepository.acceptFriendRequest]. Controller chỉ depend
+/// abstract này — KHÔNG inject [FirebaseFunctions] trực tiếp.
 abstract class SpaceRepository {
+  // ===== Firestore reads =====
+
   /// Stream of spaces where [uid] is a member (includes creator).
+  /// Filters out soft-deleted spaces (`deletedAt != null`).
   Stream<List<Space>> watchMySpaces(String uid);
 
-  /// Get a single Space by ID.
+  /// Get a single Space by ID. Returns null if not found or soft-deleted.
   Future<Space?> getSpace(String spaceId);
 
-  /// Soft-delete a Space — sets deletedAt. Creator only.
+  /// Soft-delete a Space — sets `deletedAt = serverTimestamp()`. Creator only
+  /// (Firestore rule enforces). Client-side guard cũng check creator ở
+  /// controller layer để fail-fast trước khi gọi Firestore.
   Future<void> deleteSpace(String spaceId);
+
+  // ===== Cloud Function mutations (httpsCallable wrappers) =====
+
+  /// Calls CF `createSpace` (region `asia-southeast1`).
+  ///
+  /// Server tạo `/spaces/{spaceId}` + `/space_members/{spaceId}/members/*` +
+  /// `/conversations/{spaceId}` (group chat). Returns server-generated
+  /// `spaceId`.
+  ///
+  /// Throws [AppError] on CF error: [ValidationError] (`name` rỗng /
+  /// `friendUids` > 9), [NetworkError] (offline), [UnexpectedError] (other).
+  Future<String> createSpace({
+    required String name,
+    required String iconEmoji,
+    required String colorHex,
+    required List<String> friendUids,
+  });
+
+  /// Calls CF `leaveSpace`. Server enforces creator phải `transferOwnership`
+  /// trước khi leave — throw [ValidationError] nếu vi phạm.
+  Future<void> leaveSpace(String spaceId);
+
+  /// Calls CF `kickMember`. Creator-only (server-enforced).
+  Future<void> kickMember({
+    required String spaceId,
+    required String targetUid,
+  });
+
+  /// Calls CF `transferOwnership`. Creator-only + target phải là member
+  /// (server-enforced).
+  Future<void> transferOwnership({
+    required String spaceId,
+    required String newCreatorUid,
+  });
 }

--- a/apps/mobile/lib/features/space/presentation/space_create_sheet.dart
+++ b/apps/mobile/lib/features/space/presentation/space_create_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/features/space/presentation/widgets/friend_select_step.dart';
 import 'package:meep/features/space/presentation/widgets/icon_builder_step.dart';
@@ -106,9 +107,16 @@ class _SpaceCreateSheetState extends ConsumerState<SpaceCreateSheet> {
 
   Future<void> _createSpace() async {
     if (_isCreating) return;
+    final uid = ref.read(currentUidProvider).valueOrNull;
+    if (uid == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Chưa đăng nhập')),
+      );
+      return;
+    }
     setState(() => _isCreating = true);
     try {
-      await ref.read(spaceControllerProvider.notifier).createSpace(
+      await ref.read(spaceControllerProvider(uid).notifier).createSpace(
             name: _spaceName.trim(),
             iconEmoji: _iconEmoji,
             colorHex: _colorHex,

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -22,6 +22,8 @@ import 'package:meep/features/chat/data/fake_conversation_repository.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/firebase_friend_repository.dart';
 import 'package:meep/features/friend/data/firebase_friend_request_repository.dart';
+import 'package:meep/features/space/application/space_controller.dart';
+import 'package:meep/features/space/data/firebase_space_repository.dart';
 import 'package:meep/firebase_options.dart';
 
 // Pass --dart-define=USE_EMULATOR=true khi dev local để trỏ vào Firebase Emulator Suite.
@@ -62,6 +64,12 @@ void main() async {
         ),
         friendRequestRepositoryProvider.overrideWithValue(
           FirebaseFriendRequestRepository(
+            FirebaseFirestore.instance,
+            FirebaseFunctions.instanceFor(region: 'asia-southeast1'),
+          ),
+        ),
+        spaceRepositoryProvider.overrideWithValue(
+          FirebaseSpaceRepository(
             FirebaseFirestore.instance,
             FirebaseFunctions.instanceFor(region: 'asia-southeast1'),
           ),

--- a/apps/mobile/test/features/space/firebase_space_repository_test.dart
+++ b/apps/mobile/test/features/space/firebase_space_repository_test.dart
@@ -1,0 +1,213 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/features/space/data/firebase_space_repository.dart';
+import 'package:meep/features/space/data/space.dart';
+
+class MockFirebaseFunctions extends Mock implements FirebaseFunctions {}
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late MockFirebaseFunctions functions;
+  late FirebaseSpaceRepository repository;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    functions = MockFirebaseFunctions();
+    repository = FirebaseSpaceRepository(firestore, functions);
+  });
+
+  Map<String, dynamic> spaceDoc({
+    required String spaceId,
+    required String name,
+    required String creatorId,
+    required List<String> memberIds,
+    String iconEmoji = '👥',
+    String colorHex = '#00DEEE',
+    DateTime? createdAt,
+    DateTime? deletedAt,
+  }) {
+    return {
+      'spaceId': spaceId,
+      'name': name,
+      'iconEmoji': iconEmoji,
+      'colorHex': colorHex,
+      'creatorId': creatorId,
+      'memberCount': memberIds.length,
+      'memberIds': memberIds,
+      'createdAt': Timestamp.fromDate(createdAt ?? DateTime(2026, 6, 1)),
+      if (deletedAt != null) 'deletedAt': Timestamp.fromDate(deletedAt),
+    };
+  }
+
+  group('watchMySpaces', () {
+    test('streams spaces where uid in memberIds', () async {
+      const uid = 'user1';
+      await firestore.collection('spaces').doc('s1').set(
+            spaceDoc(
+              spaceId: 's1',
+              name: 'Family',
+              creatorId: uid,
+              memberIds: [uid, 'user2'],
+            ),
+          );
+      await firestore.collection('spaces').doc('s2').set(
+            spaceDoc(
+              spaceId: 's2',
+              name: 'Friends',
+              creatorId: 'user3',
+              memberIds: ['user3', uid],
+            ),
+          );
+
+      final stream = repository.watchMySpaces(uid);
+
+      await expectLater(
+        stream,
+        emits(
+          predicate<List<Space>>((list) {
+            final ids = list.map((s) => s.spaceId).toSet();
+            return list.length == 2 && ids.containsAll(['s1', 's2']);
+          }),
+        ),
+      );
+    });
+
+    test('excludes spaces where uid is not a member', () async {
+      const uid = 'user1';
+      await firestore.collection('spaces').doc('s1').set(
+            spaceDoc(
+              spaceId: 's1',
+              name: 'Other group',
+              creatorId: 'user2',
+              memberIds: ['user2', 'user3'],
+            ),
+          );
+
+      final stream = repository.watchMySpaces(uid);
+
+      await expectLater(stream, emits(isEmpty));
+    });
+
+    test('filters out soft-deleted spaces', () async {
+      const uid = 'user1';
+      await firestore.collection('spaces').doc('s1').set(
+            spaceDoc(
+              spaceId: 's1',
+              name: 'Active',
+              creatorId: uid,
+              memberIds: [uid],
+            ),
+          );
+      await firestore.collection('spaces').doc('s2').set(
+            spaceDoc(
+              spaceId: 's2',
+              name: 'Deleted',
+              creatorId: uid,
+              memberIds: [uid],
+              deletedAt: DateTime(2026, 5, 30),
+            ),
+          );
+
+      final stream = repository.watchMySpaces(uid);
+
+      await expectLater(
+        stream,
+        emits(
+          predicate<List<Space>>((list) {
+            return list.length == 1 && list.first.spaceId == 's1';
+          }),
+        ),
+      );
+    });
+
+    test('returns empty list when no spaces', () async {
+      final stream = repository.watchMySpaces('user1');
+
+      await expectLater(stream, emits(isEmpty));
+    });
+  });
+
+  group('getSpace', () {
+    test('returns Space when doc exists', () async {
+      await firestore.collection('spaces').doc('s1').set(
+            spaceDoc(
+              spaceId: 's1',
+              name: 'Family',
+              creatorId: 'user1',
+              memberIds: ['user1', 'user2'],
+            ),
+          );
+
+      final result = await repository.getSpace('s1');
+
+      expect(result, isNotNull);
+      expect(result!.spaceId, 's1');
+      expect(result.name, 'Family');
+      expect(result.memberIds, ['user1', 'user2']);
+    });
+
+    test('returns null when doc not found', () async {
+      final result = await repository.getSpace('nonexistent');
+
+      expect(result, isNull);
+    });
+
+    test('returns null when doc soft-deleted', () async {
+      await firestore.collection('spaces').doc('s1').set(
+            spaceDoc(
+              spaceId: 's1',
+              name: 'Deleted',
+              creatorId: 'user1',
+              memberIds: ['user1'],
+              deletedAt: DateTime(2026, 5, 30),
+            ),
+          );
+
+      final result = await repository.getSpace('s1');
+
+      expect(result, isNull);
+    });
+  });
+
+  group('deleteSpace', () {
+    test('sets deletedAt field (soft delete)', () async {
+      await firestore.collection('spaces').doc('s1').set(
+            spaceDoc(
+              spaceId: 's1',
+              name: 'Family',
+              creatorId: 'user1',
+              memberIds: ['user1'],
+            ),
+          );
+
+      await repository.deleteSpace('s1');
+
+      final doc = await firestore.collection('spaces').doc('s1').get();
+      expect(doc.exists, isTrue);
+      expect(doc.data()!['deletedAt'], isNotNull);
+    });
+
+    test('keeps document existing (not hard delete)', () async {
+      await firestore.collection('spaces').doc('s1').set(
+            spaceDoc(
+              spaceId: 's1',
+              name: 'Family',
+              creatorId: 'user1',
+              memberIds: ['user1'],
+            ),
+          );
+
+      await repository.deleteSpace('s1');
+
+      final doc = await firestore.collection('spaces').doc('s1').get();
+      expect(doc.exists, isTrue);
+      // Other fields preserved
+      expect(doc.data()!['name'], 'Family');
+      expect(doc.data()!['creatorId'], 'user1');
+    });
+  });
+}

--- a/apps/mobile/test/features/space/space_controller_test.dart
+++ b/apps/mobile/test/features/space/space_controller_test.dart
@@ -1,0 +1,439 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/space/application/space_controller.dart';
+import 'package:meep/features/space/data/space.dart';
+import 'package:meep/features/space/data/space_repository.dart';
+
+class MockSpaceRepository extends Mock implements SpaceRepository {}
+
+Space _spaceFixture({
+  required String spaceId,
+  required String creatorId,
+  List<String>? memberIds,
+  String name = 'Space',
+}) {
+  return Space(
+    spaceId: spaceId,
+    name: name,
+    iconEmoji: '👥',
+    colorHex: '#00DEEE',
+    creatorId: creatorId,
+    memberCount: memberIds?.length ?? 1,
+    memberIds: memberIds ?? [creatorId],
+    createdAt: DateTime(2026, 6, 1),
+  );
+}
+
+ProviderContainer _makeContainer({
+  required SpaceRepository repo,
+  String? currentUid,
+}) {
+  return ProviderContainer(
+    overrides: [
+      spaceRepositoryProvider.overrideWithValue(repo),
+      currentUidProvider.overrideWith(
+        (ref) => Stream.value(currentUid),
+      ),
+    ],
+  );
+}
+
+void main() {
+  late MockSpaceRepository repo;
+
+  setUp(() {
+    repo = MockSpaceRepository();
+    // Default stream: empty list, no error
+    when(() => repo.watchMySpaces(any())).thenAnswer(
+      (_) => Stream.value(<Space>[]),
+    );
+  });
+
+  group('build(uid) — stream subscription', () {
+    test('subscribes watchMySpaces and updates state.spaces', () async {
+      final spaces = [
+        _spaceFixture(spaceId: 's1', creatorId: 'user1', name: 'Family'),
+      ];
+      when(() => repo.watchMySpaces('user1')).thenAnswer(
+        (_) => Stream.value(spaces),
+      );
+
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      // Wait for stream emit
+      await Future<void>.delayed(Duration.zero);
+
+      final state = container.read(spaceControllerProvider('user1'));
+      expect(state.spaces, hasLength(1));
+      expect(state.spaces.first.spaceId, 's1');
+      expect(state.errorMessage, isNull);
+    });
+
+    test('sets errorMessage when stream errors', () async {
+      when(() => repo.watchMySpaces('user1')).thenAnswer(
+        (_) => Stream.error(Exception('permission-denied')),
+      );
+
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await Future<void>.delayed(Duration.zero);
+
+      final state = container.read(spaceControllerProvider('user1'));
+      expect(state.errorMessage, contains('Không thể tải danh sách Space'));
+    });
+  });
+
+  group('createSpace — client-side validation', () {
+    test('sets errorMessage when name is empty (trimmed)', () async {
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .createSpace(
+        name: '   ',
+        iconEmoji: '👥',
+        colorHex: '#00DEEE',
+        friendUids: ['friend1'],
+      );
+
+      expect(
+        container.read(spaceControllerProvider('user1')).errorMessage,
+        'Tên Space không được trống',
+      );
+      verifyNever(
+        () => repo.createSpace(
+          name: any(named: 'name'),
+          iconEmoji: any(named: 'iconEmoji'),
+          colorHex: any(named: 'colorHex'),
+          friendUids: any(named: 'friendUids'),
+        ),
+      );
+    });
+
+    test('sets errorMessage when name exceeds 30 chars', () async {
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .createSpace(
+        name: 'a' * 31,
+        iconEmoji: '👥',
+        colorHex: '#00DEEE',
+        friendUids: ['friend1'],
+      );
+
+      expect(
+        container.read(spaceControllerProvider('user1')).errorMessage,
+        'Tên Space tối đa 30 ký tự',
+      );
+      verifyNever(
+        () => repo.createSpace(
+          name: any(named: 'name'),
+          iconEmoji: any(named: 'iconEmoji'),
+          colorHex: any(named: 'colorHex'),
+          friendUids: any(named: 'friendUids'),
+        ),
+      );
+    });
+
+    test('sets errorMessage when friendUids exceeds 9', () async {
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .createSpace(
+            name: 'Family',
+            iconEmoji: '👥',
+            colorHex: '#00DEEE',
+            friendUids: List.generate(10, (i) => 'friend$i'),
+          );
+
+      expect(
+        container.read(spaceControllerProvider('user1')).errorMessage,
+        contains('tối đa 10 người'),
+      );
+      verifyNever(
+        () => repo.createSpace(
+          name: any(named: 'name'),
+          iconEmoji: any(named: 'iconEmoji'),
+          colorHex: any(named: 'colorHex'),
+          friendUids: any(named: 'friendUids'),
+        ),
+      );
+    });
+
+    test('delegates to repository with trimmed name on success', () async {
+      when(
+        () => repo.createSpace(
+          name: any(named: 'name'),
+          iconEmoji: any(named: 'iconEmoji'),
+          colorHex: any(named: 'colorHex'),
+          friendUids: any(named: 'friendUids'),
+        ),
+      ).thenAnswer((_) async => 'new-space-id');
+
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .createSpace(
+        name: '  Family  ',
+        iconEmoji: '👨‍👩‍👧‍👦',
+        colorHex: '#BFD5FF',
+        friendUids: ['friend1', 'friend2'],
+      );
+
+      verify(
+        () => repo.createSpace(
+          name: 'Family',
+          iconEmoji: '👨‍👩‍👧‍👦',
+          colorHex: '#BFD5FF',
+          friendUids: ['friend1', 'friend2'],
+        ),
+      ).called(1);
+      final state = container.read(spaceControllerProvider('user1'));
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('sets errorMessage when repo throws AppError', () async {
+      when(
+        () => repo.createSpace(
+          name: any(named: 'name'),
+          iconEmoji: any(named: 'iconEmoji'),
+          colorHex: any(named: 'colorHex'),
+          friendUids: any(named: 'friendUids'),
+        ),
+      ).thenThrow(const ValidationError(message: 'Server: friendUids invalid'));
+
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .createSpace(
+        name: 'Family',
+        iconEmoji: '👥',
+        colorHex: '#00DEEE',
+        friendUids: ['friend1'],
+      );
+
+      final state = container.read(spaceControllerProvider('user1'));
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, 'Server: friendUids invalid');
+    });
+  });
+
+  group('leaveSpace — client-side guard', () {
+    test('sets errorMessage when not signed in', () async {
+      final container = _makeContainer(repo: repo, currentUid: null);
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .leaveSpace('s1');
+
+      expect(
+        container.read(spaceControllerProvider('user1')).errorMessage,
+        'Chưa đăng nhập',
+      );
+      verifyNever(() => repo.leaveSpace(any()));
+    });
+
+    test('blocks when current user is creator', () async {
+      when(() => repo.watchMySpaces('user1')).thenAnswer(
+        (_) => Stream.value([
+          _spaceFixture(spaceId: 's1', creatorId: 'user1'),
+        ]),
+      );
+
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+      container.listen(currentUidProvider, (_, __) {});
+      await container.read(currentUidProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .leaveSpace('s1');
+
+      expect(
+        container.read(spaceControllerProvider('user1')).errorMessage,
+        contains('Chọn người quản trị mới'),
+      );
+      verifyNever(() => repo.leaveSpace(any()));
+    });
+
+    test('delegates to repo when current user is non-creator', () async {
+      when(() => repo.watchMySpaces('user2')).thenAnswer(
+        (_) => Stream.value([
+          _spaceFixture(
+            spaceId: 's1',
+            creatorId: 'user1',
+            memberIds: ['user1', 'user2'],
+          ),
+        ]),
+      );
+      when(() => repo.leaveSpace(any())).thenAnswer((_) async {});
+
+      final container = _makeContainer(repo: repo, currentUid: 'user2');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user2'), (_, __) {});
+      container.listen(currentUidProvider, (_, __) {});
+      await container.read(currentUidProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      await container
+          .read(spaceControllerProvider('user2').notifier)
+          .leaveSpace('s1');
+
+      verify(() => repo.leaveSpace('s1')).called(1);
+      expect(
+        container.read(spaceControllerProvider('user2')).errorMessage,
+        isNull,
+      );
+    });
+  });
+
+  group('deleteSpace — client-side guard', () {
+    test('blocks non-creator with ForbiddenError message', () async {
+      when(() => repo.watchMySpaces('user2')).thenAnswer(
+        (_) => Stream.value([
+          _spaceFixture(
+            spaceId: 's1',
+            creatorId: 'user1',
+            memberIds: ['user1', 'user2'],
+          ),
+        ]),
+      );
+
+      final container = _makeContainer(repo: repo, currentUid: 'user2');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user2'), (_, __) {});
+      container.listen(currentUidProvider, (_, __) {});
+      await container.read(currentUidProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      await container
+          .read(spaceControllerProvider('user2').notifier)
+          .deleteSpace('s1');
+
+      expect(
+        container.read(spaceControllerProvider('user2')).errorMessage,
+        contains('Chỉ creator'),
+      );
+      verifyNever(() => repo.deleteSpace(any()));
+    });
+
+    test('delegates to repo when current user is creator', () async {
+      when(() => repo.watchMySpaces('user1')).thenAnswer(
+        (_) => Stream.value([
+          _spaceFixture(spaceId: 's1', creatorId: 'user1'),
+        ]),
+      );
+      when(() => repo.deleteSpace(any())).thenAnswer((_) async {});
+
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+      container.listen(currentUidProvider, (_, __) {});
+      await container.read(currentUidProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .deleteSpace('s1');
+
+      verify(() => repo.deleteSpace('s1')).called(1);
+    });
+  });
+
+  group('kickMember', () {
+    test('delegates to repo with named args', () async {
+      when(
+        () => repo.kickMember(
+          spaceId: any(named: 'spaceId'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .kickMember('s1', 'user2');
+
+      verify(
+        () => repo.kickMember(spaceId: 's1', targetUid: 'user2'),
+      ).called(1);
+    });
+
+    test('sets errorMessage on repo failure', () async {
+      when(
+        () => repo.kickMember(
+          spaceId: any(named: 'spaceId'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      ).thenThrow(ForbiddenError('xoá thành viên'));
+
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .kickMember('s1', 'user2');
+
+      expect(
+        container.read(spaceControllerProvider('user1')).errorMessage,
+        contains('Not allowed to xoá thành viên'),
+      );
+    });
+  });
+
+  group('transferOwnership', () {
+    test('delegates to repo with named args', () async {
+      when(
+        () => repo.transferOwnership(
+          spaceId: any(named: 'spaceId'),
+          newCreatorUid: any(named: 'newCreatorUid'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final container = _makeContainer(repo: repo, currentUid: 'user1');
+      addTearDown(container.dispose);
+      container.listen(spaceControllerProvider('user1'), (_, __) {});
+
+      await container
+          .read(spaceControllerProvider('user1').notifier)
+          .transferOwnership('s1', 'user2');
+
+      verify(
+        () => repo.transferOwnership(spaceId: 's1', newCreatorUid: 'user2'),
+      ).called(1);
+    });
+  });
+}

--- a/docs/plans/2026-05-23-space.md
+++ b/docs/plans/2026-05-23-space.md
@@ -13,7 +13,7 @@
 |-----------|------|--------|-------------|
 | `lib/features/space/data/space.dart` | freezed model | ✅ merged (LX10) | `spaceId`, `name` (≤30), `iconEmoji`, `colorHex` (hex 7 chars), `creatorId`, `memberCount`, `memberIds List<String>` (≤10), `createdAt`, `deletedAt?` |
 | `lib/features/space/data/space_member.dart` | freezed model | ✅ merged (LX10) | `uid`, `role SpaceRole` (creator/member), `joinedAt` |
-| `lib/features/space/data/space_repository.dart` | abstract class | ✅ merged (LX10) | `watchMySpaces(uid)`, `getSpace(spaceId)`, `deleteSpace(spaceId)` |
+| `lib/features/space/data/space_repository.dart` | abstract class | ✅ merged (LX10) + ⚠️ extend trước T1 | Read-only (LX10): `watchMySpaces(uid)`, `getSpace(spaceId)`, `deleteSpace(spaceId)`. CF mutations (#133 extend — leader gate): `createSpace({name, iconEmoji, colorHex, friendUids})`, `leaveSpace(spaceId)`, `kickMember(spaceId, targetUid)`, `transferOwnership(spaceId, newCreatorUid)`. **Quyết định Option A:** repository wrap `httpsCallable` cho 4 CF, parallel với `FriendRequestRepository.acceptFriendRequest`. Controller delegate, không gọi `FirebaseFunctions` trực tiếp. |
 | `lib/features/space/application/space_controller.dart` | Riverpod stub + gate change | ✅ stub có `friendUids`; ❌ `currentSpaceProvider` chưa thêm | Stub: `SpaceState`, `createSpace({name, iconEmoji, colorHex, friendUids})`, `leaveSpace`, `kickMember`, `transferOwnership`. Gate change (leader): thêm `currentSpaceProvider` (`@Riverpod(keepAlive:true)`, `Space?`) — watch bởi `CameraSection` (KhoaLND) |
 | `lib/features/space/presentation/space_create_sheet.dart` | widget stub | ✅ stub (TODO SP/T6) | 3-step bottom sheet |
 | `lib/features/space/presentation/space_context_bottom_sheet.dart` | widget stub | ✅ stub (TODO SP/T7) | `spaceId` param |
@@ -37,47 +37,69 @@
 ## PART 2 — Tasks
 
 ---
-**T1 · feat(space): FirebaseSpaceRepository — watchMySpaces + getSpace + deleteSpace**
+**T1 · feat(space): FirebaseSpaceRepository — Firestore reads + 4 CF mutations**
 
 | | |
 |---|---|
-| Assignee | TBD |
-| Estimate | S (~4h) |
-| Branch | `feat/TBD/space-repository` |
-| Blocked by | contracts Part 1 |
+| Assignee | ThienPDM |
+| Estimate | M (~6h) |
+| Branch | `feat/ThienPDM/space-data-controller` |
+| Blocked by | contracts Part 1 (LX10) + abstract extend (#133) |
 
 Files:
-- `lib/features/space/data/firebase_space_repository.dart` — impl `SpaceRepository`
+- `lib/features/space/data/firebase_space_repository.dart` — impl `SpaceRepository` (Firestore + Functions)
 - `test/features/space/firebase_space_repository_test.dart`
 
-Acceptance criteria:
+Acceptance criteria — Firestore reads:
 - [ ] `watchMySpaces(uid)` query `/spaces` `.where('memberIds', arrayContains, uid)` filter `deletedAt == null` — 1 query (denormalized memberIds)
-- [ ] `deleteSpace(spaceId)` soft delete: update `deletedAt = serverTimestamp()` — KHÔNG hard delete
+- [ ] `getSpace(spaceId)` đọc 1 doc, return null nếu không tồn tại hoặc đã soft-delete
+- [ ] `deleteSpace(spaceId)` soft delete: update `deletedAt = serverTimestamp()` — KHÔNG hard delete document
+
+Acceptance criteria — CF mutations (wrap `httpsCallable`, region `asia-southeast1`):
+- [ ] `createSpace({name, iconEmoji, colorHex, friendUids})` gọi CF `createSpace` — return `spaceId` (server-generated)
+- [ ] `leaveSpace(spaceId)` gọi CF `leaveSpace` — server enforce "creator phải transfer trước"
+- [ ] `kickMember(spaceId, targetUid)` gọi CF `kickMember` — server enforce creator-only
+- [ ] `transferOwnership(spaceId, newCreatorUid)` gọi CF `transferOwnership` — server enforce creator-only + member-only target
+- [ ] Convert `FirebaseFunctionsException` thành `AppError` ở repository boundary (NotFoundError / ForbiddenError / ValidationError / NetworkError tuỳ `code`)
+
+Acceptance criteria — boundary contract:
 - [ ] Client KHÔNG create `/spaces` trực tiếp (rule `create: if false`) — chỉ CF Admin SDK
+- [ ] Client KHÔNG delete `/space_members/*` trực tiếp (rule `delete: if false`) — chỉ qua CF leaveSpace/kickMember
+- [ ] Repository wrap `httpsCallable` (KHÔNG inject `FirebaseFunctions` vào controller) → consistent với `FirebaseFriendRequestRepository`
 
 Cross-module imports: None
 
 ---
-**T2 · feat(space): SpaceController — createSpace + loadMySpaces + leaveSpace + deleteSpace**
+**T2 · feat(space): SpaceController — state + delegate qua repository**
 
 | | |
 |---|---|
-| Assignee | TBD |
-| Estimate | M (~8h) |
-| Branch | `feat/TBD/space-controller` |
+| Assignee | ThienPDM |
+| Estimate | M (~6h) |
+| Branch | `feat/ThienPDM/space-data-controller` (cùng PR với T1) |
 | Blocked by | T1 |
 
 Files:
 - `lib/features/space/application/space_controller.dart` — `SpaceState`, full impl
 - `test/features/space/space_controller_test.dart`
 
-Acceptance criteria:
-- [ ] `createSpace({name, iconEmoji, colorHex, friendUids})`: validate `name.isNotEmpty`, `friendUids.length ≤ 9` → gọi CF `createSpace`
-- [ ] `leaveSpace(spaceId)`: nếu là creator → throw `AppError("Chọn người quản trị mới trước")`
-- [ ] `deleteSpace(spaceId)`: chỉ creator → soft delete; non-creator → throw `AppError`
-- [ ] `loadMySpaces()` watch stream từ repository, filter soft-deleted
+Acceptance criteria — state stream:
+- [ ] `build(uid)` subscribe `spaceRepository.watchMySpaces(uid)` → cập nhật `state.spaces` + `isLoading=false` sau lần emit đầu
+- [ ] Self-healing retry pattern (parallel với `FriendController._listenFriends`) — re-subscribe sau 3s nếu stream error
+- [ ] `ref.onDispose` cancel `StreamSubscription` + retry `Timer`
 
-Cross-module imports: None
+Acceptance criteria — mutations (client-side validate, delegate qua repository):
+- [ ] `createSpace({name, iconEmoji, colorHex, friendUids})`: validate `name.trim().isNotEmpty` + `name.length ≤ 30` + `friendUids.length ≤ 9` → delegate `spaceRepository.createSpace(...)`. Catch `AppError` → set `errorMessage`
+- [ ] `leaveSpace(spaceId)`: client-side guard `if (currentUid == space.creatorId) throw ValidationError('Chọn người quản trị mới trước khi rời Space')` → delegate `spaceRepository.leaveSpace(spaceId)`
+- [ ] `deleteSpace(spaceId)`: client-side guard `if (currentUid != space.creatorId) throw ForbiddenError('delete space — chỉ creator')` → delegate `spaceRepository.deleteSpace(spaceId)`
+- [ ] `kickMember(spaceId, targetUid)`: delegate `spaceRepository.kickMember(...)` (CF enforce creator-only — không double-check ở client)
+- [ ] `transferOwnership(spaceId, newCreatorUid)`: delegate `spaceRepository.transferOwnership(...)`
+
+Acceptance criteria — boundary contract:
+- [ ] Controller KHÔNG inject `FirebaseFunctions` — chỉ depend `SpaceRepository`
+- [ ] Test mock `SpaceRepository` (không cần mock Functions)
+
+Cross-module imports: `currentUidProvider` từ **auth** — controller cần biết uid để check creator
 
 ---
 **T3 · feat(space): SpaceCreateSheet — 3-step flow (FriendSelect + SpaceConfig + IconBuilder)**

--- a/docs/specs/2026-05-23-space.md
+++ b/docs/specs/2026-05-23-space.md
@@ -241,16 +241,21 @@ spaceId:   string?  — null nếu post "All friends", spaceId nếu post Space
 Presentation               Application                Data
 ────────────────           ──────────────────         ──────────────────────
 SpaceCreateSheet           SpaceController            SpaceRepository
- ├─ FriendSelectStep        ├─ SpaceState              ├─ createSpace()
- ├─ SpaceConfigStep         ├─ createSpace()           ├─ getMySpaces()
- └─ IconBuilderStep         ├─ loadMySpaces()          ├─ addMember()
-SpaceContextBottomSheet     ├─ leaveSpace()  ← gọi CF   ├─ removeMember()  ← CF-internal
- └─ SpaceListTile           └─ deleteSpace()           └─ deleteSpace()
-                                                        > addMember/removeMember: chỉ CFs gọi
-CameraTopBar (reuse)
- └─ SpaceContextBadge      FeedController (reuse)      PostRepository (reuse)
-FeedScreen (reuse)          └─ loadFeed(spaceId?)       └─ createPost(spaceId?)
+ ├─ FriendSelectStep        ├─ SpaceState              │  Firestore reads:
+ ├─ SpaceConfigStep         ├─ createSpace()    ───►   ├─ watchMySpaces(uid)
+ └─ IconBuilderStep         ├─ leaveSpace()     ───►   ├─ getSpace(spaceId)
+SpaceContextBottomSheet     ├─ deleteSpace()    ───►   ├─ deleteSpace(spaceId)
+ └─ SpaceListTile           ├─ kickMember()     ───►   │  CF wrappers (httpsCallable):
+                            └─ transferOwnership() ─►  ├─ createSpace(...)
+CameraTopBar (reuse)                                   ├─ leaveSpace(spaceId)
+ └─ SpaceContextBadge      FeedController (reuse)      ├─ kickMember(spaceId, uid)
+FeedScreen (reuse)          └─ loadFeed(spaceId?)      └─ transferOwnership(spaceId, uid)
+
+                            PostRepository (reuse)
+                            └─ createPost(spaceId?)
 ```
+
+> **Option A (#133):** `SpaceRepository` abstract wrap cả Firestore reads + 4 CF callables (parallel với `FriendRequestRepository`). Controller depend duy nhất `SpaceRepository` — KHÔNG inject `FirebaseFunctions` trực tiếp. Test controller mock 1 repository, không cần fake Functions.
 
 **Reuse:** `FeedScreen` (thêm `spaceId` param), `PostRepository.createPost()`, `FriendsButton` component, `ChatScreen` (group chat).
 
@@ -389,7 +394,7 @@ match /posts/{postId} {
 |---|---|---|
 | `Space` freezed model | `lib/features/space/data/space.dart` | ✅ merged (LX10) |
 | `SpaceMember` freezed model | `lib/features/space/data/space_member.dart` | ✅ merged (LX10) |
-| `SpaceRepository` abstract interface | `lib/features/space/data/space_repository.dart` | ✅ merged (LX10) |
+| `SpaceRepository` abstract interface | `lib/features/space/data/space_repository.dart` | ✅ merged (LX10) + ⚠️ extend (#133) — thêm `createSpace`, `leaveSpace`, `kickMember`, `transferOwnership` wrap `httpsCallable` |
 | `SpaceController` stub + `SpaceState` | `lib/features/space/application/space_controller.dart` | ✅ stub — `friendUids` param đã có |
 | `SpaceCreateSheet` stub | `lib/features/space/presentation/space_create_sheet.dart` | ✅ stub (TODO SP/T6) |
 | `SpaceContextBottomSheet` stub | `lib/features/space/presentation/space_context_bottom_sheet.dart` | ✅ stub (TODO SP/T7, có `spaceId` param) |
@@ -450,3 +455,4 @@ match /posts/{postId} {
 | 2026-05-23 | Tạo spec ban đầu | ThienPDM |
 | 2026-05-27 | Cập nhật luồng tạo Space dựa trên Figma thực tế (5 frames): "Tiếp tục" button color `#39404166`; Step 2 là scrollable preset list; thêm bảng paired preset (iconEmoji + colorHex); Step 3 cơ chế 2 tab buttons + Gợi ý = color suggestions; color picker = preset + shade slider. Out-of-scope cập nhật. `emoji_picker_flutter` ✅ đã có. CF Option A: `onSpacePostCreated` merge vào `onPostCreated` qua helper `spacePostFanOut.ts`. Fix scope wording, data model, unit tests, risks. Contract table cập nhật đúng thực tế (routes ✅ đã wired, stubs ✅ đã có). Thêm `currentSpaceProvider` vào architecture. OQ5 resolved. | ThienPDM |
 | 2026-05-30 | Fix button "Tiếp tục →" color: `#39404180` → `#39404166` (Figma source of truth, alpha 40% thay vì 50%). | ThienPDM |
+| 2026-06-01 | **Option A — extend `SpaceRepository` abstract:** thêm 4 method wrap CF callables (`createSpace`, `leaveSpace`, `kickMember`, `transferOwnership`) — parallel với `FriendRequestRepository` pattern. Controller delegate qua repository, KHÔNG inject `FirebaseFunctions` trực tiếp. Update architecture diagram + contract table + plan T1/T2 acceptance criteria tương ứng. Refs #133. | ThienPDM |

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -25,6 +25,14 @@
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "spaces",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "memberIds", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Mô tả

Implement data + application layer cho Space module — FirebaseSpaceRepository (Firestore reads + 4 CF callable wrappers) + SpaceController (family `String uid`, validate + delegate qua repository). Quyết định Option A: repository wrap `httpsCallable` cho mutations, controller chỉ depend abstract — parallel với pattern `FriendRequestRepository`. Unblock T3 SpaceCreateSheet (đã merge) hoạt động end-to-end khi Space CF (#136) ready.

## Refs

- Closes #133
- Spec: `docs/specs/2026-05-23-space.md`
- Plan: `docs/plans/2026-05-23-space.md`

## Thay đổi chính

**Contract extension (#133):**
- `apps/mobile/lib/features/space/data/space_repository.dart`: abstract +4 method signatures `createSpace` / `leaveSpace` / `kickMember` / `transferOwnership` (Option A — controller delegate qua repo, không inject `FirebaseFunctions`)
- `docs/specs/2026-05-23-space.md`: architecture diagram + contract table + changelog 2026-06-01
- `docs/plans/2026-05-23-space.md`: Part 1 abstract key contents + T1/T2 acceptance criteria (Firestore reads + CF wrappers + boundary contract)

**T1 — FirebaseSpaceRepository:**
- `apps/mobile/lib/features/space/data/firebase_space_repository.dart`: Firestore reads (watchMySpaces với arrayContains + orderBy createdAt DESC + client-side filter deletedAt; getSpace; deleteSpace soft delete serverTimestamp) + 4 CF wrappers (region `asia-southeast1`, error mapping `FirebaseFunctionsException` → `AppError` theo code)
- `firebase/firestore.indexes.json`: composite index `spaces`(memberIds CONTAINS, createdAt DESC) — Firestore không auto-index khi where + orderBy trên field khác nhau

**T2 — SpaceController:**
- `apps/mobile/lib/features/space/application/space_controller.dart`: family `build(String uid)` subscribe stream với self-healing retry 3s. Mutations validate + delegate (createSpace: name/friendUids guard; leaveSpace: creator-block; deleteSpace: non-creator-block)
- `apps/mobile/lib/features/space/presentation/space_create_sheet.dart`: pass uid từ `currentUidProvider` vào `spaceControllerProvider(uid).notifier`
- `apps/mobile/lib/main.dart`: wire `spaceRepositoryProvider` → `FirebaseSpaceRepository(firestore, functions)`
- `apps/mobile/lib/features/chat/presentation/group_chat_screen.dart`: sync TODO comment với family signature mới

**Tests:**
- `apps/mobile/test/features/space/firebase_space_repository_test.dart`: 9 tests (watchMySpaces / getSpace / deleteSpace edge cases — CF wrappers skip ở unit, parallel với friend_request pattern, cover qua controller mock)
- `apps/mobile/test/features/space/space_controller_test.dart`: 15 tests (stream subscribe + error + 5 mutations: validate / guards / delegate / error mapping)

## Loại thay đổi

- [x] feat — Tính năng mới

## Test

- [x] Đã chạy `flutter test test/features/space/` → 41/41 PASS (9 repo + 15 controller + 17 sheet test cũ)
- [x] Đã chạy `flutter analyze` clean (0 warning)
- [x] Đã chạy `dart format --set-exit-if-changed .` PASS
- [ ] (Nếu sửa Functions) `npm test` + `npm run lint` PASS — không sửa
- [ ] (Nếu sửa Firestore rules) Rules tests PASS — không sửa rules (scope T10b+T11 #137)
- [ ] Đã test thủ công trên Android/iOS — chưa, Space CF chưa ready (#136 OPEN)

### Cách test thủ công (khi CF ready)

1. Wire Firebase Emulator (`USE_EMULATOR=true`)
2. Deploy `createSpace` CF lên emulator (#136)
3. Mở SpaceCreateSheet từ Camera long-press FriendsButton (T4 chưa wire — test catalog `widget_catalog_page` thay thế)
4. Tạo Space với name + iconEmoji + colorHex + 1-2 friend
5. Verify: stream `watchMySpaces` emit Space mới → SpaceCreateSheet đóng + Space xuất hiện trong list

## Lưu ý cho reviewer

- **Option A confirmed**: repository wrap CF callables (không tạo `SpaceCallableRepository` riêng). Spec changelog 2026-06-01 ghi rõ quyết định + lý do (parallel `FriendRequestRepository.acceptFriendRequest`).
- **Family controller**: `spaceControllerProvider` đổi từ non-family → family `String uid`. Consumer hiện tại (`space_create_sheet.dart`) đã update; `group_chat_screen.dart:111` TODO comment cũng sync.
- **Composite index**: `spaces`(memberIds CONTAINS, createdAt DESC) — Firestore deploy sẽ tự pick up khi merge develop → staging.
- **Self-healing stream retry**: pattern copy từ `FriendController._listenFriends` — re-subscribe sau 3s khi stream error (permission-denied rules-deploy window).
- **CF chưa ready**: T1+T2 chỉ implement repository wrappers + controller. CF (#136) chưa làm → mutation gọi sẽ throw NotFound khi test thực tế. Tests dùng mock repo nên không bị block.

## Self-review checklist

- [x] Branch name đúng format `feature/ThienPDM/space-data-controller`
- [x] Commit message tiếng Việt, theo Conventional Commits
- [x] Không có file lớn vô tình (.env, keystore, service account)
- [x] Không có `print` debug còn sót
- [x] Không có `// TODO` chưa link issue (TODO trong group_chat_screen có link #133 implicit + giải thích)
- [x] Không có code comment-out dead code
- [x] Đã chạy `/review` self-check — 2 🟡 fix (orderBy + TODO sync), 1 🟡 skip theo plan AC (kickMember/transferOwnership guard chưa-đăng-nhập)

🤖 Generated with [Claude Code](https://claude.com/claude-code)