### PR TITLE
chore(space): leader gate change — currentSpaceProvider cho Camera context

### DIFF
--- a/apps/mobile/lib/features/space/application/space_controller.dart
+++ b/apps/mobile/lib/features/space/application/space_controller.dart
@@ -27,6 +27,27 @@ SpaceRepository spaceRepository(Ref ref) => throw UnimplementedError(
       'wire FirebaseSpaceRepository in main.dart',
     );
 
+/// Current Space context cho Camera. `null` = "All friends" (mặc định).
+///
+/// Set: `ref.read(currentSpaceProvider.notifier).select(space)` khi user
+/// chọn Space từ [SpaceContextBottomSheet] (T4). Reset về null khi chọn
+/// "All friends" (`.clear()`) hoặc khi user signout.
+///
+/// `keepAlive: true` để Space context persist khi user qua lại Camera/Feed
+/// — không reset chỉ vì page rebuild. Disposed cùng app lifetime.
+///
+/// Watch bởi `CameraSection` (KhoaLND) để đổi viền + nút chụp theo
+/// `space.colorHex` + hiển thị badge "Đang gửi: [SpaceName]".
+@Riverpod(keepAlive: true)
+class CurrentSpace extends _$CurrentSpace {
+  @override
+  Space? build() => null;
+
+  void select(Space? space) => state = space;
+
+  void clear() => state = null;
+}
+
 /// Family controller — instance per uid. Sheet/screen lấy uid từ
 /// [currentUidProvider] trước khi watch để đảm bảo signed-in.
 @riverpod

