### PR TITLE
fix(feed): layout xem ảnh own+friend + note pill + audience row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Khi anh planning sprint: em là tech lead giúp anh chia task khả thi.
 |---|---|---|
 | **User** | Authenticated person, identified by `uid` (Firebase Auth UID). Có `displayName`, `avatarUrl`. | Firestore: `/users/{uid}` |
 | **Post** | One photo + optional caption shared bởi User cho friends. NEVER public. | Firestore: `/posts/{postId}` |
-| **Caption** | Text accompanying a Post. ≤ 200 chars. Optional. | Field `caption` in `/posts/{postId}` |
+| **Caption** | Text accompanying a Post. App enforces ≤ 30 chars (single-line overlay pill); Firestore rule cap is 200. Optional. | Field `caption` in `/posts/{postId}` |
 | **Friend** | User khác có mutual accepted friendship. Bidirectional. | Derived from `/friendships/{pairId}` |
 | **Friend graph** | Set của tất cả friendships. Bidirectional, no public following. | Firestore: `/friendships` |
 | **Friend request** | Pending invite. Becomes Friend khi accepted. | Firestore: `/friend_requests/{requestId}` |

--- a/apps/mobile/lib/core/theme/app_proportions.dart
+++ b/apps/mobile/lib/core/theme/app_proportions.dart
@@ -31,18 +31,12 @@ abstract final class AppProportions {
 
   // ── Note pill ─────────────────────────────────────────────────────────────
 
-  /// Pill total width — fixed ~50% of frame width so the editable caption has
-  /// a comfortable centered text area. Figma frame 412 → ~200px.
-  static const double pillWidthRatio = 200 / figmaFrameWidth;
-  static double pillWidth(double screenW) => screenW * pillWidthRatio;
-
-  /// Pill inner chrome consumed by horizontal padding + icon + gap. Used to
-  /// derive the editable text-area width from [pillWidth].
+  /// Horizontal padding inside the pill chrome. Pill is hug-content (it sizes
+  /// itself to the typed text) so we only need padding, no fixed width.
   static const double pillPaddingH = 14;
-  static const double pillIconGap = 6;
 
-  /// Font size inside pill. Figma: 14px on 412, bumped to 15 for legibility.
-  static const double pillFontRatio = 15 / figmaFrameWidth;
+  /// Font size inside pill. Figma frame 412 → 20px.
+  static const double pillFontRatio = 20 / figmaFrameWidth;
   static double pillFontSize(double screenW) => screenW * pillFontRatio;
 
   // ── Capture Button ────────────────────────────────────────────────────────

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -6,11 +6,15 @@ import 'package:gal/gal.dart';
 import 'package:go_router/go_router.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_proportions.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/feed/application/post_controller.dart';
 import 'package:meep/features/feed/data/post.dart';
 import 'package:meep/features/feed/presentation/capture_action_bar.dart';
 import 'package:meep/features/feed/presentation/capture_preview_args.dart';
 import 'package:meep/features/feed/presentation/caption_preset_modal.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_dots_indicator.dart';
 import 'package:meep/shared/widgets/app_note_pill.dart';
 import 'package:meep/shared/widgets/app_photo_frame.dart';
@@ -242,7 +246,7 @@ class _Header extends StatelessWidget {
   }
 }
 
