### PR TITLE
feat(chat): wire chatUserProfile từ userRepository thay seed (Phase 1)

### DIFF
--- a/apps/mobile/lib/features/chat/application/chat_providers.dart
+++ b/apps/mobile/lib/features/chat/application/chat_providers.dart
@@ -51,10 +51,16 @@ Stream<List<Message>> messages(Ref ref, String conversationId) {
 @riverpod
 Map<String, int> unreadCounts(Ref ref) => ChatSeed.seedUnreadCounts();
 
-/// User profiles keyed by uid, for resolving 1-1 conversation display info.
-/// TODO(C/wire): replace seed lookup with `userRepository` reads.
+/// Resolve a single [UserProfile] by [uid] for display in chat tiles,
+/// headers, and member lists.
+///
+/// Uses [UserRepository.getProfile] (auth module). Riverpod auto-deduplicates
+/// when multiple widgets watch the same uid — only one Firestore read per uid.
 @riverpod
-Map<String, UserProfile> chatUserProfiles(Ref ref) => ChatSeed.usersByUid;
+Future<UserProfile?> chatUserProfile(Ref ref, String uid) async {
+  if (uid.isEmpty) return null;
+  return ref.watch(userRepositoryProvider).getProfile(uid);
+}
 
 /// The single demo space backing group chat.
 /// TODO(C/wire): replace with `spaceRepository.watchSpace(spaceId)`.

--- a/apps/mobile/lib/features/chat/presentation/chat_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/chat_screen.dart
@@ -3,10 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/chat/application/chat_controller.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
-import 'package:meep/features/chat/data/conversation.dart';
 import 'package:meep/features/chat/presentation/chat_thread_view.dart';
 import 'package:meep/features/chat/presentation/widgets/chat_confirm_dialogs.dart';
 import 'package:meep/features/chat/presentation/widgets/chat_input_bar.dart';
@@ -27,8 +25,10 @@ class ChatScreen extends ConsumerWidget {
         .firstOrNull;
 
     final myUid = ref.watch(currentChatUidProvider);
-    final profiles = ref.watch(chatUserProfilesProvider);
-    final peer = _resolvePeer(conversation, myUid, profiles);
+    final peerUid =
+        conversation?.participantIds.where((id) => id != myUid).firstOrNull;
+    final peerAsync = ref.watch(chatUserProfileProvider(peerUid ?? ''));
+    final peer = peerAsync.valueOrNull;
 
     final messagesAsync = ref.watch(messagesProvider(conversationId));
     final sendStatus = ref.watch(chatControllerProvider);
@@ -84,17 +84,6 @@ class ChatScreen extends ConsumerWidget {
         ),
       ),
     );
