### PR TITLE
feat(profile): T7 BE wire — FriendProfileScreen + audience filter #113

### DIFF
--- a/apps/mobile/lib/features/profile/application/friend_posts_provider.dart
+++ b/apps/mobile/lib/features/profile/application/friend_posts_provider.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/core/utils/pair_id.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/feed/application/feed_controller.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+
+part 'friend_posts_provider.g.dart';
+
+/// Posts của một friend, đã filter theo audience để chỉ hiển thị ảnh
+/// chia sẻ với current user (spec Q OQ5 — không thêm field mới, dùng
+/// `audienceType` + `audienceUids` đã có trong Post model).
+///
+/// Filter rule:
+/// - `audienceType == 'all'` → all friends thấy
+/// - `audienceType == 'select' && audienceUids.contains(currentUid)` → chỉ
+///   user được chỉ định thấy
+///
+/// Trả `null` khi current user chưa login. Caller phải gate UI bằng
+/// `isFriendProvider` trước khi watch.
+@riverpod
+Future<List<Post>?> friendPosts(Ref ref, String friendUid) async {
+  final currentUid = ref.watch(currentUidProvider).valueOrNull;
+  if (currentUid == null) return null;
+
+  final all =
+      await ref.read(postRepositoryProvider).getPostsByAuthor(friendUid);
+  final visible = all.where((p) {
+    if (p.audienceType == AudienceType.all) return true;
+    if (p.audienceType == AudienceType.select) {
+      return p.audienceUids.contains(currentUid);
+    }
+    return false;
+  }).toList();
+
+  // Defensive sort — repo orders by createdAt desc.
+  visible.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+  return visible;
+}
+
+/// True nếu [friendUid] là bạn bè của current user, kiểm tra qua FriendRepository
+/// (Firestore `/friendships/{pairId}` doc). False khi pair doc không tồn tại
+/// hoặc current user chưa login.
+@riverpod
+Future<bool> isFriendOfCurrent(Ref ref, String friendUid) async {
+  final currentUid = ref.watch(currentUidProvider).valueOrNull;
+  if (currentUid == null || currentUid == friendUid) return false;
+
+  final friendUids =
+      await ref.read(friendRepositoryProvider).getFriendUids(currentUid);
+  return friendUids.contains(friendUid);
+}
+
+/// Helper để compute pairId từ current user + friend uid — dùng cho unfriend
+/// action trong FriendSheet.
+String? pairIdWithCurrent(WidgetRef ref, String friendUid) {
+  final currentUid = ref.read(currentUidProvider).valueOrNull;
+  if (currentUid == null) return null;
+  return pairIdOf(currentUid, friendUid);
+}

--- a/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -5,23 +6,14 @@ import 'package:go_router/go_router.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
+import 'package:meep/features/profile/application/friend_posts_provider.dart';
+import 'package:meep/features/profile/application/profile_controller.dart';
 import 'package:meep/features/profile/presentation/widgets/diary_tab_content.dart';
 import 'package:meep/features/profile/presentation/widgets/photo_grid.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 import 'package:meep/shared/widgets/share_profile_sheet.dart';
 
-// ─── MOCK DATA — xoá khi wire ProfileController ──────────────────────────────
-const _kFriendUsername = 'bk';
-const _kFriendBio = '🍚 👚 🌾 💵\n💙 Mê xe độ 💙\nĐối sao đáp vậy 👍';
-const _kFriendPostCount = 6;
-const _kFriendFriendCount = 15;
-const _kFriendSpaceCount = 4;
-
-final _kFriendPhotos = List.generate(
-  _kFriendPostCount,
-  (i) => 'https://picsum.photos/seed/friend_mock_$i/400',
-);
-
+// ─── Missing design tokens — ping leader để add vào core/theme/ ──────────────
 const _cBg = Color(0xFF050F10);
 const _cButtonFill = Color(0xFF363636);
 const _cButtonText = Color(0xFFDDDDDD);
@@ -43,6 +35,7 @@ class _FriendProfileScreenState extends ConsumerState<FriendProfileScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final isFriendAsync = ref.watch(isFriendOfCurrentProvider(widget.uid));
     final unreadCounts = ref.watch(unreadCountsProvider);
     final totalUnread =
         unreadCounts.values.fold<int>(0, (sum, val) => sum + val);
