### PR TITLE
feat(reaction): T1 FirebaseReactionRepository — data layer

### DIFF
--- a/apps/mobile/lib/features/reaction/data/firebase_reaction_repository.dart
+++ b/apps/mobile/lib/features/reaction/data/firebase_reaction_repository.dart
@@ -1,0 +1,55 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:meep/features/reaction/data/reaction.dart';
+import 'package:meep/features/reaction/data/reaction_repository.dart';
+
+class FirebaseReactionRepository implements ReactionRepository {
+  FirebaseReactionRepository(this._db);
+
+  final FirebaseFirestore _db;
+
+  CollectionReference<Map<String, dynamic>> _reactionsRef(String postId) =>
+      _db.collection('posts').doc(postId).collection('reactions');
+
+  @override
+  Stream<List<Reaction>> watchReactions(String postId) {
+    return _reactionsRef(postId).snapshots().map(
+          (snap) =>
+              snap.docs.map((doc) => Reaction.fromJson(doc.data())).toList(),
+        );
+  }
+
+  @override
+  Future<void> upsertReaction({
+    required String postId,
+    required String reactorUid,
+    required String reactorName,
+    required String emoji,
+  }) async {
+    // docId = reactorUid → enforce 1 reaction/user/post. set() upsert, KHÔNG add().
+    await _reactionsRef(postId).doc(reactorUid).set({
+      'reactorUid': reactorUid,
+      'reactorName': reactorName,
+      'emoji': emoji,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  @override
+  Future<void> deleteReaction({
+    required String postId,
+    required String reactorUid,
+  }) async {
+    // Firestore delete() idempotent — không throw khi doc không tồn tại.
+    await _reactionsRef(postId).doc(reactorUid).delete();
+  }
+
+  @override
+  Future<Reaction?> getMyReaction({
+    required String postId,
+    required String uid,
+  }) async {
+    final snap = await _reactionsRef(postId).doc(uid).get();
+    if (!snap.exists) return null;
+    return Reaction.fromJson(snap.data()!);
+  }
+}

--- a/apps/mobile/test/features/reaction/data/firebase_reaction_repository_test.dart
+++ b/apps/mobile/test/features/reaction/data/firebase_reaction_repository_test.dart
@@ -1,0 +1,173 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/reaction/data/firebase_reaction_repository.dart';
+import 'package:meep/features/reaction/data/reaction.dart';
+
+void main() {
+  late FakeFirebaseFirestore db;
+  late FirebaseReactionRepository repo;
+
+  const postId = 'post-1';
+  const reactorUid = 'uid-alice';
+  const reactorName = 'Alice';
+
+  setUp(() {
+    db = FakeFirebaseFirestore();
+    repo = FirebaseReactionRepository(db);
+  });
+
+  CollectionReference<Map<String, dynamic>> reactionsRef() =>
+      db.collection('posts').doc(postId).collection('reactions');
+
+  group('upsertReaction', () {
+    test('creates doc with docId = reactorUid (NOT add())', () async {
+      await repo.upsertReaction(
+        postId: postId,
+        reactorUid: reactorUid,
+        reactorName: reactorName,
+        emoji: '🤣',
+      );
+
+      // Doc tồn tại tại đường dẫn /posts/{postId}/reactions/{reactorUid}
+      final snap = await reactionsRef().doc(reactorUid).get();
+      expect(snap.exists, isTrue);
+      expect(snap.data()!['reactorUid'], reactorUid);
+      expect(snap.data()!['reactorName'], reactorName);
+      expect(snap.data()!['emoji'], '🤣');
+
+      // Subcollection chỉ chứa đúng 1 doc — chứng minh KHÔNG dùng add() (sẽ tạo doc auto-id).
+      final all = await reactionsRef().get();
+      expect(all.docs.length, 1);
+      expect(all.docs.first.id, reactorUid);
+    });
+
+    test('second upsert with different emoji overwrites in place', () async {
+      await repo.upsertReaction(
+        postId: postId,
+        reactorUid: reactorUid,
+        reactorName: reactorName,
+        emoji: '🤣',
+      );
+      await repo.upsertReaction(
+        postId: postId,
+        reactorUid: reactorUid,
+        reactorName: reactorName,
+        emoji: '🥰',
+      );
+
+      final all = await reactionsRef().get();
+      expect(all.docs.length, 1); // overwrite, không tạo doc mới
+      expect(all.docs.first.data()['emoji'], '🥰');
+    });
+
+    test('sets createdAt via serverTimestamp', () async {
+      await repo.upsertReaction(
+        postId: postId,
+        reactorUid: reactorUid,
+        reactorName: reactorName,
+        emoji: '🤣',
+      );
+
+      final snap = await reactionsRef().doc(reactorUid).get();
+      // FakeFirebaseFirestore resolve serverTimestamp → Timestamp instance.
+      expect(snap.data()!['createdAt'], isA<Timestamp>());
+    });
+  });
+
+  group('deleteReaction', () {
+    test('removes the doc', () async {
+      await repo.upsertReaction(
+        postId: postId,
+        reactorUid: reactorUid,
+        reactorName: reactorName,
+        emoji: '🤣',
+      );
+      await repo.deleteReaction(postId: postId, reactorUid: reactorUid);
+
+      final snap = await reactionsRef().doc(reactorUid).get();
+      expect(snap.exists, isFalse);
+    });
+
+    test('does not throw when doc is missing', () async {
+      // Acceptance criteria: delete idempotent — re-tap khi đã un-react không vỡ.
+      await expectLater(
+        repo.deleteReaction(postId: postId, reactorUid: 'never-reacted'),
+        completes,
+      );
+    });
+  });
+
+  group('getMyReaction', () {
+    test('returns null when user has not reacted', () async {
+      final result = await repo.getMyReaction(postId: postId, uid: reactorUid);
+      expect(result, isNull);
+    });
+
+    test('returns Reaction when user has reacted', () async {
+      await repo.upsertReaction(
+        postId: postId,
+        reactorUid: reactorUid,
+        reactorName: reactorName,
+        emoji: '🥰',
+      );
+
+      final result = await repo.getMyReaction(postId: postId, uid: reactorUid);
+      expect(result, isA<Reaction>());
+      expect(result!.reactorUid, reactorUid);
+      expect(result.reactorName, reactorName);
+      expect(result.emoji, '🥰');
+    });
+  });
+
+  group('watchReactions', () {
+    test('emits empty list when subcollection is empty', () async {
+      final first = await repo.watchReactions(postId).first;
+      expect(first, isEmpty);
+    });
+
+    test('emits all reactions across multiple reactors', () async {
+      await repo.upsertReaction(
+        postId: postId,
+        reactorUid: 'uid-alice',
+        reactorName: 'Alice',
+        emoji: '🤣',
+      );
+      await repo.upsertReaction(
+        postId: postId,
+        reactorUid: 'uid-bob',
+        reactorName: 'Bob',
+        emoji: '🥰',
+      );
+
+      final list = await repo.watchReactions(postId).first;
+      expect(list.length, 2);
+      expect(
+        list.map((Reaction r) => r.reactorUid),
+        containsAll(['uid-alice', 'uid-bob']),
+      );
+    });
+
+    test('re-emits when a reaction is added', () async {
+      // Verify realtime: stream emit lần 2 khi có doc mới.
+      final stream = repo.watchReactions(postId);
+      final values = <List<Reaction>>[];
+      final sub = stream.listen(values.add);
+
+      // Cho lần emit đầu (empty) chạy.
+      await Future<void>.delayed(Duration.zero);
+      await repo.upsertReaction(
+        postId: postId,
+        reactorUid: reactorUid,
+        reactorName: reactorName,
+        emoji: '🤣',
+      );
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(values.length, greaterThanOrEqualTo(2));
+      expect(values.last.length, 1);
+      expect(values.last.first.emoji, '🤣');
+    });
+  });
+}


### PR DESCRIPTION
## Mô tả

Implement `ReactionRepository` abstract bằng `FirebaseReactionRepository` cho subcollection `/posts/{postId}/reactions/{reactorUid}`. Đây là foundation layer cho T2 (controller toggleReact) và T3+T4 (UI).

Key design: docId = reactorUid → tự enforce **1 reaction/user/post** mà không cần unique constraint. Mọi upsert dùng `set()` (không phải `add()`).

## Refs

- Closes #122
- Epic: #121
- Spec: `docs/specs/2026-05-23-reaction.md`
- Plan: `docs/plans/2026-05-23-reaction.md` (Task T1)

## Thay đổi chính

- `apps/mobile/lib/features/reaction/data/firebase_reaction_repository.dart`: implement 4 method (`upsertReaction`, `deleteReaction`, `getMyReaction`, `watchReactions`)
- `apps/mobile/test/features/reaction/data/firebase_reaction_repository_test.dart`: 10 unit test với `fake_cloud_firestore`

## Loại thay đổi

- [x] feat — Tính năng mới

## Test

- [x] `flutter test test/features/reaction/data/` — 10/10 PASS
- [x] `flutter test` (full suite) — 467/467 PASS
- [x] `flutter analyze` (full project) — No issues
- [x] `dart format --set-exit-if-changed` — Clean

### Cách test thủ công

T1 là pure data-layer, chưa wire vào UI (M2 ActText bar vẫn `SizedBox.shrink()`). Verify qua unit test:

1. `cd apps/mobile`
2. `flutter test test/features/reaction/data/firebase_reaction_repository_test.dart`
3. Expected: 10/10 PASS, bao gồm docId enforce, overwrite, idempotent delete, getMyReaction null/found, watchReactions realtime re-emit

## Lưu ý cho reviewer

**1. Error mapping (intentional):** Repo KHÔNG wrap `FirebaseException → AppError`. Pattern này match `firebase_post_repository.dart` (cùng family Feed). Controller T2 sẽ wrap qua `AppError.fromUnknown()`. Khác với `firebase_auth_repository.dart` (có `_mapXxxError` boundary) — đây là design choice consistent với feed module.

**2. Provider chưa wire:** `reactionRepositoryProvider` (trong controller stub) vẫn throw `UnimplementedError`. Sẽ wire ở T3 khi UI cần dùng (theo skeleton rule: app vẫn launch được vì M2 ActText bar là no-op).

**3. Figma phát hiện thêm (cho T2/T3/T4):**
- 2 mode ActText bar khác nhau (Own post: avatar stack + "Hoạt động" / Friend post: input "Gửi tin nhắn..." + 3 emoji + smile-plus)
- Reaction count display = **stacked avatars (max 3 + "+N")**, KHÔNG phải số (OQ3 đã giải)
- ReactionListSheet chỉ mở từ Own post (privacy by design)
- T2 sẽ compute `topNReactors(3)` trong `ReactionState` (không thêm method vào abstract)

Các điểm trên KHÔNG ảnh hưởng T1.

## Self-review checklist

- [x] Branch name `feature/NganTNK/reaction-repository`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không có file lớn vô tình
- [x] Không có `print` debug
- [x] Không có `TODO` chưa link issue
- [x] Không có dead code
- [x] Đã self-review qua `/review` — clean, no 🔴/🟡