### PR TITLE
feat(chat): inbox topbar avatar wire SettingsSheet + AppAvatar #234

### DIFF
--- a/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
@@ -8,6 +8,8 @@ import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/chat/data/conversation.dart';
 import 'package:meep/features/chat/presentation/widgets/conversation_tile.dart';
+import 'package:meep/features/settings/presentation/settings_sheet.dart';
+import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 
 /// Inbox — list of all conversations (1-1 + group), newest first.
@@ -90,13 +92,16 @@ class InboxScreen extends ConsumerWidget {
   }
 }
 
-/// Topbar: centered title + trailing avatar slot.
-/// TODO(C/HanDHG): thay bằng shared home-feed topbar khi Khoa implement.
-class _InboxTopbar extends StatelessWidget {
+/// Topbar: centered title + trailing avatar (tap → SettingsSheet). Match
+/// home topbar pattern (`home_screen.dart`) — `AppAvatar` shared widget,
+/// no ring decoration, real user avatar từ `currentUserProfileProvider`.
+class _InboxTopbar extends ConsumerWidget {
   const _InboxTopbar();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final avatarUrl =
+        ref.watch(currentUserProfileProvider).valueOrNull?.avatarUrl;
     return Padding(
       padding: const EdgeInsets.only(top: 8),
       child: Row(
@@ -109,12 +114,17 @@ class _InboxTopbar extends StatelessWidget {
               style: AppTextStyles.baseBold,
             ),
           ),
-          Container(
-            width: 40,
-            height: 40,
-            decoration: const BoxDecoration(
-              shape: BoxShape.circle,
-              color: AppColors.bw700,
+          Semantics(
+            button: true,
+            label: 'Cài đặt',
+            child: GestureDetector(
+              onTap: () => showModalBottomSheet<void>(
+                context: context,
+                isScrollControlled: true,
+                backgroundColor: Colors.transparent,
+                builder: (_) => const SettingsSheet(),
+              ),
+              child: AppAvatar(imageUrl: avatarUrl, size: 40),
             ),
           ),
         ],


### PR DESCRIPTION
Closes #234 (PR 2/2 — cross-module Chat inbox topbar avatar).

PR 1/2: #236 (in-module Settings polish — đã merge ✓ hoặc sắp merge).

## Scope (cross-module)

Wire issue B1 cuối cùng của epic #234 polish phase: inbox topbar avatar phải match home topbar pattern (tap → SettingsSheet, AppAvatar shared, no ring).

**Touch chat module (HanDHG own)** — cần HanDHG approve trước merge per solo-dev rule.

## Changes

**File**: \`lib/features/chat/presentation/inbox_screen.dart\` (line 93-124)

- \`_InboxTopbar\` \`StatelessWidget\` → \`ConsumerWidget\`
- Replace placeholder \`Container(40x40, bw700 circle)\` với:
  \`\`\`dart
  Semantics(
    button: true,
    label: 'Cài đặt',
    child: GestureDetector(
      onTap: () => showModalBottomSheet<void>(
        context: context,
        isScrollControlled: true,
        backgroundColor: Colors.transparent,
        builder: (_) => const SettingsSheet(),
      ),
      child: AppAvatar(imageUrl: avatarUrl, size: 40),
    ),
  )
  \`\`\`
- Avatar đọc \`avatarUrl\` từ \`currentUserProfileProvider.valueOrNull?.avatarUrl\`
- KHÔNG truyền \`ringColor\` → no ring (match home pattern)
- Gỡ TODO comment \`TODO(C/HanDHG): thay bằng shared home-feed topbar\` — resolved

**Imports thêm**:
- \`package:meep/features/settings/presentation/settings_sheet.dart\`
- \`package:meep/shared/widgets/app_avatar.dart\`

## Acceptance criteria

- [x] Inbox topbar dùng \`AppAvatar\` shared (size 40, no ring)
- [x] Avatar đọc từ \`currentUserProfileProvider\` (self avatar, không phải peer)
- [x] Tap → mở \`SettingsSheet\` (giống home pattern)
- [x] Gỡ TODO HanDHG cũ (resolved)

## Test plan

- [x] \`flutter analyze\` clean (toàn project)
- [x] \`dart format\` clean
- [x] \`flutter test test/features/chat/\` — 55/55 pass (existing inbox_screen_test.dart đã có ProviderScope, không cần update)
- [ ] Reviewer @HanDHG: trace cross-module touch — ok với change này
- [ ] Reviewer @ThienPDM: trace SettingsSheet caller cross-module
- [ ] Manual smoke:
  - [ ] Tap inbox tab → topbar avatar = real user avatar (không grey placeholder)
  - [ ] KHÔNG có ring quanh avatar
  - [ ] Tap avatar → SettingsSheet mở (giống home behavior)

## Caveats

- **Cross-module ownership**: file \`lib/features/chat/presentation/inbox_screen.dart\` là HanDHG own (per solo-dev rule). Em (NganTNK) touch vì:
  1. Issue #234 acceptance requires inbox topbar polish
  2. HanDHG TODO cũ explicit cho biết chờ home topbar pattern (giờ đã có)
  3. Touch scope siêu nhỏ (1 widget, 20 lines)
- **Tag @HanDHG** trước merge để approve cross-module touch.