### PR TITLE
feat(feed): zoom + flash + animation cho camera + preview

### DIFF
--- a/apps/mobile/lib/features/feed/application/app_camera_controller.dart
+++ b/apps/mobile/lib/features/feed/application/app_camera_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -70,10 +72,27 @@ class AppCameraController extends _$AppCameraController {
     );
     await ctrl.initialize();
     _cameraCtrl = ctrl;
+    final minZoom = await ctrl.getMinZoomLevel();
+    final maxZoom = await ctrl.getMaxZoomLevel();
     state = state.copyWith(
       isInitialized: true,
       error: null,
+      minZoom: minZoom,
+      maxZoom: maxZoom,
+      zoomLevel: 1.0,
     );
+    await _applyFlashForActiveLens(direction);
+  }
+
+  /// Apply the user's flashEnabled preference to the live controller, but only
+  /// if the active lens is back — front-facing capture doesn't trigger the
+  /// physical flash, so we keep that lens at FlashMode.off regardless.
+  Future<void> _applyFlashForActiveLens(CameraLensDirection direction) async {
+    final ctrl = _cameraCtrl;
+    if (ctrl == null || !ctrl.value.isInitialized) return;
+    final wantFlash =
+        state.flashEnabled && direction == CameraLensDirection.back;
+    await ctrl.setFlashMode(wantFlash ? FlashMode.always : FlashMode.off);
   }
 
   /// Returns local file path on success, null on failure or double-tap.
@@ -197,18 +216,52 @@ class AppCameraController extends _$AppCameraController {
     if (state.mode != CameraMode.single) return;
     final wasInit = state.isInitialized;
     await _disposeController();
+    final flippingToFront = !state.isFrontCamera;
     state = state.copyWith(
-      isFrontCamera: !state.isFrontCamera,
+      isFrontCamera: flippingToFront,
       isInitialized: false,
+      // Flash is a back-lens-only feature; flipping to front turns it off so
+      // the UI button reflects what the next capture will actually do.
+      flashEnabled: flippingToFront ? false : state.flashEnabled,
     );
     if (wasInit) await initialize();
   }
 
