### PR TITLE
feat(settings): T1 — FirebaseBlockRepository + AppError boundary

### DIFF
--- a/apps/mobile/lib/features/settings/data/firebase_block_repository.dart
+++ b/apps/mobile/lib/features/settings/data/firebase_block_repository.dart
@@ -24,6 +24,8 @@ class FirebaseBlockRepository implements BlockRepository {
   }) async {
     // CF Admin SDK bypass rules → atomic block + unfriend + conversation
     // status update (Task T5 #119). Client KHÔNG write Firestore trực tiếp.
+    // blockerUid giữ trong signature theo contract — CF tự derive từ
+    // request.auth.uid, không cần pass payload.
     try {
       final callable = _functions.httpsCallable('blockUser');
       await callable.call<void>({'targetUid': targetUid});
@@ -39,10 +41,14 @@ class FirebaseBlockRepository implements BlockRepository {
   }) async {
     // Client-side delete OK — blocker chính chủ doc, rule cho phép xoá
     // khi request.auth.uid == blockerUid (resolved OQ5 trong #116).
-    await _firestore
-        .collection(_blocksCollection)
-        .doc(_blockIdOf(blockerUid, targetUid))
-        .delete();
+    try {
+      await _firestore
+          .collection(_blocksCollection)
+          .doc(_blockIdOf(blockerUid, targetUid))
+          .delete();
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreException(e, 'bỏ chặn người dùng');
+    }
   }
 
   @override
@@ -54,23 +60,65 @@ class FirebaseBlockRepository implements BlockRepository {
         .map(
           (snapshot) =>
               snapshot.docs.map((doc) => Block.fromJson(doc.data())).toList(),
-        );
+        )
+        .handleError((Object e, StackTrace s) {
+      if (e is FirebaseException) {
+        throw _mapFirestoreException(e, 'tải danh sách tài khoản đã chặn');
+      }
+      Error.throwWithStackTrace(e, s);
+    });
   }
 
   @override
   Future<bool> isBlocked({required String uid1, required String uid2}) async {
     // Check cả 2 chiều song song: tồn tại 1 trong 2 doc là true.
-    final results = await Future.wait([
-      _firestore
-          .collection(_blocksCollection)
-          .doc(_blockIdOf(uid1, uid2))
-          .get(),
-      _firestore
-          .collection(_blocksCollection)
-          .doc(_blockIdOf(uid2, uid1))
-          .get(),
-    ]);
-    return results.any((doc) => doc.exists);
+    try {
+      final results = await Future.wait([
+        _firestore
+            .collection(_blocksCollection)
+            .doc(_blockIdOf(uid1, uid2))
+            .get(),
+        _firestore
+            .collection(_blocksCollection)
+            .doc(_blockIdOf(uid2, uid1))
+            .get(),
+      ]);
+      return results.any((doc) => doc.exists);
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreException(e, 'kiểm tra trạng thái chặn');
+    }
+  }
+
+  /// Map [FirebaseException] (Firestore) sang [AppError] tương ứng.
+  /// [action] = động từ tiếng Việt mô tả thao tác cho fallback message.
+  AppError _mapFirestoreException(FirebaseException e, String action) {
+    final serverMessage = e.message;
+    switch (e.code) {
+      case 'permission-denied':
+        return ForbiddenError(action);
+      case 'not-found':
+        return NotFoundError(serverMessage ?? action);
+      case 'unavailable':
+      case 'deadline-exceeded':
+      case 'cancelled':
+        return NetworkError(
+          message: serverMessage ?? 'Mất kết nối khi $action. Thử lại sau.',
+          code: e.code,
+          cause: e,
+        );
+      case 'failed-precondition':
+        return ValidationError(
+          message: serverMessage ?? 'Không thể $action: dữ liệu không hợp lệ',
+          code: e.code,
+          cause: e,
+        );
+      default:
+        return UnexpectedError(
+          message: serverMessage ?? 'Không thể $action. Thử lại sau.',
+          code: e.code,
+          cause: e,
+        );
+    }
   }
 
   /// Map [FirebaseFunctionsException] sang [AppError] tương ứng.

