### PR TITLE
feat(settings): T5 — CF blockUser atomic batch

### DIFF
--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -8,6 +8,9 @@ import { z } from 'zod';
 export { onPostCreated } from './feed/onPostCreated.js';
 export { onPostDeleted } from './feed/onPostDeleted.js';
 
+// Settings module
+export { blockUser } from './settings/blockUser.js';
+
 initializeApp();
 
 setGlobalOptions({
@@ -64,48 +67,19 @@ export { onFriendshipDeleted } from './friend/onFriendshipDeleted.js';
 
 // ===== Settings module stubs =====
 
-/**
- * Block a user: create /blocks doc + remove friendship + update conversation status.
- *
- * TODO(SE/impl):
- *   - verify target exists + caller != target
- *   - create /blocks/{blockerUid}_{targetUid}
- *   - delete /friendships/{pairId} if exists
- *   - update /conversations/{pairId}.status = 'blocked' if exists
- */
-export const blockUser = onCall((request) => {
-  if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
-  // TODO(SE/impl): see comment above.
-  return { ok: true };
-});
-
-/**
- * Unblock a user: delete /blocks doc + delete /friendships/{pairId} if exists.
- * Atomic via Admin SDK batch — client cannot write /blocks directly.
- *
- * TODO(SE/impl):
- *   - verify caller != target
- *   - delete /blocks/{blockerUid}_{targetUid} if exists
- *   - delete /friendships/{pairId} if exists
- */
-export const unblockUser = onCall((request) => {
-  if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
-  // TODO(SE/impl): see comment above.
-  return { ok: true };
-});
+// blockUser — implemented in ./settings/blockUser.ts (exported above).
+// unblockUser stub gỡ bỏ: T1 đã quyết unblock = client-side delete
+// `/blocks/{blockerUid}_{targetUid}` (OQ5 resolved trong #116). CF không cần.
 
 /**
  * Delete account: re-authenticate, then cascade-delete all user data.
  *
- * TODO(SE/impl):
- *   - delete /users/{uid} + subcollections
- *   - delete /posts by uid from Storage + Firestore
- *   - delete /friendships where uid is member
- *   - delete Firebase Auth account
+ * TODO(SE/T7 #119): implement cascade Storage → Firestore subcollections →
+ *   docs → admin.auth().deleteUser (Auth xóa cuối, idempotent, retry-safe).
  */
 export const deleteAccount = onCall((request) => {
   if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
-  // TODO(SE/impl): see comment above.
+  // TODO(SE/T7 #119): see comment above.
   return { ok: true };
 });
 

--- a/firebase/functions/src/settings/blockUser.ts
+++ b/firebase/functions/src/settings/blockUser.ts
@@ -1,0 +1,107 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { z } from 'zod';
+
+/**
+ * Schema validation for blockUser CF input.
+ *
+ * Server source of truth: client (`FirebaseBlockRepository.blockUser`) chỉ
+ * gửi `targetUid` — server tự derive `blockerUid` từ `request.auth.uid`.
+ */
+const blockUserSchema = z.object({
+  targetUid: z.string().min(1).max(128),
+});
+
+/**
+ * Block a user atomically.
+ *
+ * Steps:
+ * 1. Auth + schema validate.
+ * 2. Guard: blockerUid != targetUid (no self-block).
+ * 3. Idempotent: nếu /blocks/{blockerUid}_{targetUid} đã tồn tại → return success.
+ * 4. Atomic batch (Admin SDK bypass rules):
+ *    a. Create /blocks/{blockerUid}_{targetUid} { blockId, blockerUid,
+ *       blockedUid, createdAt }
+ *    b. Delete /friendships/{pairId} nếu tồn tại — pairId sorted (lex thấp
+ *       trước), match Friend repository convention.
+ *    c. Update /conversations/{pairId}.status = 'blocked' nếu tồn tại.
+ * 5. Return { success: true }.
+ *
+ * Notes:
+ * - blockId asymmetric ({blockerUid}_{blockedUid}, NOT sorted) — khác pairId.
+ *   Client `isBlocked()` query cả 2 chiều để detect bidirectional.
+ * - Friendship deletion sẽ trigger `onFriendshipDeleted` CF (đã wire) →
+ *   cross-feed cleanup handled there.
+ * - `batch.delete()` an toàn với doc không tồn tại (no-op), nên không cần
+ *   pre-read friendship. `batch.update()` throws NOT_FOUND → phải pre-read
+ *   conversation.
+ */
+export const blockUser = onCall(
+  { region: 'asia-southeast1' },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Login required');
+    }
+
+    const parsed = blockUserSchema.safeParse(request.data);
+    if (!parsed.success) {
+      throw new HttpsError('invalid-argument', parsed.error.message);
+    }
+
+    const { targetUid } = parsed.data;
+    const blockerUid = request.auth.uid;
+
+    if (blockerUid === targetUid) {
+      throw new HttpsError('invalid-argument', 'Cannot block yourself');
+    }
+
+    const db = getFirestore();
+    const blockId = `${blockerUid}_${targetUid}`;
+    const blockRef = db.collection('blocks').doc(blockId);
+
+    // Step 3: Idempotent check.
+    const existing = await blockRef.get();
+    if (existing.exists) {
+      return { success: true };
+    }
+
+    // pairId sorted (lex thấp trước) — match FirebaseFriendRepository.
+    const pairId =
+      blockerUid < targetUid
+        ? `${blockerUid}_${targetUid}`
+        : `${targetUid}_${blockerUid}`;
+
+    const friendshipRef = db.collection('friendships').doc(pairId);
+    const conversationRef = db.collection('conversations').doc(pairId);
+
+    // Pre-read conversation: batch.update() throws NOT_FOUND nếu doc không
+    // tồn tại; conditional update.
+    const conversationSnap = await conversationRef.get();
+
+    const now = FieldValue.serverTimestamp();
+    const batch = db.batch();
+
+    // 4a. Create /blocks/{blockerUid}_{targetUid}
+    batch.set(blockRef, {
+      blockId,
+      blockerUid,
+      blockedUid: targetUid,
+      createdAt: now,
+    });
+
+    // 4b. Delete /friendships/{pairId} — batch.delete an toàn với non-existent.
+    batch.delete(friendshipRef);
+
+    // 4c. Update /conversations/{pairId}.status = 'blocked' nếu tồn tại.
+    if (conversationSnap.exists) {
+      batch.update(conversationRef, {
+        status: 'blocked',
+        updatedAt: now,
+      });
+    }
+
+    await batch.commit();
+
+    return { success: true };
+  },
+);

