### PR TITLE
feat(settings): T6 — DeleteAccountDialog wire reauth xoá tài khoản

### DIFF
--- a/apps/mobile/lib/features/auth/data/auth_repository.dart
+++ b/apps/mobile/lib/features/auth/data/auth_repository.dart
@@ -74,8 +74,51 @@ abstract class AuthRepository {
   Future<void> deleteCurrentUser();
 
   /// Re-authenticate before sensitive operations (email change, delete account).
+  ///
+  /// Implementations must wrap Firebase errors:
+  /// - `wrong-password` / `invalid-credential` → [UnauthenticatedError] ("Mật khẩu không đúng")
+  /// - `user-mismatch` → [UnauthenticatedError] ("Thông tin xác thực không khớp tài khoản")
+  /// - `requires-recent-login` → [UnauthenticatedError] với `code: 'requires-recent-login'`
+  /// - `network-request-failed` → [NetworkError]
   Future<void> reauthenticateWithCredential(AuthCredential credential);
+
+  /// Helper: reauthenticate current email/password user.
+  ///
+  /// Widgets/controllers KHÔNG được tự build [EmailAuthProvider.credential]
+  /// (layering rule — không touch Firebase types). Method này wrap construction
+  /// + reauth.
+  ///
+  /// Throws [UnauthenticatedError] nếu user chưa login hoặc không có email.
+  Future<void> reauthenticateWithPassword(String password);
+
+  /// Helper: reauthenticate current Google user.
+  ///
+  /// Trigger Google account picker → lấy credential → reauth. Throws
+  /// [OperationCancelledError] nếu user dismiss picker (silent no-op upstream,
+  /// match `signInWithGoogle`).
+  Future<void> reauthenticateWithGoogle();
+
+  /// Returns the primary provider ID của user hiện tại — 'password',
+  /// 'google.com', etc. Returns null nếu chưa login hoặc providerData rỗng.
+  ///
+  /// MVP Meep chỉ hỗ trợ 1 provider per account (không link). Tương lai có
+  /// thể return list providers.
+  String? get currentProviderId;
 
   /// Update the email address of the current user.
   Future<void> updateEmail(String newEmail);
+
+  /// Cascade-delete user account qua Cloud Function `deleteAccount`.
+  ///
+  /// Server (Admin SDK) xóa Storage prefixes + Firestore subcollections +
+  /// documents + Firebase Auth account theo thứ tự đảm bảo retry-safe (xem
+  /// `firebase/functions/src/settings/deleteAccount.ts`).
+  ///
+  /// Khi server xóa Auth thành công, client local session tự invalidate qua
+  /// [watchUid] → router auth listener redirect về `/intro`.
+  ///
+  /// Pre-condition: caller (DeleteAccountDialog) phải gọi
+  /// [reauthenticateWithCredential] trước để xác nhận identity. CF dùng Admin
+  /// SDK bypass token freshness, nhưng UX yêu cầu reauth.
+  Future<void> deleteAccountCascade();
 }

