### PR TITLE
test(space): T11 — Firestore rules tests cho /spaces + /space_members + posts (#137)

### DIFF
--- a/firebase/functions/test/rules/space.rules.test.ts
+++ b/firebase/functions/test/rules/space.rules.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Firestore security rules tests for Space module.
+ * Run via: firebase emulators:exec --only firestore "npm run test:rules"
+ *
+ * Tests:
+ *   - /spaces/{spaceId}: read (isMember), create/delete (false), update (isCreator)
+ *   - /space_members/{spaceId}/members/{uid}: read (isMember), CRUD (false → CF only)
+ *   - /posts/{postId} with spaceId: Space member read ✓ (via /users/{uid}/feed/{postId})
+ *
+ * Pattern mirror friend.rules.test.ts.
+ */
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
+
+// ===== Setup =====
+
+let testEnv: RulesTestEnvironment;
+
+const RULES_PATH = resolve(__dirname, '../../../firestore.rules');
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: 'meep-test-space',
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: '127.0.0.1',
+      port: 9999,
+    },
+  });
+});
+
+afterAll(async () => {
+  if (testEnv) {
+    await testEnv.cleanup();
+  }
+});
+
+beforeEach(async () => {
+  if (testEnv) {
+    await testEnv.clearFirestore();
+  }
+});
+
+// ===== Helpers =====
+
+const uid = (n: string) => `user-${n}`;
+
+function authed(userId: string) {
+  return testEnv.authenticatedContext(userId);
+}
+
+function unauthed() {
+  return testEnv.unauthenticatedContext();
+}
+
+/**
+ * Seed Space + members subcollection bypassing rules — preconditions cho
+ * test cases. Mirror pattern client/CF tạo Space.
+ */
+async function seedSpace(
+  spaceId: string,
+  creatorId: string,
+  memberIds: string[],
+): Promise<void> {
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    await db.doc(`spaces/${spaceId}`).set({
+      spaceId,
+      name: 'Test Space',
+      iconEmoji: '👥',
+      colorHex: '#00DEEE',
+      creatorId,
+      memberCount: memberIds.length,
+      memberIds,
+      createdAt: new Date(),
+    });
+    for (const memberUid of memberIds) {
+      await db
+        .doc(`space_members/${spaceId}/members/${memberUid}`)
+        .set({
+          uid: memberUid,
+          role: memberUid === creatorId ? 'creator' : 'member',
+          joinedAt: new Date(),
+        });
+    }
+  });
+}
+
+// ===== /spaces/{spaceId} — read =====
+
+describe('/spaces/{spaceId} — read', () => {
+  test('member can read Space', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await seedSpace('s1', alice, [alice, bob]);
+
+    await assertSucceeds(authed(bob).firestore().doc('spaces/s1').get());
+  });
+
+  test('creator can read Space', async () => {
+    const alice = uid('alice');
+    await seedSpace('s1', alice, [alice]);
+
+    await assertSucceeds(authed(alice).firestore().doc('spaces/s1').get());
+  });
+
+  test('non-member cannot read Space', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    const charlie = uid('charlie');
+    await seedSpace('s1', alice, [alice, bob]);
+
+    await assertFails(authed(charlie).firestore().doc('spaces/s1').get());
+  });
+
+  test('unauthenticated cannot read Space', async () => {
+    const alice = uid('alice');
+    await seedSpace('s1', alice, [alice]);
+
+    await assertFails(unauthed().firestore().doc('spaces/s1').get());
+  });
+});
+
+// ===== /spaces/{spaceId} — write =====
+
+describe('/spaces/{spaceId} — write', () => {
+  test('client cannot create Space (CF only)', async () => {
+    const alice = uid('alice');
+    await assertFails(
+      authed(alice).firestore().doc('spaces/s1').set({
+        spaceId: 's1',
+        name: 'New Space',
+        iconEmoji: '👥',
+        colorHex: '#00DEEE',
+        creatorId: alice,
+        memberCount: 1,
+        memberIds: [alice],
+        createdAt: new Date(),
+      }),
+    );
+  });
+
+  test('creator can update Space (e.g. soft delete via deletedAt)', async () => {
+    const alice = uid('alice');
+    await seedSpace('s1', alice, [alice]);
+
+    await assertSucceeds(
+      authed(alice)
+        .firestore()
+        .doc('spaces/s1')
+        .update({ deletedAt: new Date() }),
+    );
+  });
+
+  test('non-creator member cannot update Space', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await seedSpace('s1', alice, [alice, bob]);
+
+    await assertFails(
+      authed(bob)
+        .firestore()
+        .doc('spaces/s1')
+        .update({ name: 'Renamed' }),
+    );
+  });
+
+  test('non-member cannot update Space', async () => {
+    const alice = uid('alice');
+    const charlie = uid('charlie');
+    await seedSpace('s1', alice, [alice]);
+
+    await assertFails(
+      authed(charlie)
+        .firestore()
+        .doc('spaces/s1')
+        .update({ name: 'Renamed' }),
+    );
+  });
+
+  test('non-creator member cannot soft-delete (set deletedAt)', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await seedSpace('s1', alice, [alice, bob]);
+
+    // Soft delete = update deletedAt. Chỉ creator được phép (rule
+    // isCreator). Test này quan trọng: member KHÔNG được destroy Space
+    // của creator qua soft-delete trick.
+    await assertFails(
+      authed(bob)
+        .firestore()
+        .doc('spaces/s1')
+        .update({ deletedAt: new Date() }),
+    );
+  });
+
+  test('client cannot delete Space (soft-delete via update only)', async () => {
+    const alice = uid('alice');
+    await seedSpace('s1', alice, [alice]);
+
+    await assertFails(authed(alice).firestore().doc('spaces/s1').delete());
+  });
+});
+
+// ===== /space_members/{spaceId}/members/{uid} =====
+
+describe('/space_members/{spaceId}/members/{uid}', () => {
+  test('member can read own member doc', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await seedSpace('s1', alice, [alice, bob]);
+
+    await assertSucceeds(
+      authed(bob).firestore().doc(`space_members/s1/members/${bob}`).get(),
+    );
+  });
+
+  test('member can read other members docs', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await seedSpace('s1', alice, [alice, bob]);
+
+    await assertSucceeds(
+      authed(bob).firestore().doc(`space_members/s1/members/${alice}`).get(),
+    );
+  });
+
+  test('non-member cannot read member docs', async () => {
+    const alice = uid('alice');
+    const charlie = uid('charlie');
+    await seedSpace('s1', alice, [alice]);
+
+    await assertFails(
+      authed(charlie)
+        .firestore()
+        .doc(`space_members/s1/members/${alice}`)
+        .get(),
+    );
+  });
+
+  test('unauthenticated cannot read member docs', async () => {
+    const alice = uid('alice');
+    await seedSpace('s1', alice, [alice]);
+
+    await assertFails(
+      unauthed().firestore().doc(`space_members/s1/members/${alice}`).get(),
+    );
+  });
+
+  test('client cannot create member doc (CF only)', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await seedSpace('s1', alice, [alice]);
+
+    await assertFails(
+      authed(alice).firestore().doc(`space_members/s1/members/${bob}`).set({
+        uid: bob,
+        role: 'member',
+        joinedAt: new Date(),
+      }),
+    );
+  });
+
+  test('client cannot delete member doc (CF leaveSpace/kickMember only)', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await seedSpace('s1', alice, [alice, bob]);
+
+    await assertFails(
+      authed(bob).firestore().doc(`space_members/s1/members/${bob}`).delete(),
+    );
+  });
+
+  test('client cannot update member role (e.g. promote self to creator)', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await seedSpace('s1', alice, [alice, bob]);
+
+    await assertFails(
+      authed(bob)
+        .firestore()
+        .doc(`space_members/s1/members/${bob}`)
+        .update({ role: 'creator' }),
+    );
+  });
+});
+
+// ===== /posts/{postId} with spaceId — read =====
+//
+// Posts dùng allow read rule combined cho 3 cases (author / friend /
+// /users/{uid}/feed/{postId} exists). Space member read post Space qua
+// nhánh thứ 3 — CF spacePostFanOut ghi /users/{uid}/feed/{postId} cho
+// mọi member khi Space post create.
+
+describe('/posts/{postId} with spaceId', () => {
+  async function seedSpacePost(
+    postId: string,
+    authorId: string,
+    spaceId: string,
+    memberUids: string[],
+  ): Promise<void> {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await db.doc(`posts/${postId}`).set({
+        postId,
+        authorId,
+        authorName: 'Author',
+        imageUrl: 'https://example.com/photo.jpg',
+        audienceType: 'all',
+        audienceUids: [],
+        spaceId,
+        createdAt: new Date(),
+      });
+      // Mirror spacePostFanOut: ghi /users/{uid}/feed/{postId} cho mọi
+      // Space member (kể cả author).
+      for (const memberUid of memberUids) {
+        await db.doc(`users/${memberUid}/feed/${postId}`).set({
+          postId,
+          authorId,
+          spaceId,
+          createdAt: new Date(),
+        });
+      }
+    });
+  }
+
+  test('Space member can read Space post (via /users/{uid}/feed entry)', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await seedSpace('s1', alice, [alice, bob]);
+    await seedSpacePost('p1', alice, 's1', [alice, bob]);
+
+    await assertSucceeds(authed(bob).firestore().doc('posts/p1').get());
+  });
+
+  test('Space author can read own Space post', async () => {
+    const alice = uid('alice');
+    await seedSpace('s1', alice, [alice]);
+    await seedSpacePost('p1', alice, 's1', [alice]);
+
+    await assertSucceeds(authed(alice).firestore().doc('posts/p1').get());
+  });
+
+  test('non-member without feed entry cannot read Space post', async () => {
+    const alice = uid('alice');
+    const charlie = uid('charlie');
+    await seedSpace('s1', alice, [alice]);
+    // Note: charlie không có /users/charlie/feed/p1 entry vì không phải
+    // Space member. Cũng không phải author + không phải friend của author
+    // → 3 nhánh allow read đều fail.
+    await seedSpacePost('p1', alice, 's1', [alice]);
+
+    await assertFails(authed(charlie).firestore().doc('posts/p1').get());
+  });
+
+  test('unauthenticated cannot read Space post', async () => {
+    const alice = uid('alice');
+    await seedSpace('s1', alice, [alice]);
+    await seedSpacePost('p1', alice, 's1', [alice]);
+
+    await assertFails(unauthed().firestore().doc('posts/p1').get());
+  });
+});


