### PR TITLE
feat(profile): T2 ProfileController + wire main + AuthRepository.updateEmail #110

### DIFF
--- a/apps/mobile/lib/features/auth/data/auth_repository.dart
+++ b/apps/mobile/lib/features/auth/data/auth_repository.dart
@@ -105,7 +105,19 @@ abstract class AuthRepository {
   /// thể return list providers.
   String? get currentProviderId;
 
-  /// Update the email address of the current user.
+  /// Gửi email xác nhận tới [newEmail] để bắt đầu flow đổi email.
+  ///
+  /// Firebase Auth 5.x: dùng `verifyBeforeUpdateEmail` thay cho `updateEmail`
+  /// deprecated — email chỉ thực sự đổi sau khi user click link trong inbox
+  /// mới. UI nên show toast "Đã gửi email xác nhận" thay vì "Đã đổi email".
+  ///
+  /// Yêu cầu re-auth gần đây — caller phải gọi `reauthenticateWithPassword`
+  /// / `reauthenticateWithGoogle` trước khi gọi method này.
+  ///
+  /// Throws:
+  /// - [UnauthenticatedError] code `requires-recent-login` khi session cũ
+  /// - [ValidationError] khi email invalid / đã được dùng
+  /// - [NetworkError] khi mất mạng
   Future<void> updateEmail(String newEmail);
 
   /// Cascade-delete user account qua Cloud Function `deleteAccount`.

--- a/apps/mobile/lib/features/auth/data/firebase_auth_repository.dart
+++ b/apps/mobile/lib/features/auth/data/firebase_auth_repository.dart
@@ -246,8 +246,20 @@ class FirebaseAuthRepository implements AuthRepository {
 
   @override
   Future<void> updateEmail(String newEmail) async {
-    // TODO(A/T7/ThienPDM): implement — needed by Profile for email change
-    throw UnimplementedError('updateEmail — implement at T7');
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw const UnauthenticatedError(
+        message: 'Bạn cần đăng nhập để đổi email',
+      );
+    }
+    try {
+      // Firebase Auth 5.x deprecate updateEmail() — dùng verifyBeforeUpdateEmail
+      // để chống account takeover. Email chỉ đổi sau khi user click link
+      // verification trong inbox của địa chỉ mới.
+      await user.verifyBeforeUpdateEmail(newEmail);
+    } on FirebaseAuthException catch (e) {
+      throw _mapUpdateEmailError(e);
+    }
   }
 
   @override
@@ -305,6 +317,26 @@ class FirebaseAuthRepository implements AuthRepository {
       };
 
   AppError _mapGenericError(FirebaseAuthException e) => switch (e.code) {
+        'network-request-failed' =>
+          const NetworkError(message: 'Không có kết nối mạng'),
+        _ => UnexpectedError(message: e.message ?? e.code, cause: e),
+      };
+
+  /// `verifyBeforeUpdateEmail` có thể fail vì email invalid, đã tồn tại,
+  /// hoặc session quá cũ (`requires-recent-login`) — caller phải gọi
+  /// `reauthenticateWithPassword` / `reauthenticateWithGoogle` trước.
+  AppError _mapUpdateEmailError(FirebaseAuthException e) => switch (e.code) {
+        'invalid-email' => const ValidationError(message: 'Email không hợp lệ'),
+        'email-already-in-use' =>
+          const ValidationError(message: 'Email này đã được sử dụng'),
+        'requires-recent-login' => UnauthenticatedError(
+            message: 'Phiên đăng nhập hết hạn. Vui lòng xác thực lại',
+            code: e.code,
+            cause: e,
+          ),
+        'too-many-requests' => const UnauthenticatedError(
+            message: 'Quá nhiều lần thử. Vui lòng thử lại sau',
+          ),
         'network-request-failed' =>
           const NetworkError(message: 'Không có kết nối mạng'),
         _ => UnexpectedError(message: e.message ?? e.code, cause: e),

--- a/apps/mobile/lib/features/profile/application/profile_controller.dart
+++ b/apps/mobile/lib/features/profile/application/profile_controller.dart
@@ -1,11 +1,21 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:meep/core/config/app_config.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/profile/data/profile_repository.dart';
 
 part 'profile_controller.freezed.dart';
 part 'profile_controller.g.dart';
+
+/// Spec acceptance — bio tối đa 150 chars (xem docs/specs/2026-05-22-profile.md).
+const int _kBioMaxLength = 150;
 
 @freezed
 class ProfileState with _$ProfileState {
@@ -18,34 +28,128 @@ class ProfileState with _$ProfileState {
 }
 
 @Riverpod(keepAlive: true)
-ProfileRepository profileRepository(ProfileRepositoryRef ref) =>
-    throw UnimplementedError(
+ProfileRepository profileRepository(Ref ref) => throw UnimplementedError(
       'profileRepositoryProvider must be overridden — '
-      'wire FirestoreProfileRepository in main.dart (TODO: P/T1/TBD)',
+      'wire FirebaseProfileRepository.firebase(...) in main.dart',
     );
 
 @riverpod
 class ProfileController extends _$ProfileController {
-  @override
-  ProfileState build(String uid) => const ProfileState();
+  StreamSubscription<UserProfile?>? _sub;
 
-  Future<void> loadProfile() async {
-    // TODO(P/T2/TBD): implement loadProfile
-    throw UnimplementedError('loadProfile — TODO: P/T2/TBD');
+  @override
+  ProfileState build(String uid) {
+    ref.onDispose(() => _sub?.cancel());
+    _watchProfile(uid);
+    return const ProfileState(isLoading: true);
+  }
+
+  /// Subscribe `watchUserProfile(uid)` từ ProfileRepository — Firestore stream
+  /// đẩy update mới về [state.profile] tự động. Lỗi stream → errorMessage.
+  void _watchProfile(String uid) {
+    _sub?.cancel();
+    _sub = ref.read(profileRepositoryProvider).watchUserProfile(uid).listen(
+      (profile) {
+        state = state.copyWith(
+          profile: profile,
+          isLoading: false,
+          errorMessage: null,
+        );
+      },
+      onError: (Object e) {
+        state = _afterFailure(e, fallback: 'Không tải được hồ sơ');
+      },
+    );
+  }
+
+  void clearError() {
+    if (state.errorMessage != null) {
+      state = state.copyWith(errorMessage: null);
+    }
+  }
+
+  /// Validate bio length ≤ [_kBioMaxLength] trước repository call (issue #110
+  /// acceptance). Other fields delegate trực tiếp sang [updateProfile].
+  Future<void> updateField(String field, Object? value) async {
+    if (field == 'bio' && value is String && value.length > _kBioMaxLength) {
+      state = state.copyWith(
+        errorMessage: 'Tiểu sử tối đa $_kBioMaxLength ký tự',
+      );
+      return;
+    }
+    await updateProfile({field: value});
   }
 
   Future<void> updateProfile(Map<String, dynamic> fields) async {
-    // TODO(P/T3/TBD): implement updateProfile
-    throw UnimplementedError('updateProfile — TODO: P/T3/TBD');
+    state = state.copyWith(isSaving: true, errorMessage: null);
+    try {
+      await ref.read(profileRepositoryProvider).updateProfile(uid, fields);
+      state = state.copyWith(isSaving: false);
+    } catch (e) {
+      state = _afterFailure(e);
+    }
   }
 
-  Future<void> updateAvatar() async {
-    // TODO(P/T4/TBD): pick image + updateAvatar via ProfileRepository
-    throw UnimplementedError('updateAvatar — TODO: P/T4/TBD');
+  /// Avatar upload fail → rollback `state.profile.avatarUrl` về giá trị cũ
+  /// (issue #110 acceptance). Success path: Firestore stream qua [_watchProfile]
+  /// sẽ tự sync URL mới.
+  Future<void> updateAvatar(File imageFile) async {
+    final originalUrl = state.profile?.avatarUrl;
+    state = state.copyWith(isSaving: true, errorMessage: null);
+    try {
+      await ref.read(profileRepositoryProvider).updateAvatar(uid, imageFile);
+      state = state.copyWith(isSaving: false);
+    } catch (e) {
+      // Rollback avatarUrl: nếu UI/state đã optimistic-update sang URL mới,
+      // restore lại URL cũ trước khi report error.
+      final current = state.profile;
+      final rollback = current != null && current.avatarUrl != originalUrl
+          ? current.copyWith(avatarUrl: originalUrl)
+          : current;
+      state = _afterFailure(e, fallback: 'Tải ảnh thất bại').copyWith(
+        profile: rollback,
+      );
+    }
   }
 
   Future<void> removeAvatar() async {
-    // TODO(P/T5/TBD): implement removeAvatar
-    throw UnimplementedError('removeAvatar — TODO: P/T5/TBD');
+    state = state.copyWith(isSaving: true, errorMessage: null);
+    try {
+      await ref.read(profileRepositoryProvider).removeAvatar(uid);
+      state = state.copyWith(isSaving: false);
+    } catch (e) {
+      state = _afterFailure(e);
+    }
+  }
+
+  /// Delegate sang `UserRepository.isUsernameAvailable` (auth module) —
+  /// KHÔNG call Firestore trực tiếp trong controller per spec §H4.
+  Future<bool> isUsernameAvailable(String username) async {
+    try {
+      return await ref
+          .read(userRepositoryProvider)
+          .isUsernameAvailable(username);
+    } catch (e) {
+      state = _afterFailure(e);
+      return false;
+    }
+  }
+
+  /// Share URL = `AppConfig.shareBaseUrl/{username}` — không hardcode (spec Q3
+  /// chốt deep link `meep://profile/{username}`).
+  String shareProfileUrl(String username) {
+    return '${AppConfig.shareBaseUrl}/$username';
+  }
+
+  ProfileState _afterFailure(
+    Object e, {
+    String fallback = 'Đã có lỗi xảy ra',
+  }) {
+    final err = AppError.fromUnknown(e, fallback: fallback);
+    return state.copyWith(
+      isLoading: false,
+      isSaving: false,
+      errorMessage: err is OperationCancelledError ? null : err.message,
+    );
   }
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -22,6 +22,8 @@ import 'package:meep/features/chat/data/firebase_conversation_repository.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/firebase_friend_repository.dart';
 import 'package:meep/features/friend/data/firebase_friend_request_repository.dart';
+import 'package:meep/features/profile/application/profile_controller.dart';
+import 'package:meep/features/profile/data/firebase_profile_repository.dart';
 import 'package:meep/features/settings/application/settings_controller.dart';
 import 'package:meep/features/settings/data/firebase_block_repository.dart';
 import 'package:meep/features/space/application/space_controller.dart';
@@ -85,6 +87,12 @@ void main() async {
         ),
         conversationRepositoryProvider.overrideWithValue(
           FirebaseConversationRepository(FirebaseFirestore.instance),
+        ),
+        profileRepositoryProvider.overrideWithValue(
+          FirebaseProfileRepository.firebase(
+            firestore: FirebaseFirestore.instance,
+            storage: FirebaseStorage.instance,
+          ),
         ),
       ],
       child: const MeepApp(),

--- a/apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart
+++ b/apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart
@@ -328,4 +328,78 @@ void main() {
       );
     });
   });
+
+  group('updateEmail', () {
+    // mock_exceptions registers exceptions trong global map keyed by object;
+    // dùng uid unique mỗi test để tránh collision giữa MockUser instances.
+    FirebaseAuthRepository repoSignedIn(String uid, {MockUser? user}) {
+      final mockUser = user ?? MockUser(uid: uid, email: 'old@example.com');
+      final auth = MockFirebaseAuth(mockUser: mockUser, signedIn: true);
+      return FirebaseAuthRepository(auth: auth);
+    }
+
+    test('UnauthenticatedError khi chưa đăng nhập', () async {
+      await expectLater(
+        repo.updateEmail('new@example.com'),
+        throwsA(isA<UnauthenticatedError>()),
+      );
+    });
+
+    test('completes khi user signed in và Firebase trả OK', () async {
+      await expectLater(
+        repoSignedIn('uid-ok').updateEmail('new@example.com'),
+        completes,
+      );
+    });
+
+    test('UnauthenticatedError code "requires-recent-login" khi session cũ',
+        () async {
+      final user = MockUser(uid: 'uid-stale', email: 'old@example.com');
+      whenCalling(Invocation.method(#verifyBeforeUpdateEmail, null))
+          .on(user)
+          .thenThrow(FirebaseAuthException(code: 'requires-recent-login'));
+      Object? caught;
+      try {
+        await repoSignedIn('uid-stale', user: user)
+            .updateEmail('new@example.com');
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<UnauthenticatedError>());
+      expect((caught! as UnauthenticatedError).code, 'requires-recent-login');
+    });
+
+    test('ValidationError khi email đã được dùng', () async {
+      final user = MockUser(uid: 'uid-taken', email: 'old@example.com');
+      whenCalling(Invocation.method(#verifyBeforeUpdateEmail, null))
+          .on(user)
+          .thenThrow(FirebaseAuthException(code: 'email-already-in-use'));
+      await expectLater(
+        repoSignedIn('uid-taken', user: user).updateEmail('taken@example.com'),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+
+    test('ValidationError khi email không hợp lệ', () async {
+      final user = MockUser(uid: 'uid-invalid', email: 'old@example.com');
+      whenCalling(Invocation.method(#verifyBeforeUpdateEmail, null))
+          .on(user)
+          .thenThrow(FirebaseAuthException(code: 'invalid-email'));
+      await expectLater(
+        repoSignedIn('uid-invalid', user: user).updateEmail('not-an-email'),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+
+    test('NetworkError khi mất mạng', () async {
+      final user = MockUser(uid: 'uid-net', email: 'old@example.com');
+      whenCalling(Invocation.method(#verifyBeforeUpdateEmail, null))
+          .on(user)
+          .thenThrow(FirebaseAuthException(code: 'network-request-failed'));
+      await expectLater(
+        repoSignedIn('uid-net', user: user).updateEmail('new@example.com'),
+        throwsA(isA<NetworkError>()),
+      );
+    });
+  });
 }

--- a/apps/mobile/test/features/profile/application/profile_controller_test.dart
+++ b/apps/mobile/test/features/profile/application/profile_controller_test.dart
@@ -1,0 +1,343 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/core/config/app_config.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/user_repository.dart';
+import 'package:meep/features/profile/application/profile_controller.dart';
+import 'package:meep/features/profile/data/profile_repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+class _MockUserRepository extends Mock implements UserRepository {}
+
+class _FakeFile extends Fake implements File {}
+
+void main() {
+  const uid = 'uid-alice';
+
+  final profile = UserProfile(
+    uid: uid,
+    email: 'alice@example.com',
+    displayName: 'Alice',
+    username: 'alice',
+    avatarUrl: 'https://cdn/old.jpg',
+    bio: 'old bio',
+    createdAt: DateTime.utc(2026, 1, 1),
+    updatedAt: DateTime.utc(2026, 1, 1),
+  );
+
+  late _MockProfileRepository profileRepo;
+  late _MockUserRepository userRepo;
+  late StreamController<UserProfile?> profileStreamCtrl;
+
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+    registerFallbackValue(_FakeFile());
+  });
+
+  setUp(() {
+    profileRepo = _MockProfileRepository();
+    userRepo = _MockUserRepository();
+    profileStreamCtrl = StreamController<UserProfile?>.broadcast();
+    when(() => profileRepo.watchUserProfile(uid))
+        .thenAnswer((_) => profileStreamCtrl.stream);
+  });
+
+  tearDown(() async {
+    await profileStreamCtrl.close();
+  });
+
+  /// Keep provider alive across `c.read` calls — without an active listener,
+  /// autoDispose providers tear down between reads and lose the stream sub.
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer(
+      overrides: [
+        profileRepositoryProvider.overrideWithValue(profileRepo),
+        userRepositoryProvider.overrideWithValue(userRepo),
+      ],
+    );
+    final sub = c.listen(profileControllerProvider(uid), (_, __) {});
+    addTearDown(sub.close);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('build + watchUserProfile', () {
+    test('initial state: isLoading=true', () {
+      final c = makeContainer();
+      final state = c.read(profileControllerProvider(uid));
+      expect(state.isLoading, isTrue);
+      expect(state.profile, isNull);
+    });
+
+    test('stream emit → state.profile updated, isLoading=false', () async {
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid)); // trigger build + subscribe
+      await Future<void>.delayed(Duration.zero); // let listen() resolve
+
+      profileStreamCtrl.add(profile);
+      await Future<void>.delayed(Duration.zero);
+
+      final state = c.read(profileControllerProvider(uid));
+      expect(state.isLoading, isFalse);
+      expect(state.profile?.uid, uid);
+      expect(state.profile?.displayName, 'Alice');
+    });
+
+    test('stream emit lần 2 → state cập nhật theo update mới', () async {
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+      await Future<void>.delayed(Duration.zero);
+
+      profileStreamCtrl.add(profile);
+      await Future<void>.delayed(Duration.zero);
+      profileStreamCtrl.add(profile.copyWith(displayName: 'Alice Updated'));
+      await Future<void>.delayed(Duration.zero);
+
+      final state = c.read(profileControllerProvider(uid));
+      expect(state.profile?.displayName, 'Alice Updated');
+    });
+
+    test('stream error → errorMessage set', () async {
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+      await Future<void>.delayed(Duration.zero);
+
+      profileStreamCtrl.addError(
+        const NetworkError(message: 'Mất mạng'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final state = c.read(profileControllerProvider(uid));
+      expect(state.errorMessage, 'Mất mạng');
+      expect(state.isLoading, isFalse);
+    });
+  });
+
+  group('clearError', () {
+    test('xóa errorMessage', () async {
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+      profileStreamCtrl.addError(const NetworkError(message: 'err'));
+      await Future<void>.delayed(Duration.zero);
+
+      c.read(profileControllerProvider(uid).notifier).clearError();
+      expect(
+        c.read(profileControllerProvider(uid)).errorMessage,
+        isNull,
+      );
+    });
+  });
+
+  group('updateField — bio validation', () {
+    test('bio > 150 chars → errorMessage, KHÔNG gọi repository', () async {
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      await c
+          .read(profileControllerProvider(uid).notifier)
+          .updateField('bio', 'x' * 151);
+
+      expect(
+        c.read(profileControllerProvider(uid)).errorMessage,
+        contains('150'),
+      );
+      verifyNever(() => profileRepo.updateProfile(any(), any()));
+    });
+
+    test('bio = exactly 150 → repository được gọi', () async {
+      when(() => profileRepo.updateProfile(uid, any()))
+          .thenAnswer((_) async {});
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      await c
+          .read(profileControllerProvider(uid).notifier)
+          .updateField('bio', 'x' * 150);
+
+      verify(() => profileRepo.updateProfile(uid, {'bio': 'x' * 150}))
+          .called(1);
+    });
+
+    test('field khác bio → bypass length check', () async {
+      when(() => profileRepo.updateProfile(uid, any()))
+          .thenAnswer((_) async {});
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      await c
+          .read(profileControllerProvider(uid).notifier)
+          .updateField('displayName', 'A very long name ' * 20);
+
+      verify(() => profileRepo.updateProfile(uid, any())).called(1);
+    });
+  });
+
+  group('updateProfile', () {
+    test('success → isSaving=false, no error', () async {
+      when(() => profileRepo.updateProfile(uid, any()))
+          .thenAnswer((_) async {});
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      await c
+          .read(profileControllerProvider(uid).notifier)
+          .updateProfile({'displayName': 'Bob'});
+
+      final state = c.read(profileControllerProvider(uid));
+      expect(state.isSaving, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('AppError → errorMessage set, isSaving=false', () async {
+      when(() => profileRepo.updateProfile(uid, any())).thenThrow(
+        const ValidationError(message: 'Field không hợp lệ'),
+      );
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      await c
+          .read(profileControllerProvider(uid).notifier)
+          .updateProfile({'bio': 'x'});
+
+      final state = c.read(profileControllerProvider(uid));
+      expect(state.errorMessage, 'Field không hợp lệ');
+      expect(state.isSaving, isFalse);
+    });
+  });
+
+  group('updateAvatar', () {
+    test('success → isSaving=false', () async {
+      when(() => profileRepo.updateAvatar(uid, any())).thenAnswer((_) async {});
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+      await Future<void>.delayed(Duration.zero);
+      profileStreamCtrl.add(profile);
+      await Future<void>.delayed(Duration.zero);
+
+      await c
+          .read(profileControllerProvider(uid).notifier)
+          .updateAvatar(_FakeFile());
+
+      final state = c.read(profileControllerProvider(uid));
+      expect(state.isSaving, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('fail → giữ avatarUrl cũ + errorMessage', () async {
+      // Acceptance: avatar upload fail → rollback state.profile.avatarUrl.
+      // Controller không optimistic-update trước upload — state.profile
+      // mirror Firestore qua watch stream. Khi upload throw, errorMessage
+      // set và avatarUrl giữ giá trị cũ ('https://cdn/old.jpg').
+      when(() => profileRepo.updateAvatar(uid, any())).thenThrow(
+        const NetworkError(message: 'Mạng yếu'),
+      );
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+      await Future<void>.delayed(Duration.zero);
+      profileStreamCtrl.add(profile);
+      await Future<void>.delayed(Duration.zero);
+
+      await c
+          .read(profileControllerProvider(uid).notifier)
+          .updateAvatar(_FakeFile());
+
+      final state = c.read(profileControllerProvider(uid));
+      expect(state.errorMessage, 'Mạng yếu');
+      expect(
+        state.profile?.avatarUrl,
+        'https://cdn/old.jpg',
+        reason: 'phải giữ URL cũ',
+      );
+    });
+  });
+
+  group('removeAvatar', () {
+    test('success', () async {
+      when(() => profileRepo.removeAvatar(uid)).thenAnswer((_) async {});
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      await c.read(profileControllerProvider(uid).notifier).removeAvatar();
+
+      verify(() => profileRepo.removeAvatar(uid)).called(1);
+      expect(c.read(profileControllerProvider(uid)).errorMessage, isNull);
+    });
+
+    test('fail → errorMessage', () async {
+      when(() => profileRepo.removeAvatar(uid)).thenThrow(
+        const NetworkError(message: 'Mạng yếu'),
+      );
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      await c.read(profileControllerProvider(uid).notifier).removeAvatar();
+
+      expect(c.read(profileControllerProvider(uid)).errorMessage, 'Mạng yếu');
+    });
+  });
+
+  group('isUsernameAvailable — delegate UserRepository', () {
+    test('returns true khi UserRepository trả true', () async {
+      when(() => userRepo.isUsernameAvailable('newname'))
+          .thenAnswer((_) async => true);
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      final available = await c
+          .read(profileControllerProvider(uid).notifier)
+          .isUsernameAvailable('newname');
+
+      expect(available, isTrue);
+      verify(() => userRepo.isUsernameAvailable('newname')).called(1);
+      verifyNever(() => profileRepo.updateProfile(any(), any()));
+    });
+
+    test('returns false khi UserRepository trả false', () async {
+      when(() => userRepo.isUsernameAvailable('taken'))
+          .thenAnswer((_) async => false);
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      final available = await c
+          .read(profileControllerProvider(uid).notifier)
+          .isUsernameAvailable('taken');
+
+      expect(available, isFalse);
+    });
+
+    test('UserRepository throw → returns false + errorMessage', () async {
+      when(() => userRepo.isUsernameAvailable(any())).thenThrow(
+        const NetworkError(message: 'Mạng yếu'),
+      );
+      final c = makeContainer();
+      c.read(profileControllerProvider(uid));
+
+      final available = await c
+          .read(profileControllerProvider(uid).notifier)
+          .isUsernameAvailable('anything');
+
+      expect(available, isFalse);
+      expect(
+        c.read(profileControllerProvider(uid)).errorMessage,
+        'Mạng yếu',
+      );
+    });
+  });
+
+  group('shareProfileUrl', () {
+    test('= AppConfig.shareBaseUrl/{username}', () {
+      final c = makeContainer();
+      final url = c
+          .read(profileControllerProvider(uid).notifier)
+          .shareProfileUrl('alice');
+      expect(url, '${AppConfig.shareBaseUrl}/alice');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implement T2 ProfileController + wire main.dart cho Profile module, theo issue #110 / Plan §T2.

PR thứ 2 trong workflow BE integration Profile (3 PR theo issues #109/#110/#114). Phụ thuộc PR #240 (T1 FirebaseProfileRepository) đã merge develop.

## Acceptance criteria (theo issue #110)

- [x] `isUsernameAvailable` delegate sang `UserRepository.isUsernameAvailable()` — **KHÔNG** call Firestore trực tiếp trong ProfileController
- [x] Avatar upload fail → rollback `ProfileState.profile.avatarUrl` về giá trị cũ
- [x] `shareProfile(username)` → `AppConfig.shareBaseUrl/{username}` (không hardcode)
- [x] `updateField('bio', value)` validate `value.length <= 150` trước khi gọi repository
- [x] `flutter test test/features/profile/application/` — 18/18 pass

## Cross-module touch (cần leader review)

PR2 sửa **auth module** ngoài profile module:

- `lib/features/auth/data/auth_repository.dart` — update `updateEmail` docstring (signature stable)
- `lib/features/auth/data/firebase_auth_repository.dart` — implement `updateEmail` (đang là `UnimplementedError`)
- `test/features/auth/data/firebase_auth_repository_test.dart` — 6 test cases mới

Lý do: T5 EditProfile (chưa có issue PR riêng) sẽ cần `AuthRepository.updateEmail` cho email change flow. Em chốt với leader trong /start (Q3): fix updateEmail trong PR này để tránh stub `UnimplementedError` trên develop và unblock T5 sau.

### Migration verifyBeforeUpdateEmail

Firebase Auth 5.x đã deprecate `user.updateEmail()` (account takeover risk). Em migrate sang `verifyBeforeUpdateEmail(newEmail)` — Firebase gửi email confirmation tới địa chỉ mới và email chỉ đổi sau khi user click link.

**Ảnh hưởng UX spec:** EditProfileScreen spec hiện ghi toast `"Đã cập nhật email"` sau email change. Với semantic mới, email chưa đổi ngay → PR5 (T5 EditProfile) phải đổi toast text thành `"Đã gửi email xác nhận tới {newEmail}. Bấm liên kết trong email để hoàn tất."`

Spec `docs/specs/2026-05-22-profile.md` §Email update re-auth flow cần update song song. Em không touch spec trong PR này — defer cho PR5.

## Files

| File | LOC |
|---|---|
| `lib/features/profile/application/profile_controller.dart` | +112 |
| `lib/features/auth/data/auth_repository.dart` | +13/-1 docstring |
| `lib/features/auth/data/firebase_auth_repository.dart` | +33/-3 |
| `lib/main.dart` | +8 wiring |
| `test/features/profile/application/profile_controller_test.dart` | +343 (18 tests) |
| `test/features/auth/data/firebase_auth_repository_test.dart` | +74 (6 tests) |

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `dart format --set-exit-if-changed` — clean
- [x] `flutter test test/features/profile/` — 37/37 pass (19 repo + 18 controller)
- [x] `flutter test test/features/auth/` — 93/93 pass (6 cases mới cho updateEmail)
- [x] `flutter test` full suite — 457/457 pass, không break test khác
- [x] `/review` 6-axis — 0 critical, 2 documentation findings flagged in this description

## Test pattern notes

- `ProfileController` test: `c.listen(provider, ...)` keep autoDispose alive across `c.read` calls (without active listener, controller tears down giữa reads và mất stream sub).
- `updateEmail` test: dùng unique `uid` mỗi test để tránh `mock_exceptions` map key collision giữa MockUser instances cùng identity.

## Design choices

- **Stream emit sync to state via `_watchProfile`** — controller không optimistic update; success path Firestore stream sẽ tự sync URL mới về state.profile sau khi server commit.
- **`updateField` validate client-side, `updateProfile` không** — spec acceptance criteria yêu cầu bio length check trong `updateField`. `updateProfile(Map)` low-level path không validate vì allowlist check ở repository layer đã catch invalid keys.
- **Cross-module imports:** `userRepositoryProvider` từ auth/application/auth_providers.dart; `AppConfig.shareBaseUrl` từ core/config.

## Next PR

- **PR3 — Closes #114** — T8 Diary tab M3 (DiaryRepository.getPublicEntries integration) + T9 Firestore/Storage rules tests

UI screens BE wire (remove mock data trong ProfileScreen/PhotoDetailScreen/FriendProfileScreen/EditProfileScreen) chưa có issue riêng — sẽ discuss với leader để tạo issue mới hoặc gom vào sub-task của #108.

Closes #110
Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)