### PR TITLE
feat(settings): T7 — CF deleteAccount cascade Storage + Firestore + Auth

### DIFF
--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -10,6 +10,7 @@ export { onPostDeleted } from './feed/onPostDeleted.js';
 
 // Settings module
 export { blockUser } from './settings/blockUser.js';
+export { deleteAccount } from './settings/deleteAccount.js';
 
 initializeApp();
 
@@ -70,18 +71,7 @@ export { onFriendshipDeleted } from './friend/onFriendshipDeleted.js';
 // blockUser — implemented in ./settings/blockUser.ts (exported above).
 // unblockUser stub gỡ bỏ: T1 đã quyết unblock = client-side delete
 // `/blocks/{blockerUid}_{targetUid}` (OQ5 resolved trong #116). CF không cần.
-
-/**
- * Delete account: re-authenticate, then cascade-delete all user data.
- *
- * TODO(SE/T7 #119): implement cascade Storage → Firestore subcollections →
- *   docs → admin.auth().deleteUser (Auth xóa cuối, idempotent, retry-safe).
- */
-export const deleteAccount = onCall((request) => {
-  if (!request.auth) throw new HttpsError('unauthenticated', 'Login required');
-  // TODO(SE/T7 #119): see comment above.
-  return { ok: true };
-});
+// deleteAccount — implemented in ./settings/deleteAccount.ts (exported above).
 
 // onPostCreated + onPostDeleted implemented in ./feed/ — exported above
 

