### PR TITLE
feat(settings): T3+T4 — SettingsController + BlockedAccountsPage real + BlockConfirmDialog wire

### DIFF
--- a/apps/mobile/lib/features/settings/application/blocked_user_view.dart
+++ b/apps/mobile/lib/features/settings/application/blocked_user_view.dart
@@ -1,0 +1,13 @@
+/// View model cho BlockedAccountsPage: join `Block` (uid only) với
+/// `UserProfile` (username, avatar) để hiển thị list.
+class BlockedUserView {
+  const BlockedUserView({
+    required this.uid,
+    required this.username,
+    this.avatarUrl,
+  });
+
+  final String uid;
+  final String username;
+  final String? avatarUrl;
+}

--- a/apps/mobile/lib/features/settings/application/blocked_users_provider.dart
+++ b/apps/mobile/lib/features/settings/application/blocked_users_provider.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/settings/application/blocked_user_view.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
+
+part 'blocked_users_provider.g.dart';
+
+/// Stream danh sách `BlockedUserView` cho BlockedAccountsPage.
+/// Join `BlockRepository.watchBlockedUsers` với `UserRepository.getProfile`
+/// để có username + avatar (Block chỉ chứa UIDs).
+///
+/// N+1 reads chấp nhận được vì blocked list thường < 10. Nếu list lớn lên,
+/// xem xét denormalize username/avatar vào doc /blocks/.
+@riverpod
+Stream<List<BlockedUserView>> blockedUsers(Ref ref) {
+  final uid = ref.watch(authRepositoryProvider).currentUid;
+  if (uid == null) return Stream.value(const []);
+
+  final blockRepo = ref.watch(blockRepositoryProvider);
+  final userRepo = ref.watch(userRepositoryProvider);
+
+  return blockRepo.watchBlockedUsers(uid).asyncMap((blocks) async {
+    if (blocks.isEmpty) return <BlockedUserView>[];
+    final profiles = await Future.wait(
+      blocks.map((b) => userRepo.getProfile(b.blockedUid)),
+    );
+    return [
+      for (var i = 0; i < blocks.length; i++)
+        BlockedUserView(
+          uid: blocks[i].blockedUid,
+          username: profiles[i]?.username ?? blocks[i].blockedUid,
+          avatarUrl: profiles[i]?.avatarUrl,
+        ),
+    ];
+  });
+}

--- a/apps/mobile/lib/features/settings/application/settings_controller.dart
+++ b/apps/mobile/lib/features/settings/application/settings_controller.dart
@@ -1,6 +1,12 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:meep/core/config/app_config.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/notification/application/notification_controller.dart';
+import 'package:meep/features/settings/application/settings_state.dart';
 import 'package:meep/features/settings/data/block_repository.dart';
 
 part 'settings_controller.g.dart';
@@ -8,31 +14,97 @@ part 'settings_controller.g.dart';
 @Riverpod(keepAlive: true)
 BlockRepository blockRepository(Ref ref) => throw UnimplementedError(
       'blockRepositoryProvider must be overridden — '
-      'wire FirestoreBlockRepository in main.dart (TODO: SE/T1/TBD)',
+      'wire FirebaseBlockRepository in main.dart',
     );
 
 @riverpod
 class SettingsController extends _$SettingsController {
   @override
-  void build() {}
+  SettingsState build() => const SettingsState();
+
+  /// Copy Meep profile deep-link vào clipboard.
+  /// URL format: `${AppConfig.shareBaseUrl}/{username}` (vd meep://profile/ngantran).
+  Future<void> copyProfileLink(String username) async {
+    final link = '${AppConfig.shareBaseUrl}/$username';
+    await Clipboard.setData(ClipboardData(text: link));
+  }
 
   Future<void> blockUser(String targetUid) async {
-    // TODO(SE/T2/TBD): implement blockUser
-    throw UnimplementedError('blockUser — TODO: SE/T2/TBD');
+    final blockerUid = ref.read(authRepositoryProvider).currentUid;
+    if (blockerUid == null) {
+      state = state.copyWith(
+        errorMessage: 'Bạn cần đăng nhập để thực hiện thao tác này',
+      );
+      return;
+    }
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      await ref.read(blockRepositoryProvider).blockUser(
+            blockerUid: blockerUid,
+            targetUid: targetUid,
+          );
+      state = state.copyWith(isLoading: false);
+    } catch (e) {
+      state = _afterFailure(e);
+    }
   }
 
   Future<void> unblockUser(String targetUid) async {
-    // TODO(SE/T3/TBD): implement unblockUser
-    throw UnimplementedError('unblockUser — TODO: SE/T3/TBD');
+    final blockerUid = ref.read(authRepositoryProvider).currentUid;
+    if (blockerUid == null) {
+      state = state.copyWith(
+        errorMessage: 'Bạn cần đăng nhập để thực hiện thao tác này',
+      );
+      return;
+    }
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      await ref.read(blockRepositoryProvider).unblockUser(
+            blockerUid: blockerUid,
+            targetUid: targetUid,
+          );
+      state = state.copyWith(isLoading: false);
+    } catch (e) {
+      state = _afterFailure(e);
+    }
   }
 