--- a/apps/mobile/lib/features/auth/data/firebase_auth_repository.dart
+++ b/apps/mobile/lib/features/auth/data/firebase_auth_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:meep/core/config/app_config.dart';
@@ -9,11 +10,18 @@ import 'package:meep/features/auth/data/auth_repository.dart';
 class FirebaseAuthRepository implements AuthRepository {
   FirebaseAuthRepository({
     required FirebaseAuth auth,
+    FirebaseFunctions? functions,
     GoogleSignIn? googleSignIn,
   })  : _auth = auth,
+        _functions = functions,
         _googleSignIn = googleSignIn ?? GoogleSignIn();
 
   final FirebaseAuth _auth;
+
+  /// Optional — chỉ [deleteAccountCascade] cần. Existing tests construct
+  /// FirebaseAuthRepository chỉ với `auth:` nên giữ optional, throw rõ ràng
+  /// nếu method dùng tới mà chưa wire.
+  final FirebaseFunctions? _functions;
   final GoogleSignIn _googleSignIn;
 
   @override
@@ -185,14 +193,84 @@ class FirebaseAuthRepository implements AuthRepository {
 
   @override
   Future<void> reauthenticateWithCredential(AuthCredential credential) async {
-    // TODO(A/T7/ThienPDM): implement — needed by Profile/Settings for sensitive ops
-    throw UnimplementedError('reauthenticateWithCredential — implement at T7');
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw const UnauthenticatedError(
+        message: 'Bạn cần đăng nhập để thực hiện thao tác này',
+      );
+    }
+    try {
+      await user.reauthenticateWithCredential(credential);
+    } on FirebaseAuthException catch (e) {
+      throw _mapReauthError(e);
+    }
+  }
+
+  @override
+  Future<void> reauthenticateWithPassword(String password) async {
+    final user = _auth.currentUser;
+    final email = user?.email;
+    if (user == null || email == null) {
+      throw const UnauthenticatedError(
+        message: 'Bạn cần đăng nhập với email để xác thực lại',
+      );
+    }
+    final credential = EmailAuthProvider.credential(
+      email: email,
+      password: password,
+    );
+    await reauthenticateWithCredential(credential);
+  }
+
+  @override
+  Future<void> reauthenticateWithGoogle() async {
+    final googleUser = await _googleSignIn.signIn();
+    if (googleUser == null) {
+      // User dismissed picker — silent no-op upstream (match signInWithGoogle).
+      throw const OperationCancelledError();
+    }
+    final googleAuth = await googleUser.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+    await reauthenticateWithCredential(credential);
+  }
+
+  @override
+  String? get currentProviderId {
+    final user = _auth.currentUser;
+    if (user == null || user.providerData.isEmpty) return null;
+    return user.providerData[0].providerId;
   }
 
   @override
   Future<void> updateEmail(String newEmail) async {
     // TODO(A/T7/ThienPDM): implement — needed by Profile for email change
     throw UnimplementedError('updateEmail — implement at T7');
+  }
+
+  @override
+  Future<void> deleteAccountCascade() async {
+    final functions = _functions;
+    if (functions == null) {
+      // Misconfiguration: main.dart phải pass `functions:` vào constructor.
+      throw const UnexpectedError(
+        message:
+            'FirebaseFunctions chưa wire — kiểm tra FirebaseAuthRepository init trong main.dart',
+      );
+    }
+    if (_auth.currentUser == null) {
+      throw const UnauthenticatedError(
+        message: 'Bạn cần đăng nhập để xóa tài khoản',
+      );
+    }
+    try {
+      final callable = functions.httpsCallable('deleteAccount');
+      await callable.call<void>();
+    } on FirebaseFunctionsException catch (e) {
+      throw _mapDeleteAccountError(e);
+    }
   }
 
   // ── Error mapping ─────────────────────────────────────────────────────────
@@ -230,6 +308,55 @@ class FirebaseAuthRepository implements AuthRepository {
         'network-request-failed' =>
           const NetworkError(message: 'Không có kết nối mạng'),
         _ => UnexpectedError(message: e.message ?? e.code, cause: e),
+      };
+
+  /// Reauth có thể fail vì credential sai (wrong-password), provider mismatch
+  /// (user-mismatch khi GoogleAuthProvider credential nhưng account email),
+  /// hoặc session quá cũ (requires-recent-login — extremely rare ở reauth path
+  /// nhưng giữ để safety).
+  AppError _mapReauthError(FirebaseAuthException e) => switch (e.code) {
+        'wrong-password' ||
+        'invalid-credential' =>
+          const UnauthenticatedError(message: 'Mật khẩu không đúng'),
+        'user-mismatch' => const UnauthenticatedError(
+            message: 'Thông tin xác thực không khớp tài khoản hiện tại',
+          ),
+        'user-not-found' => const UnauthenticatedError(
+            message: 'Không tìm thấy tài khoản',
+          ),
+        'too-many-requests' => const UnauthenticatedError(
+            message: 'Quá nhiều lần thử. Vui lòng thử lại sau',
+          ),
+        'requires-recent-login' => UnauthenticatedError(
+            message: 'Phiên đăng nhập hết hạn. Vui lòng đăng nhập lại',
+            code: e.code,
+            cause: e,
+          ),
+        'network-request-failed' =>
+          const NetworkError(message: 'Không có kết nối mạng'),
+        _ => UnexpectedError(message: e.message ?? e.code, cause: e),
+      };
+
+  /// CF `deleteAccount` có thể fail: unauthenticated (token expired giữa
+  /// reauth và call), unavailable (CF cold start timeout), default
+  /// (cascade partial fail — retry-safe theo CF impl, surface lỗi UI).
+  AppError _mapDeleteAccountError(FirebaseFunctionsException e) =>
+      switch (e.code) {
+        'unauthenticated' => UnauthenticatedError(
+            message: e.message ?? 'Cần đăng nhập để xóa tài khoản',
+            code: e.code,
+            cause: e,
+          ),
+        'unavailable' || 'deadline-exceeded' => NetworkError(
+            message: e.message ?? 'Mất kết nối khi xóa tài khoản. Thử lại sau.',
+            code: e.code,
+            cause: e,
+          ),
+        _ => UnexpectedError(
+            message: e.message ?? 'Không thể xóa tài khoản. Thử lại sau.',
+            code: e.code,
+            cause: e,
+          ),
       };
 
   static bool _isSessionPermanentlyInvalid(String code) =>

--- a/apps/mobile/lib/features/settings/application/settings_controller.dart
+++ b/apps/mobile/lib/features/settings/application/settings_controller.dart
@@ -93,9 +93,38 @@ class SettingsController extends _$SettingsController {
     }
   }
 