--- a/firebase/functions/src/settings/deleteAccount.ts
+++ b/firebase/functions/src/settings/deleteAccount.ts
@@ -1,0 +1,272 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
+import { getAuth } from 'firebase-admin/auth';
+import { logger } from 'firebase-functions/v2';
+import { z } from 'zod';
+
+/**
+ * Schema validation for deleteAccount CF input.
+ *
+ * Không có input nào cần — uid lấy từ `request.auth.uid`. Schema chỉ để
+ * tuân thủ CLAUDE.md rule "every callable starts with safeParse" và reject
+ * gracefully nếu client gửi junk.
+ */
+const deleteAccountSchema = z.unknown();
+
+/**
+ * Firestore batch limit: 500 writes/batch (admin SDK). Dùng 499 để chừa 1 slot
+ * an toàn cho race case (mặc dù trong cascade này không có race nhưng giữ
+ * consistent với pattern onSpaceDeleted).
+ */
+const BATCH_LIMIT = 499;
+
+/**
+ * Delete tất cả documents matching `query` trong nhiều batch.
+ *
+ * Repeat get(limit) → batch.delete() → commit cho đến khi snap.empty.
+ * Idempotent: lần 2 gọi sẽ thấy empty ngay → no-op.
+ *
+ * Trả về tổng số docs đã xóa (chỉ dùng để log, không ảnh hưởng flow).
+ */
+async function deleteCollectionInBatches(
+  query: FirebaseFirestore.Query,
+  description: string,
+): Promise<number> {
+  let totalDeleted = 0;
+  while (true) {
+    const snap = await query.limit(BATCH_LIMIT).get();
+    if (snap.empty) break;
+
+    const batch = getFirestore().batch();
+    for (const doc of snap.docs) {
+      batch.delete(doc.ref);
+    }
+    await batch.commit();
+    totalDeleted += snap.size;
+
+    // snap.size < BATCH_LIMIT → đã hết, không cần round nữa.
+    if (snap.size < BATCH_LIMIT) break;
+  }
+  if (totalDeleted > 0) {
+    logger.info({ deleted: totalDeleted }, `deleteAccount: cleared ${description}`);
+  }
+  return totalDeleted;
+}
+
+/**
+ * Soft-delete conversations user đang là participant: set status='deleted'.
+ *
+ * KHÔNG xóa conversation doc — partner còn cần đọc lịch sử (parity Locket).
+ * Khi cả 2 participants đều deleted → conversation effectively orphaned, có
+ * thể GC sau (chưa scope MVP).
+ */
+async function softDeleteConversations(uid: string): Promise<number> {
+  const db = getFirestore();
+  const now = FieldValue.serverTimestamp();
+  let totalUpdated = 0;
+  let lastDoc: FirebaseFirestore.QueryDocumentSnapshot | undefined;
+
+  while (true) {
+    let query: FirebaseFirestore.Query = db
+      .collection('conversations')
+      .where('participantIds', 'array-contains', uid)
+      .limit(BATCH_LIMIT);
+    if (lastDoc) {
+      query = query.startAfter(lastDoc);
+    }
+
+    const snap = await query.get();
+    if (snap.empty) break;
+
+    const batch = db.batch();
+    for (const doc of snap.docs) {
+      batch.update(doc.ref, { status: 'deleted', updatedAt: now });
+    }
+    await batch.commit();
+    totalUpdated += snap.size;
+
+    if (snap.size < BATCH_LIMIT) break;
+    lastDoc = snap.docs[snap.docs.length - 1];
+  }
+  if (totalUpdated > 0) {
+    logger.info(
+      { updated: totalUpdated },
+      'deleteAccount: soft-deleted conversations',
+    );
+  }
+  return totalUpdated;
+}
+
+/**
+ * Cascade-delete user account: Storage → Firestore → Auth.
+ *
+ * Thứ tự BẮT BUỘC (acceptance T7 #119):
+ *   1. Storage prefixes: posts/{uid}/, avatars/{uid}/, diary/{uid}/
+ *   2. Firestore subcollections của /users/{uid}: feed, notifications,
+ *      fcmTokens, private (xóa trước parent doc — Firestore không cascade)
+ *   3. Cross-collection queries:
+ *      a. diary where authorUid == uid
+ *      b. posts where authorId == uid (triggers onPostDeleted cho mỗi post
+ *         → cross-feed cleanup tự động)
+ *      c. friendships where members array-contains uid (triggers
+ *         onFriendshipDeleted → cross-feed cleanup + friendCount decrement
+ *         cho friend còn lại)
+ *      d. friend_requests where senderId == uid (parallel)
+ *         friend_requests where receiverId == uid (parallel)
+ *      e. blocks where blockerUid == uid (parallel)
+ *         blocks where blockedUid == uid (parallel)
+ *   4. Conversations soft-delete (status='deleted', không hard delete)
+ *   5. Username reverse-lookup: read /users/{uid}.username → delete
+ *      /usernames/{username}
+ *   6. /users/{uid} document
+ *   7. admin.auth().deleteUser(uid) — CUỐI CÙNG
+ *
+ * Idempotent guarantees:
+ * - Storage bucket.deleteFiles(prefix) no-op nếu prefix empty
+ * - Firestore deleteCollectionInBatches no-op nếu query empty
+ * - Username + user doc check existence trước delete
+ * - Auth deleteUser catch 'auth/user-not-found' → skip (retry case)
+ *
+ * Failure safety: nếu CF crash giữa chừng, Auth account còn → user có thể
+ * login retry. Order Auth LAST đảm bảo Storage/Firestore cleanup không bị
+ * mất quyền truy cập (Auth gone = không re-auth được).
+ *
+ * Pre-condition: client (DeleteAccountDialog) phải reauthenticate trước
+ * khi gọi CF này (Firebase Auth requires-recent-login policy). CF chỉ check
+ * `request.auth` exists, không enforce recent-login (Firebase SDK enforce).
+ */
+export const deleteAccount = onCall(
+  {
+    region: 'asia-southeast1',
+    // Cascade có thể tốn 1-2 phút với user nhiều posts. 540s = max v2 hard
+    // limit. Memory bump cho Storage list+delete (mỗi page 1000 files).
+    timeoutSeconds: 540,
+    memory: '512MiB',
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Login required');
+    }
+
+    const parsed = deleteAccountSchema.safeParse(request.data);
+    if (!parsed.success) {
+      throw new HttpsError('invalid-argument', parsed.error.message);
+    }
+
+    const uid = request.auth.uid;
+    const db = getFirestore();
+    const bucket = getStorage().bucket();
+
+    logger.info({ uid }, 'deleteAccount: cascade starting');
+
+    // Step 1: Storage cleanup (parallel — 3 prefixes độc lập).
+    // bucket.deleteFiles({ prefix }) idempotent: empty prefix = no-op, no throw.
+    await Promise.all([
+      bucket.deleteFiles({ prefix: `posts/${uid}/` }),
+      bucket.deleteFiles({ prefix: `avatars/${uid}/` }),
+      bucket.deleteFiles({ prefix: `diary/${uid}/` }),
+    ]);
+    logger.info({ uid }, 'deleteAccount: storage cleared');
+
+    // Step 2: Subcollections của /users/{uid} (parallel — independent).
+    const userRef = db.collection('users').doc(uid);
+    await Promise.all([
+      deleteCollectionInBatches(userRef.collection('feed'), 'users/feed'),
+      deleteCollectionInBatches(
+        userRef.collection('notifications'),
+        'users/notifications',
+      ),
+      deleteCollectionInBatches(
+        userRef.collection('fcmTokens'),
+        'users/fcmTokens',
+      ),
+      deleteCollectionInBatches(userRef.collection('private'), 'users/private'),
+    ]);
+
+    // Step 3a-3c: Cross-collection queries có Firestore trigger downstream
+    // → sequential để trigger fire trong predictable order (giúp debug nếu
+    // trigger fail).
+    await deleteCollectionInBatches(
+      db.collection('diary').where('authorUid', '==', uid),
+      'diary entries',
+    );
+    await deleteCollectionInBatches(
+      db.collection('posts').where('authorId', '==', uid),
+      'posts',
+    );
+    await deleteCollectionInBatches(
+      db.collection('friendships').where('members', 'array-contains', uid),
+      'friendships',
+    );
+
+    // Step 3d-3e: friend_requests + blocks không có trigger downstream →
+    // parallel an toàn. Mỗi collection 2 query (sender/receiver,
+    // blocker/blocked) vì Firestore chỉ hỗ trợ OR qua `in` (max 10 values)
+    // — query separately đơn giản hơn.
+    await Promise.all([
+      deleteCollectionInBatches(
+        db.collection('friend_requests').where('senderId', '==', uid),
+        'friend_requests as sender',
+      ),
+      deleteCollectionInBatches(
+        db.collection('friend_requests').where('receiverId', '==', uid),
+        'friend_requests as receiver',
+      ),
+      deleteCollectionInBatches(
+        db.collection('blocks').where('blockerUid', '==', uid),
+        'blocks as blocker',
+      ),
+      deleteCollectionInBatches(
+        db.collection('blocks').where('blockedUid', '==', uid),
+        'blocks as blocked',
+      ),
+    ]);
+
+    // Step 4: Soft-delete conversations.
+    await softDeleteConversations(uid);
+
+    // Step 5: Username reverse-lookup + delete.
+    // Read user doc TRƯỚC khi delete (step 6) để biết username field.
+    const userSnap = await userRef.get();
+    if (userSnap.exists) {
+      const data = userSnap.data() as Record<string, unknown> | undefined;
+      const usernameField = data?.username;
+      if (typeof usernameField === 'string' && usernameField.length > 0) {
+        const usernameRef = db.collection('usernames').doc(usernameField);
+        const usernameSnap = await usernameRef.get();
+        if (usernameSnap.exists) {
+          await usernameRef.delete();
+          logger.info(
+            { uid, username: usernameField },
+            'deleteAccount: username released',
+          );
+        }
+      }
+    }
+
+    // Step 6: /users/{uid} document.
+    if (userSnap.exists) {
+      await userRef.delete();
+    }
+
+    // Step 7: Auth account (LAST — idempotent qua catch user-not-found).
+    try {
+      await getAuth().deleteUser(uid);
+      logger.info({ uid }, 'deleteAccount: auth account deleted');
+    } catch (e: unknown) {
+      const code =
+        e !== null && typeof e === 'object' && 'code' in e
+          ? String(e.code)
+          : '';
+      if (code === 'auth/user-not-found') {
+        // Retry case: auth already deleted, các step trước cũng đã xong.
+        logger.info({ uid }, 'deleteAccount: auth user not found, retry skip');
+      } else {
+        throw e;
+      }
+    }
+
+    return { success: true };
+  },
+);