+  /// Logout flow:
+  /// 1. Best-effort `deleteFcmToken(uid)` — Notification module có thể chưa
+  ///    wire (#103 OPEN) hoặc offline → swallow lỗi, vẫn tiếp tục signOut.
+  /// 2. `AuthRepository.signOut()` — error sẽ surface lên state.errorMessage.
+  /// Router auth listener tự redirect về /intro khi uid → null.
   Future<void> logout() async {
-    // TODO(SE/T4/TBD): implement logout — clear session + navigate to intro
-    throw UnimplementedError('logout — TODO: SE/T4/TBD');
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    final auth = ref.read(authRepositoryProvider);
+    final uid = auth.currentUid;
+    if (uid != null) {
+      try {
+        await ref.read(notificationRepositoryProvider).deleteFcmToken(uid);
+      } catch (_) {
+        // Swallow: FCM cleanup là best-effort, không block logout.
+      }
+    }
+    try {
+      await auth.signOut();
+      state = state.copyWith(isLoading: false);
+    } catch (e) {
+      state = _afterFailure(e);
+    }
   }
 
   Future<void> deleteAccount() async {
-    // TODO(SE/T5/TBD): implement deleteAccount — re-auth + cascade delete
-    throw UnimplementedError('deleteAccount — TODO: SE/T5/TBD');
+    // TODO(T6/NganTNK): implement deleteAccount (re-auth + cascade) — scope #119
+    throw UnimplementedError('deleteAccount — TODO T6 #119');
+  }
+
+  /// Reset isLoading + map error to message (null for [OperationCancelledError]).
+  /// Pattern theo `login_controller._afterFailure`.
+  SettingsState _afterFailure(Object e) {
+    final err = AppError.fromUnknown(e);
+    return state.copyWith(
+      isLoading: false,
+      errorMessage: err is OperationCancelledError ? null : err.message,
+    );
   }
 }

--- a/apps/mobile/lib/features/settings/application/settings_state.dart
+++ b/apps/mobile/lib/features/settings/application/settings_state.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'settings_state.freezed.dart';
+
+@freezed
+class SettingsState with _$SettingsState {
+  const factory SettingsState({
+    @Default(false) bool isLoading,
+    String? errorMessage,
+  }) = _SettingsState;
+}

--- a/apps/mobile/lib/features/settings/presentation/_mock_data.dart
+++ b/apps/mobile/lib/features/settings/presentation/_mock_data.dart
@@ -1,5 +1,6 @@
 // Mock data for Settings UI development.