+  /// Cascade-delete account flow:
+  /// 1. Best-effort `deleteFcmToken(uid)` — match logout pattern (#103 OPEN
+  ///    có thể chưa wire / offline → swallow, vẫn tiếp tục).
+  /// 2. `AuthRepository.deleteAccountCascade()` — CF xóa Storage + Firestore
+  ///    + Auth (T7). Khi server xóa Auth, client local session tự invalidate
+  ///    qua `watchUid` → router auth listener redirect `/intro`.
+  ///
+  /// Pre-condition: caller (DeleteAccountDialog) phải reauthenticate trước
+  /// (xem `AuthRepository.reauthenticateWithCredential`). Controller giả
+  /// định identity đã được verify — không tự gọi reauth.
   Future<void> deleteAccount() async {
-    // TODO(T6/NganTNK): implement deleteAccount (re-auth + cascade) — scope #119
-    throw UnimplementedError('deleteAccount — TODO T6 #119');
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    final auth = ref.read(authRepositoryProvider);
+    final uid = auth.currentUid;
+    if (uid == null) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: 'Bạn cần đăng nhập để xóa tài khoản',
+      );
+      return;
+    }
+    try {
+      await ref.read(notificationRepositoryProvider).deleteFcmToken(uid);
+    } catch (_) {
+      // Swallow: FCM cleanup là best-effort, không block delete.
+    }
+    try {
+      await auth.deleteAccountCascade();
+      state = state.copyWith(isLoading: false);
+    } catch (e) {
+      state = _afterFailure(e);
+    }
   }
 
   /// Reset isLoading + map error to message (null for [OperationCancelledError]).

--- a/apps/mobile/lib/features/settings/presentation/delete_account_dialog.dart
+++ b/apps/mobile/lib/features/settings/presentation/delete_account_dialog.dart
@@ -1,12 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:meep/core/error/app_error.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_spacing.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
 import 'package:meep/shared/widgets/app_confirm_dialog.dart';
 