--- a/firebase/functions/test/settings/deleteAccount.test.ts
+++ b/firebase/functions/test/settings/deleteAccount.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+// Mirror schema từ src/settings/deleteAccount.ts để test isolated (không
+// cần emulator). Cascade order + idempotent + Storage/Firestore/Auth
+// integration test sẽ ở rules test với emulator (T8 #120) — mock toàn bộ
+// Firebase Admin SDK (Storage bucket + Firestore + Auth) là 1 day work,
+// out of scope task T7 L estimate.
+//
+// Schema = z.unknown() vì CF không nhận input từ client — uid lấy từ
+// request.auth.uid. Schema chỉ để tuân thủ CLAUDE.md "safeParse mọi callable".
+const deleteAccountSchema = z.unknown();
+
+describe('deleteAccount schema', () => {
+  it('accepts empty object (no input expected)', () => {
+    const result = deleteAccountSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts undefined (client gọi không truyền arg)', () => {
+    const result = deleteAccountSchema.safeParse(undefined);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts arbitrary payload (z.unknown — ignore client junk)', () => {
+    const result = deleteAccountSchema.safeParse({
+      junkField: 'ignored',
+      nested: { also: 'ignored' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts null', () => {
+    const result = deleteAccountSchema.safeParse(null);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #224
Part of #119 (phase 2/3)

## Scope
Implement HTTPS Callable `deleteAccount` thay stub trong [index.ts](firebase/functions/src/index.ts) per [docs/plans/2026-05-23-settings.md](docs/plans/2026-05-23-settings.md) Task T7. Phase 2/3 của #119 (T5+6+7) — phase 1 = PR #219 (T5 blockUser, đã merge).

Pattern theo [firebase/functions/src/space/onSpaceDeleted.ts](firebase/functions/src/space/onSpaceDeleted.ts) cho batch 499 + [firebase/functions/src/settings/blockUser.ts](firebase/functions/src/settings/blockUser.ts) cho callable boilerplate.

## Files
- `firebase/functions/src/settings/deleteAccount.ts` — NEW, ~245 lines (impl + 2 helpers + JSDoc)
- `firebase/functions/test/settings/deleteAccount.test.ts` — NEW, 35 lines schema tests (4 cases)
- `firebase/functions/src/index.ts` — gỡ stub `deleteAccount`, add export `settings/deleteAccount`

## Cascade order (acceptance T7 #224)

```
1. Storage (parallel — 3 prefixes độc lập):
   - posts/{uid}/   (bucket.deleteFiles)
   - avatars/{uid}/
   - diary/{uid}/

2. /users/{uid} subcollections (parallel — 4 independent):
   - feed, notifications, fcmTokens, private

3. Cross-collection queries:
   3a. diary where authorUid == uid  (sequential — trigger may downstream)
   3b. posts where authorId == uid   (triggers onPostDeleted → cross-feed cleanup)
   3c. friendships where members array-contains uid  (triggers onFriendshipDeleted)
   3d-3e. friend_requests sender+receiver + blocks blocker+blocked (parallel — no triggers)

4. Conversations participantIds contains uid → set status='deleted'
   (soft delete — partner còn cần đọc lịch sử, parity Locket)

5. Username reverse-lookup: read /users/{uid}.username → delete /usernames/{username}

6. /users/{uid} document

7. admin.auth().deleteUser(uid) — CUỐI CÙNG
```

## Acceptance criteria #224 — deleteAccount

- [x] Thứ tự: Storage → Firestore subcollections → Firestore documents → Auth (Auth xóa CUỐI CÙNG)
- [x] Storage pagination 1000 files/batch: `posts/{uid}/**`, `avatars/{uid}/**`, `diary/{uid}/**` (bucket.deleteFiles auto-paginates)
- [x] Firestore subcollections TRƯỚC document
- [x] Idempotent: bucket.deleteFiles no-op empty prefix, deleteCollectionInBatches no-op empty query, userSnap.exists check, auth/user-not-found catch
- [x] CF fail giữa chừng → Auth account vẫn còn → user có thể retry (Auth xóa LAST)

## Pattern decisions

| Decision | Rationale |
|---|---|
| Batch 499 ops/batch | Match `onSpaceDeleted` convention (admin SDK hard limit 500) |
| Cursor pagination `startAfter` cho conversations | Soft-delete update không change `participantIds` → cần cursor để advance, tránh infinite loop |
| `friendships.where('members', 'array-contains', uid)` | 1 query thay vì 2 (`uid1` + `uid2`) — match `acceptFriendRequest.ts` doc structure |
| friend_requests + blocks parallel | Không có Firestore trigger downstream → an toàn parallel |
| diary/posts/friendships sequential | Có trigger downstream → sequential giúp debug nếu trigger fail |
| Username lookup TRƯỚC user doc delete | Read `data.username` để biết reverse key — phải đọc trước khi `userRef.delete()` |
| Auth catch `auth/user-not-found` | Retry case: Auth đã xóa lần trước, Firestore/Storage cleanup re-run — skip Auth, return success |
| `timeoutSeconds: 540, memory: '512MiB'` | Cascade nhiều posts có thể ~1-2 phút; 540s = max v2 hard limit |
| `z.unknown()` schema | CF không nhận input (uid lấy từ `request.auth`). Schema chỉ để tuân thủ CLAUDE.md "safeParse mọi callable" |

## Known limitations (acceptable cho MVP)

- **TOCTOU race conversation soft-delete**: query result + batch update không atomic. Nếu conversation bị xoá ngoài (rare) giữa query và `batch.commit()` → batch throws NOT_FOUND. Match T5 convention (cũng không dùng `runTransaction`). Probability cực thấp khi user đang delete account.
- **Subcollection unbounded for batch.delete**: `users/{uid}/feed` có thể rất lớn (1000s). Helper paginate qua nhiều round 499/batch → an toàn nhưng tốn thời gian. 540s timeout đủ cho user typical.
- **Storage delete không list trước**: `bucket.deleteFiles({ prefix })` SDK auto-paginate + delete. Không return count → log chỉ ghi "storage cleared" không có số file. Acceptable cho cleanup operation.

## Test plan
- [x] `npm test` — 78/78 pass (4 mới)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Reviewer: trace cascade order — Storage trước, Auth sau cùng
- [ ] Reviewer: verify idempotent path (re-run sau partial fail)
- [ ] Integration test full cascade flow → T8 #120 (rules + emulator) — mock toàn bộ Storage + Firestore + Auth là 1 day work, out of scope T7 L estimate

## Phase 3 plan (#223 — T6 wire UI)

- `DeleteAccountDialog` 2-step: confirm → reauthenticate (email password / Google credential)
- `SettingsController.deleteAccount()` thêm impl gọi CF callable
- Handle `requires-recent-login` → hiện error inline, KHÔNG auto-dismiss