### PR TITLE
feat(chat): wire chatSpace + 3 actions + readonly banners (Phase 2+3+4)

### DIFF
--- a/apps/mobile/lib/features/chat/application/chat_providers.dart
+++ b/apps/mobile/lib/features/chat/application/chat_providers.dart
@@ -8,6 +8,7 @@ import 'package:meep/features/chat/data/chat_seed_data.dart';
 import 'package:meep/features/chat/data/conversation.dart';
 import 'package:meep/features/chat/data/message.dart';
 import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/features/space/data/space.dart';
 import 'package:meep/features/space/data/space_member.dart';
 
@@ -62,16 +63,24 @@ Future<UserProfile?> chatUserProfile(Ref ref, String uid) async {
   return ref.watch(userRepositoryProvider).getProfile(uid);
 }
 
-/// The single demo space backing group chat.
-/// TODO(C/wire): replace with `spaceRepository.watchSpace(spaceId)`.
+/// Live Space document for a group conversation header / tile.
+///
+/// Delegates to [SpaceRepository.watchSpace] (space module). Empty spaceId →
+/// emits null without hitting Firestore (defensive cho conversation 1-1).
 @riverpod
-Space chatSpace(Ref ref, String spaceId) => ChatSeed.seedSpace();
+Stream<Space?> chatSpace(Ref ref, String spaceId) {
+  if (spaceId.isEmpty) return Stream.value(null);
+  return ref.watch(spaceRepositoryProvider).watchSpace(spaceId);
+}
 
-/// Members of the demo space.
-/// TODO(C/wire): replace with `spaceRepository.watchMembers(spaceId)`.
+/// Live member list for [SpaceMembersSheet].
+///
+/// Delegates to [SpaceRepository.watchMembers] (space module).
 @riverpod
-List<SpaceMember> chatSpaceMembers(Ref ref, String spaceId) =>
-    ChatSeed.seedMembers();
+Stream<List<SpaceMember>> chatSpaceMembers(Ref ref, String spaceId) {
+  if (spaceId.isEmpty) return Stream.value(const []);
+  return ref.watch(spaceRepositoryProvider).watchMembers(spaceId);
+}
 
 /// The post that a 1-1 conversation was started from (quoted photo header).
 /// Returns null when the conversation has no originating post.

--- a/apps/mobile/lib/features/chat/presentation/chat_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/chat_screen.dart
@@ -1,14 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/chat/application/chat_controller.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
+import 'package:meep/features/chat/data/conversation.dart';
 import 'package:meep/features/chat/presentation/chat_thread_view.dart';
 import 'package:meep/features/chat/presentation/widgets/chat_confirm_dialogs.dart';
 import 'package:meep/features/chat/presentation/widgets/chat_input_bar.dart';
 import 'package:meep/features/chat/presentation/widgets/chat_menu_sheet.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/settings/application/settings_controller.dart';
 import 'package:meep/shared/widgets/app_avatar.dart';
 
 /// 1-1 direct chat thread. Figma `564:6934` (+ empty `769:3019`).