+/// 2-step delete account flow (Figma `572:4605` → reauth inline).
+///
+/// Step 1: confirm intent qua [showAppConfirmDialog].
+/// Step 2: [_ReauthDialog] — reauth + cascade delete. Provider detection:
+///   - `password` → email + password field
+///   - `google.com` → trigger Google account picker (no password field)
+///
+/// On reauth success → `SettingsController.deleteAccount()` → CF cascade.
+/// Khi CF xóa Auth account, client `authStateChanges` emit null → router
+/// auth listener auto-redirect `/intro` (xem `main.dart` + `app_router`).
+///
+/// Dialog returns:
+/// - `true` → account deleted, navigation đã trigger
+/// - `false` → user cancelled (step 1 hoặc step 2 huỷ)
+/// - `null` → step 2 barrierDismissible=false, không xảy ra
 class DeleteAccountDialog {
   static Future<bool?> show(BuildContext context) async {
-    // Step 1: Confirm intent using shared dialog
     final confirmed = await showAppConfirmDialog(
       context,
       title: 'Bạn có chắc muốn xoá tài khoản này không?',
@@ -16,28 +35,29 @@ class DeleteAccountDialog {
     );
 
     if (!confirmed) return false;
+    if (!context.mounted) return false;
 
-    // Step 2: Re-auth
-    if (context.mounted) {
-      return showDialog<bool>(
-        context: context,
-        builder: (_) => const _ReauthDialog(),
-      );
-    }
-    return false;
+    return showDialog<bool>(
+      context: context,
+      // Prevent auto-dismiss on tap outside — match plan acceptance:
+      // requires-recent-login + reauth errors phải giữ dialog mở để user fix.
+      barrierDismissible: false,
+      builder: (_) => const _ReauthDialog(),
+    );
   }
 }
 
-class _ReauthDialog extends StatefulWidget {
+class _ReauthDialog extends ConsumerStatefulWidget {
   const _ReauthDialog();
 
   @override
-  State<_ReauthDialog> createState() => _ReauthDialogState();
+  ConsumerState<_ReauthDialog> createState() => _ReauthDialogState();
 }
 
-class _ReauthDialogState extends State<_ReauthDialog> {
+class _ReauthDialogState extends ConsumerState<_ReauthDialog> {
   final _passwordController = TextEditingController();
   String? _errorText;
+  bool _isProcessing = false;
 
   @override
   void dispose() {
@@ -45,8 +65,70 @@ class _ReauthDialogState extends State<_ReauthDialog> {
     super.dispose();
   }
 
+  bool get _isGoogleUser =>
+      ref.read(authRepositoryProvider).currentProviderId == 'google.com';
+
+  Future<void> _onConfirm() async {
+    if (_isProcessing) return;
+
+    final isGoogle = _isGoogleUser;
+
+    if (!isGoogle && _passwordController.text.isEmpty) {
+      setState(() => _errorText = 'Vui lòng nhập mật khẩu');
+      return;
+    }
+
+    setState(() {
+      _errorText = null;
+      _isProcessing = true;
+    });
+
+    final auth = ref.read(authRepositoryProvider);
+    try {
+      if (isGoogle) {
+        await auth.reauthenticateWithGoogle();
+      } else {
+        await auth.reauthenticateWithPassword(_passwordController.text);
+      }
+    } on OperationCancelledError {
+      // User dismissed Google picker — keep dialog open silently.
+      if (mounted) setState(() => _isProcessing = false);
+      return;
+    } catch (e) {
+      if (!mounted) return;
+      final err = AppError.fromUnknown(e);
+      setState(() {
+        _errorText = err.message;
+        _isProcessing = false;
+      });
+      return;
+    }
+
+    if (!mounted) return;
+
+    // Reauth success → trigger cascade delete.
+    await ref.read(settingsControllerProvider.notifier).deleteAccount();
+
+    if (!mounted) return;
+
+    final settings = ref.read(settingsControllerProvider);
+    if (settings.errorMessage != null) {
+      setState(() {
+        _errorText = settings.errorMessage;
+        _isProcessing = false;
+      });
+      return;
+    }
+
+    // Success — close dialog. Router auth listener (main.dart watchUid)
+    // sẽ navigate /intro khi authStateChanges emit null sau CF deleteUser.
+    Navigator.pop(context, true);
+  }
+
   @override
   Widget build(BuildContext context) {
+    final isGoogle = _isGoogleUser;
+
     return Dialog(
       backgroundColor: AppColors.bw800,
       insetPadding: const EdgeInsets.symmetric(horizontal: 64),
@@ -66,43 +148,56 @@ class _ReauthDialogState extends State<_ReauthDialog> {
             ),
             const SizedBox(height: AppSpacing.sm),
             Text(
-              'Vui lòng nhập mật khẩu để xác nhận',
+              isGoogle
+                  ? 'Chạm xác nhận để xác thực lại với Google'
+                  : 'Vui lòng nhập mật khẩu để xác nhận',
               style: AppTextStyles.smRegular.copyWith(color: AppColors.bw400),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: AppSpacing.lg),
-            TextField(
-              controller: _passwordController,
-              obscureText: true,
-              style: AppTextStyles.mdRegular.copyWith(color: Colors.white),
-              decoration: InputDecoration(
-                hintText: 'Mật khẩu',
-                hintStyle:
-                    AppTextStyles.mdRegular.copyWith(color: AppColors.bw500),
-                filled: true,
-                fillColor: AppColors.bw700,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 20,
-                  vertical: 14,
-                ),
-                errorText: _errorText,
-                errorStyle: AppTextStyles.xsRegular.copyWith(
-                  color: AppColors.error500,
-                ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(30),
-                  borderSide: BorderSide.none,
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(30),
-                  borderSide: BorderSide.none,
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(30),
-                  borderSide: const BorderSide(color: AppColors.turquoise500),
+            if (!isGoogle)
+              TextField(
+                controller: _passwordController,
+                obscureText: true,
+                enabled: !_isProcessing,
+                style: AppTextStyles.mdRegular.copyWith(color: Colors.white),
+                decoration: InputDecoration(
+                  hintText: 'Mật khẩu',
+                  hintStyle:
+                      AppTextStyles.mdRegular.copyWith(color: AppColors.bw500),
+                  filled: true,
+                  fillColor: AppColors.bw700,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                    vertical: 14,
+                  ),
+                  errorText: _errorText,
+                  errorStyle: AppTextStyles.xsRegular.copyWith(
+                    color: AppColors.error500,
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(30),
+                    borderSide: BorderSide.none,
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(30),
+                    borderSide: BorderSide.none,
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(30),
+                    borderSide: const BorderSide(color: AppColors.turquoise500),
+                  ),
                 ),
               ),
-            ),
+            if (isGoogle && _errorText != null) ...[
+              Text(
+                _errorText!,
+                style: AppTextStyles.xsRegular.copyWith(
+                  color: AppColors.error500,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
             const SizedBox(height: AppSpacing.xl),
             Row(
               children: [
@@ -110,26 +205,17 @@ class _ReauthDialogState extends State<_ReauthDialog> {
                   child: _ConfirmDialogButton(
                     label: 'Huỷ',
                     textColor: AppColors.bw100,
+                    enabled: !_isProcessing,
                     onTap: () => Navigator.pop(context, false),
                   ),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
                   child: _ConfirmDialogButton(
-                    label: 'Xác nhận',
+                    label: _isProcessing ? 'Đang xử lý...' : 'Xác nhận',
                     textColor: AppColors.error800,
-                    onTap: () {
-                      if (_passwordController.text.isEmpty) {
-                        setState(
-                          () => _errorText = 'Vui lòng nhập mật khẩu',
-                        );
-                        return;
-                      }
-                      // TODO(T6/NganTNK): reauthenticate + SettingsController.deleteAccount()
-                      // On FirebaseAuthException(requires-recent-login):
-                      //   setState(() => _errorText = 'Vui lòng xác thực lại để tiếp tục');
-                      Navigator.pop(context, true);
-                    },
+                    enabled: !_isProcessing,
+                    onTap: _onConfirm,
                   ),
                 ),
               ],
@@ -146,11 +232,13 @@ class _ConfirmDialogButton extends StatelessWidget {
     required this.label,
     required this.textColor,
     required this.onTap,
+    this.enabled = true,
   });
 
   final String label;
   final Color textColor;
   final VoidCallback onTap;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -159,17 +247,21 @@ class _ConfirmDialogButton extends StatelessWidget {
       label: label,
       excludeSemantics: true,
       child: GestureDetector(
-        onTap: onTap,
+        onTap: enabled ? onTap : null,
         child: Container(
           padding: const EdgeInsets.symmetric(vertical: 15),
           alignment: Alignment.center,
           decoration: BoxDecoration(
-            color: AppColors.bw700,
+            color: enabled
+                ? AppColors.bw700
+                : AppColors.bw700.withValues(alpha: 0.5),
             borderRadius: BorderRadius.circular(30),
           ),
           child: Text(
             label,
-            style: AppTextStyles.smSemiBold.copyWith(color: textColor),
+            style: AppTextStyles.smSemiBold.copyWith(
+              color: enabled ? textColor : textColor.withValues(alpha: 0.5),
+            ),
           ),
         ),
       ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -45,6 +45,7 @@ void main() async {
 
   final authRepo = FirebaseAuthRepository(
     auth: FirebaseAuth.instance,
+    functions: FirebaseFunctions.instanceFor(region: 'asia-southeast1'),
     googleSignIn: GoogleSignIn(
       serverClientId: AppConfig.googleServerClientId,
     ),

--- a/apps/mobile/test/features/settings/application/settings_controller_test.dart
+++ b/apps/mobile/test/features/settings/application/settings_controller_test.dart
@@ -222,4 +222,77 @@ void main() {
       expect(state.errorMessage, contains('không thể đăng xuất'));
     });
   });
+
+  group('deleteAccount', () {
+    late MockAuthRepository auth;
+    late MockNotificationRepository notif;
+    late ProviderContainer container;
+
+    setUp(() {
+      auth = MockAuthRepository();
+      notif = MockNotificationRepository();
+      when(() => auth.currentUid).thenReturn('me');
+      when(() => auth.deleteAccountCascade()).thenAnswer((_) async {});
+      when(() => notif.deleteFcmToken(any())).thenAnswer((_) async {});
+
+      container = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(auth),
+          notificationRepositoryProvider.overrideWithValue(notif),
+        ],
+      );
+    });
+
+    tearDown(() => container.dispose());
+
+    test('gọi deleteFcmToken(uid) → deleteAccountCascade() theo đúng thứ tự',
+        () async {
+      await container.read(settingsControllerProvider.notifier).deleteAccount();
+
+      verifyInOrder([
+        () => notif.deleteFcmToken('me'),
+        () => auth.deleteAccountCascade(),
+      ]);
+      expect(container.read(settingsControllerProvider).isLoading, isFalse);
+      expect(container.read(settingsControllerProvider).errorMessage, isNull);
+    });
+
+    test('chưa login (uid null) → errorMessage set, KHÔNG gọi cascade',
+        () async {
+      when(() => auth.currentUid).thenReturn(null);
+
+      await container.read(settingsControllerProvider.notifier).deleteAccount();
+
+      verifyNever(() => notif.deleteFcmToken(any()));
+      verifyNever(() => auth.deleteAccountCascade());
+      final state = container.read(settingsControllerProvider);
+      expect(state.errorMessage, isNotNull);
+      expect(state.isLoading, isFalse);
+    });
+
+    test('deleteFcmToken throw → vẫn gọi cascade (best-effort cleanup)',
+        () async {
+      when(() => notif.deleteFcmToken(any()))
+          .thenThrow(const NetworkError(message: 'offline'));
+
+      await container.read(settingsControllerProvider.notifier).deleteAccount();
+
+      verify(() => auth.deleteAccountCascade()).called(1);
+      // errorMessage null vì FCM cleanup KHÔNG block cascade.
+      expect(container.read(settingsControllerProvider).errorMessage, isNull);
+    });
+
+    test('cascade throw AppError → errorMessage set, isLoading reset',
+        () async {
+      when(() => auth.deleteAccountCascade()).thenThrow(
+        const NetworkError(message: 'không thể xóa tài khoản'),
+      );
+
+      await container.read(settingsControllerProvider.notifier).deleteAccount();
+
+      final state = container.read(settingsControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, contains('không thể xóa tài khoản'));
+    });
+  });
 }

--- a/apps/mobile/test/features/settings/delete_account_dialog_test.dart
+++ b/apps/mobile/test/features/settings/delete_account_dialog_test.dart
@@ -1,16 +1,51 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/auth_repository.dart';
+import 'package:meep/features/notification/application/notification_controller.dart';
+import 'package:meep/features/notification/data/notification_repository.dart';
 import 'package:meep/features/settings/presentation/delete_account_dialog.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+class _MockNotificationRepository extends Mock
+    implements NotificationRepository {}
 
 void main() {
   group('DeleteAccountDialog', () {
-    Widget harness() => MaterialApp(
-          home: Scaffold(
-            body: Builder(
-              builder: (context) => Center(
-                child: ElevatedButton(
-                  onPressed: () => DeleteAccountDialog.show(context),
-                  child: const Text('open'),
+    late _MockAuthRepository auth;
+    late _MockNotificationRepository notif;
+
+    setUp(() {
+      auth = _MockAuthRepository();
+      notif = _MockNotificationRepository();
+      // Default: signed in as email user.
+      when(() => auth.currentUid).thenReturn('me');
+      when(() => auth.currentProviderId).thenReturn('password');
+      when(() => auth.reauthenticateWithPassword(any()))
+          .thenAnswer((_) async {});
+      when(() => auth.reauthenticateWithGoogle()).thenAnswer((_) async {});
+      when(() => auth.deleteAccountCascade()).thenAnswer((_) async {});
+      when(() => notif.deleteFcmToken(any())).thenAnswer((_) async {});
+    });
+
+    Widget harness() => ProviderScope(
+          overrides: [
+            authRepositoryProvider.overrideWithValue(auth),
+            notificationRepositoryProvider.overrideWithValue(notif),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => Center(
+                  child: ElevatedButton(
+                    onPressed: () => DeleteAccountDialog.show(context),
+                    child: const Text('open'),
+                  ),
                 ),
               ),
             ),
@@ -20,6 +55,12 @@ void main() {
     Future<void> openStep1(WidgetTester tester) async {
       await tester.pumpWidget(harness());
       await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> openStep2(WidgetTester tester) async {
+      await openStep1(tester);
+      await tester.tap(find.text('Xoá'));
       await tester.pumpAndSettle();
     }
 
@@ -35,29 +76,125 @@ void main() {
       expect(find.text('Huỷ'), findsOneWidget);
     });
 
-    testWidgets('step 1 confirm → step 2 re-auth (ô nhập mật khẩu)',
+    testWidgets(
+        'step 2 email user: hiện password field + caption "nhập mật khẩu"',
         (tester) async {
-      await openStep1(tester);
-
-      await tester.tap(find.text('Xoá'));
-      await tester.pumpAndSettle();
+      await openStep2(tester);
 
       expect(find.text('Xác thực lại'), findsOneWidget);
+      expect(find.text('Vui lòng nhập mật khẩu để xác nhận'), findsOneWidget);
       expect(find.byType(TextField), findsOneWidget);
     });
 
-    testWidgets('step 2: mật khẩu rỗng + "Xác nhận" → hiện lỗi, không submit',
+    testWidgets(
+        'step 2 Google user: KHÔNG hiện password field, caption "Chạm xác nhận"',
         (tester) async {
-      await openStep1(tester);
-      await tester.tap(find.text('Xoá'));
-      await tester.pumpAndSettle();
+      when(() => auth.currentProviderId).thenReturn('google.com');
 
-      // Không nhập gì, bấm Xác nhận.
+      await openStep2(tester);
+
+      expect(find.text('Xác thực lại'), findsOneWidget);
+      expect(
+        find.text('Chạm xác nhận để xác thực lại với Google'),
+        findsOneWidget,
+      );
+      expect(find.byType(TextField), findsNothing);
+    });
+
+    testWidgets('step 2 email: mật khẩu rỗng → hiện lỗi, KHÔNG submit',
+        (tester) async {
+      await openStep2(tester);
+
       await tester.tap(find.text('Xác nhận'));
       await tester.pumpAndSettle();
 
       expect(find.text('Vui lòng nhập mật khẩu'), findsOneWidget);
-      // Dialog re-auth vẫn còn (không bị pop khi mật khẩu rỗng).
+      expect(find.text('Xác thực lại'), findsOneWidget);
+      verifyNever(() => auth.reauthenticateWithPassword(any()));
+    });
+
+    testWidgets(
+        'step 2 email: reauth success → gọi deleteAccountCascade → pop true',
+        (tester) async {
+      await openStep2(tester);
+
+      await tester.enterText(find.byType(TextField), 'correct-password');
+      await tester.tap(find.text('Xác nhận'));
+      await tester.pumpAndSettle();
+
+      verify(() => auth.reauthenticateWithPassword('correct-password'))
+          .called(1);
+      verify(() => auth.deleteAccountCascade()).called(1);
+      // Dialog đã pop → step 2 widget không còn.
+      expect(find.text('Xác thực lại'), findsNothing);
+    });
+
+    testWidgets(
+        'step 2 email: reauth wrong password → hiện lỗi inline, dialog VẪN mở',
+        (tester) async {
+      when(() => auth.reauthenticateWithPassword(any())).thenThrow(
+        const UnauthenticatedError(message: 'Mật khẩu không đúng'),
+      );
+
+      await openStep2(tester);
+
+      await tester.enterText(find.byType(TextField), 'wrong');
+      await tester.tap(find.text('Xác nhận'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Mật khẩu không đúng'), findsOneWidget);
+      // Dialog vẫn mở để user thử lại.
+      expect(find.text('Xác thực lại'), findsOneWidget);
+      // Không gọi cascade khi reauth fail.
+      verifyNever(() => auth.deleteAccountCascade());
+    });
+
+    testWidgets(
+        'step 2 Google: user dismiss picker (OperationCancelled) → '
+        'dialog VẪN mở, KHÔNG hiện lỗi', (tester) async {
+      when(() => auth.currentProviderId).thenReturn('google.com');
+      when(() => auth.reauthenticateWithGoogle())
+          .thenThrow(const OperationCancelledError());
+
+      await openStep2(tester);
+      await tester.tap(find.text('Xác nhận'));
+      await tester.pumpAndSettle();
+
+      // Dialog vẫn mở, không có error message.
+      expect(find.text('Xác thực lại'), findsOneWidget);
+      expect(
+        find.text('Chạm xác nhận để xác thực lại với Google'),
+        findsOneWidget,
+      );
+      verifyNever(() => auth.deleteAccountCascade());
+    });
+
+    testWidgets(
+        'step 2 Google: reauth success → gọi deleteAccountCascade → pop true',
+        (tester) async {
+      when(() => auth.currentProviderId).thenReturn('google.com');
+
+      await openStep2(tester);
+      await tester.tap(find.text('Xác nhận'));
+      await tester.pumpAndSettle();
+
+      verify(() => auth.reauthenticateWithGoogle()).called(1);
+      verify(() => auth.deleteAccountCascade()).called(1);
+      expect(find.text('Xác thực lại'), findsNothing);
+    });
+
+    testWidgets('step 2: cascade throw → hiện lỗi inline, dialog VẪN mở',
+        (tester) async {
+      when(() => auth.deleteAccountCascade()).thenThrow(
+        const NetworkError(message: 'Mất kết nối khi xóa tài khoản'),
+      );
+
+      await openStep2(tester);
+      await tester.enterText(find.byType(TextField), 'pwd');
+      await tester.tap(find.text('Xác nhận'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Mất kết nối khi xóa tài khoản'), findsOneWidget);
       expect(find.text('Xác thực lại'), findsOneWidget);
     });
   });


### PR DESCRIPTION
Closes #223

## Scope
T6 phase 3/3 của #119 — wire DeleteAccountDialog với reauth flow (email password / Google) trước khi gọi `deleteAccountCascade()` qua Cloud Function.

## Files
- `apps/mobile/lib/features/auth/data/auth_repository.dart` — thêm 3 helpers: `reauthenticateWithPassword`, `reauthenticateWithGoogle`, `currentProviderId` (cross-module allowed per leader)
- `apps/mobile/lib/features/auth/data/firebase_auth_repository.dart` — impl reauth helpers + `deleteAccountCascade` (gọi CF `deleteAccount`)
- `apps/mobile/lib/features/settings/application/settings_controller.dart` — `deleteAccount()`: best-effort FCM cleanup → cascade
- `apps/mobile/lib/features/settings/presentation/delete_account_dialog.dart` — ConsumerStatefulWidget, detect email/Google, inline errors, `barrierDismissible=false`
- `apps/mobile/lib/main.dart` — wire `functions:` vào `FirebaseAuthRepository`
- Tests: 4 controller + 9 dialog widget tests, 23/23 pass

## Flow
1. Step 1: `showAppConfirmDialog` confirm intent
2. Step 2: detect `currentProviderId`:
   - `password` → text field "Mật khẩu" → `reauthenticateWithPassword`
   - `google.com` → "Chạm xác nhận" button → `reauthenticateWithGoogle`
3. Reauth OK → `SettingsController.deleteAccount()` → CF `deleteAccount`
4. CF xóa Auth → `watchUid` emit null → router auth listener auto-redirect `/intro`

## Error handling (match plan acceptance)
- Wrong password → `UnauthenticatedError` inline, dialog VẪN mở
- Google picker dismissed → `OperationCancelledError` swallowed, dialog VẪN mở
- Cascade fail (network/CF error) → error inline, dialog VẪN mở
- `barrierDismissible=false` — dialog không đóng outside tap

## Test plan
- [x] `flutter analyze` — clean on changed files
- [x] `flutter test test/features/settings/` — 39 pass / 2 fail pre-existing (settings_sheet: Space `spaceByIdProvider` missing)
- [x] Controller: deleteAccount FCM cleanup + cascade + error
- [x] Dialog: step1 confirm, step2 email password field, Google no field, empty password error, reauth success, wrong password, Google dismiss, cascade error

## Note cross-module touch
`AuthRepository` + `FirebaseAuthRepository` modified với permission của `NganTNK` (settings owner) từ leader `ThienPDM` — reauth helpers cần cho delete flow.