--- a/firebase/functions/test/settings/blockUser.test.ts
+++ b/firebase/functions/test/settings/blockUser.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+// Mirror schema từ src/settings/blockUser.ts để test isolated (không cần
+// emulator). Integration test full batch flow (blocks create + friendships
+// delete + conversations status update) sẽ ở rules test với emulator (T8 #120).
+const blockUserSchema = z.object({
+  targetUid: z.string().min(1).max(128),
+});
+
+describe('blockUser schema', () => {
+  it('accepts valid targetUid', () => {
+    const result = blockUserSchema.safeParse({ targetUid: 'user1' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty targetUid', () => {
+    const result = blockUserSchema.safeParse({ targetUid: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing targetUid', () => {
+    const result = blockUserSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-string targetUid', () => {
+    const result = blockUserSchema.safeParse({ targetUid: 123 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects targetUid > 128 chars (Firebase Auth UID hard limit)', () => {
+    const result = blockUserSchema.safeParse({ targetUid: 'a'.repeat(129) });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts targetUid = 128 chars (boundary)', () => {
+    const result = blockUserSchema.safeParse({ targetUid: 'a'.repeat(128) });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #119 (phase 1/3)

## Scope
Implement HTTPS Callable `blockUser` thay stub trong [index.ts](firebase/functions/src/index.ts) per [docs/plans/2026-05-23-settings.md](docs/plans/2026-05-23-settings.md) Task T5. Phase 1/3 của #119 (T5+6+7).

Pattern theo [firebase/functions/src/space/createSpace.ts](firebase/functions/src/space/createSpace.ts) — module-per-file, zod schema validate, atomic batch via Admin SDK.

## Files
- `firebase/functions/src/settings/blockUser.ts` — NEW, 107 lines
- `firebase/functions/test/settings/blockUser.test.ts` — NEW, 41 lines schema tests (6 cases)
- `firebase/functions/src/index.ts` — gỡ stub `blockUser` + `unblockUser`, add export `settings/blockUser`

## Flow

```
1. Auth check → unauthenticated nếu chưa login
2. zod safeParse { targetUid: string(1-128) }
3. Guard: blockerUid != targetUid → INVALID_ARGUMENT
4. Idempotent: nếu /blocks/{blockerUid}_{targetUid} tồn tại → return success
5. Pre-read /conversations/{pairId}.exists (batch.update throws nếu NOT_FOUND)
6. Atomic batch (Admin SDK bypass rules):
   a. set /blocks/{blockerUid}_{targetUid} { blockId, blockerUid, blockedUid, createdAt }
   b. delete /friendships/{pairId} — pairId sorted lex (match Friend convention)
                                     batch.delete an toàn với non-existent
   c. update /conversations/{pairId}.status = 'blocked' (nếu pre-read exists)
7. Return { success: true }
```

## Acceptance criteria #119 — blockUser
- [x] Guard: `blockerUid != targetUid` → `INVALID_ARGUMENT`
- [x] Batch: create `/blocks` + delete `/friendships` + update `/conversations` status
- [x] Idempotent: re-block doc đã tồn tại → return success, không throw
- [x] Return `{ success: true }`

## Pattern decisions

| Decision | Rationale |
|---|---|
| `unblockUser` CF stub gỡ bỏ | T1 (#116) đã quyết unblock = client-side delete (OQ5 resolved). CF không cần. |
| `pairId` sorted lex `min_max` | Match `FirebaseFriendRepository` convention (Friend doc dùng pairId cùng format) |
| Pre-read conversation, không pre-read friendship | `batch.delete()` an toàn với non-existent; `batch.update()` throws NOT_FOUND |
| Friendship delete trigger `onFriendshipDeleted` (#92 wired) | Cross-feed cleanup tự động, không cần em redundant |
| Schema-only unit test, không emulator | Match Space convention. Full batch integration test ở T8 #120 với emulator |

## Known limitations (acceptable cho MVP)

- **TOCTOU race conversation update**: pre-read `conversationSnap.exists` rồi batch update conditional. Nếu conversation bị xoá GIỮA pre-read và `batch.commit()` → batch fail. Probability rất thấp (conversation deletion là rare event). Match Space convention (cũng không dùng `runTransaction`). Có thể wrap TX trong future PR nếu observe lỗi production.

## Test plan
- [x] `npm test` — 74/74 pass (6 mới)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Reviewer: trace happy path (block flow)
- [ ] Reviewer: confirm acceptance accept gỡ stub `unblockUser` (T1 client-side decision)
- [ ] Integration test full batch flow → T8 #120 (rules + emulator)

## Phase 2+3 plan
- **Phase 2** — T7 CF `deleteAccount` (cascade Storage → Firestore → Auth, idempotent, retry-safe)
- **Phase 3** — T6 `DeleteAccountDialog` wire (detect email vs Google, reauthenticate, gọi CF deleteAccount)

## Note rebase
Branch rebase trên develop tip `3fbdf2d` (Space T1 HomeFeed dropdown). Em rebase + force push `33e54a2 → 6d63ad0` để clean history. **No conflicts** — em edit `index.ts` section Settings, Space edit section Space (line cách xa). 74/74 tests pass sau rebase.