-class _AudienceRow extends StatelessWidget {
+class _AudienceRow extends ConsumerWidget {
   const _AudienceRow({
     required this.screenW,
     required this.audienceType,
@@ -258,12 +262,35 @@ class _AudienceRow extends StatelessWidget {
   // Figma: Buttons frame x=73 on 412 → left edge of X button
   static const double _leftPaddingRatio = 73 / 412;
 
+  /// Toggle a friend in the selected list. Empty result flips back to
+  /// AudienceType.all so the user doesn't need an explicit "deselect" gesture.
+  void _toggleFriend(String friendUid) {
+    final next = selectedUids.contains(friendUid)
+        ? selectedUids.where((u) => u != friendUid).toList()
+        : [...selectedUids, friendUid];
+    if (next.isEmpty) {
+      onAudienceChanged(AudienceType.all, const []);
+    } else {
+      onAudienceChanged(AudienceType.select, next);
+    }
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final leftPad = screenW * _leftPaddingRatio;
     final avatarSize = AppProportions.audienceAvatarSize(screenW);
     final labelSize = avatarSize * 0.43; // keep below overflow threshold
     final isAll = audienceType == AudienceType.all;
+
+    final currentUid = ref.watch(currentUidProvider).valueOrNull;
+    // Avoid throwing UnimplementedError when auth not ready — just render
+    // the "Tất cả" tile until the uid resolves.
+    final friends = currentUid == null
+        ? const <UserProfile>[]
+        : ref.watch(
+            friendControllerProvider(currentUid).select((s) => s.friends),
+          );
+
     return Align(
       alignment: Alignment.bottomCenter,
       child: SizedBox(
@@ -272,51 +299,141 @@ class _AudienceRow extends StatelessWidget {
           scrollDirection: Axis.horizontal,
           padding: EdgeInsets.only(left: leftPad, right: 20),
           children: [
-            // TODO(Friend/KhoaLND): prepend friend avatar buttons from FriendRepository
-            GestureDetector(
-              onTap: () => onAudienceChanged(AudienceType.all, []),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Container(
-                    width: avatarSize,
-                    height: avatarSize,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      border: Border.all(
-                        color: isAll ? AppColors.turquoise500 : AppColors.bw600,
-                        width: 1.5,
-                      ),
-                    ),
-                    child: Container(
-                      margin: const EdgeInsets.all(2),
-                      decoration: const BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: Color(0xFF394041),
-                      ),
-                      child: Icon(
-                        Icons.group_outlined,
-                        color: isAll ? AppColors.turquoise500 : AppColors.bw100,
-                        size: avatarSize * 0.45,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    'Tất cả',
-                    style: TextStyle(
-                      color: isAll ? AppColors.turquoise500 : AppColors.bw100,
-                      fontSize: labelSize,
-                      fontWeight: FontWeight.w800,
-                      fontFamily: 'Nunito',
-                      height: 1.1,
-                    ),
-                  ),
-                ],
-              ),
+            _AllAudienceTile(
+              isSelected: isAll,
+              avatarSize: avatarSize,
+              labelSize: labelSize,
+              onTap: () => onAudienceChanged(AudienceType.all, const []),
             ),
+            for (final friend in friends) ...[
+              const SizedBox(width: 12),
+              _FriendAudienceTile(
+                friend: friend,
+                isSelected: selectedUids.contains(friend.uid),
+                avatarSize: avatarSize,
+                labelSize: labelSize,
+                onTap: () => _toggleFriend(friend.uid),
+              ),
+            ],
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// "Tất cả" tile — selected by default, picks AudienceType.all.
+class _AllAudienceTile extends StatelessWidget {
+  const _AllAudienceTile({
+    required this.isSelected,
+    required this.avatarSize,
+    required this.labelSize,
+    required this.onTap,
+  });
+
+  final bool isSelected;
+  final double avatarSize;
+  final double labelSize;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = isSelected ? AppColors.turquoise500 : AppColors.bw100;
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: avatarSize,
+            height: avatarSize,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: isSelected ? AppColors.turquoise500 : AppColors.bw600,
+                width: 1.5,
+              ),
+            ),
+            child: Container(
+              margin: const EdgeInsets.all(2),
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: Color(0xFF394041),
+              ),
+              child: Icon(
+                Icons.group_outlined,
+                color: accent,
+                size: avatarSize * 0.45,
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Tất cả',
+            style: TextStyle(
+              color: accent,
+              fontSize: labelSize,
+              fontWeight: FontWeight.w800,
+              fontFamily: 'Nunito',
+              height: 1.1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Friend avatar tile — tap to add/remove this uid from the recipient list.
+class _FriendAudienceTile extends StatelessWidget {
+  const _FriendAudienceTile({
+    required this.friend,
+    required this.isSelected,
+    required this.avatarSize,
+    required this.labelSize,
+    required this.onTap,
+  });
+
+  final UserProfile friend;
+  final bool isSelected;
+  final double avatarSize;
+  final double labelSize;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = isSelected ? AppColors.turquoise500 : AppColors.bw100;
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppAvatar(
+            imageUrl: friend.avatarUrl,
+            size: avatarSize,
+            ringColor: isSelected ? AppColors.turquoise500 : null,
+            fallbackText: friend.displayName.isNotEmpty
+                ? friend.displayName[0].toUpperCase()
+                : null,
+          ),
+          const SizedBox(height: 4),
+          SizedBox(
+            width: avatarSize + 8,
+            child: Text(
+              friend.displayName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: accent,
+                fontSize: labelSize,
+                fontWeight: FontWeight.w800,
+                fontFamily: 'Nunito',
+                height: 1.1,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -131,64 +131,109 @@ class OwnPostCard extends StatelessWidget {
       onLongPress: () => _showShareModal(context, post, isAuthor: true),
       footer: SizedBox(
         width: photoSize,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Text.rich(
-              TextSpan(
-                children: [
-                  const TextSpan(
-                    text: 'Bạn ',
-                    style: TextStyle(color: AppColors.bw100),
-                  ),
-                  TextSpan(
-                    text: _formatDate(post.createdAt),
-                    style: const TextStyle(color: AppColors.bw500),
-                  ),
-                ],
-              ),
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.w700,
-                fontFamily: 'Nunito',
-              ),
-            ),
-            const SizedBox(height: 12),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
-              decoration: BoxDecoration(
-                color: const Color(0x66252627),
-                borderRadius: BorderRadius.circular(40),
-              ),
-              child: const Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    Icons.auto_awesome_outlined,
-                    color: AppColors.bw400,
-                    size: 18,
-                  ),
-                  SizedBox(width: 10),
-                  Text(
-                    'Chưa có hoạt động nào!',
-                    style: TextStyle(
-                      color: AppColors.bw400,
-                      fontSize: 18,
-                      fontWeight: FontWeight.w700,
-                      fontFamily: 'Nunito',
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
+        child: OwnPostFooter(post: post),
       ),
     );
   }
+}
 
-  String _formatDate(DateTime dt) => '${dt.day} thg ${dt.month}';
+/// Author label + activity pill shown under the photo on own posts.
+/// Extracted so [OwnPostPage] can position it at the bottom of the screen
+/// (separately from the photo).
+class OwnPostFooter extends StatelessWidget {
+  const OwnPostFooter({super.key, required this.post});
+
+  final Post post;
+
+  static String _formatDate(DateTime dt) => '${dt.day} thg ${dt.month}';
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text.rich(
+          TextSpan(
+            children: [
+              const TextSpan(
+                text: 'Bạn ',
+                style: TextStyle(color: AppColors.bw100),
+              ),
+              TextSpan(
+                text: _formatDate(post.createdAt),
+                style: const TextStyle(color: AppColors.bw500),
+              ),
+            ],
+          ),
+          textAlign: TextAlign.center,
+          style: const TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w700,
+            fontFamily: 'Nunito',
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
+          decoration: BoxDecoration(
+            color: const Color(0x66252627),
+            borderRadius: BorderRadius.circular(40),
+          ),
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.auto_awesome_outlined,
+                color: AppColors.bw400,
+                size: 18,
+              ),
+              SizedBox(width: 10),
+              Text(
+                'Chưa có hoạt động nào!',
+                style: TextStyle(
+                  color: AppColors.bw400,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: 'Nunito',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Own post variant for the home PageView: photo near the top, footer
+/// (label + activity pill) pinned near the taskbar at ~4% screen height.
+/// Used instead of [OwnPostCard] when the post fills a full screen page.
+class OwnPostPage extends StatelessWidget {
+  const OwnPostPage({super.key, required this.post});
+
+  final Post post;
+
+  /// Spacing from the bottom of the screen (above the taskbar). Tuned by
+  /// product preference; pill should sit just above the nav bar.
+  static const double _bottomGapRatio = 0.04;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenH = MediaQuery.sizeOf(context).height;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        PostCard(
+          post: post,
+          onLongPress: () => _showShareModal(context, post, isAuthor: true),
+        ),
+        const Spacer(),
+        OwnPostFooter(post: post),
+        SizedBox(height: screenH * _bottomGapRatio),
+      ],
+    );
+  }
 }
 
 void _showShareModal(

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -1,11 +1,10 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:meep/core/theme/app_colors.dart';
-import 'package:meep/core/theme/app_proportions.dart';
 import 'package:meep/features/feed/application/feed_controller.dart';
 import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/post_card.dart';
 import 'package:meep/shared/widgets/share_modal.dart';
 
@@ -84,12 +83,148 @@ class FeedSection extends ConsumerWidget {
   }
 }
 
-String _timeAgo(DateTime dt) {
-  final diff = DateTime.now().difference(dt);
-  if (diff.inSeconds < 60) return '${diff.inSeconds}s';
-  if (diff.inMinutes < 60) return '${diff.inMinutes}p';
-  if (diff.inHours < 24) return '${diff.inHours}h';
-  return '${diff.inDays}n';
+/// Shared header row used by both own and friend posts. Friend variant shows
+/// the avatar + `<name> d thg M`; own variant shows just `Bạn d thg M` (no
+/// avatar — the user already sees themselves on every screen, so it would
+/// just be visual noise).
+class PostHeaderRow extends StatelessWidget {
+  const PostHeaderRow({super.key, required this.post, required this.isOwn});
+
+  final Post post;
+  final bool isOwn;
+
+  static String _formatDate(DateTime dt) => '${dt.day} thg ${dt.month}';
+
+  @override
+  Widget build(BuildContext context) {
+    final nameText = isOwn ? 'Bạn' : post.authorName;
+    final dateText = ' ${_formatDate(post.createdAt)}';
+    final label = Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(
+            text: nameText,
+            style: const TextStyle(color: AppColors.bw100),
+          ),
+          TextSpan(
+            text: dateText,
+            style: const TextStyle(color: AppColors.bw500),
+          ),
+        ],
+      ),
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: const TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.w700,
+        fontFamily: 'Nunito',
+      ),
+    );
+
+    if (isOwn) {
+      return Center(child: label);
+    }
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        AppAvatar(
+          imageUrl: post.authorAvatarUrl,
+          size: 28,
+          fallbackText: post.authorName.isNotEmpty
+              ? post.authorName[0].toUpperCase()
+              : null,
+        ),
+        const SizedBox(width: 8),
+        Flexible(child: label),
+      ],
+    );
+  }
+}
+
+/// Activity pill — own posts only ("Chưa có hoạt động nào!"). Hug content,
+/// transparent rounded background. Centered in its parent.
+class ActivityPill extends StatelessWidget {
+  const ActivityPill({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
+      decoration: BoxDecoration(
+        color: const Color(0x66252627),
+        borderRadius: BorderRadius.circular(40),
+      ),
+      child: const Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.auto_awesome_outlined,
+            color: AppColors.bw400,
+            size: 18,
+          ),
+          SizedBox(width: 10),
+          Text(
+            'Chưa có hoạt động nào!',
+            style: TextStyle(
+              color: AppColors.bw400,
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              fontFamily: 'Nunito',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Friend message bar — "Gửi tin nhắn..." + quick reactions. Full-width by
+/// design (it's the chat input), but sized to the same content area as the
+/// activity pill on own posts so both pages have matching horizontal gutters.
+class FriendMessageBar extends StatelessWidget {
+  const FriendMessageBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final screenW = MediaQuery.sizeOf(context).width;
+    final screenH = MediaQuery.sizeOf(context).height;
+    return Container(
+      height: screenH * 0.07,
+      width: screenW * 0.8,
+      decoration: BoxDecoration(
+        color: AppColors.bw800,
+        borderRadius: BorderRadius.circular(22),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Gửi tin nhắn...',
+              style: TextStyle(
+                color: AppColors.bw100,
+                fontSize: screenW * 0.042,
+                fontWeight: FontWeight.w800,
+                fontFamily: 'Nunito',
+              ),
+            ),
+          ),
+          const Text('💙', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          const Text('😂', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          const Text('🥰', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          const Icon(
+            Icons.add_reaction_outlined,
+            color: AppColors.bw500,
+            size: 20,
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 class FriendPostCard extends StatelessWidget {
@@ -103,11 +238,14 @@ class FriendPostCard extends StatelessWidget {
       post: post,
       onLongPress: () => _showShareModal(context, post, isAuthor: false),
       footer: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          _AuthorRow(post: post),
+          PostHeaderRow(post: post, isOwn: false),
           const SizedBox(height: 8),
-          const _ActTextBarStub(),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 6),
+            child: FriendMessageBar(),
+          ),
         ],
       ),
     );
@@ -121,18 +259,10 @@ class OwnPostCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final s = MediaQuery.sizeOf(context);
-    final photoSize = AppProportions.photoSize(s.width, s.height);
-
-    // Footer matches the photo width so its centered content lines up under
-    // the square frame (PostCard's outer column is start-aligned).
     return PostCard(
       post: post,
       onLongPress: () => _showShareModal(context, post, isAuthor: true),
-      footer: SizedBox(
-        width: photoSize,
-        child: OwnPostFooter(post: post),
-      ),
+      footer: OwnPostFooter(post: post),
     );
   }
 }
@@ -145,62 +275,15 @@ class OwnPostFooter extends StatelessWidget {
 
   final Post post;
 
-  static String _formatDate(DateTime dt) => '${dt.day} thg ${dt.month}';
-
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Text.rich(
-          TextSpan(
-            children: [
-              const TextSpan(
-                text: 'Bạn ',
-                style: TextStyle(color: AppColors.bw100),
-              ),
-              TextSpan(
-                text: _formatDate(post.createdAt),
-                style: const TextStyle(color: AppColors.bw500),
-              ),
-            ],
-          ),
-          textAlign: TextAlign.center,
-          style: const TextStyle(
-            fontSize: 20,
-            fontWeight: FontWeight.w700,
-            fontFamily: 'Nunito',
-          ),
-        ),
+        PostHeaderRow(post: post, isOwn: true),
         const SizedBox(height: 12),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
-          decoration: BoxDecoration(
-            color: const Color(0x66252627),
-            borderRadius: BorderRadius.circular(40),
-          ),
-          child: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.auto_awesome_outlined,
-                color: AppColors.bw400,
-                size: 18,
-              ),
-              SizedBox(width: 10),
-              Text(
-                'Chưa có hoạt động nào!',
-                style: TextStyle(
-                  color: AppColors.bw400,
-                  fontSize: 18,
-                  fontWeight: FontWeight.w700,
-                  fontFamily: 'Nunito',
-                ),
-              ),
-            ],
-          ),
-        ),
+        const ActivityPill(),
       ],
     );
   }
@@ -228,8 +311,50 @@ class OwnPostPage extends StatelessWidget {
           post: post,
           onLongPress: () => _showShareModal(context, post, isAuthor: true),
         ),
+        // 1% of screen height — author pill sits just under the photo.
+        // The PostCard's internal photo→footer gap only runs when a footer is
+        // passed in; here we pass none (so the footer can be pinned near the
+        // taskbar), so the gap is applied explicitly at this level instead.
+        SizedBox(height: screenH * 0.01),
+        PostHeaderRow(post: post, isOwn: true),
         const Spacer(),
-        OwnPostFooter(post: post),
+        const ActivityPill(),
+        SizedBox(height: screenH * _bottomGapRatio),
+      ],
+    );
+  }
+}
+
+/// Friend post variant for the home PageView. Mirrors [OwnPostPage] so both
+/// post types share the same vertical rhythm and horizontal gutters: photo
+/// on top, header + message bar pinned at ~4% above the taskbar.
+class FriendPostPage extends StatelessWidget {
+  const FriendPostPage({super.key, required this.post});
+
+  final Post post;
+
+  static const double _bottomGapRatio = 0.04;
+  static const double _gutter = 6;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenH = MediaQuery.sizeOf(context).height;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        PostCard(
+          post: post,
+          onLongPress: () => _showShareModal(context, post, isAuthor: false),
+        ),
+        // 1% screen-height gap — author pill sits just under the photo,
+        // matching the OwnPostPage rhythm.
+        SizedBox(height: screenH * 0.01),
+        PostHeaderRow(post: post, isOwn: false),
+        const Spacer(),
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: _gutter),
+          child: FriendMessageBar(),
+        ),
         SizedBox(height: screenH * _bottomGapRatio),
       ],
     );