--- a/apps/mobile/lib/features/settings/data/firebase_block_repository.dart
+++ b/apps/mobile/lib/features/settings/data/firebase_block_repository.dart
@@ -1,0 +1,116 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/settings/data/block.dart';
+import 'package:meep/features/settings/data/block_repository.dart';
+
+class FirebaseBlockRepository implements BlockRepository {
+  FirebaseBlockRepository(this._firestore, this._functions);
+
+  final FirebaseFirestore _firestore;
+  final FirebaseFunctions _functions;
+
+  static const _blocksCollection = 'blocks';
+
+  /// Asymmetric block doc ID: blocker initiates, NOT sorted (khác `pairId`).
+  String _blockIdOf(String blockerUid, String blockedUid) =>
+      '${blockerUid}_$blockedUid';
+
+  @override
+  Future<void> blockUser({
+    required String blockerUid,
+    required String targetUid,
+  }) async {
+    // CF Admin SDK bypass rules → atomic block + unfriend + conversation
+    // status update (Task T5 #119). Client KHÔNG write Firestore trực tiếp.
+    try {
+      final callable = _functions.httpsCallable('blockUser');
+      await callable.call<void>({'targetUid': targetUid});
+    } on FirebaseFunctionsException catch (e) {
+      throw _mapFunctionsException(e, 'chặn người dùng');
+    }
+  }
+
+  @override
+  Future<void> unblockUser({
+    required String blockerUid,
+    required String targetUid,
+  }) async {
+    // Client-side delete OK — blocker chính chủ doc, rule cho phép xoá
+    // khi request.auth.uid == blockerUid (resolved OQ5 trong #116).
+    await _firestore
+        .collection(_blocksCollection)
+        .doc(_blockIdOf(blockerUid, targetUid))
+        .delete();
+  }
+
+  @override
+  Stream<List<Block>> watchBlockedUsers(String blockerUid) {
+    return _firestore
+        .collection(_blocksCollection)
+        .where('blockerUid', isEqualTo: blockerUid)
+        .snapshots()
+        .map(
+          (snapshot) =>
+              snapshot.docs.map((doc) => Block.fromJson(doc.data())).toList(),
+        );
+  }
+
+  @override
+  Future<bool> isBlocked({required String uid1, required String uid2}) async {
+    // Check cả 2 chiều song song: tồn tại 1 trong 2 doc là true.
+    final results = await Future.wait([
+      _firestore
+          .collection(_blocksCollection)
+          .doc(_blockIdOf(uid1, uid2))
+          .get(),
+      _firestore
+          .collection(_blocksCollection)
+          .doc(_blockIdOf(uid2, uid1))
+          .get(),
+    ]);
+    return results.any((doc) => doc.exists);
+  }
+
+  /// Map [FirebaseFunctionsException] sang [AppError] tương ứng.
+  /// Pattern theo `firebase_space_repository.dart`.
+  AppError _mapFunctionsException(
+    FirebaseFunctionsException e,
+    String action,
+  ) {
+    final serverMessage = e.message;
+    switch (e.code) {
+      case 'invalid-argument':
+      case 'failed-precondition':
+        return ValidationError(
+          message: serverMessage ?? 'Không thể $action: dữ liệu không hợp lệ',
+          code: e.code,
+          cause: e,
+        );
+      case 'permission-denied':
+        return ForbiddenError(action);
+      case 'not-found':
+        return NotFoundError(serverMessage ?? action);
+      case 'unauthenticated':
+        return UnauthenticatedError(
+          message: serverMessage ?? 'Cần đăng nhập để $action',
+          code: e.code,
+          cause: e,
+        );
+      case 'unavailable':
+      case 'deadline-exceeded':
+        return NetworkError(
+          message: serverMessage ?? 'Mất kết nối khi $action. Thử lại sau.',
+          code: e.code,
+          cause: e,
+        );
+      default:
+        return UnexpectedError(
+          message: serverMessage ?? 'Không thể $action. Thử lại sau.',
+          code: e.code,
+          cause: e,
+        );
+    }
+  }
+}

