### PR TITLE
fix(theme): CircularProgressIndicator dùng turquoise500 thay seed hồng

### DIFF
--- a/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
+++ b/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
@@ -242,7 +242,9 @@ class _FriendSheetState extends ConsumerState<FriendSheet> {
           ),
         );
       },
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const Center(
+        child: CircularProgressIndicator(color: AppColors.turquoise500),
+      ),
       error: (_, __) => const SizedBox.shrink(),
     );
   }

--- a/apps/mobile/lib/features/space/presentation/widgets/friend_select_step.dart
+++ b/apps/mobile/lib/features/space/presentation/widgets/friend_select_step.dart
@@ -174,7 +174,11 @@ class _FriendSelectStepState extends ConsumerState<FriendSelectStep> {
               stream: friendsStream,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const Center(child: CircularProgressIndicator());
+                  return const Center(
+                    child: CircularProgressIndicator(
+                      color: AppColors.turquoise500,
+                    ),
+                  );
                 }
                 if (snapshot.hasError) {
                   return Center(


### PR DESCRIPTION
## Mô tả

Anh báo loading màu hồng khi mở SpaceCreateSheet → bước chọn bạn bè. Root cause: 2 chỗ dùng `CircularProgressIndicator()` không override `color` → fallback `Theme.colorScheme.primary` derive từ seed `0xFFE85D75` (hồng pink).

## Fix surgical (Option B em recommend)

Add `color: AppColors.turquoise500` cho 2 spot thiếu, match convention 15 spot khác đã có:
- `friend_select_step.dart:177` — loading khi watch friends trong Space create flow (chỗ anh thấy hồng)
- `friend_sheet.dart:245` — loading khi current uid chưa resolve

KHÔNG đổi seed color — `Switch/Chip/Slider/FocusBorder` vẫn dùng hồng theo design hiện tại. Đổi seed cần discuss design riêng (Option A2).

## Test

- [x] `flutter analyze` → No issues found
- [x] `flutter test` → 365/365 pass
- [x] `flutter build apk --debug` → BUILT

## Self-review

- [x] Branch `fix/ThienPDM/loading-color-turquoise`
- [x] Surgical, không touch shared theme
- [x] Convention match (15 spot khác đã set turquoise500 explicit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)