### PR TITLE
feat(profile): T1 FirebaseProfileRepository (data layer) #109

### DIFF
--- a/apps/mobile/lib/features/profile/data/firebase_profile_repository.dart
+++ b/apps/mobile/lib/features/profile/data/firebase_profile_repository.dart
@@ -1,0 +1,238 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/profile/data/profile_repository.dart';
+
+/// Firebase-backed implementation of [ProfileRepository].
+///
+/// Storage upload tách qua [AvatarStorageClient] để test inject stub (mocktail
+/// hard-to-use với `UploadTask extends Future`). Compress tách qua
+/// [AvatarCompressor] để control output bytes trong test.
+///
+/// Storage và Firestore là 2 boundary tách biệt — nếu Storage OK nhưng
+/// Firestore update fail, file orphan ở `avatars/{uid}/avatar.jpg` (chấp nhận:
+/// lần upload tới overwrite cùng path).
+class FirebaseProfileRepository implements ProfileRepository {
+  FirebaseProfileRepository({
+    required FirebaseFirestore firestore,
+    required AvatarStorageClient storageClient,
+    AvatarCompressor? compressor,
+  })  : _firestore = firestore,
+        _storageClient = storageClient,
+        _compressor = compressor ?? const _FlutterAvatarCompressor();
+
+  /// Convenience factory: wire FirebaseStorage instance trực tiếp.
+  /// main.dart dùng factory này; tests dùng constructor với stub.
+  factory FirebaseProfileRepository.firebase({
+    required FirebaseFirestore firestore,
+    required FirebaseStorage storage,
+    AvatarCompressor? compressor,
+  }) {
+    return FirebaseProfileRepository(
+      firestore: firestore,
+      storageClient: _FirebaseAvatarStorageClient(storage),
+      compressor: compressor,
+    );
+  }
+
+  final FirebaseFirestore _firestore;
+  final AvatarStorageClient _storageClient;
+  final AvatarCompressor _compressor;
+
+  /// Whitelist khớp với Firestore rule `/users/{uid}` update (firestore.rules):
+  /// uid/email/createdAt + 3 counter (postCount/friendCount/spaceCount) +
+  /// username là server-only → KHÔNG nằm trong list.
+  ///
+  /// username change đi qua Firestore transaction riêng (`/usernames/{username}`
+  /// uniqueness doc + batch update `/users/{uid}.username`) — sẽ wire ở T5
+  /// (#110) qua UserRepository, KHÔNG qua updateProfile path này.
+  static const Set<String> _allowedFields = {
+    'displayName',
+    'avatarUrl',
+    'bio',
+    'dateOfBirth',
+    'phoneNumber',
+    'gender',
+  };
+
+  /// Hard ceiling theo issue #109 acceptance criteria.
+  /// Note: storage.rules hiện ship 2MB (firebase/storage.rules:23); T9 (#114)
+  /// sẽ sync rule lên 5MB cùng rules tests.
+  static const int _maxAvatarBytes = 5 * 1024 * 1024;
+
+  @override
+  Future<UserProfile?> getUserProfile(String uid) async {
+    try {
+      final snap = await _firestore.doc('users/$uid').get();
+      if (!snap.exists) return null;
+      return UserProfile.fromJson(snap.data()!);
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+  }
+
+  @override
+  Stream<UserProfile?> watchUserProfile(String uid) {
+    return _firestore.doc('users/$uid').snapshots().map((snap) {
+      if (!snap.exists) return null;
+      return UserProfile.fromJson(snap.data()!);
+    });
+  }
+
+  @override
+  Future<void> updateProfile(String uid, Map<String, dynamic> fields) async {
+    if (fields.isEmpty) {
+      throw const ValidationError(
+        message: 'Không có thay đổi nào để cập nhật',
+        code: 'profile/empty-update',
+      );
+    }
+    final invalid =
+        fields.keys.where((k) => !_allowedFields.contains(k)).toList();
+    if (invalid.isNotEmpty) {
+      throw ValidationError(
+        message: 'Không được phép cập nhật: ${invalid.join(', ')}',
+        code: 'profile/field-not-allowed',
+      );
+    }
+    try {
+      await _firestore.doc('users/$uid').update({
+        ...fields,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+  }
+
+  @override
+  Future<void> updateAvatar(String uid, File imageFile) async {
+    final compressed = await _compressor.compress(imageFile);
+    if (compressed.lengthInBytes > _maxAvatarBytes) {
+      throw const ValidationError(
+        message: 'Ảnh quá lớn (giới hạn 5MB)',
+        code: 'profile/avatar-too-large',
+      );
+    }
+
+    final String url;
+    try {
+      url = await _storageClient.upload(uid: uid, bytes: compressed);
+    } on FirebaseException catch (e) {
+      throw _mapStorageError(e);
+    }
+
+    try {
+      await _firestore.doc('users/$uid').update({
+        'avatarUrl': url,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+  }
+
+  @override
+  Future<void> removeAvatar(String uid) async {
+    try {
+      await _firestore.doc('users/$uid').update({
+        'avatarUrl': null,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+  }
+
+  AppError _mapFirestoreError(FirebaseException e) => switch (e.code) {
+        'permission-denied' => ForbiddenError('truy cập hồ sơ'),
+        'not-found' => NotFoundError('Hồ sơ'),
+        'unavailable' ||
+        'cancelled' ||
+        'deadline-exceeded' =>
+          NetworkError(message: 'Không có kết nối mạng', cause: e),
+        _ => UnexpectedError(
+            message: e.message ?? e.code,
+            code: e.code,
+            cause: e,
+          ),
+      };
+
+  AppError _mapStorageError(FirebaseException e) => switch (e.code) {
+        'unauthorized' ||
+        'permission-denied' =>
+          ForbiddenError('tải lên ảnh đại diện'),
+        'object-not-found' => NotFoundError('Ảnh đại diện'),
+        'quota-exceeded' => const UnexpectedError(
+            message: 'Bộ nhớ đã đầy, vui lòng thử lại sau',
+            code: 'quota-exceeded',
+          ),
+        'retry-limit-exceeded' ||
+        'unavailable' ||
+        'canceled' ||
+        'cancelled' =>
+          NetworkError(message: 'Không có kết nối mạng', cause: e),
+        _ => UnexpectedError(
+            message: e.message ?? e.code,
+            code: e.code,
+            cause: e,
+          ),
+      };
+}
+
+/// Uploads avatar bytes và trả về download URL. Tách interface để unit-test
+/// inject stub deterministic — mocktail không tự stub Future-implementing
+/// classes như `UploadTask`.
+abstract class AvatarStorageClient {
+  /// Upload `bytes` lên `avatars/{uid}/avatar.jpg` (overwrite) và trả URL.
+  /// Throws [FirebaseException] khi Storage lỗi — repository map sang AppError.
+  Future<String> upload({required String uid, required Uint8List bytes});
+}
+
+class _FirebaseAvatarStorageClient implements AvatarStorageClient {
+  _FirebaseAvatarStorageClient(this._storage);
+
+  final FirebaseStorage _storage;
+
+  @override
+  Future<String> upload({
+    required String uid,
+    required Uint8List bytes,
+  }) async {
+    final ref = _storage.ref('avatars/$uid/avatar.jpg');
+    await ref.putData(bytes, SettableMetadata(contentType: 'image/jpeg'));
+    return ref.getDownloadURL();
+  }
+}
+
+/// Pluggable image compressor — extracted để test inject stub deterministic.
+/// `flutter_image_compress` cần platform plugin; tests dùng compressor giả.
+abstract class AvatarCompressor {
+  Future<Uint8List> compress(File file);
+}
+
+class _FlutterAvatarCompressor implements AvatarCompressor {
+  const _FlutterAvatarCompressor();
+
+  @override
+  Future<Uint8List> compress(File file) async {
+    final result = await FlutterImageCompress.compressWithFile(
+      file.absolute.path,
+      minWidth: 512,
+      minHeight: 512,
+      quality: 85,
+      format: CompressFormat.jpeg,
+    );
+    if (result == null) {
+      // Fallback: plugin trả null khi format/platform không hỗ trợ.
+      // Caller vẫn enforce size cap trên raw bytes.
+      return file.readAsBytes();
+    }
+    return result;
+  }
+}

--- a/apps/mobile/test/features/profile/data/firebase_profile_repository_test.dart
+++ b/apps/mobile/test/features/profile/data/firebase_profile_repository_test.dart
@@ -1,0 +1,299 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/profile/data/firebase_profile_repository.dart';
+
+void main() {
+  const uid = 'uid-alice';
+  const otherUid = 'uid-other';
+
+  late FakeFirebaseFirestore firestore;
+  late _StubStorageClient storage;
+  late _StubCompressor compressor;
+  late FirebaseProfileRepository repo;
+
+  final initialProfile = <String, Object?>{
+    'uid': uid,
+    'email': 'alice@example.com',
+    'displayName': 'Alice Nguyen',
+    'username': 'alice',
+    'avatarUrl': null,
+    'bio': null,
+    'dateOfBirth': null,
+    'phoneNumber': null,
+    'gender': null,
+    'postCount': 5,
+    'friendCount': 3,
+    'spaceCount': 1,
+    'isSearchable': true,
+    'createdAt': Timestamp.fromDate(DateTime.utc(2026, 1, 1)),
+    'updatedAt': Timestamp.fromDate(DateTime.utc(2026, 1, 1)),
+  };
+
+  setUp(() async {
+    firestore = FakeFirebaseFirestore();
+    storage = _StubStorageClient();
+    compressor = _StubCompressor(Uint8List(1024));
+    repo = FirebaseProfileRepository(
+      firestore: firestore,
+      storageClient: storage,
+      compressor: compressor,
+    );
+    await firestore.doc('users/$uid').set(initialProfile);
+  });
+
+  group('getUserProfile', () {
+    test('returns UserProfile khi doc tồn tại', () async {
+      final result = await repo.getUserProfile(uid);
+
+      expect(result, isNotNull);
+      expect(result!.uid, uid);
+      expect(result.displayName, 'Alice Nguyen');
+      expect(result.postCount, 5);
+      expect(result.friendCount, 3);
+      expect(result.spaceCount, 1);
+    });
+
+    test('returns null khi doc không tồn tại', () async {
+      final result = await repo.getUserProfile(otherUid);
+      expect(result, isNull);
+    });
+  });
+
+  group('watchUserProfile', () {
+    test('emits profile khi doc tồn tại', () async {
+      final first = await repo.watchUserProfile(uid).first;
+      expect(first?.uid, uid);
+    });
+
+    test('emits null khi doc không tồn tại', () async {
+      final first = await repo.watchUserProfile(otherUid).first;
+      expect(first, isNull);
+    });
+
+    test('emits update mới khi profile thay đổi', () async {
+      final values = <String?>[];
+      final sub =
+          repo.watchUserProfile(uid).listen((p) => values.add(p?.displayName));
+
+      await Future<void>.delayed(Duration.zero);
+      await firestore.doc('users/$uid').update({'displayName': 'Updated'});
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(values, contains('Updated'));
+    });
+  });
+
+  group('updateProfile — allowlist enforcement', () {
+    test('throws ValidationError khi fields rỗng', () async {
+      expect(
+        () => repo.updateProfile(uid, const {}),
+        throwsA(
+          isA<ValidationError>()
+              .having((e) => e.code, 'code', 'profile/empty-update'),
+        ),
+      );
+    });
+
+    test('throws ValidationError khi field ngoài allowlist (uid)', () async {
+      expect(
+        () => repo.updateProfile(uid, {'uid': 'hacker'}),
+        throwsA(
+          isA<ValidationError>()
+              .having((e) => e.code, 'code', 'profile/field-not-allowed'),
+        ),
+      );
+    });
+
+    test('throws khi cố update server-only counter (postCount)', () async {
+      expect(
+        () => repo.updateProfile(uid, {'postCount': 999}),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+
+    test('throws khi cố update username (server-only — dùng transaction)',
+        () async {
+      expect(
+        () => repo.updateProfile(uid, {'username': 'newname'}),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+
+    test('throws khi mix allowed + disallowed', () async {
+      expect(
+        () => repo.updateProfile(uid, {
+          'displayName': 'OK',
+          'email': 'new@x.com',
+        }),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+
+    test('cập nhật khi tất cả fields trong allowlist', () async {
+      await repo.updateProfile(uid, {
+        'displayName': 'Bob',
+        'bio': 'New bio',
+        'gender': 'other',
+      });
+
+      final updated = (await firestore.doc('users/$uid').get()).data()!;
+      expect(updated['displayName'], 'Bob');
+      expect(updated['bio'], 'New bio');
+      expect(updated['gender'], 'other');
+    });
+
+    test('luôn set updatedAt khi update', () async {
+      await repo.updateProfile(uid, {'displayName': 'Bob'});
+      final updated = (await firestore.doc('users/$uid').get()).data()!;
+      expect(updated['updatedAt'], isNotNull);
+    });
+  });
+
+  group('updateAvatar', () {
+    Future<File> createTempFile() async {
+      final tmp = File(
+        '${Directory.systemTemp.path}/avatar_${uid}_${DateTime.now().microsecondsSinceEpoch}.bin',
+      );
+      await tmp.writeAsBytes(const [1, 2, 3]);
+      addTearDown(() async {
+        if (await tmp.exists()) await tmp.delete();
+      });
+      return tmp;
+    }
+
+    test('throws ValidationError khi compressed > 5MB', () async {
+      final file = await createTempFile();
+      compressor.output = Uint8List(5 * 1024 * 1024 + 1);
+
+      await expectLater(
+        repo.updateAvatar(uid, file),
+        throwsA(
+          isA<ValidationError>()
+              .having((e) => e.code, 'code', 'profile/avatar-too-large'),
+        ),
+      );
+      expect(
+        storage.uploadCount,
+        0,
+        reason: 'không được upload khi vượt size cap',
+      );
+    });
+
+    test('cho phép exactly 5MB', () async {
+      final file = await createTempFile();
+      compressor.output = Uint8List(5 * 1024 * 1024);
+      storage.urlToReturn = 'https://cdn/avatar.jpg';
+
+      await repo.updateAvatar(uid, file);
+
+      expect(storage.uploadCount, 1);
+      expect(storage.lastBytes?.lengthInBytes, 5 * 1024 * 1024);
+    });
+
+    test('compress → upload → cập nhật avatarUrl khi compressed <= 5MB',
+        () async {
+      final file = await createTempFile();
+      compressor.output = Uint8List.fromList(List.filled(2048, 0xAB));
+      storage.urlToReturn = 'https://cdn/avatars/$uid/avatar.jpg';
+
+      await repo.updateAvatar(uid, file);
+
+      expect(compressor.calledWith?.path, file.path);
+      expect(storage.lastUid, uid);
+      expect(storage.lastBytes?.lengthInBytes, 2048);
+
+      final updated = (await firestore.doc('users/$uid').get()).data()!;
+      expect(updated['avatarUrl'], 'https://cdn/avatars/$uid/avatar.jpg');
+      expect(updated['updatedAt'], isNotNull);
+    });
+
+    test('FirebaseException từ Storage → ForbiddenError khi unauthorized',
+        () async {
+      final file = await createTempFile();
+      compressor.output = Uint8List(100);
+      storage.exceptionToThrow =
+          FirebaseException(plugin: 'storage', code: 'unauthorized');
+
+      await expectLater(
+        repo.updateAvatar(uid, file),
+        throwsA(isA<ForbiddenError>()),
+      );
+
+      // Firestore KHÔNG được update khi upload fail
+      final unchanged = (await firestore.doc('users/$uid').get()).data()!;
+      expect(unchanged['avatarUrl'], isNull);
+    });
+
+    test('FirebaseException unavailable từ Storage → NetworkError', () async {
+      final file = await createTempFile();
+      compressor.output = Uint8List(100);
+      storage.exceptionToThrow =
+          FirebaseException(plugin: 'storage', code: 'unavailable');
+
+      await expectLater(
+        repo.updateAvatar(uid, file),
+        throwsA(isA<NetworkError>()),
+      );
+    });
+  });
+
+  group('removeAvatar', () {
+    test('set avatarUrl = null + updatedAt', () async {
+      // Pre-set một avatarUrl
+      await firestore.doc('users/$uid').update({
+        'avatarUrl': 'https://cdn/old.jpg',
+      });
+
+      await repo.removeAvatar(uid);
+
+      final updated = (await firestore.doc('users/$uid').get()).data()!;
+      expect(updated['avatarUrl'], isNull);
+      expect(updated['updatedAt'], isNotNull);
+    });
+
+    test('không xóa Storage file (orphan acceptable)', () async {
+      await repo.removeAvatar(uid);
+      // removeAvatar không gọi storageClient → storage.uploadCount remains 0
+      expect(storage.uploadCount, 0);
+    });
+  });
+}
+
+class _StubStorageClient implements AvatarStorageClient {
+  int uploadCount = 0;
+  String? lastUid;
+  Uint8List? lastBytes;
+  String urlToReturn = 'https://stub/avatar.jpg';
+  FirebaseException? exceptionToThrow;
+
+  @override
+  Future<String> upload({
+    required String uid,
+    required Uint8List bytes,
+  }) async {
+    if (exceptionToThrow != null) throw exceptionToThrow!;
+    uploadCount++;
+    lastUid = uid;
+    lastBytes = bytes;
+    return urlToReturn;
+  }
+}
+
+class _StubCompressor implements AvatarCompressor {
+  _StubCompressor(this.output);
+
+  Uint8List output;
+  File? calledWith;
+
+  @override
+  Future<Uint8List> compress(File file) async {
+    calledWith = file;
+    return output;
+  }
+}


### PR DESCRIPTION
## Summary

Implement T1 FirebaseProfileRepository — data layer cho Profile module, theo issue #109 / Plan §T1.

PR đầu tiên trong workflow BE integration Profile (3 PR theo issues #109/#110/#114).

## Acceptance criteria (theo issue #109)

- [x] `updateProfile(uid, fields)` chỉ cho phép update allowlist (`displayName, avatarUrl, bio, dateOfBirth, phoneNumber, gender, updatedAt`) — field khác throw `ValidationError` code `profile/field-not-allowed`
- [x] `updateAvatar(uid, file)`: compress → upload `avatars/{uid}/avatar.jpg` (overwrite) → update `avatarUrl`
- [x] `removeAvatar(uid)`: update `avatarUrl = null` (không xóa Storage file ngay — orphan acceptable)
- [x] Avatar upload >5MB → throw `AppError` trước khi upload
- [x] `watchUserProfile(uid)` — realtime stream
- [x] `flutter test test/features/profile/data/` — 19/19 pass

## Design choices

- **`username` KHÔNG trong allowlist** — server rule `/users/{uid}` cấm `username` thay đổi qua update path. Username change đi qua Firestore transaction riêng (`/usernames/{username}` uniqueness doc) — sẽ wire ở T5 (#110) qua `UserRepository`.
- **`AvatarStorageClient` + `AvatarCompressor` extract làm seam cho test** — mocktail không tự stub được `UploadTask extends Future`; tách interface để inject stub deterministic. Factory `FirebaseProfileRepository.firebase(...)` wrap default impl cho main.dart wiring.
- **2 boundary Storage + Firestore tách biệt** — nếu Storage OK nhưng Firestore update fail, file orphan ở `avatars/{uid}/avatar.jpg`. Lần upload tới overwrite cùng path → chấp nhận được.
- **Error mapping** theo Auth reference architecture pattern #2: `FirebaseException → AppError` tại boundary với message tiếng Việt (`ForbiddenError('truy cập hồ sơ')`, `NetworkError('Không có kết nối mạng')`).

## Discrepancy cần follow-up

- `firebase/storage.rules:23` đang ship 2MB nhưng client check 5MB theo issue #109 acceptance + spec §Security. T9 (#114) sẽ sync rule lên 5MB cùng rules tests. Trong giai đoạn giữa T1 merge và T9 deploy, upload > 2MB sẽ bị server reject `permission-denied` → `ForbiddenError`.

## Files

- `apps/mobile/lib/features/profile/data/firebase_profile_repository.dart` (+238)
- `apps/mobile/test/features/profile/data/firebase_profile_repository_test.dart` (+299, 19 test cases)

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `dart format --set-exit-if-changed` — clean
- [x] `flutter test test/features/profile/data/` — 19/19 pass
- [x] `flutter test` full suite — 430/430 pass, không break test khác
- [x] `/review` — 2 finding fix (allowlist mismatch + error message context)

## Next PR

- **PR2 — Closes #110** — T2 ProfileController + wire `main.dart` + remove mock data từ 5 screens + fix `AuthRepository.updateEmail`

Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)