-  void toggleFlash() {
-    if (_cameraCtrl == null || !_cameraCtrl!.value.isInitialized) return;
+  /// Toggle flash for back-lens capture. Front lens is always FlashMode.off —
+  /// see [_applyFlashForActiveLens]. State always tracks user intent so the
+  /// preference is restored when switching back to a back lens.
+  Future<void> toggleFlash() async {
     final next = !state.flashEnabled;
-    _cameraCtrl!.setFlashMode(next ? FlashMode.torch : FlashMode.off);
     state = state.copyWith(flashEnabled: next);
+    final ctrl = _cameraCtrl;
+    if (ctrl == null || !ctrl.value.isInitialized) return;
+    final activeDirection = ctrl.description.lensDirection;
+    await _applyFlashForActiveLens(activeDirection);
+  }
+
+  /// Pinch-to-zoom entry point. Clamps to the live lens's reported range so
+  /// callers can multiply by a raw scale delta without bothering with bounds.
+  /// State updates synchronously and the native zoom call is fire-and-forget —
+  /// awaiting it would queue per-frame onScaleUpdate callbacks behind the
+  /// platform channel and make the pinch feel laggy.
+  void setZoom(double level) {
+    final ctrl = _cameraCtrl;
+    if (ctrl == null || !ctrl.value.isInitialized) return;
+    final clamped = level.clamp(state.minZoom, state.maxZoom);
+    if (clamped == state.zoomLevel) return;
+    state = state.copyWith(zoomLevel: clamped);
+    unawaited(ctrl.setZoomLevel(clamped));
+  }
+
+  /// Drop the frozen back/front photos kept on the dual viewfinder after a
+  /// successful capture. Called once we've pushed the preview route so the
+  /// camera screen is clean if the user navigates back.
+  Future<void> clearDualPhotos() async {
+    if (state.mode != CameraMode.dual) return;
+    state = state.copyWith(backPhotoPath: null, frontPhotoPath: null);
+    if (state.activeLens != CameraLens.back) {
+      await _switchToLens(CameraLens.back);
+    }
   }
 
   void stopPreview() => _cameraCtrl?.pausePreview();

--- a/apps/mobile/lib/features/feed/application/camera_state.dart
+++ b/apps/mobile/lib/features/feed/application/camera_state.dart
@@ -14,6 +14,12 @@ class CameraState with _$CameraState {
     @Default(false) bool isFrontCamera, // Used in single mode only
     @Default(false) bool flashEnabled,
     @Default(false) bool isCapturing,
+    // Pinch-to-zoom — bounds populated after camera init from
+    // CameraController.getMin/MaxZoomLevel(). zoomLevel resets to 1.0 on lens
+    // switch because each lens reports its own zoom range.
+    @Default(1.0) double zoomLevel,
+    @Default(1.0) double minZoom,
+    @Default(1.0) double maxZoom,
     // Dual mode fields
     @Default(CameraLens.back) CameraLens activeLens,
     String? backPhotoPath,

--- a/apps/mobile/lib/features/feed/presentation/camera_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/camera_section.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:camera/camera.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -11,6 +13,7 @@ import 'package:meep/core/theme/app_proportions.dart';
 import 'package:meep/core/utils/hex_color.dart';
 import 'package:meep/features/feed/application/app_camera_controller.dart';
 import 'package:meep/features/feed/application/camera_state.dart';
+import 'package:meep/features/feed/application/feed_controller.dart';
 import 'package:meep/features/feed/presentation/capture_action_bar.dart';
 import 'package:meep/features/feed/presentation/capture_preview_args.dart';
 import 'package:meep/features/space/application/space_controller.dart';
@@ -28,30 +31,53 @@ class CameraSection extends ConsumerStatefulWidget {
 }
 
 class _CameraSectionState extends ConsumerState<CameraSection> {
-  // Min horizontal velocity (px/s) to count as a mode-switch swipe.
-  static const double _swipeVelocityThreshold = 200;
+  // Pages: 0 = single mode, 1 = dual mode. Drives the horizontal PageView
+  // inside the viewfinder so the user can swipe through modes one-to-one with
+  // their finger — mirrors the vertical PageView that drives camera ↔ feed in
+  // HomeScreen.
+  late final PageController _modePageController;
+
+  // Snapshot of the live zoomLevel at the moment a pinch starts, so each
+  // onScaleUpdate can multiply against the stable base instead of compounding.
+  double _baseZoom = 1.0;
 
   @override
   void initState() {
     super.initState();
+    _modePageController = PageController();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(appCameraControllerProvider.notifier).initialize();
     });
   }
 
-  // Swipe right over the viewfinder → dual mode; swipe left → single.
-  void _onViewfinderSwipe(double? velocity) {
-    if (velocity == null) return;
-    final notifier = ref.read(appCameraControllerProvider.notifier);
-    if (velocity > _swipeVelocityThreshold) {
-      notifier.setMode(CameraMode.single);
-    } else if (velocity < -_swipeVelocityThreshold) {
-      notifier.setMode(CameraMode.dual);
-    }
+  @override
+  void dispose() {
+    _modePageController.dispose();
+    super.dispose();
+  }
+
+  void _onModePageChanged(int page) {
+    final mode = page == 0 ? CameraMode.single : CameraMode.dual;
+    ref.read(appCameraControllerProvider.notifier).setMode(mode);
+  }
+
+  /// Animate the viewfinder PageView to match the requested mode. Called from
+  /// taps on the dots indicator below — without this the dots feel dead since
+  /// state changes alone don't move the PageView.
+  void _animateToMode(CameraMode mode) {
+    final target = mode == CameraMode.dual ? 1 : 0;
+    if (!_modePageController.hasClients) return;
+    if (_modePageController.page?.round() == target) return;
+    _modePageController.animateToPage(
+      target,
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOut,
+    );
   }
 
   Future<void> _onCapture() async {
-    final path = await ref.read(appCameraControllerProvider.notifier).capture();
+    final notifier = ref.read(appCameraControllerProvider.notifier);
+    final path = await notifier.capture();
     if (!mounted || path == null) return;
     final camState = ref.read(appCameraControllerProvider);
     if (camState.mode == CameraMode.single) {
@@ -74,6 +100,9 @@ class _CameraSectionState extends ConsumerState<CameraSection> {
           ),
         ),
       );
+      // Drop the frozen back/front photos so coming back to the camera page
+      // shows a live viewfinder instead of the previous capture.
+      unawaited(notifier.clearDualPhotos());
     }
   }
 
