### PR TITLE
feat(reaction): T2 ReactionController — toggleReact + optimistic + in-flight lock

### DIFF
--- a/apps/mobile/lib/features/reaction/application/reaction_controller.dart
+++ b/apps/mobile/lib/features/reaction/application/reaction_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -14,26 +16,138 @@ class ReactionState with _$ReactionState {
     @Default([]) List<Reaction> reactions,
     @Default(false) bool isSubmitting,
     String? myEmoji,
+    String? errorMessage,
   }) = _ReactionState;
+
+  const ReactionState._();
+
+  /// Top N reactors theo `createdAt` DESC. Dùng cho avatar stack
+  /// `OwnPostActBar` (Figma 472:2052) — KHÔNG cần thêm method vào
+  /// abstract repository (Decision A — compute trong State).
+  List<Reaction> topNReactors(int n) {
+    final sorted = [...reactions]
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return sorted.take(n).toList();
+  }
 }
 
 @Riverpod(keepAlive: true)
 ReactionRepository reactionRepository(Ref ref) => throw UnimplementedError(
       'reactionRepositoryProvider must be overridden — '
-      'wire FirestoreReactionRepository in main.dart (TODO: R/T1/TBD)',
+      'wire FirebaseReactionRepository in main.dart (TODO: R/T3/NganTNK)',
     );
 
 @riverpod
 class ReactionController extends _$ReactionController {
-  @override
-  ReactionState build(String postId) => const ReactionState();
+  late String _postId;
 
+  @override
+  ReactionState build(String postId) {
+    _postId = postId;
+    final repo = ref.watch(reactionRepositoryProvider);
+    final sub = repo.watchReactions(postId).listen((reactions) {
+      state = state.copyWith(reactions: reactions);
+    });
+    ref.onDispose(sub.cancel);
+    return const ReactionState();
+  }
+
+  /// Toggle reaction theo spec §toggleReact:
+  /// - existing == null              → upsertReaction (react lần đầu)
+  /// - existing.emoji == emoji       → deleteReaction (un-react)
+  /// - existing.emoji != emoji       → upsertReaction (change)
+  ///
+  /// Optimistic update: state thay đổi ngay, rollback khi Firestore fail.
+  /// In-flight lock: tap thứ 2 bị bỏ qua khi `isSubmitting`.
   Future<void> toggleReact({
     required String uid,
     required String displayName,
     required String emoji,
   }) async {
-    // TODO(R/T2/TBD): getMyReaction → if same emoji delete, else upsert
-    throw UnimplementedError('toggleReact — TODO: R/T2/TBD');
+    if (state.isSubmitting) return; // in-flight lock
+
+    final repo = ref.read(reactionRepositoryProvider);
+    final prevState = state;
+
+    final Reaction? existing;
+    try {
+      existing = await repo.getMyReaction(postId: _postId, uid: uid);
+    } catch (_) {
+      // Không thể detect existing → bail out, không touch state.
+      state = state.copyWith(
+        errorMessage: 'Thả cảm xúc thất bại — thử lại',
+      );
+      return;
+    }
+
+    final optimisticReactions = _applyOptimistic(
+      current: state.reactions,
+      existing: existing,
+      uid: uid,
+      displayName: displayName,
+      emoji: emoji,
+    );
+    final newMyEmoji = (existing?.emoji == emoji) ? null : emoji;
+    state = state.copyWith(
+      isSubmitting: true,
+      reactions: optimisticReactions,
+      myEmoji: newMyEmoji,
+      errorMessage: null,
+    );
+
+    try {
+      if (existing != null && existing.emoji == emoji) {
+        await repo.deleteReaction(postId: _postId, reactorUid: uid);
+      } else {
+        await repo.upsertReaction(
+          postId: _postId,
+          reactorUid: uid,
+          reactorName: displayName,
+          emoji: emoji,
+        );
+      }
+      state = state.copyWith(isSubmitting: false);
+    } catch (_) {
+      state = prevState.copyWith(
+        isSubmitting: false,
+        errorMessage: 'Thả cảm xúc thất bại — thử lại',
+      );
+    }
+  }
+
+  void clearError() {
+    state = state.copyWith(errorMessage: null);
+  }
+
+  /// Tính reactions list sau optimistic update. createdAt = now (client clock)
+  /// — sẽ được replace bởi serverTimestamp từ watchReactions stream khi
+  /// Firestore confirm. Đủ chính xác cho UI feedback < 1s.
+  static List<Reaction> _applyOptimistic({
+    required List<Reaction> current,
+    required Reaction? existing,
+    required String uid,
+    required String displayName,
+    required String emoji,
+  }) {
+    if (existing == null) {
+      // react lần đầu — append
+      return [
+        ...current,
+        Reaction(
+          reactorUid: uid,
+          reactorName: displayName,
+          emoji: emoji,
+          createdAt: DateTime.now(),
+        ),
+      ];
+    }
+    if (existing.emoji == emoji) {
+      // un-react — remove
+      return current.where((r) => r.reactorUid != uid).toList();
+    }
+    // change emoji — overwrite
+    return current
+        .map((r) => r.reactorUid == uid ? r.copyWith(emoji: emoji) : r)
+        .toList();
   }
 }