--- a/docs/plans/2026-05-23-space.md
+++ b/docs/plans/2026-05-23-space.md
@@ -14,7 +14,7 @@
 | `lib/features/space/data/space.dart` | freezed model | ✅ merged (LX10) | `spaceId`, `name` (≤30), `iconEmoji`, `colorHex` (hex 7 chars), `creatorId`, `memberCount`, `memberIds List<String>` (≤10), `createdAt`, `deletedAt?` |
 | `lib/features/space/data/space_member.dart` | freezed model | ✅ merged (LX10) | `uid`, `role SpaceRole` (creator/member), `joinedAt` |
 | `lib/features/space/data/space_repository.dart` | abstract class | ✅ merged (LX10) + ⚠️ extend trước T1 | Read-only (LX10): `watchMySpaces(uid)`, `getSpace(spaceId)`, `deleteSpace(spaceId)`. CF mutations (#133 extend — leader gate): `createSpace({name, iconEmoji, colorHex, friendUids})`, `leaveSpace(spaceId)`, `kickMember(spaceId, targetUid)`, `transferOwnership(spaceId, newCreatorUid)`. **Quyết định Option A:** repository wrap `httpsCallable` cho 4 CF, parallel với `FriendRequestRepository.acceptFriendRequest`. Controller delegate, không gọi `FirebaseFunctions` trực tiếp. |
-| `lib/features/space/application/space_controller.dart` | Riverpod stub + gate change | ✅ stub có `friendUids`; ❌ `currentSpaceProvider` chưa thêm | Stub: `SpaceState`, `createSpace({name, iconEmoji, colorHex, friendUids})`, `leaveSpace`, `kickMember`, `transferOwnership`. Gate change (leader): thêm `currentSpaceProvider` (`@Riverpod(keepAlive:true)`, `Space?`) — watch bởi `CameraSection` (KhoaLND) |
+| `lib/features/space/application/space_controller.dart` | Riverpod stub + gate change | ✅ T2 merged (#133) + ✅ `currentSpaceProvider` (2026-06-01) | Full impl T2: `SpaceState`, family `build(uid)` watch stream, 5 mutations. Gate change leader: `currentSpaceProvider` (`@Riverpod(keepAlive:true)`, class `CurrentSpace` với `select(space)` + `clear()`) — watch bởi `CameraSection` (KhoaLND) |
 | `lib/features/space/presentation/space_create_sheet.dart` | widget stub | ✅ stub (TODO SP/T6) | 3-step bottom sheet |
 | `lib/features/space/presentation/space_context_bottom_sheet.dart` | widget stub | ✅ stub (TODO SP/T7) | `spaceId` param |
 | `lib/features/space/presentation/widgets/space_list_tile.dart` | widget stub | ✅ stub (TODO SP/T8) | `spaceId` param |
@@ -22,13 +22,13 @@
 | `lib/features/feed/data/post.dart` | gate change | ✅ merged (LX5) | `spaceId String?` field |
 | `lib/features/feed/application/feed_controller.dart` | gate change | ✅ merged | `FeedFilter.space` enum case + `filterSpaceId String?` param trong `build()` |
 | `lib/core/router/app_router.dart` | routes | ✅ wired (LX10) | `/space/create` → `SpaceCreateSheet`, `/space/:spaceId` → `SpaceContextBottomSheet` |
-| `lib/features/feed/presentation/feed_screen.dart` (hoặc `home_screen.dart`) | **gate change** — leader only | ❌ cần thêm | `FeedScreen` nhận `spaceId?` param + pass `filterSpaceId` tới `FeedController` |
+| `lib/features/feed/presentation/home_screen.dart` | **gate change** — leader only | ✅ merged (PR #195 T7-T8) | `HomeScreen({this.spaceId})` + `_filter` derive `FeedFilter.space` khi `spaceId != null` + pass `filterSpaceId` tới `FeedController` |
 | `firebase/functions/src/space/spacePostFanOut.ts` | CF helper | ❌ ThienPDM implement T9 | `async function spacePostFanOut(post)`: (1) đọc Space members, (2) fan-out `/users/{uid}/feed/{postId}` với `spaceId`, (3) FCM cho members trừ author. Gọi từ `onPostCreated` (KhoaLND) khi `post.spaceId != null` |
 | `pubspec.yaml` | dep | ✅ đã có | `emoji_picker_flutter: ^4.4.0` (MIT) |
 
-> **Gate changes còn lại trước T4+5 (#135):**
-> 1. `currentSpaceProvider` stub — ThienPDM thêm vào `space_controller.dart`
-> 2. `FeedScreen(spaceId?)` — ThienPDM gate change vào Feed module
+> **Gate changes leader — DONE trước T4+T5 (#135):**
+> 1. ✅ `currentSpaceProvider` (`@Riverpod(keepAlive:true)` class `CurrentSpace`) — merged 2026-06-01 vào `space_controller.dart`. Dev T4 dùng `ref.read(currentSpaceProvider.notifier).select(space)` khi user chọn từ `SpaceContextBottomSheet`; `clear()` khi chọn "All friends".
+> 2. ✅ `HomeScreen(spaceId?)` — đã merge cùng PR #195 (T7-T8 feed), không cần gate change riêng. `_filter` đã derive `FeedFilter.space` khi `spaceId != null`.
 >
 > **CF Option A (single source of truth):** Không có `onSpacePostCreated` trigger riêng. Space fan-out được ThienPDM implement trong `spacePostFanOut.ts` helper, KhoaLND import + gọi từ bên trong `onPostCreated` khi `spaceId != null`.
 

--- a/docs/specs/2026-05-23-space.md
+++ b/docs/specs/2026-05-23-space.md
@@ -402,8 +402,8 @@ match /posts/{postId} {
 | `SpaceContextBadge` stub | `lib/features/space/presentation/widgets/space_context_badge.dart` | ✅ stub (TODO SP/T9, có `spaceId` param) |
 | `Post` model — `spaceId` field | `lib/features/feed/data/post.dart` | ✅ merged (LX5) |
 | `FeedFilter.space` enum + `filterSpaceId` param | `lib/features/feed/application/feed_controller.dart` | ✅ cả 2 đã có |
-| `currentSpaceProvider` (Riverpod, cho Camera context) | `lib/features/space/application/space_controller.dart` | ❌ chưa có — leader gate change, ThienPDM thêm trước T4+5 (#135) |
-| `FeedScreen` — param `spaceId` | `lib/features/feed/presentation/feed_screen.dart` | ❌ leader gate change — ThienPDM merge trước T4+5 (#135) |
+| `currentSpaceProvider` (Riverpod, cho Camera context) | `lib/features/space/application/space_controller.dart` | ✅ merged 2026-06-01 — `@Riverpod(keepAlive: true)` class `CurrentSpace extends _$CurrentSpace { Space? build() => null; select(space); clear(); }` |
+| `HomeScreen` — param `spaceId` (Feed per Space) | `lib/features/feed/presentation/home_screen.dart` | ✅ merged (PR #195 T7-T8) — `HomeScreen({this.spaceId})` + `_filter` derive `FeedFilter.space` khi `spaceId != null` |
 | Route: `/space/create`, `/space/:spaceId` | `lib/core/router/app_router.dart` | ✅ đã wired (LX10) |
 | `spacePostFanOut.ts` helper (cho `onPostCreated` Option A) | `firebase/functions/src/space/spacePostFanOut.ts` | ❌ ThienPDM implement trong #136 |
 | Cloud Functions (7 functions) | `firebase/functions/src/space/` | ❌ dir chưa có — #136 |
@@ -456,3 +456,4 @@ match /posts/{postId} {
 | 2026-05-27 | Cập nhật luồng tạo Space dựa trên Figma thực tế (5 frames): "Tiếp tục" button color `#39404166`; Step 2 là scrollable preset list; thêm bảng paired preset (iconEmoji + colorHex); Step 3 cơ chế 2 tab buttons + Gợi ý = color suggestions; color picker = preset + shade slider. Out-of-scope cập nhật. `emoji_picker_flutter` ✅ đã có. CF Option A: `onSpacePostCreated` merge vào `onPostCreated` qua helper `spacePostFanOut.ts`. Fix scope wording, data model, unit tests, risks. Contract table cập nhật đúng thực tế (routes ✅ đã wired, stubs ✅ đã có). Thêm `currentSpaceProvider` vào architecture. OQ5 resolved. | ThienPDM |
 | 2026-05-30 | Fix button "Tiếp tục →" color: `#39404180` → `#39404166` (Figma source of truth, alpha 40% thay vì 50%). | ThienPDM |
 | 2026-06-01 | **Option A — extend `SpaceRepository` abstract:** thêm 4 method wrap CF callables (`createSpace`, `leaveSpace`, `kickMember`, `transferOwnership`) — parallel với `FriendRequestRepository` pattern. Controller delegate qua repository, KHÔNG inject `FirebaseFunctions` trực tiếp. Update architecture diagram + contract table + plan T1/T2 acceptance criteria tương ứng. Refs #133. | ThienPDM |
+| 2026-06-01 | **Gate change leader:** thêm `currentSpaceProvider` (`@Riverpod(keepAlive: true)` class `CurrentSpace` với `select(space)` + `clear()`) vào `space_controller.dart`. Cập nhật contract table — `HomeScreen.spaceId` đã có từ PR #195 (T7-T8 feed), không phải `feed_screen.dart` riêng. Unblock T4+T5 (#135) cho dev Space. | ThienPDM |


### PR DESCRIPTION
## Mô tả

Leader gate change cho Space module — thêm `currentSpaceProvider` (`@Riverpod(keepAlive: true)` class `CurrentSpace`) vào `space_controller.dart`. Provider type `Space?` — null = "All friends", non-null = Space context. Unblock T4+T5 (#135) cho dev Space wire Camera context switch + SpaceContextBadge + Feed per Space.

## Refs

- Spec: `docs/specs/2026-05-23-space.md` (changelog 2026-06-01)
- Plan: `docs/plans/2026-05-23-space.md` (Part 1 contract table updated)
- Unblocks #135 (Space T4+T5 — Camera context switch + SpaceContextBadge + Feed per Space)
- Không có issue riêng — leader gate change chỉ là prep work, không thuộc task module owner.

## Thay đổi chính

- `apps/mobile/lib/features/space/application/space_controller.dart`: thêm `@Riverpod(keepAlive: true) class CurrentSpace extends _$CurrentSpace { Space? build() => null; select(space); clear(); }`
- `docs/specs/2026-05-23-space.md`: contract table — `currentSpaceProvider` ✅ merged; `HomeScreen.spaceId` ✅ đã có từ PR #195 (T7-T8 feed, không phải `feed_screen.dart` riêng). Changelog entry 2026-06-01.
- `docs/plans/2026-05-23-space.md`: Part 1 contract table + "Gate changes leader" note — cả 2 gate changes đã DONE, T4+T5 sẵn sàng cho dev start.

## Loại thay đổi

- [x] chore — Maintenance, deps, config (leader gate change cho contract sync)

## Test

- [x] Đã chạy `flutter test test/features/space/` → 41/41 PASS (existing tests không bị ảnh hưởng vì `CurrentSpace` là provider mới, không touch `SpaceController`)
- [x] Đã chạy `flutter analyze` clean (0 warning)
- [x] Đã chạy `dart format --set-exit-if-changed .` PASS
- [ ] (Nếu sửa Functions) — không sửa
- [ ] (Nếu sửa Firestore rules) — không sửa rules
- [ ] Đã test thủ công — N/A (provider stub, chưa có consumer wire — T4 dev sẽ test e2e khi wire CameraSection)

### Cách test thủ công (khi T4 wire)

1. Mở Camera (Home tab)
2. Long-press FriendsButton trên topbar → `SpaceContextBottomSheet` (T4)
3. Chọn 1 Space → `ref.read(currentSpaceProvider.notifier).select(space)` → CameraSection rebuild với viền + nút chụp `space.colorHex` + badge "Đang gửi: [SpaceName]"
4. Chọn "All friends" → `.clear()` → Camera reset về mặc định, badge ẩn

## Lưu ý cho reviewer

- **Provider shape:** dùng `@Riverpod(keepAlive: true) class CurrentSpace` (class-based notifier) thay vì `StateProvider<Space?>` để có 2 method explicit `select(space)` + `clear()` — UX rõ ràng hơn khi đọc call-site (`.select(space)` đọc tự nhiên hơn `.state = space`).
- **keepAlive: true:** Space context persist khi user qua lại Camera/Feed. Disposed cùng app lifetime — không cần handle dispose riêng.
- **Signout handling:** khi auth signout, T4 dev cần `ref.read(currentSpaceProvider.notifier).clear()` để reset (không tự auto-clear vì Space provider không depend currentUidProvider).
- **HomeScreen.spaceId:** đã có từ PR #195 (T7-T8 feed) — `_filter` logic line 84-91 đã derive `FeedFilter.space` khi `spaceId != null`. Không cần gate change riêng cho FeedScreen.
- **Cross-module impact:** Provider mới, không phá consumer hiện tại. Test 41/41 pass confirm.

## Self-review checklist

- [x] Branch name đúng format `chore/ThienPDM/space-currentspace-provider`
- [x] Commit message tiếng Việt, theo Conventional Commits
- [x] Không có file lớn vô tình
- [x] Không có `print` debug còn sót
- [x] Không có `// TODO` chưa link issue
- [x] Không có code comment-out dead code
- [x] Đã chạy `flutter analyze` + tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)