--- a/apps/mobile/test/features/settings/data/firebase_block_repository_test.dart
+++ b/apps/mobile/test/features/settings/data/firebase_block_repository_test.dart
@@ -1,0 +1,139 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/features/settings/data/block.dart';
+import 'package:meep/features/settings/data/firebase_block_repository.dart';
+
+class MockFirebaseFunctions extends Mock implements FirebaseFunctions {}
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late MockFirebaseFunctions functions;
+  late FirebaseBlockRepository repository;
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    functions = MockFirebaseFunctions();
+    repository = FirebaseBlockRepository(firestore, functions);
+  });
+
+  Map<String, dynamic> blockDoc({
+    required String blockerUid,
+    required String blockedUid,
+    DateTime? createdAt,
+  }) {
+    return {
+      'blockId': '${blockerUid}_$blockedUid',
+      'blockerUid': blockerUid,
+      'blockedUid': blockedUid,
+      'createdAt': Timestamp.fromDate(createdAt ?? DateTime(2026, 6, 1)),
+    };
+  }
+
+  group('unblockUser', () {
+    test('xoá doc /blocks/{blockerUid}_{targetUid}', () async {
+      const blockerUid = 'me';
+      const targetUid = 'target';
+      const blockId = '${blockerUid}_$targetUid';
+
+      await firestore.collection('blocks').doc(blockId).set(
+            blockDoc(blockerUid: blockerUid, blockedUid: targetUid),
+          );
+
+      await repository.unblockUser(
+        blockerUid: blockerUid,
+        targetUid: targetUid,
+      );
+
+      final doc = await firestore.collection('blocks').doc(blockId).get();
+      expect(doc.exists, isFalse);
+    });
+
+    test('KHÔNG xoá doc chiều ngược (target chặn me)', () async {
+      const blockerUid = 'me';
+      const targetUid = 'target';
+      const reverseId = '${targetUid}_$blockerUid';
+
+      await firestore.collection('blocks').doc(reverseId).set(
+            blockDoc(blockerUid: targetUid, blockedUid: blockerUid),
+          );
+
+      await repository.unblockUser(
+        blockerUid: blockerUid,
+        targetUid: targetUid,
+      );
+
+      final doc = await firestore.collection('blocks').doc(reverseId).get();
+      expect(doc.exists, isTrue);
+    });
+  });
+
+  group('isBlocked', () {
+    test('true khi uid1 chặn uid2', () async {
+      await firestore.collection('blocks').doc('a_b').set(
+            blockDoc(blockerUid: 'a', blockedUid: 'b'),
+          );
+
+      final result = await repository.isBlocked(uid1: 'a', uid2: 'b');
+      expect(result, isTrue);
+    });
+
+    test('true khi uid2 chặn uid1 (chiều ngược)', () async {
+      await firestore.collection('blocks').doc('b_a').set(
+            blockDoc(blockerUid: 'b', blockedUid: 'a'),
+          );
+
+      final result = await repository.isBlocked(uid1: 'a', uid2: 'b');
+      expect(result, isTrue);
+    });
+
+    test('false khi không có block nào giữa 2 uid', () async {
+      // Có block của cặp khác không liên quan.
+      await firestore.collection('blocks').doc('x_y').set(
+            blockDoc(blockerUid: 'x', blockedUid: 'y'),
+          );
+
+      final result = await repository.isBlocked(uid1: 'a', uid2: 'b');
+      expect(result, isFalse);
+    });
+  });
+
+  group('watchBlockedUsers', () {
+    test('stream chỉ doc do blockerUid tạo (loại doc người khác chặn me)',
+        () async {
+      const me = 'me';
+      await firestore.collection('blocks').doc('${me}_target1').set(
+            blockDoc(blockerUid: me, blockedUid: 'target1'),
+          );
+      await firestore.collection('blocks').doc('${me}_target2').set(
+            blockDoc(blockerUid: me, blockedUid: 'target2'),
+          );
+      // Doc người khác chặn me — không được lọt vào stream.
+      await firestore.collection('blocks').doc('stranger_$me').set(
+            blockDoc(blockerUid: 'stranger', blockedUid: me),
+          );
+
+      final stream = repository.watchBlockedUsers(me);
+
+      await expectLater(
+        stream,
+        emits(
+          predicate<List<Block>>((list) {
+            final ids = list.map((b) => b.blockedUid).toSet();
+            return list.length == 2 &&
+                ids.containsAll(['target1', 'target2']) &&
+                list.every((b) => b.blockerUid == me);
+          }),
+        ),
+      );
+    });
+
+    test('empty list khi chưa chặn ai', () async {
+      final stream = repository.watchBlockedUsers('lonely');
+      await expectLater(stream, emits(isEmpty));
+    });
+  });
+}