--- a/apps/mobile/test/features/reaction/application/reaction_controller_test.dart
+++ b/apps/mobile/test/features/reaction/application/reaction_controller_test.dart
@@ -1,0 +1,364 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/reaction/application/reaction_controller.dart';
+import 'package:meep/features/reaction/data/reaction.dart';
+import 'package:meep/features/reaction/data/reaction_repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockReactionRepository extends Mock implements ReactionRepository {}
+
+Reaction _r({
+  required String uid,
+  String name = 'User',
+  String emoji = '🤣',
+  DateTime? createdAt,
+}) =>
+    Reaction(
+      reactorUid: uid,
+      reactorName: name,
+      emoji: emoji,
+      createdAt: createdAt ?? DateTime(2026, 6, 3, 10, 0),
+    );
+
+const _postId = 'post-1';
+const _myUid = 'uid-alice';
+const _myName = 'Alice';
+
+ProviderContainer makeContainer(MockReactionRepository repo) {
+  // Mặc định watchReactions trả empty để build() không null-ref.
+  // Test cần emit custom thì override trước khi spawn container.
+  when(() => repo.watchReactions(any()))
+      .thenAnswer((_) => const Stream.empty());
+  return ProviderContainer(
+    overrides: [reactionRepositoryProvider.overrideWithValue(repo)],
+  );
+}
+
+void main() {
+  setUpAll(() {
+    // Mocktail: fallback values cho any() khi method nhận named args.
+    registerFallbackValue('');
+  });
+
+  group('ReactionController — initial state', () {
+    test('reactions=[], isSubmitting=false, myEmoji=null, errorMessage=null',
+        () {
+      final repo = MockReactionRepository();
+      final container = makeContainer(repo);
+      addTearDown(container.dispose);
+
+      final state = container.read(reactionControllerProvider(_postId));
+      expect(state.reactions, isEmpty);
+      expect(state.isSubmitting, isFalse);
+      expect(state.myEmoji, isNull);
+      expect(state.errorMessage, isNull);
+    });
+  });
+
+  group('ReactionController — watchReactions', () {
+    test('state.reactions cập nhật theo stream từ repository', () async {
+      final repo = MockReactionRepository();
+      final streamCtrl = StreamController<List<Reaction>>.broadcast();
+      when(() => repo.watchReactions(_postId))
+          .thenAnswer((_) => streamCtrl.stream);
+
+      final container = ProviderContainer(
+        overrides: [reactionRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+
+      // Capture mọi state change qua container.listen.
+      final states = <ReactionState>[];
+      container.listen(
+        reactionControllerProvider(_postId),
+        (prev, next) => states.add(next),
+        fireImmediately: true,
+      );
+
+      streamCtrl.add([_r(uid: 'uid-bob', name: 'Bob', emoji: '🥰')]);
+      // Pump đủ microtasks để listener fire + state update.
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(states.last.reactions.length, 1);
+      expect(states.last.reactions.first.reactorUid, 'uid-bob');
+
+      await streamCtrl.close();
+    });
+  });
+
+  group('ReactionController — toggleReact', () {
+    test('existing == null → upsertReaction (react lần đầu)', () async {
+      final repo = MockReactionRepository();
+      when(() => repo.getMyReaction(postId: _postId, uid: _myUid))
+          .thenAnswer((_) async => null);
+      when(
+        () => repo.upsertReaction(
+          postId: any(named: 'postId'),
+          reactorUid: any(named: 'reactorUid'),
+          reactorName: any(named: 'reactorName'),
+          emoji: any(named: 'emoji'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final container = makeContainer(repo);
+      addTearDown(container.dispose);
+
+      await container
+          .read(reactionControllerProvider(_postId).notifier)
+          .toggleReact(uid: _myUid, displayName: _myName, emoji: '🤣');
+
+      verify(
+        () => repo.upsertReaction(
+          postId: _postId,
+          reactorUid: _myUid,
+          reactorName: _myName,
+          emoji: '🤣',
+        ),
+      ).called(1);
+      verifyNever(
+        () => repo.deleteReaction(
+          postId: any(named: 'postId'),
+          reactorUid: any(named: 'reactorUid'),
+        ),
+      );
+      final state = container.read(reactionControllerProvider(_postId));
+      expect(state.myEmoji, '🤣');
+      expect(state.isSubmitting, isFalse);
+    });
+
+    test('existing.emoji == emoji → deleteReaction (un-react)', () async {
+      final repo = MockReactionRepository();
+      when(() => repo.getMyReaction(postId: _postId, uid: _myUid)).thenAnswer(
+        (_) async => _r(uid: _myUid, name: _myName, emoji: '🤣'),
+      );
+      when(
+        () => repo.deleteReaction(
+          postId: any(named: 'postId'),
+          reactorUid: any(named: 'reactorUid'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final container = makeContainer(repo);
+      addTearDown(container.dispose);
+
+      await container
+          .read(reactionControllerProvider(_postId).notifier)
+          .toggleReact(uid: _myUid, displayName: _myName, emoji: '🤣');
+
+      verify(() => repo.deleteReaction(postId: _postId, reactorUid: _myUid))
+          .called(1);
+      verifyNever(
+        () => repo.upsertReaction(
+          postId: any(named: 'postId'),
+          reactorUid: any(named: 'reactorUid'),
+          reactorName: any(named: 'reactorName'),
+          emoji: any(named: 'emoji'),
+        ),
+      );
+      final state = container.read(reactionControllerProvider(_postId));
+      expect(state.myEmoji, isNull); // un-react → myEmoji null
+    });
+
+    test('existing.emoji != emoji → upsertReaction (change emoji)', () async {
+      final repo = MockReactionRepository();
+      when(() => repo.getMyReaction(postId: _postId, uid: _myUid)).thenAnswer(
+        (_) async => _r(uid: _myUid, name: _myName, emoji: '🤣'),
+      );
+      when(
+        () => repo.upsertReaction(
+          postId: any(named: 'postId'),
+          reactorUid: any(named: 'reactorUid'),
+          reactorName: any(named: 'reactorName'),
+          emoji: any(named: 'emoji'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final container = makeContainer(repo);
+      addTearDown(container.dispose);
+
+      await container
+          .read(reactionControllerProvider(_postId).notifier)
+          .toggleReact(uid: _myUid, displayName: _myName, emoji: '🥰');
+
+      verify(
+        () => repo.upsertReaction(
+          postId: _postId,
+          reactorUid: _myUid,
+          reactorName: _myName,
+          emoji: '🥰',
+        ),
+      ).called(1);
+      final state = container.read(reactionControllerProvider(_postId));
+      expect(state.myEmoji, '🥰'); // change → myEmoji = new emoji
+    });
+  });
+
+  group('ReactionController — optimistic rollback', () {
+    test('upsert fail → rollback state + errorMessage set', () async {
+      final repo = MockReactionRepository();
+      when(() => repo.getMyReaction(postId: _postId, uid: _myUid))
+          .thenAnswer((_) async => null);
+      when(
+        () => repo.upsertReaction(
+          postId: any(named: 'postId'),
+          reactorUid: any(named: 'reactorUid'),
+          reactorName: any(named: 'reactorName'),
+          emoji: any(named: 'emoji'),
+        ),
+      ).thenThrow(Exception('network'));
+
+      final container = makeContainer(repo);
+      addTearDown(container.dispose);
+
+      await container
+          .read(reactionControllerProvider(_postId).notifier)
+          .toggleReact(uid: _myUid, displayName: _myName, emoji: '🤣');
+
+      final state = container.read(reactionControllerProvider(_postId));
+      expect(state.errorMessage, contains('Thả cảm xúc thất bại'));
+      expect(state.isSubmitting, isFalse);
+      // Rollback: myEmoji về null (vì optimistic đã set '🤣', rollback prev null)
+      expect(state.myEmoji, isNull);
+      // Rollback: reactions giữ nguyên rỗng
+      expect(state.reactions, isEmpty);
+    });
+  });
+
+  group('ReactionController — in-flight lock', () {
+    test('tap thứ 2 khi đang submit → bỏ qua', () async {
+      final repo = MockReactionRepository();
+      // Cả 2 future đều dùng Completer để control timing thủ công.
+      final getMyReactionCompleter = Completer<Reaction?>();
+      final upsertCompleter = Completer<void>();
+      when(() => repo.getMyReaction(postId: _postId, uid: _myUid))
+          .thenAnswer((_) => getMyReactionCompleter.future);
+      when(
+        () => repo.upsertReaction(
+          postId: any(named: 'postId'),
+          reactorUid: any(named: 'reactorUid'),
+          reactorName: any(named: 'reactorName'),
+          emoji: any(named: 'emoji'),
+        ),
+      ).thenAnswer((_) => upsertCompleter.future);
+
+      final container = makeContainer(repo);
+      addTearDown(container.dispose);
+
+      // Subscribe để giữ provider alive — `container.read` không subscribe
+      // nên provider sẽ bị dispose + reset state giữa các read.
+      container.listen(reactionControllerProvider(_postId), (_, __) {});
+      final notifier =
+          container.read(reactionControllerProvider(_postId).notifier);
+
+      // Tap 1 — start. Suspend ở `await getMyReaction`.
+      final future1 = notifier.toggleReact(
+        uid: _myUid,
+        displayName: _myName,
+        emoji: '🤣',
+      );
+
+      // Resolve getMyReaction → toggleReact tiếp tục, set isSubmitting=true,
+      // suspend ở `await upsertReaction` (vẫn pending).
+      getMyReactionCompleter.complete(null);
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(
+        container.read(reactionControllerProvider(_postId)).isSubmitting,
+        isTrue,
+      );
+
+      // Tap 2 — phải bị ignore vì isSubmitting=true.
+      await notifier.toggleReact(
+        uid: _myUid,
+        displayName: _myName,
+        emoji: '🥰',
+      );
+
+      // Resolve upsert tap 1.
+      upsertCompleter.complete();
+      await future1;
+
+      // upsert chỉ gọi đúng 1 lần (cho tap 1).
+      verify(
+        () => repo.upsertReaction(
+          postId: _postId,
+          reactorUid: _myUid,
+          reactorName: _myName,
+          emoji: '🤣',
+        ),
+      ).called(1);
+      // getMyReaction chỉ gọi 1 lần (tap 1) — tap 2 early-return ở in-flight check.
+      verify(() => repo.getMyReaction(postId: _postId, uid: _myUid)).called(1);
+    });
+  });
+
+  group('ReactionState — topNReactors getter', () {
+    test('trả top N theo createdAt DESC', () {
+      const state = ReactionState();
+      final reactions = [
+        _r(uid: 'u1', createdAt: DateTime(2026, 6, 1)),
+        _r(uid: 'u2', createdAt: DateTime(2026, 6, 3)),
+        _r(uid: 'u3', createdAt: DateTime(2026, 6, 2)),
+        _r(uid: 'u4', createdAt: DateTime(2026, 5, 30)),
+      ];
+      final populated = state.copyWith(reactions: reactions);
+
+      final top3 = populated.topNReactors(3);
+      expect(top3.map((Reaction r) => r.reactorUid), ['u2', 'u3', 'u1']);
+    });
+
+    test('n > reactions.length → trả tất cả', () {
+      const state = ReactionState();
+      final populated = state.copyWith(reactions: [_r(uid: 'u1')]);
+      expect(populated.topNReactors(5).length, 1);
+    });
+
+    test('empty reactions → empty list', () {
+      const state = ReactionState();
+      expect(state.topNReactors(3), isEmpty);
+    });
+  });
+
+  group('ReactionController — clearError', () {
+    test('errorMessage về null', () async {
+      final repo = MockReactionRepository();
+      when(() => repo.getMyReaction(postId: _postId, uid: _myUid))
+          .thenAnswer((_) async => null);
+      when(
+        () => repo.upsertReaction(
+          postId: any(named: 'postId'),
+          reactorUid: any(named: 'reactorUid'),
+          reactorName: any(named: 'reactorName'),
+          emoji: any(named: 'emoji'),
+        ),
+      ).thenThrow(Exception('network'));
+
+      final container = makeContainer(repo);
+      addTearDown(container.dispose);
+
+      final notifier =
+          container.read(reactionControllerProvider(_postId).notifier);
+      await notifier.toggleReact(
+        uid: _myUid,
+        displayName: _myName,
+        emoji: '🤣',
+      );
+      expect(
+        container.read(reactionControllerProvider(_postId)).errorMessage,
+        isNotNull,
+      );
+
+      notifier.clearError();
+      expect(
+        container.read(reactionControllerProvider(_postId)).errorMessage,
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Mô tả

Implement `ReactionController` với toggleReact 3-nhánh logic + optimistic update + in-flight lock. Đây là application layer cho module Reaction, dựa trên T1 `FirebaseReactionRepository` đã merge.

Key design decisions:
- **Optimistic update**: state thay đổi ngay, rollback toàn bộ về `prevState` khi Firestore fail
- **In-flight lock**: `isSubmitting` guard — tap thứ 2 bị bỏ qua cho đến khi request trước resolve
- **`topNReactors(n)` getter** trên State (không thêm method vào abstract) — sort `createdAt` DESC, dùng cho avatar stack OwnPostActBar ở T3
- **`errorMessage`**: field mới non-breaking (pattern LoginState), cho UI toast

## Refs

- Closes #123
- Epic: #121
- Spec: `docs/specs/2026-05-23-reaction.md`
- Plan: `docs/plans/2026-05-23-reaction.md` (Task T2)

## Thay đổi chính

- `apps/mobile/lib/features/reaction/application/reaction_controller.dart`: implement `ReactionController` + thêm `topNReactors` getter + `errorMessage` field + `clearError()` vào `ReactionState`
- `apps/mobile/test/features/reaction/application/reaction_controller_test.dart`: 11 unit test (mocktail mock `ReactionRepository`)

## Loại thay đổi

- [x] feat — Tính năng mới

## Test

- [x] `flutter test test/features/reaction/application/` — 11/11 PASS
- [x] `flutter test` (full suite) — 478/478 PASS
- [x] `flutter analyze` — info-only (10 trailing comma cosmetic trong test file, non-blocking)
- [x] `dart format` — clean

### Cách test thủ công

T2 là application-layer, chưa wire UI (M2 ActText bar vẫn `SizedBox.shrink()`). Verify qua unit test:
1. `cd apps/mobile`
2. `flutter test test/features/reaction/application/reaction_controller_test.dart`
3. Expected: 11/11 PASS — bao gồm 3 nhánh toggleReact, optimistic rollback, in-flight lock, topN getter, clearError

## Lưu ý cho reviewer

1. **`AppError.fromUnknown()` không dùng trong toggleReact** — tất cả exception đều map về generic `"Thả cảm xúc thất bại — thử lại"` (theo spec worst-case). Khác với LoginController có `OperationCancelledError` silent no-op (reaction không có user-initiated cancel flow).

2. **`clientClock.now()` cho optimistic createdAt** — sẽ được stream `watchReactions` replace bằng `serverTimestamp` khi Firestore confirm. Đủ chính xác cho UI feedback < 1s, không ảnh hưởng sort (serverTimestamp atomic).

3. **Provider chưa wire** — `reactionRepositoryProvider` vẫn throw `UnimplementedError`. Sẽ wire ở T3 (UI).

4. **Schema `isSubmitting` + `myEmoji` giữ nguyên từ stub** — issue body dùng `isLoading` + `myReaction` (outdated). Stub = source of truth.

## Self-review checklist

- [x] Branch name `feature/NganTNK/reaction-controller`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] No secret, no debug print, no dead code
- [x] No cross-module touch
- [x] `/review` passed — no 🔴/🟡