-  }
-
-  UserProfile? _resolvePeer(
-    Conversation? conversation,
-    String myUid,
-    Map<String, UserProfile> profiles,
-  ) {
-    if (conversation == null) return null;
-    final otherUid =
-        conversation.participantIds.where((id) => id != myUid).firstOrNull;
-    return otherUid == null ? null : profiles[otherUid];
   }
 
   Future<void> _onMenu(BuildContext context, WidgetRef ref, String name) async {

--- a/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
@@ -130,7 +130,6 @@ class _ConversationList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final profiles = ref.watch(chatUserProfilesProvider);
     final unread = ref.watch(unreadCountsProvider);
     final myUid = ref.watch(currentChatUidProvider);
 
@@ -157,7 +156,8 @@ class _ConversationList extends ConsumerWidget {
           (id) => id != myUid,
           orElse: () => myUid,
         );
-        final other = profiles[otherUid];
+        final otherAsync = ref.watch(chatUserProfileProvider(otherUid));
+        final other = otherAsync.valueOrNull;
         return ConversationTile.direct(
           displayName: other?.displayName ?? 'Người dùng',
           avatarUrl: other?.avatarUrl,

--- a/apps/mobile/lib/features/chat/presentation/widgets/space_members_sheet.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/space_members_sheet.dart
@@ -27,7 +27,6 @@ class SpaceMembersSheet extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final members = ref.watch(chatSpaceMembersProvider(spaceId));
-    final profiles = ref.watch(chatUserProfilesProvider);
     final myUid = ref.watch(currentChatUidProvider);
 
     // Tall sheet (~75% screen) per Figma `564:8865`, not a half-height sheet.
@@ -61,7 +60,9 @@ class SpaceMembersSheet extends ConsumerWidget {
                     itemCount: members.length,
                     itemBuilder: (context, index) {
                       final member = members[index];
-                      final profile = profiles[member.uid];
+                      final profileAsync =
+                          ref.watch(chatUserProfileProvider(member.uid));
+                      final profile = profileAsync.valueOrNull;
                       final isMe = member.uid == myUid;
                       return _MemberRow(
                         name: isMe

--- a/apps/mobile/test/features/chat/presentation/inbox_screen_test.dart
+++ b/apps/mobile/test/features/chat/presentation/inbox_screen_test.dart
@@ -3,10 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/firebase_user_repository.dart';
 import 'package:meep/features/chat/application/chat_controller.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/chat/data/chat_seed_data.dart';
-import 'package:meep/features/chat/data/conversation_repository.dart';
 import 'package:meep/features/chat/data/firebase_conversation_repository.dart';
 import 'package:meep/features/chat/presentation/inbox_screen.dart';
 import 'package:meep/features/chat/presentation/widgets/conversation_tile.dart';
@@ -20,11 +21,22 @@ void main() {
             c.toJson(),
           );
     }
+    // Also seed user profiles so chatUserProfileProvider can resolve them.
+    for (final entry in ChatSeed.usersByUid.entries) {
+      await firestore.collection('users').doc(entry.key).set(
+            entry.value.toJson(),
+          );
+    }
   }
 
-  Widget wrap(ConversationRepository repo) => ProviderScope(
+  Widget wrap(FakeFirebaseFirestore firestore) => ProviderScope(
         overrides: [
-          conversationRepositoryProvider.overrideWithValue(repo),
+          conversationRepositoryProvider.overrideWithValue(
+            FirebaseConversationRepository(firestore),
+          ),
+          userRepositoryProvider.overrideWithValue(
+            FirebaseUserRepository(firestore: firestore),
+          ),
           currentChatUidProvider.overrideWith((ref) => ChatSeed.currentUid),
         ],
         child: const MaterialApp(home: InboxScreen()),
@@ -34,7 +46,7 @@ void main() {
     final firestore = FakeFirebaseFirestore();
     await seedSeedData(firestore);
 
-    await tester.pumpWidget(wrap(FirebaseConversationRepository(firestore)));
+    await tester.pumpWidget(wrap(firestore));
     await tester.pumpAndSettle();
 
     expect(find.text('Tin nhắn'), findsOneWidget);
@@ -45,7 +57,7 @@ void main() {
     final firestore = FakeFirebaseFirestore();
     await seedSeedData(firestore);
 
-    await tester.pumpWidget(wrap(FirebaseConversationRepository(firestore)));
+    await tester.pumpWidget(wrap(firestore));
     await tester.pumpAndSettle();
 
     expect(find.text('Talaki'), findsOneWidget); // direct
@@ -56,7 +68,7 @@ void main() {
     // Don't seed — Firestore starts empty.
     final firestore = FakeFirebaseFirestore();
 
-    await tester.pumpWidget(wrap(FirebaseConversationRepository(firestore)));
+    await tester.pumpWidget(wrap(firestore));
     await tester.pumpAndSettle();
 
     expect(

--- a/apps/mobile/test/features/chat/presentation/space_members_sheet_test.dart
+++ b/apps/mobile/test/features/chat/presentation/space_members_sheet_test.dart
@@ -1,14 +1,31 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/firebase_user_repository.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/chat/data/chat_seed_data.dart';
 import 'package:meep/features/chat/presentation/widgets/space_members_sheet.dart';
 
 void main() {
-  Widget wrap(Widget child) => ProviderScope(
+  Future<FakeFirebaseFirestore> seededFirestore() async {
+    final firestore = FakeFirebaseFirestore();
+    // Seed user profiles so chatUserProfileProvider resolves names + avatars.
+    for (final entry in ChatSeed.usersByUid.entries) {
+      await firestore.collection('users').doc(entry.key).set(
+            entry.value.toJson(),
+          );
+    }
+    return firestore;
+  }
+
+  Widget wrap(FakeFirebaseFirestore firestore, Widget child) => ProviderScope(
         overrides: [
+          userRepositoryProvider.overrideWithValue(
+            FirebaseUserRepository(firestore: firestore),
+          ),
           currentChatUidProvider.overrideWith((ref) => ChatSeed.currentUid),
         ],
         child: MaterialApp(home: Scaffold(body: child)),
@@ -16,8 +33,9 @@ void main() {
 
   testWidgets('lists members with count and labels current user "Bạn"',
       (tester) async {
+    final firestore = await seededFirestore();
     await tester.pumpWidget(
-      wrap(const SpaceMembersSheet(spaceId: 'space-fun')),
+      wrap(firestore, const SpaceMembersSheet(spaceId: 'space-fun')),
     );
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Mô tả

Phase 1 của Chat wire-production: thay `chatUserProfilesProvider` (Map trả `ChatSeed.usersByUid` hardcoded 4 user) bằng `chatUserProfileProvider` — `FutureProvider.family<UserProfile?, String>` đọc từ `userRepositoryProvider.getProfile(uid)` (auth module).

Sau PR này: Inbox + Chat + SpaceMembersSheet hiện **tên + avatar thật từ Firestore `/users/{uid}`** thay vì 4 user mock.

## Refs

- Refs #142 (parent Chat epic)
- Continues post-#143, #227 production wire

## Thay đổi chính

### Provider
- `chat_providers.dart` — xoá `chatUserProfilesProvider` (Map), thêm `chatUserProfileProvider` (FutureProvider.family per uid)
  - Empty uid → return null sớm (defensive cho unauthenticated state)
  - Delegate vào `userRepositoryProvider.getProfile(uid)` (đã có sẵn trong auth module — không đụng auth code)
  - Riverpod auto-dedupe: 5 widget cùng watch 1 uid → chỉ 1 Firestore read

### UI consumers (AsyncValue unwrap)
- `inbox_screen.dart:159` — `profiles[otherUid]` → `ref.watch(chatUserProfileProvider(otherUid)).valueOrNull`
- `chat_screen.dart:28-32` — xoá `_resolvePeer` method (4 lines), inline `peerUid` extract + AsyncValue unwrap
- `space_members_sheet.dart:63` — per-row watch `chatUserProfileProvider(member.uid)`

### Tests
- `inbox_screen_test.dart` + `space_members_sheet_test.dart` — override `userRepositoryProvider` với `FirebaseUserRepository(FakeFirebaseFirestore())`, seed `/users/{uid}` collection từ `ChatSeed.usersByUid`

## Loại thay đổi

- [x] feat — Wire production data

## Test

- [x] `flutter test test/features/chat/` — **55/55 PASS**
- [x] `flutter test` (full project) — **402/402 PASS** (no regression)
- [x] `flutter analyze` — clean
- [x] `dart format --set-exit-if-changed .` — PASS (pre-commit hook auto-format)

## Out of scope (defer cho Phase 2-4)

| Item | Phase |
|---|---|
| `chatSpace` + `chatSpaceMembers` providers | Phase 2 |
| `chatQuotedPost` (cần `getPost` trên PostRepository) | Phase 3 hoặc defer |
| `unreadCounts` (cần `lastReadAt` field) | Defer leader decision |
| Block / unfriend / leave space action handlers | Phase 3 |
| UI banners (unfriended/blocked), load-more pagination, skeleton | Phase 4 |

## Risk / Note

- Provider type đổi từ sync `Provider<Map>` → async `FutureProvider.family<UserProfile?>`. UI dùng `.valueOrNull` → trong vài ms đầu khi user profile chưa load, UI hiện `'Người dùng'` / `'Thành viên'` (fallback). Acceptable UX.
- Trường hợp uid empty (chưa login) → provider trả null sớm, không gọi Firestore. UI vẫn render fallback text.
- Nhiều widget watch cùng 1 uid → Riverpod dedupe → 1 read only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)