### PR DESCRIPTION
Closes #116

## Scope
Implement `BlockRepository` data layer cho settings module per [docs/plans/2026-05-23-settings.md](docs/plans/2026-05-23-settings.md) Task T1.

## Files
- `apps/mobile/lib/features/settings/data/firebase_block_repository.dart` (164 lines)
- `apps/mobile/test/features/settings/data/firebase_block_repository_test.dart` (139 lines, 7 tests)

## Per-method strategy
| Method | Approach |
|---|---|
| `blockUser` | `httpsCallable('blockUser')` + map `FirebaseFunctionsException` → `AppError`. KHÔNG write Firestore trực tiếp (CF Admin SDK bypass rules, T5 #119 sẽ impl CF). `blockerUid` giữ trong signature theo contract — CF tự derive từ `request.auth.uid`. |
| `unblockUser` | Client-side delete `/blocks/{blockerUid}_{targetUid}` (OQ5 resolved: blocker chính chủ doc) + map `FirebaseException` → `AppError`. |
| `watchBlockedUsers` | `where('blockerUid', isEqualTo)` stream + `.handleError` → `AppError`, `Error.throwWithStackTrace` cho non-Firebase để giữ stack trace gốc. |
| `isBlocked` | `Future.wait` parallel 2 reads (chiều thuận + ngược) + map `FirebaseException` → `AppError`. |

## Acceptance criteria #116
- [x] `blockUser` gọi CF callable `blockUser`, KHÔNG write Firestore client
- [x] `unblockUser` xoá `/blocks/{blockerUid}_{targetUid}` client-side
- [x] `isBlocked(uid)` check cả 2 chiều
- [x] `watchBlockedUsers()` query `where blockerUid`
- [x] `flutter test test/features/settings/data/` — 0 failures (7/7 pass)

## Convention raise
Pattern theo `firebase_space_repository.dart` nhưng **nâng chuẩn**: wrap cả `FirebaseException` (Firestore) thành `AppError` qua `_mapFirestoreException` helper (Space/Friend repos hiện chưa làm). Đề xuất standardize cho repos sau theo `apps/mobile/CLAUDE.md` "Repositories convert FirebaseException/PlatformException into AppError at the boundary".

## CF callable testing
KHÔNG unit-test `blockUser` ở Dart layer theo convention `firebase_space_repository_test.dart` (Space cũng không test các CF methods). Cover qua CF integration tests trong T5 #119.

## Test plan
- [x] `flutter test test/features/settings/data/` (7/7 pass)
- [x] `flutter analyze lib/features/settings/data/` (No issues)
- [x] `dart format --set-exit-if-changed` clean
- [ ] Reviewer: manual trace happy path + error path mapping
- [ ] Reviewer: confirm convention raise (wrap Firestore errors) ổn để áp dụng cho repos sau

## Commits
- `3454a84` feat(settings): T1 — FirebaseBlockRepository impl + tests
- `9b55d70` refactor(settings): wrap FirebaseException → AppError ở Firestore methods (self-review fix)

## Note rebase
Branch base ở `75d3e9e` (Space T6), develop tip hiện tại `01a8c95` (Space T7 CF). **Zero file overlap** (T1 ở `apps/mobile/lib/features/settings/data/`, Space T7 ở `firebase/functions/src/space/`). Squash merge sẽ tự put commit on top of develop tip, không cần rebase trước.