### PR DESCRIPTION
## Mô tả

T11 (#137): viết Firestore security rules tests cho Space module — `/spaces`, `/space_members`, `/posts` với `spaceId`. 21 test cases cover member/non-member/creator/unauthenticated paths cho mọi action; lock down rules đã merge từ LX (#163) trước khi deploy production.

## Refs

- Closes #137 (T11 phần rules tests; T10b SpaceManagementSheet split sang PR riêng)
- Spec: `docs/specs/2026-05-23-space.md` §Security
- Plan: `docs/plans/2026-05-23-space.md` T11
- Pattern parallel: `firebase/functions/test/rules/friend.rules.test.ts`

## Thay đổi chính

**File mới:** `firebase/functions/test/rules/space.rules.test.ts` (370 lines, 21 tests)

**Coverage:**

| Path | Action | Test |
|---|---|---|
| `/spaces/{id}` | read | member ✓ / creator ✓ / non-member ✗ / unauthenticated ✗ |
| `/spaces/{id}` | create | client ✗ (CF only) |
| `/spaces/{id}` | update | creator ✓ (deletedAt) / non-creator ✗ / non-member ✗ / non-creator soft-delete ✗ |
| `/spaces/{id}` | delete | client ✗ (soft delete only) |
| `/space_members/{id}/members/{uid}` | read | member ✓ / non-member ✗ / unauthenticated ✗ |
| `/space_members/{id}/members/{uid}` | create | client ✗ |
| `/space_members/{id}/members/{uid}` | delete | member self ✗ |
| `/space_members/{id}/members/{uid}` | update | role promote ✗ |
| `/posts/{id}` (spaceId) | read | Space member ✓ / author ✓ / non-member ✗ / unauthenticated ✗ |

**Pattern:**
- `initializeTestEnvironment` + emulator port 9999 (mirror friend tests)
- `withSecurityRulesDisabled` seed Space + members + posts + feed entries
- `assertFails` / `assertSucceeds` for each scenario
- Helper `seedSpace(id, creator, members)` mirror CF createSpace data shape
- Helper `seedSpacePost(postId, authorId, spaceId, memberUids)` mirror `spacePostFanOut` helper (ghi `/users/{uid}/feed/{postId}` cho mọi Space member)

## Loại thay đổi

- [x] test — Thêm rules unit tests cho Space

## Test

- [x] `firebase emulators:exec --only firestore "cd functions && npm run test:rules"` → **107/107 pass** (87 prior + 20 Space + 1 non-creator soft-delete fix-up)
- [x] `eslint src` clean (pre-commit hook xác nhận)

### Cách test thủ công

```bash
cd firebase
firebase emulators:exec --only firestore "cd functions && npm run test:rules -- test/rules/space.rules.test.ts" --project meep-test
```

Expected: `21 passed (21)`

## Lưu ý cho reviewer

- **Self-review finding fix:** initial draft thiếu test "non-creator member cannot soft-delete (set deletedAt)" — security-relevant edge case (member spy bypass creator destroy Space). Đã add test trước khi push.
- **`isMember` helper hot point:** mỗi rule check `/spaces` + `/space_members` đều `get()`/`exists()` — tốn Firestore reads. Mitigation đã có via `memberIds` denormalized array trong `/spaces/{id}`, nhưng rules vẫn dùng subcollection check vì security boundary. Trade-off documented spec §Risks.
- **Rule gap (out-of-scope #137 — flag riêng):** `allow update: if isCreator(spaceId)` không restrict fields → creator có thể tự update `creatorId` bypass CF transferOwnership. Em không fix trong PR này vì sẽ break test "creator can update Space" với deletedAt scenario. Nên fix qua field-level rule sau (e.g. allow update only specific keys).
- **T10b split:** Issue #137 gồm T11 (rules tests — PR này) + T10b (SpaceManagementSheet — PR sau). Em ship T11 trước vì critical path không có UI dependency.
- **Branch type:** `test/` thay vì `feature/` vì 100% test file, không có production code.

## Self-review checklist

- [x] Branch `test/ThienPDM/space-rules` đúng convention
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không file lớn vô tình
- [x] Không có `print`/`console.log` debug
- [x] Không có `// TODO` chưa link issue
- [x] Đã `/review` self-check — 1 🟡 fix (add non-creator soft-delete test), 1 🟡 flag riêng (rule gap creatorId update, scope ngoài)

🤖 Generated with [Claude Code](https://claude.com/claude-code)