@@ -101,6 +130,15 @@ class _CameraSectionState extends ConsumerState<CameraSection> {
     // Mirror _AudienceRow height: avatarSize + gap(4) + labelSize(avatarSize*0.4) + bottomPad(4)
     final historyRowH = AppProportions.audienceAvatarSize(screenW) * 1.4 + 8;
 
+    // Listen for external mode changes (e.g. dots tap, programmatic
+    // setMode) so the PageView animates to match. PageView's own onPageChanged
+    // already calls setMode, so the listener no-ops when the page is already
+    // in sync.
+    ref.listen<CameraMode>(
+      appCameraControllerProvider.select((s) => s.mode),
+      (_, next) => _animateToMode(next),
+    );
+
     return Column(
       children: [
         // Spacer above the photo, balanced by the spacer below the dots, so
@@ -113,44 +151,29 @@ class _CameraSectionState extends ConsumerState<CameraSection> {
           SpaceContextBadge(),
           SizedBox(height: 8),
         ],
-        GestureDetector(
-          onHorizontalDragEnd: (d) => _onViewfinderSwipe(d.primaryVelocity),
-          child: AppPhotoFrame(
-            borderColor: accent,
-            child: camState.mode == CameraMode.single
-                ? _ViewfinderContent(
-                    controller: ref
-                        .read(appCameraControllerProvider.notifier)
-                        .cameraController,
-                    isInitialized: camState.isInitialized,
-                    error: camState.error,
-                  )
-                : _DualViewfinderContent(
-                    controller: ref
-                        .read(appCameraControllerProvider.notifier)
-                        .cameraController,
-                    isInitialized: camState.isInitialized,
-                    error: camState.error,
-                    activeLens: camState.activeLens,
-                    frontPhotoPath: camState.frontPhotoPath,
-                    backPhotoPath: camState.backPhotoPath,
-                    onTapFront: () => ref
-                        .read(appCameraControllerProvider.notifier)
-                        .setActiveLens(CameraLens.front),
-                    onTapBack: () => ref
-                        .read(appCameraControllerProvider.notifier)
-                        .setActiveLens(CameraLens.back),
-                  ),
-          ),
+        _ViewfinderArea(
+          camState: camState,
+          borderColor: accent,
+          modePageController: _modePageController,
+          onModePageChanged: _onModePageChanged,
+          onPinchStart: () => _baseZoom = camState.zoomLevel,
+          onPinchUpdate: (scale) => ref
+              .read(appCameraControllerProvider.notifier)
+              .setZoom(_baseZoom * scale),
+          onToggleFlash: () =>
+              ref.read(appCameraControllerProvider.notifier).toggleFlash(),
+          onSetActiveLens: (lens) => ref
+              .read(appCameraControllerProvider.notifier)
+              .setActiveLens(lens),
+          cameraController:
+              ref.read(appCameraControllerProvider.notifier).cameraController,
         ),
         const SizedBox(height: 12),
         GestureDetector(
           onTapUp: (details) {
             final width = MediaQuery.sizeOf(context).width;
             final isRight = details.localPosition.dx > width / 2;
-            ref
-                .read(appCameraControllerProvider.notifier)
-                .setMode(isRight ? CameraMode.dual : CameraMode.single);
+            _animateToMode(isRight ? CameraMode.dual : CameraMode.single);
           },
           child: AppDotsIndicator(
             count: 2,
@@ -178,6 +201,153 @@ class _CameraSectionState extends ConsumerState<CameraSection> {
         ),
         const SizedBox(height: 12),
       ],
+    );
+  }
+}
+
+/// Holds the photo frame, the slide animation between single/dual viewfinders,
+/// the pinch-zoom gesture, and the flash button overlay. Extracted so the main
+/// build() in [_CameraSectionState] stays readable.
+class _ViewfinderArea extends StatelessWidget {
+  const _ViewfinderArea({
+    required this.camState,
+    required this.borderColor,
+    required this.modePageController,
+    required this.onModePageChanged,
+    required this.onPinchStart,
+    required this.onPinchUpdate,
+    required this.onToggleFlash,
+    required this.onSetActiveLens,
+    required this.cameraController,
+  });
+
+  final CameraState camState;
+  final Color? borderColor;
+  final PageController modePageController;
+  final ValueChanged<int> onModePageChanged;
+  final VoidCallback onPinchStart;
+  final ValueChanged<double> onPinchUpdate;
+  final VoidCallback onToggleFlash;
+  final ValueChanged<CameraLens> onSetActiveLens;
+  final CameraController? cameraController;
+
+  /// Flash hardware lives on the back lens. In single mode that means hide the
+  /// button entirely whenever the front camera is active. In dual mode the
+  /// back lens is always part of the capture, so the button stays visible.
+  bool get _showFlashButton {
+    if (camState.mode == CameraMode.single) return !camState.isFrontCamera;
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Both pages stay in the tree at all times so the PageView can render
+    // both halves while the user drags between them. Only the page whose
+    // mode is currently live receives the camera controller; the other one
+    // renders the (typically very brief) black-while-reinitializing state.
+    final singlePage = _ViewfinderContent(
+      controller: camState.mode == CameraMode.single ? cameraController : null,
+      isInitialized:
+          camState.mode == CameraMode.single && camState.isInitialized,
+      error: camState.error,
+      isFrontCamera: camState.isFrontCamera,
+    );
+    final dualPage = _DualViewfinderContent(
+      controller: camState.mode == CameraMode.dual ? cameraController : null,
+      isInitialized: camState.mode == CameraMode.dual && camState.isInitialized,
+      error: camState.error,
+      activeLens: camState.activeLens,
+      frontPhotoPath: camState.frontPhotoPath,
+      backPhotoPath: camState.backPhotoPath,
+      onTapFront: () => onSetActiveLens(CameraLens.front),
+      onTapBack: () => onSetActiveLens(CameraLens.back),
+    );
+
+    return Stack(
+      children: [
+        AppPhotoFrame(
+          borderColor: borderColor,
+          // RawGestureDetector lets pinch-zoom (Scale recognizer) co-exist
+          // with the inner PageView's horizontal drag — the PageView's drag
+          // wins single-finger horizontal swipes (mode switch), Scale wins
+          // 2-finger pinches. The empty vertical drag claim wins arena over
+          // the parent vertical PageView (camera ↔ feed) so vertical pinches
+          // don't flip the page.
+          child: RawGestureDetector(
+            behavior: HitTestBehavior.opaque,
+            gestures: <Type, GestureRecognizerFactory>{
+              VerticalDragGestureRecognizer:
+                  GestureRecognizerFactoryWithHandlers<
+                      VerticalDragGestureRecognizer>(
+                () => VerticalDragGestureRecognizer(),
+                (r) {
+                  r.onStart = (_) {};
+                  r.onUpdate = (_) {};
+                  r.onEnd = (_) {};
+                },
+              ),
+              ScaleGestureRecognizer:
+                  GestureRecognizerFactoryWithHandlers<ScaleGestureRecognizer>(
+                () => ScaleGestureRecognizer(),
+                (r) {
+                  r.onStart = (_) => onPinchStart();
+                  r.onUpdate = (d) {
+                    if (d.pointerCount < 2) return;
+                    onPinchUpdate(d.scale);
+                  };
+                },
+              ),
+            },
+            child: PageView(
+              controller: modePageController,
+              scrollDirection: Axis.horizontal,
+              physics: const ClampingScrollPhysics(),
+              onPageChanged: onModePageChanged,
+              children: [singlePage, dualPage],
+            ),
+          ),
+        ),
+        if (_showFlashButton)
+          Positioned(
+            top: 12,
+            right: 12,
+            child: _FlashButton(
+              enabled: camState.flashEnabled,
+              onTap: onToggleFlash,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _FlashButton extends StatelessWidget {
+  const _FlashButton({required this.enabled, required this.onTap});
+
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: enabled ? 'Tắt flash' : 'Bật flash',
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          width: 34,
+          height: 34,
+          decoration: BoxDecoration(
+            color: AppColors.bw900.withValues(alpha: 0.45),
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            enabled ? Icons.bolt : Icons.bolt_outlined,
+            color: enabled ? AppColors.turquoise500 : AppColors.bw100,
+            size: 22,
+          ),
+        ),
+      ),
     );
   }
 }
@@ -289,6 +459,7 @@ class _DualSlot extends StatelessWidget {
             controller: controller,
             isInitialized: isInitialized,
             error: null,
+            isFrontCamera: lens == CameraLens.front,
           )
         : frozenPath == null
             ? const ColoredBox(color: AppColors.bw900)
@@ -338,11 +509,18 @@ class _ViewfinderContent extends StatelessWidget {
     required this.controller,
     required this.isInitialized,
     required this.error,
+    this.isFrontCamera = false,
   });
 
   final CameraController? controller;
   final bool isInitialized;
   final String? error;
+
+  /// When true the live preview is un-mirrored. Android mirrors the front
+  /// camera preview by default (selfie-mirror); the captured file is NOT
+  /// mirrored, so the preview was lying about what the photo would look like.
+  /// Flipping with scaleX:-1 here makes the preview match the saved image.
+  final bool isFrontCamera;
 
   @override
   Widget build(BuildContext context) {
@@ -363,43 +541,76 @@ class _ViewfinderContent extends StatelessWidget {
     // matching how the captured photo is later shown with BoxFit.cover.
     final previewRatio = 1 / controller!.value.aspectRatio; // portrait ratio
     final coverScale = previewRatio < 1 ? 1 / previewRatio : previewRatio;
-    return ClipRect(
-      child: Transform.scale(
-        scale: coverScale,
-        child: Center(child: CameraPreview(controller!)),
-      ),
+    Widget preview = Transform.scale(
+      scale: coverScale,
+      child: Center(child: CameraPreview(controller!)),
     );
+    if (isFrontCamera) {
+      preview = Transform(
+        alignment: Alignment.center,
+        transform: Matrix4.diagonal3Values(-1.0, 1.0, 1.0),
+        child: preview,
+      );
+    }
+    return ClipRect(child: preview);
   }
 }
 
-class _HistoryButton extends StatelessWidget {
+class _HistoryButton extends ConsumerWidget {
   const _HistoryButton({required this.onTap});
 
   final VoidCallback onTap;
 
+  static const double _thumbSize = 26;
+  static const double _thumbRadius = 6;
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Feed is sorted createdAt desc by watchFeed(), so posts.first is the
+    // newest visible post — own or friend. Empty feed falls back to a flat
+    // bw700 tile.
+    final thumbUrl =
+        ref.watch(feedControllerProvider(filter: FeedFilter.all)).whenOrNull(
+              data: (s) => s.posts.isEmpty ? null : s.posts.first.coverImageUrl,
+            );
+
+    final thumb = SizedBox(
+      width: _thumbSize,
+      height: _thumbSize,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(_thumbRadius),
+        child: thumbUrl == null || thumbUrl.isEmpty
+            ? const ColoredBox(color: AppColors.bw700)
+            : CachedNetworkImage(
+                imageUrl: thumbUrl,
+                fit: BoxFit.cover,
+                placeholder: (_, __) =>
+                    const ColoredBox(color: AppColors.bw700),
+                errorWidget: (_, __, ___) =>
+                    const ColoredBox(color: AppColors.bw700),
+              ),
+      ),
+    );
+
     return GestureDetector(
       onTap: onTap,
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            width: 24,
-            height: 24,
-            decoration: const BoxDecoration(
-              shape: BoxShape.circle,
-              color: AppColors.bw700,
-            ),
-          ),
+          thumb,
           const SizedBox(width: 6),
           const Text(
-            'Lịch sử ▾',
+            'Lịch sử',
             style: TextStyle(
               color: AppColors.bw100,
               fontSize: 16,
               fontWeight: FontWeight.w800,
             ),
+          ),
+          const Icon(
+            Icons.keyboard_arrow_down,
+            color: AppColors.bw100,
+            size: 22,
           ),
         ],
       ),

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -39,6 +39,10 @@ class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
   bool _savedToGallery = false;
   bool _primaryIsFront = false;
 
+  // Direction of the most recent caption swipe; 1 = next (slide in from right),
+  // -1 = prev (slide in from left). Drives the slide transition direction.
+  int _lastCaptionDir = 1;
+
   @override
   void initState() {
     super.initState();
@@ -57,12 +61,17 @@ class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
     _primaryIsFront = widget.args.activePrimaryLensIsFront;
   }
 
-  void _swipeCaptionLeft() =>
-      _changeCaptionIndex((_captionIndex + 1) % _captionTypes.length);
+  void _swipeCaptionLeft() {
+    _lastCaptionDir = 1;
+    _changeCaptionIndex((_captionIndex + 1) % _captionTypes.length);
+  }
 
-  void _swipeCaptionRight() => _changeCaptionIndex(
-        (_captionIndex - 1 + _captionTypes.length) % _captionTypes.length,
-      );
+  void _swipeCaptionRight() {
+    _lastCaptionDir = -1;
+    _changeCaptionIndex(
+      (_captionIndex - 1 + _captionTypes.length) % _captionTypes.length,
+    );
+  }
 
   void _changeCaptionIndex(int idx) {
     setState(() => _captionIndex = idx);
@@ -141,11 +150,39 @@ class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
                     padding: EdgeInsets.only(
                       bottom: AppProportions.pillBottomInPhoto(photoSize),
                     ),
-                    child: AppNotePill(
-                      text: postState.caption ?? '',
-                      onChanged: (t) => ref
-                          .read(postControllerProvider.notifier)
-                          .setCaption(t),
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 220),
+                      switchInCurve: Curves.easeOut,
+                      switchOutCurve: Curves.easeIn,
+                      transitionBuilder: (child, animation) {
+                        // Rebuild a Tween per child so the incoming pill slides
+                        // in from the swipe direction and the outgoing one
+                        // slides out the opposite way — keeps the gesture and
+                        // the visual motion aligned.
+                        final captionKey =
+                            ValueKey(_captionTypes[_captionIndex]);
+                        final isIncoming = child.key == captionKey;
+                        final beginX = isIncoming
+                            ? _lastCaptionDir.toDouble()
+                            : -_lastCaptionDir.toDouble();
+                        return SlideTransition(
+                          position: Tween<Offset>(
+                            begin: Offset(beginX, 0),
+                            end: Offset.zero,
+                          ).animate(animation),
+                          child: FadeTransition(
+                            opacity: animation,
+                            child: child,
+                          ),
+                        );
+                      },
+                      child: AppNotePill(
+                        key: ValueKey(_captionTypes[_captionIndex]),
+                        text: postState.caption ?? '',
+                        onChanged: (t) => ref
+                            .read(postControllerProvider.notifier)
+                            .setCaption(t),
+                      ),
                     ),
                   ),
                   child: widget.args.isDual
@@ -281,6 +318,8 @@ class _AudienceRow extends ConsumerWidget {
     final avatarSize = AppProportions.audienceAvatarSize(screenW);
     final labelSize = avatarSize * 0.43; // keep below overflow threshold
     final isAll = audienceType == AudienceType.all;
+    const tileGap = 12.0;
+    const tileLabelWidth = 8.0; // _FriendAudienceTile pads label width by 8
 
     final currentUid = ref.watch(currentUidProvider).valueOrNull;
     // Avoid throwing UnimplementedError when auth not ready — just render
@@ -291,31 +330,61 @@ class _AudienceRow extends ConsumerWidget {
             friendControllerProvider(currentUid).select((s) => s.friends),
           );
 
+    final tiles = <Widget>[
+      _AllAudienceTile(
+        isSelected: isAll,
+        avatarSize: avatarSize,
+        labelSize: labelSize,
+        onTap: () => onAudienceChanged(AudienceType.all, const []),
+      ),
+      for (final friend in friends) ...[
+        const SizedBox(width: tileGap),
+        _FriendAudienceTile(
+          friend: friend,
+          isSelected: selectedUids.contains(friend.uid),
+          avatarSize: avatarSize,
+          labelSize: labelSize,
+          onTap: () => _toggleFriend(friend.uid),
+        ),
+      ],
+    ];
+
+    // Total horizontal space the tiles + their gaps occupy. Used to decide
+    // whether the list fits without scrolling (so the leading "Tất cả" tile
+    // stays anchored at center) or needs to scroll (in which case we revert
+    // to the Figma leading padding of 73/412 so it reads consistently).
+    final estimatedContentWidth =
+        avatarSize + friends.length * (avatarSize + tileLabelWidth + tileGap);
+
     return Align(
       alignment: Alignment.bottomCenter,
       child: SizedBox(
         height: avatarSize + 4 + labelSize * 1.35 + 2,
-        child: ListView(
-          scrollDirection: Axis.horizontal,
-          padding: EdgeInsets.only(left: leftPad, right: 20),
-          children: [
-            _AllAudienceTile(
-              isSelected: isAll,
-              avatarSize: avatarSize,
-              labelSize: labelSize,
-              onTap: () => onAudienceChanged(AudienceType.all, const []),
-            ),
-            for (final friend in friends) ...[
-              const SizedBox(width: 12),
-              _FriendAudienceTile(
-                friend: friend,
-                isSelected: selectedUids.contains(friend.uid),
-                avatarSize: avatarSize,
-                labelSize: labelSize,
-                onTap: () => _toggleFriend(friend.uid),
-              ),
-            ],
-          ],
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            // Anchor the first tile ("Tất cả") at the horizontal center of the
+            // row. We pad by (viewport - allTileWidth)/2 so the avatar itself
+            // sits on the centerline, and the friend tiles fan out to the right
+            // of it. When the full list fits without overflow, this also means
+            // the row is centered visually; when it overflows, the user can
+            // scroll the friends in from the right while "Tất cả" stays at its
+            // initial centered position.
+            final centerLeadingPad = (constraints.maxWidth - avatarSize) / 2;
+            final fits = estimatedContentWidth + centerLeadingPad + 20 <=
+                constraints.maxWidth;
+            // Once the friends list grows past the visible area, switch to the
+            // Figma leading padding so the start-of-list edge matches what was
+            // already shipped.
+            final leadingPad = fits ? centerLeadingPad : leftPad;
+            return ListView(
+              scrollDirection: Axis.horizontal,
+              physics: fits
+                  ? const NeverScrollableScrollPhysics()
+                  : const ClampingScrollPhysics(),
+              padding: EdgeInsets.only(left: leadingPad, right: 20),
+              children: tiles,
+            );
+          },
         ),
       ),
     );

--- a/apps/mobile/lib/shared/widgets/app_note_pill.dart
+++ b/apps/mobile/lib/shared/widgets/app_note_pill.dart
@@ -4,10 +4,10 @@ import 'package:meep/core/theme/app_proportions.dart';
 
 /// Editable caption overlay pill. cornerRadius 30, semi-transparent bg.
 ///
-/// Hug-content: the pill sizes itself to the current text instead of being
-/// fixed-width. The text area is measured with [TextPainter] each rebuild,
-/// then clamped to a sane min (so an empty pill is still tappable) and a max
-/// (so a maxed-out 30-char caption never overflows the photo frame).
+/// Editable mode width is fixed at [editableWidthRatio] of the screen (40%)
+/// so the pill anchors at a predictable size as the user swipes between
+/// caption presets. Long text scrolls horizontally inside the TextField.
+/// Read-only mode still hugs content with a soft ellipsis safety net.
 class AppNotePill extends StatefulWidget {
   const AppNotePill({
     super.key,
@@ -24,6 +24,10 @@ class AppNotePill extends StatefulWidget {
   /// (which is 200) but app-side we keep captions short enough to render
   /// nicely in a single-line overlay.
   static const int maxLength = 30;
+
+  /// Editable pill width as a ratio of screen width. Fixed (not hug-content)
+  /// so swiping between caption presets doesn't make the pill jump around.
+  static const double editableWidthRatio = 0.40;
 
   @override
   State<AppNotePill> createState() => _AppNotePillState();
@@ -46,8 +50,6 @@ class _AppNotePillState extends State<AppNotePill> {
     _ctrl = TextEditingController(text: widget.text);
     _ctrl.addListener(() {
       widget.onChanged?.call(_ctrl.text);
-      // Re-measure so the pill grows / shrinks as the user types.
-      if (mounted) setState(() {});
     });
   }
 
@@ -63,16 +65,6 @@ class _AppNotePillState extends State<AppNotePill> {
   void dispose() {
     _ctrl.dispose();
     super.dispose();
-  }
-
-  /// Measure the visual width of [text] at the current font.
-  double _measureText(String text) {
-    final tp = TextPainter(
-      text: TextSpan(text: text, style: _textStyle(_fontSize)),
-      maxLines: 1,
-      textDirection: TextDirection.ltr,
-    )..layout();
-    return tp.width;
   }
 
   @override
@@ -106,14 +98,9 @@ class _AppNotePillState extends State<AppNotePill> {
   }
 
   Widget _buildTextField(double screenW) {
-    // Hug width: measure the typed text, clamp to [min, max] so the pill is
-    // always tappable when empty and never spills past the photo frame.
-    final text = _ctrl.text;
-    final measured = _measureText(text.isEmpty ? 'A' : text);
-    final minW = _fontSize; // ~1 character of space when empty
-    final maxW =
-        screenW - AppProportions.pillPaddingH * 2 - 24; // 24 = safety margin
-    final width = measured.clamp(minW, maxW);
+    // Fixed 40%-of-screen width. The TextField stays single-line and scrolls
+    // horizontally inside itself when the typed text exceeds the visible area.
+    final width = screenW * AppNotePill.editableWidthRatio;
 
     return SizedBox(
       width: width,

--- a/apps/mobile/test/shared/widgets/app_note_pill_test.dart
+++ b/apps/mobile/test/shared/widgets/app_note_pill_test.dart
@@ -28,7 +28,8 @@ void main() {
       expect(field.textAlign, TextAlign.center);
     });
 
-    testWidgets('editable pill width is fixed at 40% of screen', (tester) async {
+    testWidgets('editable pill width is fixed at 40% of screen',
+        (tester) async {
       // Screen is 412 in wrap(), so the editable pill (which has horizontal
       // padding around the 40% TextField) should be ≥ 0.40 * 412 ≈ 164.8 px
       // regardless of content length — the pill no longer hugs typed text.

--- a/apps/mobile/test/shared/widgets/app_note_pill_test.dart
+++ b/apps/mobile/test/shared/widgets/app_note_pill_test.dart
@@ -28,7 +28,13 @@ void main() {
       expect(field.textAlign, TextAlign.center);
     });
 
-    testWidgets('width grows with text length (hug content)', (tester) async {
+    testWidgets('editable pill width is fixed at 40% of screen', (tester) async {
+      // Screen is 412 in wrap(), so the editable pill (which has horizontal
+      // padding around the 40% TextField) should be ≥ 0.40 * 412 ≈ 164.8 px
+      // regardless of content length — the pill no longer hugs typed text.
+      const screenW = 412.0;
+      const expectedInner = screenW * AppNotePill.editableWidthRatio;
+
       await tester.pumpWidget(wrap(const AppNotePill(text: '')));
       await tester.pump();
       final emptyW = pillSize(tester).width;
@@ -39,7 +45,8 @@ void main() {
       await tester.pump();
       final longW = pillSize(tester).width;
 
-      expect(longW, greaterThan(emptyW));
+      expect(emptyW, closeTo(longW, 0.5));
+      expect(emptyW, greaterThanOrEqualTo(expectedInner));
     });
 
     testWidgets('enforces 30-char maxLength', (tester) async {


### PR DESCRIPTION
# Tóm tắt

Hoàn thiện luồng camera + preview cho feature `feed/` với 5 cải tiến UX theo plan đã chốt:

1. **Pinch-to-zoom** + **flash** cho camera (flash chỉ áp lens back ở cả 2 mode).
2. **Bỏ mirror** preview cam trước (file output không mirror, preview Android mặc định mirror → preview lệch với ảnh chụp ra).
3. **Clear dual photos** sau khi chụp xong (viewfinder không còn frozen khi user back về home).
4. **History button**: rounded square + thumbnail latest post + chevron-down (thay vòng tròn + text `▾`).
5. **Layout preview**:
   - Caption pill width cố định 40% screen.
   - Mode switch: `PageView` horizontal trong photo frame, swipe theo ngón tay (giống vertical PageView camera↔feed).
   - Caption swipe: `AnimatedSwitcher` slide + fade theo direction.
   - Audience row: "Tất cả" anchor center khi list fit; overflow giữ padding cũ 73/412.

## Files chính

- `apps/mobile/lib/features/feed/application/camera_state.dart` — thêm `zoomLevel`, `minZoom`, `maxZoom`.
- `apps/mobile/lib/features/feed/application/app_camera_controller.dart` — `setZoom()` (fire-and-forget), `clearDualPhotos()`, `_applyFlashForActiveLens()`; `FlashMode.always` thay `torch`; reset zoom khi switch lens.
- `apps/mobile/lib/features/feed/presentation/camera_section.dart` — `_ViewfinderArea` mới: `RawGestureDetector` (scale + vertical drag empty-claim) + `PageView` horizontal cho mode; `_ViewfinderContent` flip `Matrix4.diagonal3Values(-1,1,1)` cho cam trước; `_HistoryButton` → `ConsumerWidget` với `CachedNetworkImage`.
- `apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart` — `AnimatedSwitcher` slide+fade cho caption; `_AudienceRow` center-when-fit qua `LayoutBuilder`.
- `apps/mobile/lib/shared/widgets/app_note_pill.dart` — bỏ hug-content + remeasure, width = `screenW * 0.40` cố định.

## Quirks

- **Pinch không bị steal**: vùng photo viewfinder consume vertical drag (empty handlers) → parent vertical PageView (camera↔feed) chỉ active từ dots indicator trở xuống.
- **Mode swipe**: `PageView` snap; trong lúc swap, camera controller dispose+reinit (~500ms) → page bị black brief — expected behavior khi switch hardware lens.
- **Flash trên front**: không bao giờ enable trên lens front (`_applyFlashForActiveLens()` gate); flip cam sang front tự đặt `flashEnabled = false`.
- **Dual mirror**: PiP slot cam trước flip `scaleX:-1` khi live; frozen `Image.file` không cần flip vì output không mirror.

## Test plan

- [x] `dart format --set-exit-if-changed .` — 0 changed
- [x] `flutter analyze --fatal-infos` — No issues
- [x] `flutter test --coverage` — full suite pass (EXIT=0)
- [x] Test `app_note_pill_test.dart` cập nhật: assert width cố định 40% thay vì hug-content

### Cần test tay trên Android device

- [x] Flash: top-right viewfinder, ẩn single+front / hiện single+back & dual; tap → chớp lúc chụp.
- [x] Pinch zoom 2 fingers — smooth, không flip page khi pinch.
- [x] Vertical swipe trên photo → KHÔNG flip sang feed. Vuốt từ dots trở xuống → vẫn flip OK.
- [x] Horizontal swipe single↔dual — slide theo ngón tay, snap khi release. Tap dots → animate sang page.
- [x] Cam trước (single + dual PiP): preview KHÔNG mirror.
- [x] Chụp dual → preview → back về home → dual viewfinder TRỐNG.
- [x] History button: rounded square + thumbnail latest post; chevron-down rộng.
- [x] Preview screen: pill width ≈ 40% screen, swipe caption slide ngang.
- [x] Audience row: 1-2 bạn → tile "Tất cả" đúng giữa màn hình; nhiều bạn → scroll bình thường.

Refs #94 