### PR TITLE
feat(settings): wire SpaceQuickRow.onCreateSpace → SpaceCreateSheet

### DIFF
--- a/apps/mobile/lib/features/settings/presentation/settings_sheet.dart
+++ b/apps/mobile/lib/features/settings/presentation/settings_sheet.dart
@@ -17,6 +17,7 @@ import 'package:meep/features/settings/presentation/widgets/settings_header.dart
 import 'package:meep/features/settings/presentation/widgets/settings_nav_row.dart';
 import 'package:meep/features/settings/presentation/widgets/settings_quick_actions.dart';
 import 'package:meep/features/settings/presentation/widgets/space_quick_row.dart';
+import 'package:meep/features/space/presentation/space_create_sheet.dart';
 
 /// Bottom sheet cài đặt — trigger từ avatar topbar homepage (Figma 572:4183).
 class SettingsSheet extends ConsumerWidget {
@@ -50,9 +51,30 @@ class SettingsSheet extends ConsumerWidget {
                     username: SettingsMockData.username,
                   ),
                   const SizedBox(height: AppSpacing.xl),
-                  const SpaceQuickRow(
+                  SpaceQuickRow(
                     spaceNames: SettingsMockData.mockSpaces,
-                    // TODO(T2/NganTNK): navigate Space edit/create (Space module)
+                    // T2/NganTNK gate: thêm hook `onCreateSpace` để Space module
+                    // wire. Em (ThienPDM) wire tạm vào `SpaceCreateSheet` để
+                    // unblock manual test Space — capture rootContext trước pop
+                    // SettingsSheet vì sheet context unmount sau pop, không show
+                    // được modal mới với context cũ.
+                    onCreateSpace: () {
+                      final rootContext =
+                          Navigator.of(context, rootNavigator: true).context;
+                      Navigator.of(context).pop();
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (!rootContext.mounted) return;
+                        showModalBottomSheet<void>(
+                          context: rootContext,
+                          isScrollControlled: true,
+                          backgroundColor: Colors.transparent,
+                          builder: (_) => const FractionallySizedBox(
+                            heightFactor: 0.9,
+                            child: SpaceCreateSheet(),
+                          ),
+                        );
+                      });
+                    },
                   ),
                   const SizedBox(height: AppSpacing.xl),
                   _divider(),


### PR DESCRIPTION
## Mô tả

Wire callback `onCreateSpace` của `SpaceQuickRow` (Settings T2 — NganTNK đã chừa hook) để mở `SpaceCreateSheet`. Unblock manual test luồng Space M3 — production user giờ có entry point production đầu tiên để tạo Space.

## Refs

- Refs #134 (T3 SpaceCreateSheet — em wire entry point)
- Liên quan PR #180 (NganTNK Settings T2 — đã có `onCreateSpace: VoidCallback?` placeholder + TODO marker)
- Liên quan PR #213 (T10b SpaceManagementSheet — vừa merge nhưng chưa test e2e được vì thiếu entry tạo Space)

## Thay đổi chính

`apps/mobile/lib/features/settings/presentation/settings_sheet.dart`:
- Pass `onCreateSpace` callback xuống `SpaceQuickRow`:
  ```dart
  final rootContext = Navigator.of(context, rootNavigator: true).context;
  Navigator.of(context).pop();  // close settings sheet
  WidgetsBinding.instance.addPostFrameCallback((_) {
    if (!rootContext.mounted) return;
    showModalBottomSheet<void>(
      context: rootContext,
      ...
      builder: (_) => const FractionallySizedBox(
        heightFactor: 0.9,
        child: SpaceCreateSheet(),
      ),
    );
  });
  ```
- Capture `rootContext` từ rootNavigator TRƯỚC khi pop SettingsSheet (sheet context unmount sau pop).
- Đợi 1 frame qua `addPostFrameCallback` để SettingsSheet unmount xong, tránh race show sheet trên context invalid.

## Loại thay đổi

- [x] feat — Wire entry point production cho SpaceCreateSheet

## Test

- [x] `flutter analyze` → No issues found
- [x] `flutter test` → **364/364 pass** (toàn app, tăng từ analyze-only)
- [x] `flutter build apk --debug` → BUILT app-debug.apk (catch compile error mà test/analyze miss — em đã miss lần trước)
- [ ] Manual test trên device — sẽ verify sau khi merge

### Cách test thủ công

1. Auth signin
2. Home topbar → tap avatar → SettingsSheet mở
3. Tap card "+ Tạo Space mới" trong `SpaceQuickRow`
4. SettingsSheet pop xuống → SpaceCreateSheet hiện (3-step flow)
5. Step 1: chọn 1-2 friends → Tiếp tục
6. Step 2: đặt tên + chọn preset → Hoàn tất
7. Verify: Space được tạo (cần CF createSpace đã deploy), navigate về Home

## Lưu ý cho reviewer

- **Đây là wire tạm để unblock manual test** — em (ThienPDM) wire vào module Settings (NganTNK) vì NganTNK đã chừa hook `onCreateSpace: VoidCallback?` placeholder + TODO marker. Cross-module touch minimal (1 callback wire), không sửa logic Settings nào khác.
- **Đúng UX spec Meep:** Theo flow Settings sheet, mục Space hiện ngay sau SettingsQuickActions — user dễ tìm tạo Space từ Settings. Spec Space có 2 luồng long-press FriendsButton mâu thuẫn (line 73 vs 134), em đã wire luồng 134 (context switch) ở T4 — luồng 73 (long-press → create) bị conflict, nên Settings entry là cleanest cho production.
- **Context unmount race:** showModalBottomSheet ngay sau pop sẽ fail vì sheet context bị unmount. Pattern em dùng capture rootContext BEFORE pop + đợi addPostFrameCallback đảm bảo SettingsSheet đóng xong rồi mới show SpaceCreateSheet.
- **Em rút bài học workflow:** đã chạy đủ analyze + test + build APK trước commit (lần trước em miss build APK → develop bị flag "build failed" do regen `.g.dart` không chạy).

## Self-review checklist

- [x] Branch `feature/ThienPDM/wire-space-create-from-settings` đúng convention
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không file lớn vô tình
- [x] Không có `print` debug
- [x] Không có `// TODO` chưa link issue
- [x] Cross-module touch minimal + justified (Settings có hook chừa sẵn cho Space)

🤖 Generated with [Claude Code](https://claude.com/claude-code)