### PR TITLE
fix(space): createSpace conversation thiếu lastMessageAt → Inbox loại trừ (Phase A)

### DIFF
--- a/firebase/functions/scripts/backfill-space-conversations.mjs
+++ b/firebase/functions/scripts/backfill-space-conversations.mjs
@@ -1,0 +1,91 @@
+// Backfill /conversations/{spaceId} docs thiếu lastMessageAt / lastMessage /
+// lastSenderId. Bug fix #142: CF createSpace cũ KHÔNG init 3 field này → Inbox
+// query orderBy('lastMessageAt') loại trừ docs → group chat invisible.
+//
+// CHẠY (staging):
+//   1. Tải service account JSON từ Firebase Console → Project Settings →
+//      Service accounts → Generate new private key
+//   2. cd firebase/functions
+//   3. GOOGLE_APPLICATION_CREDENTIALS=/abs/path/to/sa.json \
+//      node scripts/backfill-space-conversations.mjs --dry-run
+//   4. Verify danh sách doc, sau đó bỏ --dry-run để apply
+//
+// CHẠY (prod) — KHÔNG TỰ Ý CHẠY, ping leader trước:
+//   FIREBASE_PROJECT=meep-product \
+//   GOOGLE_APPLICATION_CREDENTIALS=/abs/path/to/prod-sa.json \
+//   node scripts/backfill-space-conversations.mjs
+//
+// An toàn:
+// - Admin SDK bypass rules — bắt buộc service account JSON.
+// - Dry-run trước khi commit: pass --dry-run flag để in ra danh sách doc cần backfill
+//   mà KHÔNG ghi gì.
+// - Idempotent: chỉ backfill doc THIẾU field (skip doc đã có).
+
+import { initializeApp, applicationDefault } from 'firebase-admin/app';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+
+const PROJECT_ID = process.env.FIREBASE_PROJECT || 'meep-staging';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  console.error(
+    'Missing GOOGLE_APPLICATION_CREDENTIALS env var. Tải service account JSON ' +
+    'từ Firebase Console rồi export GOOGLE_APPLICATION_CREDENTIALS=/abs/path/to/sa.json',
+  );
+  process.exit(1);
+}
+
+const app = initializeApp({
+  credential: applicationDefault(),
+  projectId: PROJECT_ID,
+});
+const db = getFirestore(app);
+
+async function main() {
+  console.log(`Backfill /conversations missing fields trong project ${PROJECT_ID}`);
+  console.log(DRY_RUN ? '  [DRY-RUN] không ghi gì\n' : '  [LIVE] sẽ ghi vào Firestore\n');
+
+  // Query tất cả conversations type='space' — bug chỉ ảnh hưởng group chat.
+  const snap = await db
+    .collection('conversations')
+    .where('type', '==', 'space')
+    .get();
+
+  console.log(`Tìm thấy ${snap.size} group conversations.\n`);
+
+  let backfilled = 0;
+  let alreadyOk = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const missing = {};
+
+    if (data.lastMessageAt == null) {
+      // Fallback dùng createdAt nếu có, nếu không thì serverTimestamp().
+      missing.lastMessageAt = data.createdAt ?? Timestamp.now();
+    }
+    if (typeof data.lastMessage !== 'string') missing.lastMessage = '';
+    if (typeof data.lastSenderId !== 'string') missing.lastSenderId = '';
+
+    if (Object.keys(missing).length === 0) {
+      alreadyOk++;
+      continue;
+    }
+
+    console.log(`  - ${doc.id}: missing ${Object.keys(missing).join(', ')}`);
+    if (!DRY_RUN) {
+      await doc.ref.update(missing);
+    }
+    backfilled++;
+  }
+
+  console.log(`\nDone. Backfilled: ${backfilled}. Đã OK sẵn: ${alreadyOk}.`);
+  if (DRY_RUN && backfilled > 0) {
+    console.log('Re-run KHÔNG có --dry-run để apply.');
+  }
+}
+
+main().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/firebase/functions/src/space/createSpace.ts
+++ b/firebase/functions/src/space/createSpace.ts
@@ -140,12 +140,21 @@ export const createSpace = onCall(
     // 3c. /conversations/{spaceId} — group chat. conversationId === spaceId
     // để Chat module lookup conversation từ Space context không cần extra
     // mapping. participantIds đồng bộ memberIds.
+    //
+    // lastMessage/lastMessageAt/lastSenderId BẮT BUỘC khởi tạo dù chưa có
+    // message nào — Inbox query dùng .orderBy('lastMessageAt') sẽ LOẠI TRỪ
+    // docs thiếu field này (Firestore behavior). Thiếu = group chat invisible
+    // cho đến khi gửi msg đầu tiên. Init lastMessageAt = now để Space mới hiện
+    // ngay trên đầu Inbox.
     batch.set(db.collection('conversations').doc(spaceId), {
       conversationId: spaceId,
       type: 'space',
       participantIds: memberIds,
       spaceId,
       status: 'active',
+      lastMessage: '',
+      lastMessageAt: now,
+      lastSenderId: '',
       createdAt: now,
       updatedAt: now,
     });


### PR DESCRIPTION
## Mô tả

**Bug:** Tạo Space mới thành công nhưng không hiện trên Inbox tab — phải gửi message đầu tiên mới hiện.

**Root cause:** CF `createSpace` (line 143-151 cũ) tạo `/conversations/{spaceId}` doc thiếu 3 field `lastMessage` / `lastMessageAt` / `lastSenderId`. Inbox query mobile dùng:

```dart
firestore.collection('conversations')
  .where('participantIds', arrayContains: uid)
  .orderBy('lastMessageAt', descending: true)
```

Firestore behavior: docs **thiếu field orderBy** sẽ bị LOẠI TRỪ khỏi kết quả. Group chat của Space mới invisible trên Inbox cho đến khi có message → bạn bè không biết tới hoặc tưởng tạo Space lỗi.

## Refs

- Refs #142 (parent Chat epic — Space group chat fix)
- Phần Phase A của plan chat closeout

## Thay đổi chính

### Fix
- `firebase/functions/src/space/createSpace.ts:143-160` — thêm 3 field vào batch.set:
  ```typescript
  lastMessage: '',
  lastMessageAt: now,   // serverTimestamp → Inbox orderBy match
  lastSenderId: '',
  ```
- Thêm comment giải thích vì sao 3 field này bắt buộc init.

### Backfill data hiện có
- **NEW** `firebase/functions/scripts/backfill-space-conversations.mjs` (90 lines):
  - Query `/conversations` where `type == 'space'`
  - Detect docs thiếu `lastMessageAt` / `lastMessage` / `lastSenderId`
  - Update missing fields (fallback `lastMessageAt = createdAt`)
  - **Idempotent** (skip docs đã đủ field)
  - **--dry-run** flag để verify trước khi apply
  - Yêu cầu `GOOGLE_APPLICATION_CREDENTIALS=path/to/sa.json` env var

## Test

- [x] `npm test` — **78/78 PASS** (Functions)
- [x] `npm run lint` — clean
- [x] Deployed `createSpace` CF lên staging trước commit (anh có thể test ngay)
- [ ] **Backfill chưa chạy** — cần dev có service account JSON, ping leader để chạy:
  ```bash
  cd firebase/functions
  GOOGLE_APPLICATION_CREDENTIALS=/path/to/staging-sa.json \
    node scripts/backfill-space-conversations.mjs --dry-run   # verify
  GOOGLE_APPLICATION_CREDENTIALS=/path/to/staging-sa.json \
    node scripts/backfill-space-conversations.mjs              # apply
  ```

## Verify manual

1. Mở app trên staging → Settings → Tạo Space mới
2. Sau khi tạo xong → mở Inbox tab → **phải thấy ngay group chat tile** (icon emoji + name)
3. Trước fix: tile chỉ hiện sau khi gửi message đầu tiên

## Risk

- **Không breaking** — chỉ thêm field, không đổi schema cũ.
- Backfill chỉ touch docs thiếu field — idempotent, an toàn chạy nhiều lần.
- Schema rule `conversations` update whitelist KHÔNG cần đổi — fields đã trong list cho phép update từ trước.

🤖 Generated with [Claude Code](https://claude.com/claude-code)