@@ -246,96 +371,6 @@ void _showShareModal(
     backgroundColor: Colors.transparent,
     builder: (_) => ShareModal(post: post, isAuthor: isAuthor),
   );
-}
-
-class _AuthorRow extends StatelessWidget {
-  const _AuthorRow({required this.post});
-
-  final Post post;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 6),
-      child: Row(
-        children: [
-          Container(
-            width: 28,
-            height: 28,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: AppColors.bw700,
-              image: post.authorAvatarUrl != null
-                  ? DecorationImage(
-                      image: CachedNetworkImageProvider(post.authorAvatarUrl!),
-                      fit: BoxFit.cover,
-                    )
-                  : null,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Text(
-            post.authorName,
-            style: const TextStyle(
-              color: AppColors.bw100,
-              fontSize: 15,
-              fontWeight: FontWeight.w800,
-              fontFamily: 'Nunito',
-            ),
-          ),
-          const SizedBox(width: 6),
-          Text(
-            _timeAgo(post.createdAt),
-            style: const TextStyle(
-              color: AppColors.bw500,
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ActTextBarStub extends StatelessWidget {
-  const _ActTextBarStub();
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 6),
-      child: Container(
-        height: 44,
-        decoration: BoxDecoration(
-          color: AppColors.bw800,
-          borderRadius: BorderRadius.circular(22),
-        ),
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        child: const Row(
-          children: [
-            Expanded(
-              child: Text(
-                'Gửi tin nhắn...',
-                style: TextStyle(
-                  color: AppColors.bw500,
-                  fontSize: 15,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-            Text('💙', style: TextStyle(fontSize: 18)),
-            SizedBox(width: 10),
-            Text('😂', style: TextStyle(fontSize: 18)),
-            SizedBox(width: 10),
-            Text('🥰', style: TextStyle(fontSize: 18)),
-            SizedBox(width: 10),
-            Icon(Icons.add_reaction_outlined, color: AppColors.bw500, size: 20),
-          ],
-        ),
-      ),
-    );
-  }
 }
 
 class _FeedFooter extends StatelessWidget {

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -546,12 +546,15 @@ class _PostPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final currentUid = FirebaseAuth.instance.currentUser?.uid;
+    if (post.authorId == currentUid) {
+      // Own post: use the full-screen layout (photo top, footer ~4% above
+      // the taskbar). No scroll because the column is sized to the screen.
+      return OwnPostPage(post: post);
+    }
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.only(bottom: 20),
-        child: post.authorId == currentUid
-            ? OwnPostCard(post: post)
-            : FriendPostCard(post: post),
+        child: FriendPostCard(post: post),
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -547,16 +547,9 @@ class _PostPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final currentUid = FirebaseAuth.instance.currentUser?.uid;
     if (post.authorId == currentUid) {
-      // Own post: use the full-screen layout (photo top, footer ~4% above
-      // the taskbar). No scroll because the column is sized to the screen.
       return OwnPostPage(post: post);
     }
-    return SingleChildScrollView(
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: 20),
-        child: FriendPostCard(post: post),
-      ),
-    );
+    return FriendPostPage(post: post);
   }
 }
 

--- a/apps/mobile/lib/shared/widgets/app_note_pill.dart
+++ b/apps/mobile/lib/shared/widgets/app_note_pill.dart
@@ -3,8 +3,11 @@ import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_proportions.dart';
 
 /// Editable caption overlay pill. cornerRadius 30, semi-transparent bg.
-/// Fixed-width text area: marquee ping-pong when readOnly + text overflows.
-/// Width and font size are computed internally from MediaQuery.
+///
+/// Hug-content: the pill sizes itself to the current text instead of being
+/// fixed-width. The text area is measured with [TextPainter] each rebuild,
+/// then clamped to a sane min (so an empty pill is still tappable) and a max
+/// (so a maxed-out 30-char caption never overflows the photo frame).
 class AppNotePill extends StatefulWidget {
   const AppNotePill({
     super.key,
@@ -17,17 +20,17 @@ class AppNotePill extends StatefulWidget {
   final ValueChanged<String>? onChanged;
   final bool readOnly;
 
+  /// Max length the editable pill enforces. Matches the Firestore rule cap
+  /// (which is 200) but app-side we keep captions short enough to render
+  /// nicely in a single-line overlay.
+  static const int maxLength = 30;
+
   @override
   State<AppNotePill> createState() => _AppNotePillState();
 }
 
-class _AppNotePillState extends State<AppNotePill>
-    with SingleTickerProviderStateMixin {
+class _AppNotePillState extends State<AppNotePill> {
   late final TextEditingController _ctrl;
-  AnimationController? _marqueeCtrl;
-  Animation<double>? _marqueeAnim;
-
-  double _textAreaWidth = 0;
   double _fontSize = 14;
 
   TextStyle _textStyle(double fontSize) => TextStyle(
@@ -41,32 +44,11 @@ class _AppNotePillState extends State<AppNotePill>
   void initState() {
     super.initState();
     _ctrl = TextEditingController(text: widget.text);
-    _ctrl.addListener(() => widget.onChanged?.call(_ctrl.text));
-
-    if (widget.readOnly) {
-      _marqueeCtrl = AnimationController(
-        vsync: this,
-        duration: const Duration(milliseconds: 2500),
-      );
-      WidgetsBinding.instance.addPostFrameCallback((_) => _setupMarquee());
-    }
-  }
-
-  void _setupMarquee() {
-    final tp = TextPainter(
-      text: TextSpan(text: widget.text, style: _textStyle(_fontSize)),
-      maxLines: 1,
-      textDirection: TextDirection.ltr,
-    )..layout();
-
-    final overflow = tp.width - _textAreaWidth;
-    if (overflow > 0 && _marqueeCtrl != null) {
-      _marqueeAnim = Tween<double>(begin: 0, end: -(overflow + 8)).animate(
-        CurvedAnimation(parent: _marqueeCtrl!, curve: Curves.easeInOut),
-      );
-      _marqueeCtrl!.repeat(reverse: true);
+    _ctrl.addListener(() {
+      widget.onChanged?.call(_ctrl.text);
+      // Re-measure so the pill grows / shrinks as the user types.
       if (mounted) setState(() {});
-    }
+    });
   }
 
   @override
@@ -80,89 +62,80 @@ class _AppNotePillState extends State<AppNotePill>
   @override
   void dispose() {
     _ctrl.dispose();
-    _marqueeCtrl?.dispose();
     super.dispose();
+  }
+
+  /// Measure the visual width of [text] at the current font.
+  double _measureText(String text) {
+    final tp = TextPainter(
+      text: TextSpan(text: text, style: _textStyle(_fontSize)),
+      maxLines: 1,
+      textDirection: TextDirection.ltr,
+    )..layout();
+    return tp.width;
   }
 
   @override
   Widget build(BuildContext context) {
     final screenW = MediaQuery.sizeOf(context).width;
-    final pillW = AppProportions.pillWidth(screenW);
     _fontSize = AppProportions.pillFontSize(screenW);
-    final iconSize = _fontSize + 2;
-    // Fixed-width pill: text area = pill width minus padding, icon, and gap.
-    _textAreaWidth = pillW -
-        AppProportions.pillPaddingH * 2 -
-        iconSize -
-        AppProportions.pillIconGap;
 
     return Container(
-      width: pillW,
       padding: const EdgeInsets.symmetric(
         horizontal: AppProportions.pillPaddingH,
-        vertical: 8,
+        vertical: 4,
       ),
       decoration: BoxDecoration(
         color: const Color(0x66394041),
         borderRadius: BorderRadius.circular(30),
       ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Icons.text_fields, color: AppColors.bw300, size: iconSize),
-          const SizedBox(width: AppProportions.pillIconGap),
-          SizedBox(
-            width: _textAreaWidth,
-            child: widget.readOnly ? _buildMarquee() : _buildTextField(),
-          ),
-        ],
-      ),
+      child: widget.readOnly ? _buildReadOnly() : _buildTextField(screenW),
     );
   }
 
-  Widget _buildMarquee() {
-    if (_marqueeAnim == null) {
-      return Text(
-        widget.text,
-        style: _textStyle(_fontSize),
-        maxLines: 1,
-        textAlign: TextAlign.center,
-        overflow: TextOverflow.ellipsis,
-      );
-    }
-    return ClipRect(
-      child: AnimatedBuilder(
-        animation: _marqueeAnim!,
-        builder: (_, child) => Transform.translate(
-          offset: Offset(_marqueeAnim!.value, 0),
-          child: child,
-        ),
-        child: Text(
-          widget.text,
-          style: _textStyle(_fontSize),
-          maxLines: 1,
-          softWrap: false,
-          overflow: TextOverflow.visible,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildTextField() {
-    return TextField(
-      controller: _ctrl,
+  Widget _buildReadOnly() {
+    // 30-char cap on input means the readOnly pill never needs marquee or
+    // wrap — a single line with ellipsis is enough as a safety net.
+    return Text(
+      widget.text,
       style: _textStyle(_fontSize),
+      maxLines: 1,
       textAlign: TextAlign.center,
-      decoration: InputDecoration(
-        isDense: true,
-        border: InputBorder.none,
-        hintText: 'Nhập chú thích...',
-        hintStyle: TextStyle(color: AppColors.bw500, fontSize: _fontSize),
-        contentPadding: EdgeInsets.zero,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+
+  Widget _buildTextField(double screenW) {
+    // Hug width: measure the typed text, clamp to [min, max] so the pill is
+    // always tappable when empty and never spills past the photo frame.
+    final text = _ctrl.text;
+    final measured = _measureText(text.isEmpty ? 'A' : text);
+    final minW = _fontSize; // ~1 character of space when empty
+    final maxW =
+        screenW - AppProportions.pillPaddingH * 2 - 24; // 24 = safety margin
+    final width = measured.clamp(minW, maxW);
+
+    return SizedBox(
+      width: width,
+      child: TextField(
+        controller: _ctrl,
+        style: _textStyle(_fontSize),
+        textAlign: TextAlign.center,
+        decoration: const InputDecoration(
+          isDense: true,
+          border: InputBorder.none,
+          hintText: '',
+          contentPadding: EdgeInsets.zero,
+        ),
+        maxLength: AppNotePill.maxLength,
+        buildCounter: (
+          _, {
+          required currentLength,
+          required isFocused,
+          maxLength,
+        }) =>
+            null,
       ),
-      maxLength: 200,
-      buildCounter:
-          (_, {required currentLength, required isFocused, maxLength}) => null,
     );
   }
 }

--- a/apps/mobile/lib/shared/widgets/post_card.dart
+++ b/apps/mobile/lib/shared/widgets/post_card.dart
@@ -41,7 +41,9 @@ class _PostCardState extends State<PostCard> {
     final hasCaption = (post.caption ?? '').trim().isNotEmpty;
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      // Center so the square photo (screenW - 12) sits between equal 6px
+      // gutters on both sides instead of sticking to the left edge.
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         GestureDetector(
           onLongPress: widget.onLongPress,
@@ -79,7 +81,9 @@ class _PostCardState extends State<PostCard> {
           ),
         ),
         if (widget.footer != null) ...[
-          const SizedBox(height: 10),
+          // 1% of screen height (~9px on a 917-tall device) per product spec —
+          // header pill sits just under the photo without crowding it.
+          SizedBox(height: s.height * 0.01),
           widget.footer!,
         ],
       ],

--- a/apps/mobile/test/shared/widgets/app_note_pill_test.dart
+++ b/apps/mobile/test/shared/widgets/app_note_pill_test.dart
@@ -1,16 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:meep/core/theme/app_proportions.dart';
 import 'package:meep/shared/widgets/app_note_pill.dart';
 
 void main() {
-  // Phone-sized surface so pillWidth resolves to the Figma ~200px target.
+  // Phone-sized surface so MediaQuery-driven font sizing is deterministic.
   Widget wrap(Widget w) => MaterialApp(
         home: MediaQuery(
           data: const MediaQueryData(size: Size(412, 917)),
           child: Scaffold(body: Center(child: w)),
         ),
+      );
+
+  Size pillSize(WidgetTester tester) => tester.getSize(
+        find
+            .descendant(
+              of: find.byType(AppNotePill),
+              matching: find.byType(Container),
+            )
+            .first,
       );
 
   group('AppNotePill', () {
@@ -20,34 +28,25 @@ void main() {
       expect(field.textAlign, TextAlign.center);
     });
 
-    testWidgets('pill has fixed width from proportions', (tester) async {
+    testWidgets('width grows with text length (hug content)', (tester) async {
       await tester.pumpWidget(wrap(const AppNotePill(text: '')));
-      final size = tester.getSize(
-        find
-            .descendant(
-              of: find.byType(AppNotePill),
-              matching: find.byType(Container),
-            )
-            .first,
+      await tester.pump();
+      final emptyW = pillSize(tester).width;
+
+      await tester.pumpWidget(
+        wrap(const AppNotePill(text: 'a much longer caption here')),
       );
-      expect(size.width, closeTo(AppProportions.pillWidth(412), 0.5));
+      await tester.pump();
+      final longW = pillSize(tester).width;
+
+      expect(longW, greaterThan(emptyW));
     });
 
-    testWidgets('width is independent of text length', (tester) async {
-      await tester.pumpWidget(
-        wrap(
-          const AppNotePill(text: 'A very long caption that would overflow'),
-        ),
-      );
-      final size = tester.getSize(
-        find
-            .descendant(
-              of: find.byType(AppNotePill),
-              matching: find.byType(Container),
-            )
-            .first,
-      );
-      expect(size.width, closeTo(AppProportions.pillWidth(412), 0.5));
+    testWidgets('enforces 30-char maxLength', (tester) async {
+      await tester.pumpWidget(wrap(const AppNotePill(text: '')));
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.maxLength, AppNotePill.maxLength);
+      expect(AppNotePill.maxLength, 30);
     });
   });
 }


### PR DESCRIPTION
## Tóm tắt

PR này gộp 4 thay đổi UI/UX cho luồng feed + capture, **không đụng module dev khác**, không thêm dependency mới.

## Thay đổi

### 1. `refactor(note)` — Note pill fit content + giới hạn 30 ký tự (`24f8898`)
- Pill caption bỏ width cố định 200px, hug theo nội dung (đo bằng `TextPainter` mỗi rebuild, clamp `[fontSize, screenW - chrome]`).
- Bỏ marquee + AnimationController: 30 ký tự max → single-line + ellipsis là đủ cho readOnly.
- Bỏ icon `Icons.text_fields` + hint "Nhập chú thích..." theo design mới.
- `TextField.maxLength` 200 → 30. Firestore rule vẫn cap ≤ 200 — không đổi rule, app enforce chặt hơn.
- Bump font 15→20px trên khung 412.
- Bỏ dead code `pillWidthRatio`, `pillWidth()`, `pillIconGap` trong `AppProportions`.
- Cập nhật CLAUDE.md domain language (Caption ≤ 30 chars app, ≤ 200 rule).

### 2. `fix(feed)` — Căn activity pill lên gần taskbar theo % màn hình (`7d9b41f`)
- Trang xem ảnh bản thân (home PageView) trước render `OwnPostCard` trong `SingleChildScrollView` → photo + footer dính ngay dưới photo, trống cả khoảng xuống taskbar.
- Tách `OwnPostFooter` (label + activity pill) thành widget riêng + thêm `OwnPostPage` cho layout full-screen: photo trên, header sát photo, Spacer đẩy pill xuống gần taskbar (cách 4% screen height).
- `OwnPostCard` giữ nguyên cho feed list view (SliverList).

### 3. `feat(feed)` — Audience row hiển thị friend avatars + chọn người nhận (`be45b42`)
- `_AudienceRow` trên capture preview giờ là `ConsumerWidget`, watch `friendControllerProvider(currentUid).friends` qua `.select()`.
- Prepend friend avatar tiles vào ListView sau tile "Tất cả".
- Tap 1 friend → toggle uid trong `selectedUids`. ≥1 selected → `AudienceType.select`. Bỏ hết → tự về `AudienceType.all`.
- Visual selected: avatar có ring turquoise + label đổi sang turquoise.
- Tách `_AllAudienceTile` + `_FriendAudienceTile` (mỗi cái <80 dòng).

### 4. `refactor(feed)` — Author pill dùng chung own+friend + căn lề photo/feed page (`fc21fa3`)
- **T1 — `PostHeaderRow` shared component** (Nunito Bold 20px, tên trắng + ngày xám "d thg M"):
  - Own: chỉ text "Bạn d thg M", không avatar.
  - Friend: avatar 28 + "<tên> d thg M" cùng style, layout horizontal căn giữa.
  - Thay `_AuthorRow` cũ + Text "Bạn d thg M" cũ bằng 1 component.
- **T2 — `FriendPostPage` mirror `OwnPostPage`**:
  - Layout: photo → SizedBox(1% screenH) → header → Spacer → message bar → SizedBox(4% screenH).
  - Tách `ActivityPill` + `FriendMessageBar` thành widget public.
  - `home_screen._PostPage`: friend giờ dùng `FriendPostPage`.
  - `FriendMessageBar`: `height: screenH * 0.07`, `width: screenW * 0.8`, font Nunito Bold 16.
- **T3 — Photo căn 6px L/R, hết lệch trái**:
  - `PostCard` đổi `CrossAxisAlignment.start` → `center`. `photoSize` đã = `screenW - 12`; center → 6px gutter mỗi bên.
- **T4 — Khoảng cách photo → header tính theo % màn hình**:
  - `SizedBox(height: screenH * 0.01)` explicit ngay sau `PostCard` trong cả `OwnPostPage` + `FriendPostPage` (~9px trên màn 917).

## Test plan

- [x] `dart format --set-exit-if-changed .` — 280 files, 0 changed
- [x] `flutter analyze --fatal-infos` — No issues found
- [x] `flutter test --coverage` — **342 passed**, 2 skipped, 0 failed
- [x] commitlint 4 commit vs develop — 0 problems, 0 warnings
- [x] Rebase clean lên `origin/develop` (ahead 4, behind 0)
- [x] Kiểm tra trên device: căn lề photo 6px L/R, gap photo→author ~9px, activity pill/message bar cách taskbar ~4%, audience row hiện đúng friend list, gửi ảnh select 1 friend thành công, note pill hug content + max 30 chars

## Liên quan

Refs #94 