@@ -35,10 +39,14 @@ class ChatScreen extends ConsumerWidget {
     final quotedPost =
         ref.watch(chatQuotedPostProvider(conversation?.quotedPostId));
 
+    // status-driven readonly: blocked/unfriended → input ẩn + banner hiện.
+    final status = conversation?.status ?? ConversationStatus.active;
+    final isReadonly = status != ConversationStatus.active;
+
     // No composer for a brand-new conversation with no shared Meep: the only way
     // to start is by replying to a Meep (Figma `769:3019` has no input bar).
     final hasMessages = messagesAsync.valueOrNull?.isNotEmpty ?? false;
-    final canCompose = hasMessages || quotedPost != null;
+    final canCompose = !isReadonly && (hasMessages || quotedPost != null);
 
     return Scaffold(
       backgroundColor: AppColors.bw900,
@@ -48,8 +56,12 @@ class ChatScreen extends ConsumerWidget {
             _ChatHeader(
               title: peer?.displayName ?? 'Trò chuyện',
               avatarUrl: peer?.avatarUrl,
-              onMenu: () =>
-                  _onMenu(context, ref, peer?.displayName ?? 'người này'),
+              onMenu: () => _onMenu(
+                context,
+                ref,
+                peer?.displayName ?? 'người này',
+                peerUid,
+              ),
             ),
             Expanded(
               child: messagesAsync.when(
@@ -70,6 +82,7 @@ class ChatScreen extends ConsumerWidget {
                 ),
               ),
             ),
+            if (isReadonly) _ReadonlyBanner(status: status),
             if (canCompose)
               Padding(
                 padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
@@ -86,7 +99,12 @@ class ChatScreen extends ConsumerWidget {
     );
   }
 
-  Future<void> _onMenu(BuildContext context, WidgetRef ref, String name) async {
+  Future<void> _onMenu(
+    BuildContext context,
+    WidgetRef ref,
+    String name,
+    String? peerUid,
+  ) async {
     final action = await showSettingMenu<ChatMenuAction>(context, const [
       SettingMenuItem(
         icon: Icons.person_remove_outlined,
@@ -100,18 +118,33 @@ class ChatScreen extends ConsumerWidget {
         isDestructive: true,
       ),
     ]);
-    if (action == null || !context.mounted) return;
+    if (action == null || !context.mounted || peerUid == null) return;
 
     switch (action) {
       case ChatMenuAction.unfriend:
         final confirmed = await showUnfriendDialog(context, name);
-        if (confirmed) {
-          // TODO(C/wire): ref.read(friendControllerProvider.notifier).unfriend(uid)
+        if (!confirmed || !context.mounted) return;
+        // FriendController là family on myUid — đọc từ currentChatUidProvider.
+        final myUid = ref.read(currentChatUidProvider);
+        await ref
+            .read(friendControllerProvider(myUid).notifier)
+            .unfriend(peerUid);
+        if (!context.mounted) return;
+        // Controller catch error → errorMessage trong state. Chỉ navigate khi sạch.
+        final unfriendErr =
+            ref.read(friendControllerProvider(myUid)).errorMessage;
+        if (unfriendErr == null) {
+          context.go('/inbox');
         }
+
       case ChatMenuAction.block:
         final confirmed = await showBlockSheet(context, name);
-        if (confirmed) {
-          // TODO(C/wire): ref.read(settingsControllerProvider.notifier).blockUser(uid)
+        if (!confirmed || !context.mounted) return;
+        await ref.read(settingsControllerProvider.notifier).blockUser(peerUid);
+        if (!context.mounted) return;
+        final blockErr = ref.read(settingsControllerProvider).errorMessage;
+        if (blockErr == null) {
+          context.go('/inbox');
         }
     }
   }
@@ -119,6 +152,33 @@ class ChatScreen extends ConsumerWidget {
 
 /// Overflow-menu actions for a 1-1 chat.
 enum ChatMenuAction { unfriend, block }
+
+/// Banner thay input bar khi conversation `status != active`.
+/// - `unfriended`: 2 user không còn là bạn → "Hãy thêm bạn lại để nhắn tin".
+/// - `blocked`: 1 phía đã block → "Bạn không thể nhắn tin với người này".
+class _ReadonlyBanner extends StatelessWidget {
+  const _ReadonlyBanner({required this.status});
+
+  final ConversationStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = switch (status) {
+      ConversationStatus.unfriended => 'Hãy thêm bạn lại để nhắn tin',
+      ConversationStatus.blocked => 'Bạn không thể nhắn tin với người này',
+      ConversationStatus.active => '',
+    };
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(20, 14, 20, 20),
+      child: Text(
+        text,
+        textAlign: TextAlign.center,
+        style: AppTextStyles.smRegular.copyWith(color: AppColors.bw500),
+      ),
+    );
+  }
+}
 
 class _ChatHeader extends StatelessWidget {
   const _ChatHeader({

--- a/apps/mobile/lib/features/chat/presentation/group_chat_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/group_chat_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
@@ -10,6 +11,7 @@ import 'package:meep/features/chat/presentation/widgets/chat_confirm_dialogs.dar
 import 'package:meep/features/chat/presentation/widgets/chat_input_bar.dart';
 import 'package:meep/features/chat/presentation/widgets/chat_menu_sheet.dart';
 import 'package:meep/features/chat/presentation/widgets/space_members_sheet.dart';
+import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/shared/widgets/app_avatar.dart';
 
 /// Space group chat thread. Figma `564:8603` (+ menu `564:8733`).
@@ -26,7 +28,8 @@ class GroupChatScreen extends ConsumerWidget {
         ?.where((c) => c.conversationId == conversationId)
         .firstOrNull;
     final spaceId = conversation?.spaceId ?? '';
-    final space = ref.watch(chatSpaceProvider(spaceId));
+    final spaceAsync = ref.watch(chatSpaceProvider(spaceId));
+    final space = spaceAsync.valueOrNull;
 
     final myUid = ref.watch(currentChatUidProvider);
     final messagesAsync = ref.watch(messagesProvider(conversationId));
@@ -38,9 +41,9 @@ class GroupChatScreen extends ConsumerWidget {
         child: Column(
           children: [
             _GroupHeader(
-              title: space.name,
-              emoji: space.iconEmoji,
-              colorHex: space.colorHex,
+              title: space?.name ?? 'Space',
+              emoji: space?.iconEmoji ?? '👥',
+              colorHex: space?.colorHex ?? '#00DEEE',
               onMenu: () => _onMenu(context, ref, spaceId),
             ),
             Expanded(
@@ -55,7 +58,7 @@ class GroupChatScreen extends ConsumerWidget {
                 data: (messages) => ChatThreadView(
                   messages: messages,
                   myUid: myUid,
-                  peerName: space.name,
+                  peerName: space?.name ?? '',
                 ),
               ),
             ),
@@ -101,15 +104,23 @@ class GroupChatScreen extends ConsumerWidget {
 
     switch (action) {
       case GroupMenuAction.editTheme:
-        // TODO(C/wire): open Space theme editor (Space module).
+        // TODO(C/HanDHG): open Space theme editor (Space module #137).
         break;
       case GroupMenuAction.viewMembers:
         await SpaceMembersSheet.show(context, spaceId);
       case GroupMenuAction.leaveSpace:
         final confirmed = await showLeaveSpaceDialog(context);
-        if (confirmed) {
-          // TODO(C/wire): ref.read(spaceControllerProvider(uid).notifier).leaveSpace(spaceId)
-          //   — controller giờ là family, đọc uid từ currentUidProvider trước khi gọi.
+        if (!confirmed || !context.mounted) return;
+        // SpaceController là family on myUid — đọc từ currentChatUidProvider.
+        final myUid = ref.read(currentChatUidProvider);
+        await ref
+            .read(spaceControllerProvider(myUid).notifier)
+            .leaveSpace(spaceId);
+        if (!context.mounted) return;
+        // Controller catch error → errorMessage trong state. Chỉ navigate khi sạch.
+        final leaveErr = ref.read(spaceControllerProvider(myUid)).errorMessage;
+        if (leaveErr == null) {
+          context.go('/inbox');
         }
     }
   }

--- a/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
@@ -141,11 +141,12 @@ class _ConversationList extends ConsumerWidget {
         final isUnread = (unread[conv.conversationId] ?? 0) > 0;
 
         if (conv.type == ConversationType.space) {
-          final space = ref.watch(chatSpaceProvider(conv.spaceId ?? ''));
+          final spaceAsync = ref.watch(chatSpaceProvider(conv.spaceId ?? ''));
+          final space = spaceAsync.valueOrNull;
           return ConversationTile.group(
-            spaceName: space.name,
-            emoji: space.iconEmoji,
-            colorHex: space.colorHex,
+            spaceName: space?.name ?? 'Space',
+            emoji: space?.iconEmoji ?? '👥',
+            colorHex: space?.colorHex ?? '#00DEEE',
             conversation: conv,
             isUnread: isUnread,
             onTap: () => context.push('/group-chat/${conv.conversationId}'),

--- a/apps/mobile/lib/features/chat/presentation/widgets/space_members_sheet.dart
+++ b/apps/mobile/lib/features/chat/presentation/widgets/space_members_sheet.dart
@@ -26,7 +26,8 @@ class SpaceMembersSheet extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final members = ref.watch(chatSpaceMembersProvider(spaceId));
+    final membersAsync = ref.watch(chatSpaceMembersProvider(spaceId));
+    final members = membersAsync.valueOrNull ?? const [];
     final myUid = ref.watch(currentChatUidProvider);
 
     // Tall sheet (~75% screen) per Figma `564:8865`, not a half-height sheet.

--- a/apps/mobile/test/features/chat/presentation/inbox_screen_test.dart
+++ b/apps/mobile/test/features/chat/presentation/inbox_screen_test.dart
@@ -11,6 +11,27 @@ import 'package:meep/features/chat/data/chat_seed_data.dart';
 import 'package:meep/features/chat/data/firebase_conversation_repository.dart';
 import 'package:meep/features/chat/presentation/inbox_screen.dart';
 import 'package:meep/features/chat/presentation/widgets/conversation_tile.dart';
+import 'package:meep/features/space/application/space_controller.dart';
+import 'package:meep/features/space/data/space.dart';
+import 'package:meep/features/space/data/space_member.dart';
+import 'package:meep/features/space/data/space_repository.dart';
+
+/// Minimal in-memory SpaceRepository — chỉ implement 2 method chat dùng.
+/// Các method khác throw `UnimplementedError` (mutations CF không test tới).
+class _FakeSpaceRepository implements SpaceRepository {
+  @override
+  Stream<Space?> watchSpace(String spaceId) =>
+      Stream<Space?>.value(ChatSeed.seedSpace());
+
+  @override
+  Stream<List<SpaceMember>> watchMembers(String spaceId) =>
+      Stream<List<SpaceMember>>.value(ChatSeed.seedMembers());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError(
+        '_FakeSpaceRepository: ${invocation.memberName} not implemented',
+      );
+}
 
 void main() {
   /// Seed ChatSeed conversations into fake Firestore so the inbox renders
@@ -37,6 +58,7 @@ void main() {
           userRepositoryProvider.overrideWithValue(
             FirebaseUserRepository(firestore: firestore),
           ),
+          spaceRepositoryProvider.overrideWithValue(_FakeSpaceRepository()),
           currentChatUidProvider.overrideWith((ref) => ChatSeed.currentUid),
         ],
         child: const MaterialApp(home: InboxScreen()),

--- a/apps/mobile/test/features/chat/presentation/space_members_sheet_test.dart
+++ b/apps/mobile/test/features/chat/presentation/space_members_sheet_test.dart
@@ -8,6 +8,26 @@ import 'package:meep/features/auth/data/firebase_user_repository.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/chat/data/chat_seed_data.dart';
 import 'package:meep/features/chat/presentation/widgets/space_members_sheet.dart';
+import 'package:meep/features/space/application/space_controller.dart';
+import 'package:meep/features/space/data/space.dart';
+import 'package:meep/features/space/data/space_member.dart';
+import 'package:meep/features/space/data/space_repository.dart';
+
+/// Minimal in-memory SpaceRepository — chỉ implement watchMembers cho test.
+class _FakeSpaceRepository implements SpaceRepository {
+  @override
+  Stream<List<SpaceMember>> watchMembers(String spaceId) =>
+      Stream<List<SpaceMember>>.value(ChatSeed.seedMembers());
+
+  @override
+  Stream<Space?> watchSpace(String spaceId) =>
+      Stream<Space?>.value(ChatSeed.seedSpace());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError(
+        '_FakeSpaceRepository: ${invocation.memberName} not implemented',
+      );
+}
 
 void main() {
   Future<FakeFirebaseFirestore> seededFirestore() async {
@@ -26,6 +46,7 @@ void main() {
           userRepositoryProvider.overrideWithValue(
             FirebaseUserRepository(firestore: firestore),
           ),
+          spaceRepositoryProvider.overrideWithValue(_FakeSpaceRepository()),
           currentChatUidProvider.overrideWith((ref) => ChatSeed.currentUid),
         ],
         child: MaterialApp(home: Scaffold(body: child)),


### PR DESCRIPTION
## Mô tả

Gộp **Phase 2 + 3 + 4** cuối cùng của Chat module wire-production thành 1 PR. Sau PR này Chat module **production-ready** (trừ vài item out-of-scope blocked bởi module khác — xem cuối).

## Refs

- Refs #142 (parent Chat epic)
- Continues #228 (Phase 1 — chatUserProfile)

## Thay đổi chính

### Phase 2 — Wire `chatSpace` + `chatSpaceMembers`
- `chat_providers.dart`: 2 provider đổi sync `Provider<Space>` → `Stream<Space?>` + `Stream<List<SpaceMember>>` delegate sang `spaceRepositoryProvider.watchSpace()` / `.watchMembers()` (space module — không đụng)
- Early return empty Stream khi `spaceId.isEmpty` (defensive cho conversation 1-1)
- 3 UI consumers (`inbox_screen`, `group_chat_screen`, `space_members_sheet`) unwrap `AsyncValue` với fallback default values khi loading/error

### Phase 3 — Wire 3 action handlers (bỏ TODO stubs)
- `chat_screen.dart`:
  - Unfriend → `ref.read(friendControllerProvider(myUid).notifier).unfriend(peerUid)`
  - Block → `ref.read(settingsControllerProvider.notifier).blockUser(peerUid)`
- `group_chat_screen.dart`:
  - LeaveSpace → `ref.read(spaceControllerProvider(myUid).notifier).leaveSpace(spaceId)`
- **Error handling pattern**: 3 controllers đều catch internally + set `errorMessage` trong state (không throw). UI check `state.errorMessage` sau `await`, chỉ `context.go('/inbox')` khi sạch — không navigate nếu action fail.

### Phase 4 — UI polish
- `_ReadonlyBanner` widget mới trong `chat_screen.dart`:
  - `status == unfriended` → \"Hãy thêm bạn lại để nhắn tin\"
  - `status == blocked` → \"Bạn không thể nhắn tin với người này\"
- `canCompose` logic thêm check `!isReadonly` → input bar ẩn khi conversation readonly
- Post-action navigation: `context.go('/inbox')` sau success

### Tests
- `inbox_screen_test` + `space_members_sheet_test`: tạo `_FakeSpaceRepository` inline (implement `watchSpace` + `watchMembers` từ `ChatSeed`, các method khác throw via `noSuchMethod`), override `spaceRepositoryProvider` thay vì family provider (đơn giản hơn cho test)

## Loại thay đổi

- [x] feat — wire production providers + action handlers + UI polish

## Test

- [x] `flutter test test/features/chat/` — **55/55 PASS**
- [x] `flutter test` (full project) — **412/412 PASS** (no regression)
- [x] `flutter analyze` — clean (0 issues)
- [x] `dart format --set-exit-if-changed .` — PASS (pre-commit hook)

## Out of scope (defer — blocked by other modules)

| Item | Blocker |
|---|---|
| `chatQuotedPost` wire | Cần `getPost(postId)` trên PostRepository (Feed module) |
| `unreadCounts` real | Cần `lastReadAt` field trên Conversation model (leader decision) |
| `editTheme` group menu action | Cần Space theme editor (Space module #137) |
| Inbox topbar shared widget | Cần shared home-feed topbar (Khoa #94) |
| Scroll-to-load-more pagination | UI polish, không blocker |
| Skeleton loading | UI polish, không blocker |

## Risk / Note

- `chatSpace*` providers giờ là `Stream` từ Firestore — load đầu sẽ hiện text fallback (`'Space'` / `'👥'`) trước khi data đến. Acceptable UX (~50ms thường thấy).
- `_FakeSpaceRepository` trong test dùng `noSuchMethod` để fail loud nếu test code accidentally call CF method chưa stub. Pattern này dễ debug hơn `throw UnimplementedError` cho mọi method.
- Post-action navigation tới `/inbox` — không quay về screen trước (per spec: \"đóng chat → về Inbox\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)