@@ -50,123 +43,59 @@ class _FriendProfileScreenState extends ConsumerState<FriendProfileScreen> {
     return Scaffold(
       backgroundColor: _cBg,
       body: SafeArea(
-        child: Stack(
+        child: isFriendAsync.when(
+          loading: () => const Center(
+            child: CircularProgressIndicator(color: AppColors.bw100),
+          ),
+          error: (e, _) => _GateMessage(
+            message: 'Không tải được hồ sơ bạn bè.',
+            onBack: () => context.pop(),
+          ),
+          data: (isFriend) {
+            if (!isFriend) {
+              return _GateMessage(
+                message: 'Bạn cần kết bạn để xem trang cá nhân này.',
+                onBack: () => context.pop(),
+              );
+            }
+            return _FriendProfileBody(
+              friendUid: widget.uid,
+              activeTab: _activeTab,
+              onTabChanged: (t) => setState(() => _activeTab = t),
+              totalUnread: totalUnread,
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Gate fallback — non-friend / error / unauth ─────────────────────────────
+
+class _GateMessage extends StatelessWidget {
+  const _GateMessage({required this.message, required this.onBack});
+
+  final String message;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 30, 20, 0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Row(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          _FriendAvatar(username: _kFriendUsername),
-                          SizedBox(width: 25),
-                          _StatsRow(
-                            postCount: _kFriendPostCount,
-                            friendCount: _kFriendFriendCount,
-                            spaceCount: _kFriendSpaceCount,
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 10),
-                      const Text(
-                        _kFriendUsername,
-                        style: TextStyle(
-                          fontFamily: 'Nunito',
-                          fontSize: 20,
-                          fontWeight: FontWeight.w600,
-                          height: 28 / 20,
-                          color: AppColors.bw100,
-                        ),
-                      ),
-                      if (_kFriendBio.isNotEmpty) ...[
-                        const SizedBox(height: 3),
-                        Text(
-                          _kFriendBio,
-                          style: AppTextStyles.smRegular.copyWith(
-                            color: AppColors.bw100,
-                          ),
-                        ),
-                      ],
-                      const SizedBox(height: 20),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: _FriendActionButton(
-                              label: 'Nhắn tin',
-                              onTap: () {
-                                // TODO(T3/HanDHG): navigate to chat
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 10),
-                          Expanded(
-                            child: _FriendActionButton(
-                              label: 'Chia sẻ trang cá nhân',
-                              onTap: () => ShareProfileSheet.show(
-                                context,
-                                uid: widget.uid,
-                                username: _kFriendUsername,
-                                title: 'Chia sẻ liên kết của bạn bè',
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                    ],
-                  ),
-                ),
-                _FriendTabBar(
-                  activeTab: _activeTab,
-                  onTabChanged: (t) => setState(() => _activeTab = t),
-                ),
-                const SizedBox(height: 10),
-                Expanded(
-                  child: _activeTab == 0
-                      ? PhotoGrid(
-                          photos: _kFriendPhotos,
-                          onTap: (index) => context.push(
-                            '/profile/photo/friend-$index',
-                            extra: <String, dynamic>{
-                              'index': index,
-                              'photos': _kFriendPhotos,
-                            },
-                          ),
-                        )
-                      : const DiaryTabContent(itemCount: 4),
-                ),
-              ],
+            Text(
+              message,
+              style: AppTextStyles.mdRegular.copyWith(color: AppColors.bw100),
+              textAlign: TextAlign.center,
             ),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: Padding(
-                padding: EdgeInsets.only(
-                  bottom: MediaQuery.of(context).size.height * 0.045,
-                ),
-                child: AppTaskbar(
-                  activeTab: TaskbarTab.profile,
-                  chatBadgeCount: totalUnread,
-                  onTabSelected: (tab) {
-                    switch (tab) {
-                      case TaskbarTab.streak:
-                        context.go('/streak');
-                      case TaskbarTab.diary:
-                        context.go('/diary');
-                      case TaskbarTab.home:
-                        context.go('/home');
-                      case TaskbarTab.chat:
-                        context.go('/inbox');
-                      case TaskbarTab.profile:
-                        context.go('/profile', extra: widget.uid);
-                    }
-                  },
-                ),
-              ),
+            const SizedBox(height: 20),
+            _FriendActionButton(
+              label: 'Quay lại',
+              onTap: onBack,
             ),
           ],
         ),
@@ -175,12 +104,212 @@ class _FriendProfileScreenState extends ConsumerState<FriendProfileScreen> {
   }
 }
 
+// ─── Body — load profile + posts cho friend ─────────────────────────────────
+
+class _FriendProfileBody extends ConsumerWidget {
+  const _FriendProfileBody({
+    required this.friendUid,
+    required this.activeTab,
+    required this.onTabChanged,
+    required this.totalUnread,
+  });
+
+  final String friendUid;
+  final int activeTab;
+  final ValueChanged<int> onTabChanged;
+  final int totalUnread;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(profileControllerProvider(friendUid));
+
+    if (state.isLoading && state.profile == null) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppColors.bw100),
+      );
+    }
+
+    final profile = state.profile;
+    if (profile == null) {
+      return _GateMessage(
+        message: state.errorMessage ?? 'Không tải được hồ sơ',
+        onBack: () => context.pop(),
+      );
+    }
+
+    return Stack(
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 30, 20, 0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      _FriendAvatar(
+                        username: profile.username,
+                        avatarUrl: profile.avatarUrl,
+                      ),
+                      const SizedBox(width: 25),
+                      // Friend profile chỉ hiện Khoảnh khắc + Bạn bè per spec —
+                      // Space ẩn (không gọi từ profile.spaceCount).
+                      _StatsRow(
+                        postCount: profile.postCount,
+                        friendCount: profile.friendCount,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    profile.username,
+                    style: const TextStyle(
+                      fontFamily: 'Nunito',
+                      fontSize: 20,
+                      fontWeight: FontWeight.w600,
+                      height: 28 / 20,
+                      color: AppColors.bw100,
+                    ),
+                  ),
+                  if ((profile.bio ?? '').isNotEmpty) ...[
+                    const SizedBox(height: 3),
+                    Text(
+                      profile.bio!,
+                      style: AppTextStyles.smRegular
+                          .copyWith(color: AppColors.bw100),
+                    ),
+                  ],
+                  const SizedBox(height: 20),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _FriendActionButton(
+                          label: 'Nhắn tin',
+                          onTap: () {
+                            // TODO(P/T7/HanDHG): navigate to chat conversation
+                            // qua pairId — đợi Chat module BE
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: _FriendActionButton(
+                          label: 'Chia sẻ trang cá nhân',
+                          onTap: () => ShareProfileSheet.show(
+                            context,
+                            uid: friendUid,
+                            username: profile.username,
+                            title: 'Chia sẻ liên kết của bạn bè',
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                ],
+              ),
+            ),
+            _FriendTabBar(
+              activeTab: activeTab,
+              onTabChanged: onTabChanged,
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: activeTab == 0
+                  ? _FriendPhotosTab(friendUid: friendUid)
+                  : const DiaryTabContent(),
+            ),
+          ],
+        ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: Padding(
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).size.height * 0.045,
+            ),
+            child: AppTaskbar(
+              activeTab: TaskbarTab.profile,
+              chatBadgeCount: totalUnread,
+              onTabSelected: (tab) {
+                switch (tab) {
+                  case TaskbarTab.streak:
+                    context.go('/streak');
+                  case TaskbarTab.diary:
+                    context.go('/diary');
+                  case TaskbarTab.home:
+                    context.go('/home');
+                  case TaskbarTab.chat:
+                    context.go('/inbox');
+                  case TaskbarTab.profile:
+                    context.go('/profile', extra: friendUid);
+                }
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ─── Photos tab — audience filtered ──────────────────────────────────────────
+
+class _FriendPhotosTab extends ConsumerWidget {
+  const _FriendPhotosTab({required this.friendUid});
+
+  final String friendUid;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ref.watch(friendPostsProvider(friendUid)).when(
+          loading: () => const Center(
+            child: CircularProgressIndicator(color: AppColors.bw100),
+          ),
+          error: (e, _) => Center(
+            child: Text(
+              'Không tải được ảnh.',
+              style: AppTextStyles.smRegular.copyWith(color: AppColors.bw500),
+            ),
+          ),
+          data: (posts) {
+            if (posts == null || posts.isEmpty) {
+              return Center(
+                child: Text(
+                  'Chưa có ảnh nào',
+                  style:
+                      AppTextStyles.smRegular.copyWith(color: AppColors.bw500),
+                ),
+              );
+            }
+            final urls = posts.map((p) => p.coverImageUrl).toList();
+            return PhotoGrid(
+              photos: urls,
+              onTap: (index) {
+                final post = posts[index];
+                context.push(
+                  '/profile/photo/${post.postId}',
+                  extra: <String, Object>{
+                    'posts': posts,
+                    'index': index,
+                  },
+                );
+              },
+            );
+          },
+        );
+  }
+}
+
 // ─── Avatar ──────────────────────────────────────────────────────────────────
 
 class _FriendAvatar extends StatelessWidget {
-  const _FriendAvatar({required this.username});
+  const _FriendAvatar({required this.username, this.avatarUrl});
 
   final String username;
+  final String? avatarUrl;
 
   String get _initials {
     final parts = username.trim().split(' ');
@@ -190,6 +319,7 @@ class _FriendAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final url = avatarUrl;
     return Container(
       width: 100,
       height: 100,
@@ -201,31 +331,37 @@ class _FriendAvatar extends StatelessWidget {
       ),
       padding: const EdgeInsets.all(4),
       child: ClipOval(
-        child: Container(
-          color: AppColors.bw700,
-          alignment: Alignment.center,
-          child: Text(
-            _initials,
-            style: AppTextStyles.lgBold.copyWith(color: AppColors.bw100),
-          ),
-        ),
+        child: url != null && url.isNotEmpty
+            ? CachedNetworkImage(
+                imageUrl: url,
+                fit: BoxFit.cover,
+                errorWidget: (_, __, ___) => _initialsFallback(),
+                placeholder: (_, __) => Container(color: AppColors.bw800),
+              )
+            : _initialsFallback(),
+      ),
+    );
+  }
+
+  Widget _initialsFallback() {
+    return Container(
+      color: AppColors.bw700,
+      alignment: Alignment.center,
+      child: Text(
+        _initials,
+        style: AppTextStyles.lgBold.copyWith(color: AppColors.bw100),
       ),
     );
   }
 }
 
-// ─── Stats ───────────────────────────────────────────────────────────────────
+// ─── Stats — chỉ 2 cột (Khoảnh khắc + Bạn bè), KHÔNG hiện Space ──────────────
 
 class _StatsRow extends StatelessWidget {
-  const _StatsRow({
-    required this.postCount,
-    required this.friendCount,
-    required this.spaceCount,
-  });
+  const _StatsRow({required this.postCount, required this.friendCount});
 
   final int postCount;
   final int friendCount;
-  final int spaceCount;
 
   @override
   Widget build(BuildContext context) {
@@ -235,8 +371,6 @@ class _StatsRow extends StatelessWidget {
         _StatItem(count: postCount, label: 'Khoảnh khắc'),
         const SizedBox(width: 30),
         _StatItem(count: friendCount, label: 'Bạn bè'),
-        const SizedBox(width: 30),
-        _StatItem(count: spaceCount, label: 'Space'),
       ],
     );
   }

--- a/apps/mobile/test/features/profile/application/friend_posts_provider_test.dart
+++ b/apps/mobile/test/features/profile/application/friend_posts_provider_test.dart
@@ -1,0 +1,215 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/firebase_auth_repository.dart';
+import 'package:meep/features/feed/application/feed_controller.dart';
+import 'package:meep/features/feed/data/firebase_post_repository.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/friend/data/firebase_friend_repository.dart';
+import 'package:meep/features/profile/application/friend_posts_provider.dart';
+
+void main() {
+  const currentUid = 'uid-alice';
+  const friendUid = 'uid-bob';
+  const otherUid = 'uid-charlie';
+
+  late FakeFirebaseFirestore firestore;
+
+  final basePost = Post(
+    postId: 'p1',
+    authorId: friendUid,
+    authorName: 'Bob',
+    imageUrl: 'https://cdn/p1.jpg',
+    audienceType: AudienceType.all,
+    createdAt: DateTime.utc(2026, 5, 10, 12),
+  );
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+  });
+
+  ProviderContainer makeContainer({String? signedInUid = currentUid}) {
+    final mockAuth = signedInUid != null
+        ? MockFirebaseAuth(
+            mockUser: MockUser(uid: signedInUid),
+            signedIn: true,
+          )
+        : MockFirebaseAuth();
+    final c = ProviderContainer(
+      overrides: [
+        authRepositoryProvider
+            .overrideWithValue(FirebaseAuthRepository(auth: mockAuth)),
+        postRepositoryProvider
+            .overrideWithValue(FirebasePostRepository(firestore)),
+        friendRepositoryProvider
+            .overrideWithValue(FirebaseFriendRepository(firestore)),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  Future<void> seedPost(Post post) async {
+    await firestore.doc('posts/${post.postId}').set(post.toJson());
+  }
+
+  Future<void> seedFriendship(String a, String b) async {
+    final lo = a.compareTo(b) < 0 ? a : b;
+    final hi = a.compareTo(b) < 0 ? b : a;
+    await firestore.doc('friendships/${lo}_$hi').set({
+      'uid1': lo,
+      'uid2': hi,
+      'members': [lo, hi],
+      'createdAt': Timestamp.now(),
+    });
+  }
+
+  // Keep autoDispose provider alive trong khi await `.future` — không listen →
+  // provider dispose mid-load với lỗi "no value emitted".
+  Future<List<Post>?> readFriendPosts(ProviderContainer c, String uid) async {
+    final sub = c.listen(friendPostsProvider(uid), (_, __) {});
+    addTearDown(sub.close);
+    return c.read(friendPostsProvider(uid).future);
+  }
+
+  Future<bool> readIsFriend(ProviderContainer c, String uid) async {
+    final sub = c.listen(isFriendOfCurrentProvider(uid), (_, __) {});
+    addTearDown(sub.close);
+    return c.read(isFriendOfCurrentProvider(uid).future);
+  }
+
+  group('friendPostsProvider', () {
+    test('returns null khi current user chưa login', () async {
+      final c = makeContainer(signedInUid: null);
+      final result = await readFriendPosts(c, friendUid);
+      expect(result, isNull);
+    });
+
+    test('returns empty list khi friend chưa có post', () async {
+      final c = makeContainer();
+      final result = await readFriendPosts(c, friendUid);
+      expect(result, isNotNull);
+      expect(result, isEmpty);
+    });
+
+    test('hiển thị tất cả audienceType==all posts', () async {
+      await seedPost(basePost.copyWith(postId: 'p1'));
+      await seedPost(basePost.copyWith(postId: 'p2'));
+      final c = makeContainer();
+      final result = await readFriendPosts(c, friendUid);
+      expect(result!.map((p) => p.postId).toSet(), {'p1', 'p2'});
+    });
+
+    test('hiển thị audienceType==select khi currentUid trong audienceUids',
+        () async {
+      await seedPost(
+        basePost.copyWith(
+          postId: 'p-select-me',
+          audienceType: AudienceType.select,
+          audienceUids: [currentUid],
+        ),
+      );
+      await seedPost(
+        basePost.copyWith(
+          postId: 'p-select-other',
+          audienceType: AudienceType.select,
+          audienceUids: [otherUid],
+        ),
+      );
+      final c = makeContainer();
+      final result = await readFriendPosts(c, friendUid);
+      expect(
+        result!.map((p) => p.postId).toSet(),
+        {'p-select-me'},
+        reason: 'chỉ post chia sẻ với currentUid hiển thị',
+      );
+    });
+
+    test('loại audienceType==select khi currentUid không trong audienceUids',
+        () async {
+      await seedPost(
+        basePost.copyWith(
+          postId: 'p-hidden',
+          audienceType: AudienceType.select,
+          audienceUids: [otherUid],
+        ),
+      );
+      final c = makeContainer();
+      final result = await readFriendPosts(c, friendUid);
+      expect(result, isEmpty);
+    });
+
+    test('mix all + select-me + select-other → only all + select-me', () async {
+      await seedPost(basePost.copyWith(postId: 'p-all'));
+      await seedPost(
+        basePost.copyWith(
+          postId: 'p-select-me',
+          audienceType: AudienceType.select,
+          audienceUids: [currentUid, otherUid],
+        ),
+      );
+      await seedPost(
+        basePost.copyWith(
+          postId: 'p-select-other',
+          audienceType: AudienceType.select,
+          audienceUids: [otherUid],
+        ),
+      );
+      final c = makeContainer();
+      final result = await readFriendPosts(c, friendUid);
+      expect(
+        result!.map((p) => p.postId).toSet(),
+        {'p-all', 'p-select-me'},
+      );
+    });
+
+    test('sort createdAt DESC sau filter', () async {
+      await seedPost(
+        basePost.copyWith(
+          postId: 'p-old',
+          createdAt: DateTime.utc(2026, 5, 1),
+        ),
+      );
+      await seedPost(
+        basePost.copyWith(
+          postId: 'p-new',
+          createdAt: DateTime.utc(2026, 5, 20),
+        ),
+      );
+      final c = makeContainer();
+      final result = await readFriendPosts(c, friendUid);
+      expect(result!.map((p) => p.postId).toList(), ['p-new', 'p-old']);
+    });
+  });
+
+  group('isFriendOfCurrentProvider', () {
+    test('false khi current user chưa login', () async {
+      final c = makeContainer(signedInUid: null);
+      final result = await readIsFriend(c, friendUid);
+      expect(result, isFalse);
+    });
+
+    test('false khi currentUid == friendUid (chính mình)', () async {
+      final c = makeContainer();
+      final result = await readIsFriend(c, currentUid);
+      expect(result, isFalse);
+    });
+
+    test('false khi chưa có friendship doc', () async {
+      final c = makeContainer();
+      final result = await readIsFriend(c, friendUid);
+      expect(result, isFalse);
+    });
+
+    test('true khi friendship doc tồn tại', () async {
+      await seedFriendship(currentUid, friendUid);
+      final c = makeContainer();
+      final result = await readIsFriend(c, friendUid);
+      expect(result, isTrue);
+    });
+  });
+}

--- a/apps/mobile/test/features/profile/presentation/friend_profile_screen_test.dart
+++ b/apps/mobile/test/features/profile/presentation/friend_profile_screen_test.dart
@@ -1,0 +1,184 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/firebase_auth_repository.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/feed/application/feed_controller.dart';
+import 'package:meep/features/feed/data/firebase_post_repository.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/friend/data/firebase_friend_repository.dart';
+import 'package:meep/features/profile/application/profile_controller.dart';
+import 'package:meep/features/profile/data/profile_repository.dart';
+import 'package:meep/features/profile/presentation/friend_profile_screen.dart';
+
+class _FakeProfileRepository implements ProfileRepository {
+  _FakeProfileRepository(this.profile);
+  final UserProfile? profile;
+
+  @override
+  Future<UserProfile?> getUserProfile(String uid) async => profile;
+
+  @override
+  Stream<UserProfile?> watchUserProfile(String uid) => Stream.value(profile);
+
+  @override
+  Future<void> updateProfile(String uid, Map<String, dynamic> fields) async {}
+
+  @override
+  Future<void> updateAvatar(String uid, dynamic file) async {}
+
+  @override
+  Future<void> removeAvatar(String uid) async {}
+}
+
+void main() {
+  const currentUid = 'uid-alice';
+  const friendUid = 'uid-bob';
+
+  late FakeFirebaseFirestore firestore;
+
+  final bobProfile = UserProfile(
+    uid: friendUid,
+    email: 'bob@example.com',
+    displayName: 'Bob Tran',
+    username: 'bob',
+    bio: 'Hello from Bob',
+    postCount: 5,
+    friendCount: 8,
+    spaceCount: 4,
+    createdAt: DateTime.utc(2026, 1, 1),
+    updatedAt: DateTime.utc(2026, 1, 1),
+  );
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+  });
+
+  Future<void> seedFriendship() async {
+    final lo = currentUid.compareTo(friendUid) < 0 ? currentUid : friendUid;
+    final hi = currentUid.compareTo(friendUid) < 0 ? friendUid : currentUid;
+    await firestore.doc('friendships/${lo}_$hi').set({
+      'uid1': lo,
+      'uid2': hi,
+      'members': [lo, hi],
+      'createdAt': Timestamp.now(),
+    });
+  }
+
+  Widget makeApp({
+    UserProfile? profile,
+    bool seedFriend = true,
+  }) {
+    final mockAuth = MockFirebaseAuth(
+      mockUser: MockUser(uid: currentUid),
+      signedIn: true,
+    );
+    final router = GoRouter(
+      initialLocation: '/friend-profile/$friendUid',
+      routes: [
+        GoRoute(
+          path: '/friend-profile/:uid',
+          builder: (_, state) =>
+              FriendProfileScreen(uid: state.pathParameters['uid'] ?? ''),
+        ),
+        GoRoute(
+          path: '/',
+          builder: (_, __) => const Scaffold(body: Text('HOME_PLACEHOLDER')),
+        ),
+        GoRoute(
+          path: '/streak',
+          builder: (_, __) => const Scaffold(body: Text('STREAK_PLACEHOLDER')),
+        ),
+        GoRoute(
+          path: '/diary',
+          builder: (_, __) => const Scaffold(body: Text('DIARY_PLACEHOLDER')),
+        ),
+        GoRoute(
+          path: '/home',
+          builder: (_, __) => const Scaffold(body: Text('HOME_PLACEHOLDER')),
+        ),
+        GoRoute(
+          path: '/inbox',
+          builder: (_, __) => const Scaffold(body: Text('INBOX_PLACEHOLDER')),
+        ),
+        GoRoute(
+          path: '/profile',
+          builder: (_, __) => const Scaffold(body: Text('PROFILE_PLACEHOLDER')),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    return ProviderScope(
+      overrides: [
+        authRepositoryProvider
+            .overrideWithValue(FirebaseAuthRepository(auth: mockAuth)),
+        profileRepositoryProvider
+            .overrideWithValue(_FakeProfileRepository(profile)),
+        postRepositoryProvider
+            .overrideWithValue(FirebasePostRepository(firestore)),
+        friendRepositoryProvider
+            .overrideWithValue(FirebaseFriendRepository(firestore)),
+      ],
+      child: MaterialApp.router(routerConfig: router),
+    );
+  }
+
+  testWidgets('hiện gate khi chưa là bạn bè', (tester) async {
+    await tester.pumpWidget(makeApp(profile: bobProfile, seedFriend: false));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Bạn cần kết bạn để xem trang cá nhân này.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('render profile + stats sau khi là bạn bè', (tester) async {
+    await seedFriendship();
+    await tester.pumpWidget(makeApp(profile: bobProfile));
+    await tester.pumpAndSettle();
+
+    expect(find.text('bob'), findsOneWidget); // username
+    expect(find.text('Hello from Bob'), findsOneWidget); // bio
+    expect(find.text('5'), findsOneWidget); // postCount
+    expect(find.text('8'), findsOneWidget); // friendCount
+    expect(find.text('Khoảnh khắc'), findsOneWidget);
+    expect(find.text('Bạn bè'), findsOneWidget);
+  });
+
+  testWidgets('KHÔNG hiển thị Space stat trên FriendProfile', (tester) async {
+    await seedFriendship();
+    await tester.pumpWidget(makeApp(profile: bobProfile));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Space'),
+      findsNothing,
+      reason: 'Friend profile chỉ hiện Khoảnh khắc + Bạn bè',
+    );
+    expect(
+      find.text('4'),
+      findsNothing,
+      reason: 'spaceCount=4 không nên render trong FriendProfile',
+    );
+  });
+
+  testWidgets('action button "Nhắn tin" + "Chia sẻ trang cá nhân" hiển thị',
+      (tester) async {
+    await seedFriendship();
+    await tester.pumpWidget(makeApp(profile: bobProfile));
+    await tester.pumpAndSettle();
+    expect(find.text('Nhắn tin'), findsOneWidget);
+    expect(find.text('Chia sẻ trang cá nhân'), findsOneWidget);
+  });
+
+  testWidgets('empty posts → "Chưa có ảnh nào"', (tester) async {
+    await seedFriendship();
+    await tester.pumpWidget(makeApp(profile: bobProfile));
+    await tester.pumpAndSettle();
+    expect(find.text('Chưa có ảnh nào'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Wire FriendProfileScreen với BE production (issue #113). Build trên PR #240 (T1) + #241 (T2) + #245 (T3+T4 ProfileScreen wire).

## Acceptance criteria (theo issue #113)

- [x] **isFriend gate** — render gate message khi chưa là bạn bè, không expose profile data
- [x] **Stats** — Khoảnh khắc + Bạn bè; KHÔNG hiển thị Space (per spec)
- [x] **Bio** — render từ profile.bio khi non-empty
- [x] **Grid ảnh** — \`PostRepository.getPostsByAuthor(friendUid)\` filtered theo audience visibility (spec OQ5: \`audienceType=='all'\` OR \`audienceUids.contains(currentUid)\`)
- [x] **Action buttons** — \"Nhắn tin\" + \"Chia sẻ trang cá nhân\" (không có Edit)
- [ ] Nút \"Xóa bạn\" (mở FriendSheet) — defer khi FriendSheet integration sẵn sàng

## Files

| File | Δ | Mô tả |
|---|---|---|
| `lib/features/profile/application/friend_posts_provider.dart` | +66 (new) | friendPostsProvider (audience filter) + isFriendOfCurrentProvider |
| `lib/features/profile/presentation/friend_profile_screen.dart` | +334/-137 | Wire ProfileController + isFriend gate + real stats/avatar/grid |
| `test/features/profile/application/friend_posts_provider_test.dart` | +215 (new) | 11 cases — audience filter + isFriend matrix |
| `test/features/profile/presentation/friend_profile_screen_test.dart` | +170 (new) | 5 widget tests — gate, render, no Space, action buttons, empty |

## Design choices

- **Defense-in-depth audience filter** — Firestore rule `/posts` đã reject non-friend reads server-side, nhưng client filter là layer thứ hai để chặn `audienceType=='select'` posts không dành cho current user khỏi hiển thị (server vẫn return chúng vì authorId là friend của user).
- **Stats KHÔNG hiển thị Space** — spec quyết định FriendProfile chỉ expose Khoảnh khắc + Bạn bè (privacy: friend space membership không public).
- **isFriend qua getFriendUids** — không touch Friendship model trực tiếp, dùng existing repo method. Caveat: getFriendUids load tất cả friendships của current user vào memory; OK với MVP scope (max 20 friends).
- **Empty posts → "Chưa có ảnh nào"** — distinct với non-friend gate message để UX rõ ràng.

## Caveats / follow-ups

- **\"Nhắn tin\" button TODO** — chờ Chat module BE pairId → conversation flow. Hiện tại click no-op.
- **isFriend check tại render time, KHÔNG guard route** — non-friend navigate `/friend-profile/:uid` vẫn hit screen, chỉ thấy gate. Future cải tiến qua router redirect ở `appRouterProvider`.
- **\"Xóa bạn\" button defer** — chờ FriendSheet integration.

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `dart format --set-exit-if-changed` — clean
- [x] `flutter test test/features/profile/` — 52/52 pass
- [x] `flutter test` full suite — 499/499 pass, không break
- [x] `/review` 6-axis — 0 critical, 0 important findings

## PR series progress

| PR | Issue | Task | Status |
|---|---|---|---|
| #240 | #109 | T1 FirebaseProfileRepository | ✅ Merged |
| #241 | #110 | T2 ProfileController + wire main | ✅ Merged |
| #242 | #114 | T8 Diary M2 + T9 rules tests | ✅ Merged |
| #245 | #111 | T3+T4 BE wire ProfileScreen + PhotoDetail | ✅ Merged |
| **THIS** | #113 | T7 BE wire FriendProfileScreen + audience filter | 🟡 Open |
| TBD | #112 | T5+T6 BE wire EditProfile + AvatarPicker | 📋 Pending |

Closes #113
Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)