### PR TITLE
fix(space): SpaceCreateSheet dùng currentUidProvider thật thay 'current-uid-mock'

### DIFF
--- a/apps/mobile/lib/features/space/presentation/widgets/friend_select_step.dart
+++ b/apps/mobile/lib/features/space/presentation/widgets/friend_select_step.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/shared/widgets/app_avatar.dart';
@@ -27,16 +28,25 @@ class _FriendSelectStepState extends ConsumerState<FriendSelectStep> {
   final _searchController = TextEditingController();
   String _searchQuery = '';
 
-  // Cache stream 1 lần để setState (tap chọn friend) không re-subscribe
-  // → không reload toàn bộ list.
-  late final Stream<List<UserProfile>> _friendsStream;
+  // Cache stream 1 lần khi uid available để setState (tap chọn friend)
+  // không re-subscribe → không reload toàn bộ list.
+  //
+  // KHÔNG init ở `initState` vì `currentUidProvider` là StreamProvider —
+  // emit AsyncLoading lúc mount. `.valueOrNull` ở initState sẽ trả null
+  // dù user đã signin → empty stream. Đợi `build` chạy lại khi stream
+  // emit value lần đầu rồi mới cache.
+  Stream<List<UserProfile>>? _friendsStream;
+  String? _cachedUid;
 
-  @override
-  void initState() {
-    super.initState();
-    // TODO(SP/T3.2): get current user uid from auth
-    _friendsStream =
-        ref.read(friendRepositoryProvider).watchFriends('current-uid-mock');
+  Stream<List<UserProfile>> _ensureStream(String? uid) {
+    if (uid == _cachedUid && _friendsStream != null) return _friendsStream!;
+    _cachedUid = uid;
+    if (uid == null) {
+      _friendsStream = Stream.value(const <UserProfile>[]);
+    } else {
+      _friendsStream = ref.read(friendRepositoryProvider).watchFriends(uid);
+    }
+    return _friendsStream!;
   }
 
   @override
@@ -59,6 +69,12 @@ class _FriendSelectStepState extends ConsumerState<FriendSelectStep> {
 
   @override
   Widget build(BuildContext context) {
+    // Watch để rebuild khi auth state emit lần đầu (initState quá sớm cho
+    // StreamProvider). `_ensureStream` cache theo uid — không re-subscribe
+    // khi setState do tap chọn friend.
+    final uid = ref.watch(currentUidProvider).valueOrNull;
+    final friendsStream = _ensureStream(uid);
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 18),
       child: Column(
@@ -150,7 +166,7 @@ class _FriendSelectStepState extends ConsumerState<FriendSelectStep> {
           // Friend list
           Expanded(
             child: StreamBuilder<List<UserProfile>>(
-              stream: _friendsStream,
+              stream: friendsStream,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return const Center(child: CircularProgressIndicator());

--- a/apps/mobile/test/features/space/friend_select_step_test.dart
+++ b/apps/mobile/test/features/space/friend_select_step_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/friend_repository.dart';
@@ -54,6 +55,8 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            currentUidProvider
+                .overrideWith((ref) => Stream.value('current-uid-test')),
             friendRepositoryProvider.overrideWithValue(
               FakeFriendRepository(mockFriends.take(3).toList()),
             ),
@@ -78,6 +81,8 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            currentUidProvider
+                .overrideWith((ref) => Stream.value('current-uid-test')),
             friendRepositoryProvider.overrideWithValue(
               FakeFriendRepository(mockFriends.take(3).toList()),
             ),
@@ -106,6 +111,8 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            currentUidProvider
+                .overrideWith((ref) => Stream.value('current-uid-test')),
             friendRepositoryProvider.overrideWithValue(
               FakeFriendRepository(tenFriends),
             ),
@@ -136,6 +143,8 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            currentUidProvider
+                .overrideWith((ref) => Stream.value('current-uid-test')),
             friendRepositoryProvider.overrideWithValue(
               FakeFriendRepository(mockFriends.take(5).toList()),
             ),


### PR DESCRIPTION
## Mô tả

Anh test SpaceCreateSheet qua entry mới từ Settings → báo lỗi "Lỗi tải danh sách bạn bè". Root cause: `friend_select_step.dart` line 39 hardcode `watchFriends('current-uid-mock')` — TODO `SP/T3.2` chưa wire. Production query `/friendships WHERE members arrayContains 'current-uid-mock'` → empty → stream report error.

## Refs

- Refs #134 (T3 SpaceCreateSheet — TODO `SP/T3.2` được wire trong PR này)
- Liên quan PR #214 (em wire Settings entry → SpaceCreateSheet — anh test thấy lỗi)

## Thay đổi chính

`apps/mobile/lib/features/space/presentation/widgets/friend_select_step.dart`:
- ❌ Trước: `initState` cache uid không work vì `currentUidProvider` là `StreamProvider` — emit `AsyncLoading` lúc widget mount, `.valueOrNull` trả null
- ✅ Sau: `_ensureStream(uid)` cache theo uid + watch `currentUidProvider` trong build → stream init sau khi uid emit lần đầu. Tap chọn friend setState không re-subscribe vì uid không đổi giữa session.

`apps/mobile/test/features/space/friend_select_step_test.dart`:
- Override `currentUidProvider` trong 4 widget tests (`Stream.value('current-uid-test')`)

## Loại thay đổi

- [x] fix — Sửa bug critical chặn manual test Space

## Test

- [x] `flutter analyze` → No issues found
- [x] `flutter test` → **364/364 pass** (4 friend_select_step tests fix sau khi override `currentUidProvider`)
- [x] `flutter build apk --debug` → BUILT app-debug.apk

## Lưu ý cho reviewer

- **Bug gốc rễ tự T3 (PR #192):** TODO `SP/T3.2` quên wire — em phát hiện khi anh test entry mới Settings. PR #214 wire entry chứ không phải tạo bug; bug đã có trên develop từ PR #192.
- **Pattern khác Friend module:** `FriendController.build(String uid)` nhận uid qua family arg (caller pass currentUid). Ở đây sheet không family per uid — em watch trong build + cache local. Trade-off để giữ structure sheet hiện tại.
- **3 bug khác em phát hiện khi scan** (sẽ ship PR riêng):
  1. Mock `displayNames: const {}` trong SpaceManagementSheet (kick/leave picker)
  2. Min 3 members (creator + ≥ 2 friends) chưa enforce client + server
  3. Search bạn bè TextField không có maxLength

🤖 Generated with [Claude Code](https://claude.com/claude-code)