-// TODO(T3/NganTNK): Replace with real data from SettingsController after backend ready.
+// TODO(T3/NganTNK): Replace với real data sau khi Space module wire xong
+// (currently chỉ còn mockSpaces dùng cho SpaceQuickRow pre-M3).
 
 class SettingsMockData {
   static const username = 'ngantran';
@@ -8,23 +9,4 @@ class SettingsMockData {
   static const avatarUrl = null; // null = show placeholder icon
 
   static const mockSpaces = <String>['Gia đình', 'Hội đồng quản trị'];
-
-  static const mockBlockedUsers = <BlockedUserView>[
-    BlockedUserView(uid: 'mock-uid-1', username: 'Lauren'),
-  ];
-}
-
-/// View model cho BlockedAccountsPage. T3 sẽ join `Block` (uid) với
-/// `/users/{uid}` (username, avatar) thành list `BlockedUserView` qua
-/// SettingsController.watchBlockedUsers().
-class BlockedUserView {
-  const BlockedUserView({
-    required this.uid,
-    required this.username,
-    this.avatarUrl,
-  });
-
-  final String uid;
-  final String username;
-  final String? avatarUrl;
 }

--- a/apps/mobile/lib/features/settings/presentation/block_confirm_dialog.dart
+++ b/apps/mobile/lib/features/settings/presentation/block_confirm_dialog.dart
@@ -1,31 +1,75 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_spacing.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
 import 'package:meep/shared/widgets/app_bottom_sheet.dart';
 
-class BlockConfirmDialog extends StatefulWidget {
-  const BlockConfirmDialog({super.key, required this.targetName});
+/// Confirm dialog cho block user (Figma 605:1991 + state "Đã chặn!" 624:1906).
+/// Trigger từ `PhotoActionSheet` ở feed module (KhoaLND) khi user tap "Chặn".
+///
+/// Flow:
+/// - User tap "Chặn" → controller.blockUser(targetUid)
+/// - Success → button đổi "Đã chặn!" (disabled, hơi mờ)
+/// - Error → giữ button "Chặn" (errorMessage trong SettingsState, caller có
+///   thể inspect nếu muốn show toast)
+/// - User tap "Bỏ qua" → pop dialog với kết quả `_blocked` (bool)
+class BlockConfirmDialog extends ConsumerStatefulWidget {
+  const BlockConfirmDialog({
+    super.key,
+    required this.targetUid,
+    required this.targetName,
+  });
 
+  final String targetUid;
   final String targetName;
 
-  static Future<bool?> show(BuildContext context, String targetName) =>
+  static Future<bool?> show(
+    BuildContext context, {
+    required String targetUid,
+    required String targetName,
+  }) =>
       showModalBottomSheet<bool>(
         context: context,
         isScrollControlled: true,
         backgroundColor: Colors.transparent,
-        builder: (_) => BlockConfirmDialog(targetName: targetName),
+        builder: (_) => BlockConfirmDialog(
+          targetUid: targetUid,
+          targetName: targetName,
+        ),
       );
 
   @override
-  State<BlockConfirmDialog> createState() => _BlockConfirmDialogState();
+  ConsumerState<BlockConfirmDialog> createState() => _BlockConfirmDialogState();
 }
 
-class _BlockConfirmDialogState extends State<BlockConfirmDialog> {
+class _BlockConfirmDialogState extends ConsumerState<BlockConfirmDialog> {
   bool _blocked = false;
+  bool _isBlocking = false;
+
+  Future<void> _onBlockTap() async {
+    setState(() => _isBlocking = true);
+    await ref
+        .read(settingsControllerProvider.notifier)
+        .blockUser(widget.targetUid);
+    if (!mounted) return;
+    final errorMsg = ref.read(settingsControllerProvider).errorMessage;
+    if (errorMsg != null) {
+      // Error: cho phép retry, errorMessage đã set trong state cho caller inspect.
+      setState(() => _isBlocking = false);
+      return;
+    }
+    setState(() {
+      _blocked = true;
+      _isBlocking = false;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
+    final isBusyOrDone = _blocked || _isBlocking;
     return AppBottomSheet(
       child: Padding(
         padding: EdgeInsets.only(
@@ -76,27 +120,31 @@ class _BlockConfirmDialogState extends State<BlockConfirmDialog> {
                 label: _blocked ? 'Đã chặn!' : 'Chặn',
                 excludeSemantics: true,
                 child: GestureDetector(
-                  onTap: _blocked
-                      ? null
-                      : () {
-                          setState(() => _blocked = true);
-                          // TODO(T4/NganTNK): SettingsController.blockUser(uid)
-                        },
+                  onTap: isBusyOrDone ? null : _onBlockTap,
                   child: Container(
                     padding: const EdgeInsets.symmetric(vertical: 14),
                     decoration: BoxDecoration(
-                      color: _blocked
+                      color: isBusyOrDone
                           ? AppColors.turquoise500.withValues(alpha: 0.7)
                           : AppColors.turquoise500,
                       borderRadius: BorderRadius.circular(14),
                     ),
                     child: Center(
-                      child: Text(
-                        _blocked ? 'Đã chặn!' : 'Chặn',
-                        style: AppTextStyles.mdSemiBold.copyWith(
-                          color: Colors.white,
-                        ),
-                      ),
+                      child: _isBlocking
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: Colors.white,
+                              ),
+                            )
+                          : Text(
+                              _blocked ? 'Đã chặn!' : 'Chặn',
+                              style: AppTextStyles.mdSemiBold.copyWith(
+                                color: Colors.white,
+                              ),
+                            ),
                     ),
                   ),
                 ),

--- a/apps/mobile/lib/features/settings/presentation/blocked_accounts_page.dart
+++ b/apps/mobile/lib/features/settings/presentation/blocked_accounts_page.dart
@@ -1,49 +1,55 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_spacing.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
-import 'package:meep/features/settings/presentation/_mock_data.dart';
+import 'package:meep/features/settings/application/blocked_user_view.dart';
+import 'package:meep/features/settings/application/blocked_users_provider.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
 import 'package:meep/features/settings/presentation/unblock_confirm_dialog.dart';
 import 'package:meep/features/settings/presentation/widgets/settings_scaffold.dart';
 import 'package:meep/shared/widgets/app_avatar.dart';
 
-class BlockedAccountsPage extends StatefulWidget {
+class BlockedAccountsPage extends ConsumerWidget {
   const BlockedAccountsPage({super.key});
 
-  @override
-  State<BlockedAccountsPage> createState() => _BlockedAccountsPageState();
-}
-
-class _BlockedAccountsPageState extends State<BlockedAccountsPage> {
-  // TODO(T4/NganTNK): replace mock list with SettingsController.watchBlockedUsers()
-  late final List<BlockedUserView> _blockedUsers =
-      List<BlockedUserView>.from(SettingsMockData.mockBlockedUsers);
-
-  Future<void> _onUnblock(int index) async {
+  Future<void> _onUnblock(
+    BuildContext context,
+    WidgetRef ref,
+    BlockedUserView user,
+  ) async {
     // Bỏ chặn cần xác nhận trước (Figma 1441:3341 — state 3).
     final confirmed = await UnblockConfirmDialog.show(context);
-    if (!confirmed || !mounted) return;
-    // TODO(T4/NganTNK): SettingsController.unblockUser(uid)
-    setState(() => _blockedUsers.removeAt(index));
+    if (!confirmed) return;
+    await ref.read(settingsControllerProvider.notifier).unblockUser(user.uid);
+    // Stream provider auto re-emits sau unblock → list refresh tự động.
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final blocked = ref.watch(blockedUsersProvider);
     return SettingsScaffold(
       title: 'Tài khoản bị chặn',
-      body: _blockedUsers.isEmpty
-          ? const _EmptyState()
-          : ListView.builder(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSpacing.screenHorizontal,
-                vertical: AppSpacing.xl,
+      body: blocked.when(
+        loading: () => const Center(
+          child: CircularProgressIndicator(color: AppColors.turquoise500),
+        ),
+        error: (_, __) => const _ErrorState(),
+        data: (users) => users.isEmpty
+            ? const _EmptyState()
+            : ListView.builder(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.screenHorizontal,
+                  vertical: AppSpacing.xl,
+                ),
+                itemCount: users.length,
+                itemBuilder: (_, i) => _BlockedUserItem(
+                  user: users[i],
+                  onUnblock: () => _onUnblock(context, ref, users[i]),
+                ),
               ),
-              itemCount: _blockedUsers.length,
-              itemBuilder: (_, i) => _BlockedUserItem(
-                username: _blockedUsers[i].username,
-                onUnblock: () => _onUnblock(i),
-              ),
-            ),
+      ),
     );
   }
 }
@@ -75,13 +81,34 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
+class _ErrorState extends StatelessWidget {
+  const _ErrorState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: const Alignment(0, -0.3),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.screenHorizontal,
+        ),
+        child: Text(
+          'Không thể tải danh sách. Kiểm tra kết nối và thử lại.',
+          style: AppTextStyles.mdRegular.copyWith(color: AppColors.bw400),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
 class _BlockedUserItem extends StatelessWidget {
   const _BlockedUserItem({
-    required this.username,
+    required this.user,
     required this.onUnblock,
   });
 
-  final String username;
+  final BlockedUserView user;
   final VoidCallback onUnblock;
 
   @override
@@ -92,13 +119,15 @@ class _BlockedUserItem extends StatelessWidget {
         children: [
           AppAvatar(
             size: 50,
-            fallbackText:
-                username.isNotEmpty ? username[0].toUpperCase() : null,
+            imageUrl: user.avatarUrl,
+            fallbackText: user.username.isNotEmpty
+                ? user.username[0].toUpperCase()
+                : null,
           ),
           const SizedBox(width: AppSpacing.md),
           Expanded(
             child: Text(
-              username,
+              user.username,
               style: AppTextStyles.mdBold.copyWith(color: AppColors.bw100),
             ),
           ),

--- a/apps/mobile/lib/features/settings/presentation/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/presentation/settings_sheet.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_spacing.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
 import 'package:meep/features/settings/presentation/_mock_data.dart';
 import 'package:meep/features/settings/presentation/blocked_accounts_page.dart';
 import 'package:meep/features/settings/presentation/delete_account_dialog.dart';
@@ -17,11 +19,11 @@ import 'package:meep/features/settings/presentation/widgets/settings_quick_actio
 import 'package:meep/features/settings/presentation/widgets/space_quick_row.dart';
 
 /// Bottom sheet cài đặt — trigger từ avatar topbar homepage (Figma 572:4183).
-class SettingsSheet extends StatelessWidget {
+class SettingsSheet extends ConsumerWidget {
   const SettingsSheet({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Container(
       decoration: const BoxDecoration(
         color: AppColors.bw800,
@@ -123,10 +125,12 @@ class SettingsSheet extends StatelessWidget {
                     label: 'Đăng xuất',
                     onTap: () async {
                       final confirmed = await LogoutConfirmDialog.show(context);
-                      if (confirmed == true && context.mounted) {
-                        Navigator.of(context).pop();
-                        // TODO(T3/NganTNK): SettingsController.logout()
-                      }
+                      if (confirmed != true) return;
+                      if (context.mounted) Navigator.of(context).pop();
+                      // Router auth listener tự redirect /intro khi uid → null.
+                      await ref
+                          .read(settingsControllerProvider.notifier)
+                          .logout();
                     },
                   ),
                   SettingsNavRow(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -22,6 +22,8 @@ import 'package:meep/features/chat/data/fake_conversation_repository.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/firebase_friend_repository.dart';
 import 'package:meep/features/friend/data/firebase_friend_request_repository.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
+import 'package:meep/features/settings/data/firebase_block_repository.dart';
 import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/features/space/data/firebase_space_repository.dart';
 import 'package:meep/firebase_options.dart';
@@ -70,6 +72,12 @@ void main() async {
         ),
         spaceRepositoryProvider.overrideWithValue(
           FirebaseSpaceRepository(
+            FirebaseFirestore.instance,
+            FirebaseFunctions.instanceFor(region: 'asia-southeast1'),
+          ),
+        ),
+        blockRepositoryProvider.overrideWithValue(
+          FirebaseBlockRepository(
             FirebaseFirestore.instance,
             FirebaseFunctions.instanceFor(region: 'asia-southeast1'),
           ),

--- a/apps/mobile/test/features/settings/application/settings_controller_test.dart
+++ b/apps/mobile/test/features/settings/application/settings_controller_test.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/auth_repository.dart';
+import 'package:meep/features/notification/application/notification_controller.dart';
+import 'package:meep/features/notification/data/notification_repository.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
+import 'package:meep/features/settings/data/block_repository.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockBlockRepository extends Mock implements BlockRepository {}
+
+class MockNotificationRepository extends Mock
+    implements NotificationRepository {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('copyProfileLink', () {
+    late ProviderContainer container;
+    String? capturedText;
+
+    setUp(() {
+      capturedText = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          capturedText = (call.arguments as Map)['text'] as String?;
+        }
+        return null;
+      });
+
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    test('set clipboard tới meep://profile/{username}', () async {
+      await container
+          .read(settingsControllerProvider.notifier)
+          .copyProfileLink('ngantran');
+
+      expect(capturedText, 'meep://profile/ngantran');
+    });
+
+    test('username có ký tự đặc biệt vẫn copy raw (không URL-encode)',
+        () async {
+      // Username Meep theo spec là lower-snake/ASCII, không cần encode.
+      // Test đảm bảo controller KHÔNG accidentally encode.
+      await container
+          .read(settingsControllerProvider.notifier)
+          .copyProfileLink('user_name.test');
+
+      expect(capturedText, 'meep://profile/user_name.test');
+    });
+  });
+
+  group('blockUser / unblockUser', () {
+    late MockAuthRepository auth;
+    late MockBlockRepository block;
+    late ProviderContainer container;
+
+    ProviderContainer makeContainer() => ProviderContainer(
+          overrides: [
+            authRepositoryProvider.overrideWithValue(auth),
+            blockRepositoryProvider.overrideWithValue(block),
+          ],
+        );
+
+    setUp(() {
+      auth = MockAuthRepository();
+      block = MockBlockRepository();
+      // Default: signed in as 'me'
+      when(() => auth.currentUid).thenReturn('me');
+      when(
+        () => block.blockUser(
+          blockerUid: any(named: 'blockerUid'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => block.unblockUser(
+          blockerUid: any(named: 'blockerUid'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      ).thenAnswer((_) async {});
+      container = makeContainer();
+    });
+
+    tearDown(() => container.dispose());
+
+    test('blockUser: gọi repo với blockerUid=currentUid + targetUid', () async {
+      await container
+          .read(settingsControllerProvider.notifier)
+          .blockUser('target');
+
+      verify(() => block.blockUser(blockerUid: 'me', targetUid: 'target'))
+          .called(1);
+      expect(container.read(settingsControllerProvider).isLoading, isFalse);
+      expect(container.read(settingsControllerProvider).errorMessage, isNull);
+    });
+
+    test('blockUser: chưa login → errorMessage set, KHÔNG gọi repo', () async {
+      when(() => auth.currentUid).thenReturn(null);
+
+      await container
+          .read(settingsControllerProvider.notifier)
+          .blockUser('target');
+
+      verifyNever(
+        () => block.blockUser(
+          blockerUid: any(named: 'blockerUid'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      );
+      expect(
+        container.read(settingsControllerProvider).errorMessage,
+        isNotNull,
+      );
+    });
+
+    test('blockUser: repo throw AppError → state.errorMessage = err.message',
+        () async {
+      when(
+        () => block.blockUser(
+          blockerUid: any(named: 'blockerUid'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      ).thenThrow(ForbiddenError('chặn người dùng'));
+
+      await container
+          .read(settingsControllerProvider.notifier)
+          .blockUser('target');
+
+      final state = container.read(settingsControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, contains('chặn người dùng'));
+    });
+
+    test('unblockUser: gọi repo với blockerUid + targetUid', () async {
+      await container
+          .read(settingsControllerProvider.notifier)
+          .unblockUser('target');
+
+      verify(() => block.unblockUser(blockerUid: 'me', targetUid: 'target'))
+          .called(1);
+      expect(container.read(settingsControllerProvider).isLoading, isFalse);
+    });
+  });
+
+  group('logout', () {
+    late MockAuthRepository auth;
+    late MockNotificationRepository notif;
+    late ProviderContainer container;
+
+    setUp(() {
+      auth = MockAuthRepository();
+      notif = MockNotificationRepository();
+      when(() => auth.currentUid).thenReturn('me');
+      when(() => auth.signOut()).thenAnswer((_) async {});
+      when(() => notif.deleteFcmToken(any())).thenAnswer((_) async {});
+
+      container = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(auth),
+          notificationRepositoryProvider.overrideWithValue(notif),
+        ],
+      );
+    });
+
+    tearDown(() => container.dispose());
+
+    test('gọi deleteFcmToken(uid) → signOut() theo đúng thứ tự', () async {
+      await container.read(settingsControllerProvider.notifier).logout();
+
+      verifyInOrder([
+        () => notif.deleteFcmToken('me'),
+        () => auth.signOut(),
+      ]);
+    });
+
+    test('chưa login (uid null) → skip deleteFcmToken, vẫn signOut', () async {
+      when(() => auth.currentUid).thenReturn(null);
+
+      await container.read(settingsControllerProvider.notifier).logout();
+
+      verifyNever(() => notif.deleteFcmToken(any()));
+      verify(() => auth.signOut()).called(1);
+    });
+
+    test(
+        'deleteFcmToken throw (vd offline / notification chưa wire) → '
+        'vẫn signOut, KHÔNG bubble lên', () async {
+      when(() => notif.deleteFcmToken(any()))
+          .thenThrow(const NetworkError(message: 'offline'));
+
+      await container.read(settingsControllerProvider.notifier).logout();
+
+      verify(() => auth.signOut()).called(1);
+      // errorMessage null vì FCM cleanup là best-effort.
+      expect(container.read(settingsControllerProvider).errorMessage, isNull);
+    });
+
+    test('signOut throw → errorMessage set, isLoading reset', () async {
+      when(() => auth.signOut()).thenThrow(
+        const NetworkError(message: 'không thể đăng xuất'),
+      );
+
+      await container.read(settingsControllerProvider.notifier).logout();
+
+      final state = container.read(settingsControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, contains('không thể đăng xuất'));
+    });
+  });
+}

--- a/apps/mobile/test/features/settings/block_confirm_dialog_test.dart
+++ b/apps/mobile/test/features/settings/block_confirm_dialog_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/auth_repository.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
+import 'package:meep/features/settings/data/block_repository.dart';
+import 'package:meep/features/settings/presentation/block_confirm_dialog.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockBlockRepository extends Mock implements BlockRepository {}
+
+void main() {
+  Widget harness(List<Override> overrides) {
+    return ProviderScope(
+      overrides: overrides,
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => BlockConfirmDialog.show(
+                  context,
+                  targetUid: 'target-uid',
+                  targetName: 'Lauren',
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> openDialog(WidgetTester tester) async {
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('BlockConfirmDialog', () {
+    late MockAuthRepository auth;
+    late MockBlockRepository block;
+
+    setUp(() {
+      auth = MockAuthRepository();
+      block = MockBlockRepository();
+      when(() => auth.currentUid).thenReturn('me');
+    });
+
+    testWidgets('render — title Chặn {name} + nút Chặn + Bỏ qua',
+        (tester) async {
+      when(
+        () => block.blockUser(
+          blockerUid: any(named: 'blockerUid'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        harness([
+          authRepositoryProvider.overrideWithValue(auth),
+          blockRepositoryProvider.overrideWithValue(block),
+        ]),
+      );
+      await openDialog(tester);
+
+      expect(find.text('Chặn Lauren?'), findsOneWidget);
+      expect(find.text('Chặn'), findsOneWidget);
+      expect(find.text('Bỏ qua'), findsOneWidget);
+    });
+
+    testWidgets(
+        'tap Chặn → gọi controller.blockUser(targetUid) → button đổi "Đã chặn!"',
+        (tester) async {
+      when(
+        () => block.blockUser(
+          blockerUid: any(named: 'blockerUid'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        harness([
+          authRepositoryProvider.overrideWithValue(auth),
+          blockRepositoryProvider.overrideWithValue(block),
+        ]),
+      );
+      await openDialog(tester);
+
+      await tester.tap(find.text('Chặn'));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => block.blockUser(blockerUid: 'me', targetUid: 'target-uid'),
+      ).called(1);
+      expect(find.text('Đã chặn!'), findsOneWidget);
+      expect(find.text('Chặn'), findsNothing);
+    });
+
+    testWidgets('controller throw error → button giữ "Chặn", cho phép retry',
+        (tester) async {
+      when(
+        () => block.blockUser(
+          blockerUid: any(named: 'blockerUid'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      ).thenThrow(ForbiddenError('chặn người dùng'));
+
+      await tester.pumpWidget(
+        harness([
+          authRepositoryProvider.overrideWithValue(auth),
+          blockRepositoryProvider.overrideWithValue(block),
+        ]),
+      );
+      await openDialog(tester);
+
+      await tester.tap(find.text('Chặn'));
+      await tester.pumpAndSettle();
+
+      // Vẫn nút "Chặn", KHÔNG đổi "Đã chặn!"
+      expect(find.text('Chặn'), findsOneWidget);
+      expect(find.text('Đã chặn!'), findsNothing);
+    });
+  });
+}

--- a/apps/mobile/test/features/settings/blocked_accounts_page_test.dart
+++ b/apps/mobile/test/features/settings/blocked_accounts_page_test.dart
@@ -1,23 +1,102 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/auth_repository.dart';
+import 'package:meep/features/settings/application/blocked_user_view.dart';
+import 'package:meep/features/settings/application/blocked_users_provider.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
+import 'package:meep/features/settings/data/block_repository.dart';
 import 'package:meep/features/settings/presentation/blocked_accounts_page.dart';
 
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockBlockRepository extends Mock implements BlockRepository {}
+
 void main() {
+  Widget harness(List<Override> overrides) {
+    return ProviderScope(
+      overrides: overrides,
+      child: const MaterialApp(home: BlockedAccountsPage()),
+    );
+  }
+
   group('BlockedAccountsPage', () {
-    Widget harness() => const MaterialApp(home: BlockedAccountsPage());
+    testWidgets('stream rỗng → empty state với CTA tiếng Việt', (tester) async {
+      await tester.pumpWidget(
+        harness([
+          blockedUsersProvider.overrideWith((_) => Stream.value(const [])),
+        ]),
+      );
+      await tester.pumpAndSettle();
 
-    testWidgets('hiện danh sách bị chặn, không overflow', (tester) async {
-      await tester.pumpWidget(harness());
-
-      expect(find.text('Tài khoản bị chặn'), findsOneWidget);
-      expect(find.text('Lauren'), findsOneWidget);
-      expect(find.text('Bỏ chặn'), findsOneWidget);
-      expect(tester.takeException(), isNull);
+      expect(find.text('Không có tài khoản bị chặn nào'), findsOneWidget);
+      expect(
+        find.text('Bạn có thể chặn một ai đó từ trang Bạn bè'),
+        findsOneWidget,
+      );
     });
 
-    testWidgets('tap "Bỏ chặn" → hiện confirm dialog (state 3)',
+    testWidgets('stream có data → list hiện username + nút Bỏ chặn',
         (tester) async {
-      await tester.pumpWidget(harness());
+      await tester.pumpWidget(
+        harness([
+          blockedUsersProvider.overrideWith(
+            (_) => Stream.value(const [
+              BlockedUserView(uid: 'u1', username: 'Lauren'),
+            ]),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Lauren'), findsOneWidget);
+      expect(find.text('Bỏ chặn'), findsOneWidget);
+      expect(find.text('Tài khoản bị chặn'), findsOneWidget);
+    });
+
+    testWidgets('stream error → error state, không crash', (tester) async {
+      await tester.pumpWidget(
+        harness([
+          blockedUsersProvider.overrideWith(
+            (_) => Stream.error(Exception('network down')),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Không thể tải danh sách'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tap "Bỏ chặn" → confirm dialog → [Xác nhận] → gọi controller',
+        (tester) async {
+      final block = MockBlockRepository();
+      final auth = MockAuthRepository();
+      when(() => auth.currentUid).thenReturn('me');
+      when(
+        () => block.unblockUser(
+          blockerUid: any(named: 'blockerUid'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        harness([
+          authRepositoryProvider.overrideWithValue(auth),
+          blockRepositoryProvider.overrideWithValue(block),
+          blockedUsersProvider.overrideWith(
+            (_) => Stream.value(const [
+              BlockedUserView(uid: 'target', username: 'Lauren'),
+            ]),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text('Bỏ chặn'));
       await tester.pumpAndSettle();
@@ -26,33 +105,45 @@ void main() {
         find.text('Bạn có chắc muốn bỏ chặn tài khoản này không?'),
         findsOneWidget,
       );
-      expect(find.text('Xác nhận'), findsOneWidget);
-      expect(find.text('Huỷ'), findsOneWidget);
-    });
 
-    testWidgets('[Xác nhận] → xoá user, rỗng thì hiện empty state (state 1)',
-        (tester) async {
-      await tester.pumpWidget(harness());
-
-      await tester.tap(find.text('Bỏ chặn'));
-      await tester.pumpAndSettle();
       await tester.tap(find.text('Xác nhận'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Lauren'), findsNothing);
-      expect(find.text('Không có tài khoản bị chặn nào'), findsOneWidget);
+      verify(() => block.unblockUser(blockerUid: 'me', targetUid: 'target'))
+          .called(1);
     });
 
-    testWidgets('[Huỷ] → giữ nguyên danh sách', (tester) async {
-      await tester.pumpWidget(harness());
+    testWidgets('[Huỷ] dialog → không gọi controller, list giữ nguyên',
+        (tester) async {
+      final block = MockBlockRepository();
+      final auth = MockAuthRepository();
+      when(() => auth.currentUid).thenReturn('me');
+
+      await tester.pumpWidget(
+        harness([
+          authRepositoryProvider.overrideWithValue(auth),
+          blockRepositoryProvider.overrideWithValue(block),
+          blockedUsersProvider.overrideWith(
+            (_) => Stream.value(const [
+              BlockedUserView(uid: 'target', username: 'Lauren'),
+            ]),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text('Bỏ chặn'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Huỷ'));
       await tester.pumpAndSettle();
 
+      verifyNever(
+        () => block.unblockUser(
+          blockerUid: any(named: 'blockerUid'),
+          targetUid: any(named: 'targetUid'),
+        ),
+      );
       expect(find.text('Lauren'), findsOneWidget);
-      expect(find.text('Không có tài khoản bị chặn nào'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
Closes #118

## Scope
Implement T3+T4 cho settings module per [docs/plans/2026-05-23-settings.md](docs/plans/2026-05-23-settings.md):
- **T3** — SettingsController với state + 4 methods (logout, copyProfileLink, blockUser, unblockUser)
- **T4** — BlockedAccountsPage replace mock với real stream + wire `BlockConfirmDialog` controller

## Commits
- `d968e9e` feat(settings): T3 — SettingsController state + 4 methods + tests
- `ad0681d` feat(settings): T4 — BlockedAccountsPage real stream + wire main + logout
- `6c42c0f` feat(settings): BlockConfirmDialog wire controller + state "Đã chặn!"

## Per-layer summary

| Layer | Changes |
|---|---|
| **State** | `SettingsState` freezed (isLoading, errorMessage) — pattern theo `LoginState` AUTH ref |
| **Controller** | 4 methods + `_afterFailure(e)` helper map AppError → message tiếng Việt, silent cho cancelled |
| **Provider** | `blockedUsersProvider` (StreamProvider) join `BlockRepository.watchBlockedUsers` × `UserRepository.getProfile` để có username + avatar (N+1 acceptable cho list < 10) |
| **View model** | `BlockedUserView` extract ra `application/blocked_user_view.dart` (gỡ khỏi `_mock_data`) |
| **Page** | `BlockedAccountsPage` → `ConsumerWidget`, watch provider, 4 states (loading/error/empty/data) theo `apps/mobile/CLAUDE.md` |
| **Dialog** | `BlockConfirmDialog` → `ConsumerStatefulWidget`, wire controller.blockUser, state "Đã chặn!" sau success, CircularProgress khi đang chặn |
| **Wire main** | `blockRepositoryProvider.overrideWithValue(FirebaseBlockRepository(firestore, functions))` với `region: 'asia-southeast1'` |
| **Sheet TODO** | `settings_sheet.dart` logout TODO → controller call, router auth listener tự redirect /intro |

## Acceptance criteria #118

**SettingsController**
- [x] `logout()`: best-effort `deleteFcmToken(uid)` → `signOut()` → router redirect /intro
- [x] `logout()` offline vẫn hoạt động — FCM swallow + Firebase clears local
- [x] `copyProfileLink(username)` → clipboard `meep://profile/{username}` (dùng `AppConfig.shareBaseUrl`)

**BlockedAccountsPage**
- [x] Load stream `watchBlockedUsers`, list avatar + username + nút "Bỏ chặn"
- [x] Tap "Bỏ chặn" → `UnblockConfirmDialog` → [Xác nhận] → `unblockUser()` → removed (stream auto re-emit)

**BlockConfirmDialog**
- [x] Block success → button đổi "Đã chặn!" state (Figma `624:1906`)
- [x] Error → button giữ "Chặn", cho phép retry (errorMessage trong SettingsState)

**Tests**
- [x] `flutter test test/features/settings/` — 33/33 pass (10 controller + 5 blocked_accounts + 3 block_confirm + 15 existing)

## Out-of-scope (defer)

- **`WidgetConfirmSheet.requestPinAppWidget()` Android API** → defer Issue #138. Lý do: cần native Android AppWidget setup (`MeepWidgetProvider.kt`, layout XML, manifest receiver) — em vừa thấy `b9d45c5 feat(widget): T1-T3 — Android widget layout + sync worker` merge develop. Wire `requestPinWidget()` sẽ làm sau khi #138 widget receiver expose pin entry point.
- **`PrivacyDataPage` toggle isSearchable** → blocked by OQ6 chờ leader thêm field `isSearchable` vào `UserProfile` (em check: field đã có trong `UserProfile` rồi! Có thể wire sau ở PR riêng).
- **`deleteAccount` re-auth + CF** → T6 #119 scope.

## Cross-module dependencies

| Import | Module | Status |
|---|---|---|
| `authRepositoryProvider` | auth | ✅ Wired trên develop |
| `userRepositoryProvider` | auth | ✅ Wired trên develop (em dùng trong blockedUsersProvider để join username) |
| `notificationRepositoryProvider` | notification | ⚠️ Stub UnimplementedError (#103 chưa done) — em handle graceful: try/catch swallow `deleteFcmToken()` lỗi → vẫn signOut |

## Convention notes

- Pattern theo AUTH reference (`LoginController._afterFailure`, `LoginState` freezed)
- Cross-module touch chỉ qua providers (không trực tiếp sửa code module khác)
- `main.dart` wire blockRepositoryProvider — KHÔNG vi phạm shared infra rule (main.dart không trong khoá list, Friend/Space đều wire ở đây)

## Test plan
- [x] `flutter test test/features/settings/` (33/33 pass)
- [x] `flutter analyze` settings (No issues)
- [x] `dart format --set-exit-if-changed` clean
- [ ] Reviewer: manual trace logout flow (sheet pop → router redirect)
- [ ] Reviewer: confirm acceptance #118 out-of-scope items OK defer (widget pin → #138, privacy toggle → tách PR)

## Note rebase
Branch base `6e80122` (PR #207 settings T1), develop tip hiện tại `b9d45c5`. **Zero file overlap** (Settings module độc lập với Widget Android + Space CF + Feed UI). Squash merge sẽ tự put commit on top.