### PR TITLE
feat(reaction): T3+T4 ActTextBar M3 + EmojiPickerSheet + ReactionListSheet

### DIFF
--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -254,7 +254,7 @@ class _AvatarStack extends StatelessWidget {
 
 /// Friend message bar — 2-state inline composer trên Feed:
 /// - **Collapsed** (mặc định): text "Gửi tin nhắn..." + 3 emoji quick-react
-///   (🩵🤣🥰 — Figma 472:2252) + smile-plus picker. Tap text trái → expand
+///   (💙🤣🥰 — Figma 472:2252) + smile-plus picker. Tap text trái → expand
 ///   sang modal composer. Tap emoji → `ReactionController.toggleReact`
 ///   (optimistic + in-flight lock). Tap smile-plus → `EmojiPickerSheet`.
 /// - **Expanded:** TextField focused + send button. Tap-outside hoặc submit →
@@ -289,7 +289,9 @@ class FriendMessageBar extends ConsumerStatefulWidget {
 class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
   bool _isSending = false;
 
-  static const _presets = ['🩵', '🤣', '🥰'];
+  // 💙 (U+1F499) ổn định cross-Android; tránh 🩵 (U+1FA75 — Unicode 14.0) bị
+  // tofu trên Android < 12. Khớp chat_input_bar.quickEmojis default.
+  static const _presets = ['💙', '🤣', '🥰'];
 
   /// Mở modal bottom sheet composer thay vì inline TextField.
   ///
@@ -441,6 +443,12 @@ class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
   }
 }
 
+/// Emoji preset button — visual feedback khi user đã thả reaction:
+/// - Active: scale 1.35x + translate Y -10 (nổi lên khỏi ActText) + full opacity
+/// - Inactive: scale 1.0 + opacity 0.6
+/// Animate transition 200ms easeOutBack tạo cảm giác "bouncy".
+/// KHÔNG set fontFamily — để platform emoji font render glyph, tránh tofu
+/// (theo pattern chat_input_bar — comment lý do ở đó).
 class _EmojiButton extends StatelessWidget {
   const _EmojiButton({
     required this.emoji,
@@ -456,13 +464,25 @@ class _EmojiButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
+      behavior: HitTestBehavior.opaque,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 4),
-        child: Opacity(
-          opacity: isActive ? 1.0 : 0.6,
-          child: Text(
-            emoji,
-            style: const TextStyle(fontSize: 24),
+        child: AnimatedSlide(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOutBack,
+          offset: isActive ? const Offset(0, -0.45) : Offset.zero,
+          child: AnimatedScale(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOutBack,
+            scale: isActive ? 1.35 : 1.0,
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 180),
+              opacity: isActive ? 1.0 : 0.6,
+              child: Text(
+                emoji,
+                style: const TextStyle(fontSize: 22),
+              ),
+            ),
           ),
         ),
       ),

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -318,9 +318,9 @@ class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
     final centerLocal = Offset(box.size.width / 2, box.size.height / 2);
     final centerGlobal = box.localToGlobal(centerLocal);
     final overlay = Overlay.of(context);
-    // 3 bubbles spawn delayed → wave effect kiểu Locket.
+    // 3 bubbles spawn delayed (150ms gap) → wave effect rõ kiểu Locket.
     for (var i = 0; i < 3; i++) {
-      Future.delayed(Duration(milliseconds: 90 * i), () {
+      Future.delayed(Duration(milliseconds: 150 * i), () {
         if (!mounted) return;
         late OverlayEntry entry;
         entry = OverlayEntry(
@@ -558,7 +558,7 @@ class _EmojiBubble extends StatefulWidget {
 class _EmojiBubbleState extends State<_EmojiBubble>
     with SingleTickerProviderStateMixin {
   static const _emojiSize = 32.0;
-  static const _riseDistance = 140.0;
+  static const _riseDistance = 160.0;
 
   late final AnimationController _ctrl;
 
@@ -567,7 +567,8 @@ class _EmojiBubbleState extends State<_EmojiBubble>
     super.initState();
     _ctrl = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 1500),
+      // 2.4s — đủ thong thả để mắt theo dõi quỹ đạo, không cảm giác "vọt".
+      duration: const Duration(milliseconds: 2400),
     )
       ..forward()
       ..addStatusListener((s) {
@@ -587,14 +588,17 @@ class _EmojiBubbleState extends State<_EmojiBubble>
       animation: _ctrl,
       builder: (_, __) {
         final t = _ctrl.value;
-        // EaseOutCubic cho vertical rise — chậm dần khi lên cao.
-        final tEase = 1 - math.pow(1 - t, 3).toDouble();
+        // EaseOutQuad: 1 - (1-t)² — distribution đều hơn easeOutCubic.
+        // Tại t=0.5 đi 75% distance (vs cubic 87.5%) → mắt theo dõi
+        // mượt, không cảm giác "vọt lên rồi đứng".
+        final tEase = 1 - (1 - t) * (1 - t);
         final dy = -_riseDistance * tEase;
-        // Drift X áp dụng cubic ease — wobble subtle.
-        final dx = widget.driftX * tEase;
-        // Fade nhanh hơn ở cuối (60% mới bắt đầu fade rõ).
-        final opacity = (1.0 - math.max(0.0, (t - 0.4) / 0.6)).clamp(0.0, 1.0);
-        final scale = 1.0 + (0.25 * t);
+        // Drift X theo sine wave nhẹ — wobble bồng bềnh kiểu bong bóng.
+        final dx = widget.driftX * tEase + math.sin(t * math.pi * 2) * 6.0;
+        // Fade tuyến tính 30% → 100% → bubble vẫn nhìn thấy được suốt
+        // phần lớn animation, chỉ mờ dần ở cuối.
+        final opacity = (1.0 - math.max(0.0, (t - 0.3) / 0.7)).clamp(0.0, 1.0);
+        final scale = 1.0 + (0.2 * t);
 
         return Positioned(
           left: widget.startGlobal.dx - _emojiSize / 2 + dx,
@@ -604,9 +608,17 @@ class _EmojiBubbleState extends State<_EmojiBubble>
               opacity: opacity,
               child: Transform.scale(
                 scale: scale,
+                // Overlay không có DefaultTextStyle → Flutter debug fallback
+                // render Text với gạch chân vàng + chữ đỏ. Phải set explicit
+                // decoration + color + textDirection để tắt fallback đó.
                 child: Text(
                   widget.emoji,
-                  style: const TextStyle(fontSize: _emojiSize),
+                  textDirection: TextDirection.ltr,
+                  style: const TextStyle(
+                    fontSize: _emojiSize,
+                    decoration: TextDecoration.none,
+                    color: Colors.black,
+                  ),
                 ),
               ),
             ),

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -288,10 +289,52 @@ class FriendMessageBar extends ConsumerStatefulWidget {
 
 class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
   bool _isSending = false;
+  final math.Random _rng = math.Random();
 
   // 💙 (U+1F499) ổn định cross-Android; tránh 🩵 (U+1FA75 — Unicode 14.0) bị
   // tofu trên Android < 12. Khớp chat_input_bar.quickEmojis default.
-  static const _presets = ['💙', '🤣', '🥰'];
+  static const _defaultPresets = ['💙', '🤣', '🥰'];
+
+  // 1 GlobalKey per slot — dùng để lấy global position khi spawn bubble float
+  // animation (Overlay cần absolute position, không phải local của widget).
+  final List<GlobalKey> _slotKeys = List.generate(3, (_) => GlobalKey());
+  final GlobalKey _smilePlusKey = GlobalKey();
+
+  /// Nếu user đã pick emoji custom (qua EmojiPickerSheet, không thuộc 3
+  /// default presets), replace slot 0 (💙) bằng emoji đó. Giúp user thấy
+  /// rõ mình đã chọn gì — nếu không sẽ "lost" sau khi đóng picker.
+  List<String> _displayPresets(String? myEmoji) {
+    if (myEmoji == null || _defaultPresets.contains(myEmoji)) {
+      return _defaultPresets;
+    }
+    return [myEmoji, _defaultPresets[1], _defaultPresets[2]];
+  }
+
+  /// Spawn 3 emoji bubbles staggered từ vị trí button được tap, float lên
+  /// kiểu Locket. Mỗi bubble drift X random + fade out 1.5s.
+  void _spawnBubbles(String emoji, GlobalKey slotKey) {
+    final box = slotKey.currentContext?.findRenderObject() as RenderBox?;
+    if (box == null) return;
+    final centerLocal = Offset(box.size.width / 2, box.size.height / 2);
+    final centerGlobal = box.localToGlobal(centerLocal);
+    final overlay = Overlay.of(context);
+    // 3 bubbles spawn delayed → wave effect kiểu Locket.
+    for (var i = 0; i < 3; i++) {
+      Future.delayed(Duration(milliseconds: 90 * i), () {
+        if (!mounted) return;
+        late OverlayEntry entry;
+        entry = OverlayEntry(
+          builder: (_) => _EmojiBubble(
+            emoji: emoji,
+            startGlobal: centerGlobal,
+            driftX: (_rng.nextDouble() - 0.5) * 80, // -40 → +40
+            onComplete: () => entry.remove(),
+          ),
+        );
+        overlay.insert(entry);
+      });
+    }
+  }
 
   /// Mở modal bottom sheet composer thay vì inline TextField.
   ///
@@ -351,8 +394,10 @@ class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
     );
   }
 
-  /// Safe toggle reaction — bắt lỗi, toast message nếu fail.
-  void _toggleReaction(String emoji) {
+  /// Safe toggle reaction — spawn bubble animation trước (instant UX feedback,
+  /// không đợi network), rồi gọi controller toggle. Bắt lỗi → toast message.
+  void _toggleReaction(String emoji, [GlobalKey? sourceKey]) {
+    if (sourceKey != null) _spawnBubbles(emoji, sourceKey);
     try {
       final auth = FirebaseAuth.instance;
       final uid = auth.currentUser?.uid;
@@ -422,15 +467,24 @@ class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
               ),
             ),
           ),
-          for (final emoji in _presets)
+          for (var i = 0; i < 3; i++)
             _EmojiButton(
-              emoji: emoji,
-              isActive: reactionState.myEmoji == emoji,
-              onTap: () => _toggleReaction(emoji),
+              key: _slotKeys[i],
+              emoji: _displayPresets(reactionState.myEmoji)[i],
+              isActive: reactionState.myEmoji ==
+                  _displayPresets(reactionState.myEmoji)[i],
+              onTap: () => _toggleReaction(
+                _displayPresets(reactionState.myEmoji)[i],
+                _slotKeys[i],
+              ),
             ),
           const SizedBox(width: 10),
           GestureDetector(
-            onTap: () => EmojiPickerSheet.show(context, _toggleReaction),
+            key: _smilePlusKey,
+            onTap: () => EmojiPickerSheet.show(
+              context,
+              (emoji) => _toggleReaction(emoji, _smilePlusKey),
+            ),
             child: const Icon(
               Icons.add_reaction_outlined,
               color: AppColors.bw500,
@@ -443,14 +497,15 @@ class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
   }
 }
 
-/// Emoji preset button — visual feedback khi user đã thả reaction:
-/// - Active: scale 1.35x + translate Y -10 (nổi lên khỏi ActText) + full opacity
-/// - Inactive: scale 1.0 + opacity 0.6
-/// Animate transition 200ms easeOutBack tạo cảm giác "bouncy".
+/// Emoji preset button — subtle opacity feedback active/inactive.
+/// Visual chính khi user thả reaction = bubble float animation
+/// (spawn từ _FriendMessageBarState._spawnBubbles), + replace slot 0 nếu
+/// emoji custom (xem _displayPresets).
 /// KHÔNG set fontFamily — để platform emoji font render glyph, tránh tofu
-/// (theo pattern chat_input_bar — comment lý do ở đó).
+/// (theo pattern chat_input_bar).
 class _EmojiButton extends StatelessWidget {
   const _EmojiButton({
+    super.key,
     required this.emoji,
     required this.isActive,
     required this.onTap,
@@ -467,25 +522,97 @@ class _EmojiButton extends StatelessWidget {
       behavior: HitTestBehavior.opaque,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 4),
-        child: AnimatedSlide(
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOutBack,
-          offset: isActive ? const Offset(0, -0.45) : Offset.zero,
-          child: AnimatedScale(
-            duration: const Duration(milliseconds: 200),
-            curve: Curves.easeOutBack,
-            scale: isActive ? 1.35 : 1.0,
-            child: AnimatedOpacity(
-              duration: const Duration(milliseconds: 180),
-              opacity: isActive ? 1.0 : 0.6,
-              child: Text(
-                emoji,
-                style: const TextStyle(fontSize: 22),
-              ),
-            ),
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 180),
+          opacity: isActive ? 1.0 : 0.6,
+          child: Text(
+            emoji,
+            style: const TextStyle(fontSize: 22),
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Locket-style bubble float — emoji nổi lên + drift X + scale + fade out.
+/// Spawn từ Overlay nên không bị clip bởi ActText container.
+/// Tự remove khỏi overlay khi animation complete (1.5s).
+class _EmojiBubble extends StatefulWidget {
+  const _EmojiBubble({
+    required this.emoji,
+    required this.startGlobal,
+    required this.driftX,
+    required this.onComplete,
+  });
+
+  final String emoji;
+  final Offset startGlobal;
+  final double driftX;
+  final VoidCallback onComplete;
+
+  @override
+  State<_EmojiBubble> createState() => _EmojiBubbleState();
+}
+
+class _EmojiBubbleState extends State<_EmojiBubble>
+    with SingleTickerProviderStateMixin {
+  static const _emojiSize = 32.0;
+  static const _riseDistance = 140.0;
+
+  late final AnimationController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    )
+      ..forward()
+      ..addStatusListener((s) {
+        if (s == AnimationStatus.completed) widget.onComplete();
+      });
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _ctrl,
+      builder: (_, __) {
+        final t = _ctrl.value;
+        // EaseOutCubic cho vertical rise — chậm dần khi lên cao.
+        final tEase = 1 - math.pow(1 - t, 3).toDouble();
+        final dy = -_riseDistance * tEase;
+        // Drift X áp dụng cubic ease — wobble subtle.
+        final dx = widget.driftX * tEase;
+        // Fade nhanh hơn ở cuối (60% mới bắt đầu fade rõ).
+        final opacity = (1.0 - math.max(0.0, (t - 0.4) / 0.6)).clamp(0.0, 1.0);
+        final scale = 1.0 + (0.25 * t);
+
+        return Positioned(
+          left: widget.startGlobal.dx - _emojiSize / 2 + dx,
+          top: widget.startGlobal.dy - _emojiSize / 2 + dy,
+          child: IgnorePointer(
+            child: Opacity(
+              opacity: opacity,
+              child: Transform.scale(
+                scale: scale,
+                child: Text(
+                  widget.emoji,
+                  style: const TextStyle(fontSize: _emojiSize),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/hex_color.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/chat/application/chat_controller.dart';
 import 'package:meep/features/feed/application/feed_controller.dart';
 import 'package:meep/features/feed/data/post.dart';
@@ -225,7 +226,10 @@ class _AvatarStack extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.only(right: 2),
             child: AppAvatar(
-              fallbackText: r.reactorName,
+              imageUrl: r.reactorAvatarUrl,
+              fallbackText: r.reactorName.isNotEmpty
+                  ? r.reactorName[0].toUpperCase()
+                  : '?',
               size: 32,
             ),
           ),
@@ -396,15 +400,25 @@ class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
 
   /// Safe toggle reaction — spawn bubble animation trước (instant UX feedback,
   /// không đợi network), rồi gọi controller toggle. Bắt lỗi → toast message.
+  ///
+  /// displayName + avatarUrl lấy từ UserProfile (Firestore /users/{uid}) thay
+  /// vì chỉ FirebaseAuth.currentUser — đảm bảo có data đúng cho mọi auth method
+  /// (Google / email signup). Fallback FirebaseAuth nếu profile chưa load.
   void _toggleReaction(String emoji, [GlobalKey? sourceKey]) {
     if (sourceKey != null) _spawnBubbles(emoji, sourceKey);
     try {
       final auth = FirebaseAuth.instance;
       final uid = auth.currentUser?.uid;
       if (uid == null) return;
+      final profile = ref.read(currentUserProfileProvider).valueOrNull;
+      final displayName = (profile?.displayName.isNotEmpty ?? false)
+          ? profile!.displayName
+          : (auth.currentUser?.displayName ?? '');
+      final avatarUrl = profile?.avatarUrl ?? auth.currentUser?.photoURL;
       ref.read(reactionControllerProvider(widget.postId).notifier).toggleReact(
             uid: uid,
-            displayName: auth.currentUser?.displayName ?? '',
+            displayName: displayName,
+            avatarUrl: avatarUrl,
             emoji: emoji,
           );
     } catch (_) {
@@ -568,7 +582,7 @@ class _EmojiBubbleState extends State<_EmojiBubble>
     _ctrl = AnimationController(
       vsync: this,
       // 2.4s — đủ thong thả để mắt theo dõi quỹ đạo, không cảm giác "vọt".
-      duration: const Duration(milliseconds: 2400),
+      duration: const Duration(milliseconds: 3000),
     )
       ..forward()
       ..addStatusListener((s) {

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -9,6 +9,10 @@ import 'package:meep/core/theme/hex_color.dart';
 import 'package:meep/features/chat/application/chat_controller.dart';
 import 'package:meep/features/feed/application/feed_controller.dart';
 import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/reaction/application/reaction_controller.dart';
+import 'package:meep/features/reaction/data/reaction.dart';
+import 'package:meep/features/reaction/presentation/emoji_picker_sheet.dart';
+import 'package:meep/features/reaction/presentation/reaction_list_sheet.dart';
 import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/post_card.dart';
@@ -148,53 +152,114 @@ class PostHeaderRow extends StatelessWidget {
   }
 }
 
-/// Activity pill — own posts only ("Chưa có hoạt động nào!"). Hug content,
-/// transparent rounded background. Centered in its parent.
-class ActivityPill extends StatelessWidget {
-  const ActivityPill({super.key});
+/// Activity pill — own posts only. Two states:
+/// - Empty: "Chưa có hoạt động nào!" (M2 fallback khi chưa có react)
+/// - Has reactions: "Hoạt động" + stacked avatars + ReactionListSheet on tap
+class ActivityPill extends ConsumerWidget {
+  const ActivityPill({super.key, required this.postId});
+
+  final String postId;
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
-      decoration: BoxDecoration(
-        color: const Color(0x66252627),
-        borderRadius: BorderRadius.circular(40),
-      ),
-      child: const Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.auto_awesome_outlined,
-            color: AppColors.bw400,
-            size: 18,
-          ),
-          SizedBox(width: 10),
-          Text(
-            'Chưa có hoạt động nào!',
-            style: TextStyle(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(reactionControllerProvider(postId));
+    final reactions = state.reactions;
+    final isEmpty = reactions.isEmpty;
+
+    return GestureDetector(
+      onTap: isEmpty ? null : () => ReactionListSheet.show(context, postId),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
+        decoration: BoxDecoration(
+          color: const Color(0x66252627),
+          borderRadius: BorderRadius.circular(40),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.auto_awesome_outlined,
               color: AppColors.bw400,
-              fontSize: 18,
-              fontWeight: FontWeight.w700,
-              fontFamily: 'Nunito',
+              size: 18,
             ),
-          ),
-        ],
+            const SizedBox(width: 10),
+            Text(
+              isEmpty ? 'Chưa có hoạt động nào!' : 'Hoạt động',
+              style: TextStyle(
+                color: isEmpty ? AppColors.bw400 : AppColors.bw100,
+                fontSize: 18,
+                fontWeight: FontWeight.w700,
+                fontFamily: 'Nunito',
+              ),
+            ),
+            if (!isEmpty) ...[
+              const SizedBox(width: 10),
+              _AvatarStack(reactions: reactions),
+            ],
+          ],
+        ),
       ),
     );
   }
 }
 
+/// Stacked avatars — max 3 first + "+N" badge if count > 3.
+/// Figma 472:2052 node 769:4494.
+class _AvatarStack extends StatelessWidget {
+  const _AvatarStack({required this.reactions});
+
+  final List<Reaction> reactions;
+
+  @override
+  Widget build(BuildContext context) {
+    final top3 = reactions.length <= 3
+        ? reactions
+        : reactions.sublist(0, 3); // already sorted DESC from State
+    final overflow = reactions.length - 3;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final r in top3)
+          Padding(
+            padding: const EdgeInsets.only(right: 2),
+            child: AppAvatar(
+              fallbackText: r.reactorName,
+              size: 32,
+            ),
+          ),
+        if (overflow > 0)
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: AppColors.bw300,
+              shape: BoxShape.circle,
+              border: Border.all(color: AppColors.bw100, width: 1),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              '+$overflow',
+              style: const TextStyle(
+                color: AppColors.bw700,
+                fontSize: 14,
+                fontFamily: 'Roboto',
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
 /// Friend message bar — 2-state inline composer trên Feed:
-/// - **Collapsed** (mặc định): text "Gửi tin nhắn..." + 3 emoji quick-react +
-///   icon add-reaction. Tap vùng text trái → expand sang TextField.
+/// - **Collapsed** (mặc định): text "Gửi tin nhắn..." + 3 emoji quick-react
+///   (🩵🤣🥰 — Figma 472:2252) + smile-plus picker. Tap text trái → expand
+///   sang modal composer. Tap emoji → `ReactionController.toggleReact`
+///   (optimistic + in-flight lock). Tap smile-plus → `EmojiPickerSheet`.
 /// - **Expanded:** TextField focused + send button. Tap-outside hoặc submit →
 ///   collapse. Submit gọi `ChatController.sendMessageFromFeed(postId, authorId)`
-///   để tạo/lookup direct conversation rồi append message. KHÔNG navigate —
-///   theo spec, user vẫn ở Feed sau khi gửi (input chỉ collapse).
-///
-/// Emoji quick-react ở collapsed state hiện chưa wire (chờ T5 reactions —
-/// `tasks/todo-chat.md`). Trong PR này chỉ wire text → send flow.
+///   để tạo/lookup direct conversation rồi append message.
 class FriendMessageBar extends ConsumerStatefulWidget {
   const FriendMessageBar({
     super.key,
@@ -203,7 +268,8 @@ class FriendMessageBar extends ConsumerStatefulWidget {
     this.spaceId,
   });
 
-  /// postId — context cho `sendMessageFromFeed` (lưu quotedPostId tương lai).
+  /// postId — context cho `sendMessageFromFeed` (lưu quotedPostId tương lai)
+  /// và cho `reactionControllerProvider(postId)`.
   final String postId;
 
   /// authorId — peer uid để `getOrCreateConversation` tính pairId.
@@ -222,6 +288,8 @@ class FriendMessageBar extends ConsumerStatefulWidget {
 
 class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
   bool _isSending = false;
+
+  static const _presets = ['🩵', '🤣', '🥰'];
 
   /// Mở modal bottom sheet composer thay vì inline TextField.
   ///
@@ -281,10 +349,52 @@ class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
     );
   }
 
+  /// Safe toggle reaction — bắt lỗi, toast message nếu fail.
+  void _toggleReaction(String emoji) {
+    try {
+      final auth = FirebaseAuth.instance;
+      final uid = auth.currentUser?.uid;
+      if (uid == null) return;
+      ref.read(reactionControllerProvider(widget.postId).notifier).toggleReact(
+            uid: uid,
+            displayName: auth.currentUser?.displayName ?? '',
+            emoji: emoji,
+          );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Thả cảm xúc thất bại — thử lại'),
+          backgroundColor: AppColors.bw700,
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final screenW = MediaQuery.sizeOf(context).width;
     final screenH = MediaQuery.sizeOf(context).height;
+    final reactionState = ref.watch(reactionControllerProvider(widget.postId));
+
+    // Show error toast nếu reaction controller có errorMessage.
+    if (reactionState.errorMessage != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(reactionState.errorMessage!),
+            backgroundColor: AppColors.bw700,
+            duration: const Duration(seconds: 2),
+          ),
+        );
+        ref
+            .read(reactionControllerProvider(widget.postId).notifier)
+            .clearError();
+      });
+    }
+
     return Container(
       height: screenH * 0.07,
       width: screenW * 0.8,
@@ -310,18 +420,51 @@ class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
               ),
             ),
           ),
-          const Text('💙', style: TextStyle(fontSize: 18)),
+          for (final emoji in _presets)
+            _EmojiButton(
+              emoji: emoji,
+              isActive: reactionState.myEmoji == emoji,
+              onTap: () => _toggleReaction(emoji),
+            ),
           const SizedBox(width: 10),
-          const Text('😂', style: TextStyle(fontSize: 18)),
-          const SizedBox(width: 10),
-          const Text('🥰', style: TextStyle(fontSize: 18)),
-          const SizedBox(width: 10),
-          const Icon(
-            Icons.add_reaction_outlined,
-            color: AppColors.bw500,
-            size: 20,
+          GestureDetector(
+            onTap: () => EmojiPickerSheet.show(context, _toggleReaction),
+            child: const Icon(
+              Icons.add_reaction_outlined,
+              color: AppColors.bw500,
+              size: 20,
+            ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _EmojiButton extends StatelessWidget {
+  const _EmojiButton({
+    required this.emoji,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  final String emoji;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: Opacity(
+          opacity: isActive ? 1.0 : 0.6,
+          child: Text(
+            emoji,
+            style: const TextStyle(fontSize: 24),
+          ),
+        ),
       ),
     );
   }
@@ -502,7 +645,7 @@ class OwnPostFooter extends StatelessWidget {
       children: [
         PostHeaderRow(post: post, isOwn: true),
         const SizedBox(height: 12),
-        const ActivityPill(),
+        ActivityPill(postId: post.postId),
       ],
     );
   }
@@ -536,7 +679,7 @@ class OwnPostPage extends ConsumerWidget {
         const SizedBox(height: 8),
         PostHeaderRow(post: post, isOwn: true),
         const Spacer(),
-        const ActivityPill(),
+        ActivityPill(postId: post.postId),
         SizedBox(height: screenH * _bottomGapRatio),
       ],
     );

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -403,18 +403,18 @@ class _FriendMessageBarState extends ConsumerState<FriendMessageBar> {
   ///
   /// displayName + avatarUrl lấy từ UserProfile (Firestore /users/{uid}) thay
   /// vì chỉ FirebaseAuth.currentUser — đảm bảo có data đúng cho mọi auth method
-  /// (Google / email signup). Fallback FirebaseAuth nếu profile chưa load.
+  /// (Google / email signup). uid lấy từ currentUidProvider (auth abstraction)
+  /// thay vì FirebaseAuth.instance trực tiếp — giữ layering UI → repository.
   void _toggleReaction(String emoji, [GlobalKey? sourceKey]) {
     if (sourceKey != null) _spawnBubbles(emoji, sourceKey);
     try {
-      final auth = FirebaseAuth.instance;
-      final uid = auth.currentUser?.uid;
+      final uid = ref.read(currentUidProvider).valueOrNull;
       if (uid == null) return;
       final profile = ref.read(currentUserProfileProvider).valueOrNull;
       final displayName = (profile?.displayName.isNotEmpty ?? false)
           ? profile!.displayName
-          : (auth.currentUser?.displayName ?? '');
-      final avatarUrl = profile?.avatarUrl ?? auth.currentUser?.photoURL;
+          : '';
+      final avatarUrl = profile?.avatarUrl;
       ref.read(reactionControllerProvider(widget.postId).notifier).toggleReact(
             uid: uid,
             displayName: displayName,

--- a/apps/mobile/lib/features/reaction/application/reaction_controller.dart
+++ b/apps/mobile/lib/features/reaction/application/reaction_controller.dart
@@ -59,9 +59,13 @@ class ReactionController extends _$ReactionController {
   ///
   /// Optimistic update: state thay đổi ngay, rollback khi Firestore fail.
   /// In-flight lock: tap thứ 2 bị bỏ qua khi `isSubmitting`.
+  ///
+  /// [avatarUrl] denormalize từ UserProfile.avatarUrl — null OK (fallback
+  /// sang initials trong ReactionListSheet).
   Future<void> toggleReact({
     required String uid,
     required String displayName,
+    String? avatarUrl,
     required String emoji,
   }) async {
     if (state.isSubmitting) return; // in-flight lock
@@ -85,6 +89,7 @@ class ReactionController extends _$ReactionController {
       existing: existing,
       uid: uid,
       displayName: displayName,
+      avatarUrl: avatarUrl,
       emoji: emoji,
     );
     final newMyEmoji = (existing?.emoji == emoji) ? null : emoji;
@@ -103,6 +108,7 @@ class ReactionController extends _$ReactionController {
           postId: _postId,
           reactorUid: uid,
           reactorName: displayName,
+          reactorAvatarUrl: avatarUrl,
           emoji: emoji,
         );
       }
@@ -127,6 +133,7 @@ class ReactionController extends _$ReactionController {
     required Reaction? existing,
     required String uid,
     required String displayName,
+    String? avatarUrl,
     required String emoji,
   }) {
     if (existing == null) {
@@ -136,6 +143,7 @@ class ReactionController extends _$ReactionController {
         Reaction(
           reactorUid: uid,
           reactorName: displayName,
+          reactorAvatarUrl: avatarUrl,
           emoji: emoji,
           createdAt: DateTime.now(),
         ),

--- a/apps/mobile/lib/features/reaction/data/firebase_reaction_repository.dart
+++ b/apps/mobile/lib/features/reaction/data/firebase_reaction_repository.dart
@@ -23,12 +23,15 @@ class FirebaseReactionRepository implements ReactionRepository {
     required String postId,
     required String reactorUid,
     required String reactorName,
+    String? reactorAvatarUrl,
     required String emoji,
   }) async {
     // docId = reactorUid → enforce 1 reaction/user/post. set() upsert, KHÔNG add().
     await _reactionsRef(postId).doc(reactorUid).set({
       'reactorUid': reactorUid,
       'reactorName': reactorName,
+      if (reactorAvatarUrl != null && reactorAvatarUrl.isNotEmpty)
+        'reactorAvatarUrl': reactorAvatarUrl,
       'emoji': emoji,
       'createdAt': FieldValue.serverTimestamp(),
     });

--- a/apps/mobile/lib/features/reaction/data/reaction.dart
+++ b/apps/mobile/lib/features/reaction/data/reaction.dart
@@ -11,6 +11,10 @@ class Reaction with _$Reaction {
     required String reactorUid,
     required String reactorName,
 
+    /// Avatar URL (denormalized từ UserProfile khi upsert). Null/empty →
+    /// ReactionListSheet fallback sang initials của reactorName.
+    String? reactorAvatarUrl,
+
     /// Single emoji character e.g. "😂"
     required String emoji,
     @TimestampConverter() required DateTime createdAt,

--- a/apps/mobile/lib/features/reaction/data/reaction_repository.dart
+++ b/apps/mobile/lib/features/reaction/data/reaction_repository.dart
@@ -5,10 +5,13 @@ abstract class ReactionRepository {
   Stream<List<Reaction>> watchReactions(String postId);
 
   /// Create or replace the calling user's reaction on [postId].
+  /// [reactorAvatarUrl] denormalize từ UserProfile để ReactionListSheet
+  /// render avatar không cần extra read.
   Future<void> upsertReaction({
     required String postId,
     required String reactorUid,
     required String reactorName,
+    String? reactorAvatarUrl,
     required String emoji,
   });
 

--- a/apps/mobile/lib/features/reaction/presentation/emoji_picker_sheet.dart
+++ b/apps/mobile/lib/features/reaction/presentation/emoji_picker_sheet.dart
@@ -1,11 +1,110 @@
 import 'package:flutter/material.dart';
 
-// TODO(R/T3/TBD): implement EmojiPickerSheet per Figma
+import 'package:meep/core/theme/app_colors.dart';
+
+/// Full emoji picker bottom sheet. Mở từ smile-plus button trong
+/// FriendPostActBar (Figma 472:2252). Không có search (MVP scope).
 class EmojiPickerSheet extends StatelessWidget {
   const EmojiPickerSheet({super.key, required this.onEmojiSelected});
 
   final ValueChanged<String> onEmojiSelected;
 
+  static void show(BuildContext context, ValueChanged<String> onSelected) {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: AppColors.bw800,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => EmojiPickerSheet(onEmojiSelected: onSelected),
+    );
+  }
+
   @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: MediaQuery.sizeOf(context).height * 0.4,
+      child: GridView.builder(
+        padding: const EdgeInsets.all(16),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 7,
+          mainAxisSpacing: 12,
+          crossAxisSpacing: 12,
+        ),
+        itemCount: _emojis.length,
+        itemBuilder: (context, index) {
+          final emoji = _emojis[index];
+          return GestureDetector(
+            onTap: () {
+              onEmojiSelected(emoji);
+              Navigator.of(context).pop();
+            },
+            child: Center(
+              child: Text(emoji, style: const TextStyle(fontSize: 28)),
+            ),
+          );
+        },
+      ),
+    );
+  }
 }
+
+/// Limited emoji set cho MVP — no search, no categories.
+const _emojis = [
+  '😀',
+  '😃',
+  '😄',
+  '😁',
+  '😅',
+  '😂',
+  '🤣',
+  '😊',
+  '😇',
+  '🙂',
+  '😉',
+  '😌',
+  '😍',
+  '🥰',
+  '😘',
+  '😗',
+  '😋',
+  '😛',
+  '😜',
+  '🤪',
+  '😝',
+  '😎',
+  '🤩',
+  '🥳',
+  '😏',
+  '😒',
+  '😞',
+  '😔',
+  '😢',
+  '😭',
+  '😤',
+  '😡',
+  '🤬',
+  '😈',
+  '👿',
+  '👍',
+  '👎',
+  '👏',
+  '🙌',
+  '🤝',
+  '💪',
+  '🫶',
+  '❤️',
+  '🧡',
+  '💛',
+  '💚',
+  '💙',
+  '💜',
+  '🩵',
+  '🔥',
+  '⭐',
+  '🎉',
+  '💯',
+  '✨',
+  '💩',
+  '👀',
+];

--- a/apps/mobile/lib/features/reaction/presentation/reaction_list_sheet.dart
+++ b/apps/mobile/lib/features/reaction/presentation/reaction_list_sheet.dart
@@ -1,11 +1,121 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// TODO(R/T4/TBD): implement ReactionListSheet per Figma
-class ReactionListSheet extends StatelessWidget {
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/features/reaction/application/reaction_controller.dart';
+import 'package:meep/features/reaction/data/reaction.dart';
+import 'package:meep/shared/widgets/app_avatar.dart';
+
+/// Bottom sheet hiển thị danh sách ai đã react vào post của mình.
+/// Figma 769:6014 — "Phản ứng" title + [avatar][name][emoji] rows.
+/// Sort newest first (createdAt DESC). Row inert — không nav profile (MVP).
+class ReactionListSheet extends ConsumerWidget {
   const ReactionListSheet({super.key, required this.postId});
 
   final String postId;
 
+  static Future<void> show(BuildContext context, String postId) {
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: AppColors.bw800,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => ReactionListSheet(postId: postId),
+    );
+  }
+
   @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(reactionControllerProvider(postId));
+    final reactions = state.reactions;
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.4,
+      minChildSize: 0.25,
+      maxChildSize: 0.8,
+      expand: false,
+      builder: (context, scrollController) {
+        return Column(
+          children: [
+            const SizedBox(height: 12),
+            // Drag handle
+            Container(
+              width: 55,
+              height: 5,
+              decoration: BoxDecoration(
+                color: AppColors.bw700,
+                borderRadius: BorderRadius.circular(6.5),
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Phản ứng',
+              style: TextStyle(
+                color: AppColors.bw100,
+                fontSize: 18,
+                fontWeight: FontWeight.w700,
+                fontFamily: 'Nunito',
+              ),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: reactions.isEmpty
+                  ? const Center(
+                      child: Text(
+                        'Chưa có phản ứng nào',
+                        style: TextStyle(color: AppColors.bw400),
+                      ),
+                    )
+                  : ListView.builder(
+                      controller: scrollController,
+                      itemCount: reactions.length,
+                      itemBuilder: (context, index) {
+                        final r = reactions[index];
+                        return _ReactionRow(reaction: r);
+                      },
+                    ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ReactionRow extends StatelessWidget {
+  const _ReactionRow({required this.reaction});
+
+  final Reaction reaction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 10),
+      child: Row(
+        children: [
+          AppAvatar(
+            fallbackText: reaction.reactorName,
+            size: 50,
+          ),
+          const SizedBox(width: 16),
+          Text(
+            reaction.reactorName,
+            style: const TextStyle(
+              color: AppColors.bw100,
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              fontFamily: 'Nunito',
+            ),
+          ),
+          const Spacer(),
+          Text(
+            reaction.emoji,
+            style: const TextStyle(fontSize: 24),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/apps/mobile/lib/features/reaction/presentation/reaction_list_sheet.dart
+++ b/apps/mobile/lib/features/reaction/presentation/reaction_list_sheet.dart
@@ -89,27 +89,42 @@ class _ReactionRow extends StatelessWidget {
 
   final Reaction reaction;
 
+  /// Lấy chữ cái đầu của display name làm avatar fallback. Trim + uppercase.
+  /// Empty name → '?' để không crash UI.
+  static String _initialOf(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return '?';
+    return trimmed[0].toUpperCase();
+  }
+
   @override
   Widget build(BuildContext context) {
+    final displayName =
+        reaction.reactorName.isNotEmpty ? reaction.reactorName : 'Bạn';
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 10),
       child: Row(
         children: [
           AppAvatar(
-            fallbackText: reaction.reactorName,
+            imageUrl: reaction.reactorAvatarUrl,
+            fallbackText: _initialOf(reaction.reactorName),
             size: 50,
           ),
           const SizedBox(width: 16),
-          Text(
-            reaction.reactorName,
-            style: const TextStyle(
-              color: AppColors.bw100,
-              fontSize: 16,
-              fontWeight: FontWeight.w700,
-              fontFamily: 'Nunito',
+          Expanded(
+            child: Text(
+              displayName,
+              style: const TextStyle(
+                color: AppColors.bw100,
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                fontFamily: 'Nunito',
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
           ),
-          const Spacer(),
+          const SizedBox(width: 12),
           Text(
             reaction.emoji,
             style: const TextStyle(fontSize: 24),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -19,6 +19,8 @@ import 'package:meep/features/auth/data/firebase_auth_repository.dart';
 import 'package:meep/features/auth/data/firebase_user_repository.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/chat/application/chat_controller.dart';
+import 'package:meep/features/reaction/application/reaction_controller.dart';
+import 'package:meep/features/reaction/data/firebase_reaction_repository.dart';
 import 'package:meep/features/chat/data/firebase_conversation_repository.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/firebase_friend_repository.dart';
@@ -100,6 +102,9 @@ void main() async {
         ),
         widgetDataServiceProvider.overrideWithValue(
           WidgetDataService(prefs: prefs),
+        ),
+        reactionRepositoryProvider.overrideWithValue(
+          FirebaseReactionRepository(FirebaseFirestore.instance),
         ),
       ],
       child: const MeepApp(),

--- a/apps/mobile/test/features/feed/presentation/friend_message_bar_test.dart
+++ b/apps/mobile/test/features/feed/presentation/friend_message_bar_test.dart
@@ -10,6 +10,8 @@ import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/chat/data/conversation.dart';
 import 'package:meep/features/chat/data/firebase_conversation_repository.dart';
 import 'package:meep/features/feed/presentation/feed_section.dart';
+import 'package:meep/features/reaction/application/reaction_controller.dart';
+import 'package:meep/features/reaction/data/firebase_reaction_repository.dart';
 
 void main() {
   const myUid = 'uid-me';
@@ -72,6 +74,8 @@ void main() {
         overrides: [
           conversationRepositoryProvider.overrideWithValue(repo),
           currentChatUidProvider.overrideWith((ref) => myUid),
+          reactionRepositoryProvider
+              .overrideWithValue(FirebaseReactionRepository(firestore)),
         ],
         child: MaterialApp.router(routerConfig: router),
       ),
@@ -84,8 +88,8 @@ void main() {
       await pump(tester);
 
       expect(find.text('Gửi tin nhắn...'), findsOneWidget);
-      expect(find.text('💙'), findsOneWidget);
-      expect(find.text('😂'), findsOneWidget);
+      expect(find.text('🩵'), findsOneWidget);
+      expect(find.text('🤣'), findsOneWidget);
       expect(find.text('🥰'), findsOneWidget);
       expect(find.byIcon(Icons.add_reaction_outlined), findsOneWidget);
       // Composer chưa expand → KHÔNG có TextField.
@@ -129,7 +133,7 @@ void main() {
 
       // Sheet đóng — TextField mất, collapsed bar còn nguyên emoji pills.
       expect(find.byType(TextField), findsNothing);
-      expect(find.text('💙'), findsOneWidget);
+      expect(find.text('🩵'), findsOneWidget);
     });
   });
 

--- a/apps/mobile/test/features/feed/presentation/friend_message_bar_test.dart
+++ b/apps/mobile/test/features/feed/presentation/friend_message_bar_test.dart
@@ -88,7 +88,7 @@ void main() {
       await pump(tester);
 
       expect(find.text('Gửi tin nhắn...'), findsOneWidget);
-      expect(find.text('🩵'), findsOneWidget);
+      expect(find.text('💙'), findsOneWidget);
       expect(find.text('🤣'), findsOneWidget);
       expect(find.text('🥰'), findsOneWidget);
       expect(find.byIcon(Icons.add_reaction_outlined), findsOneWidget);
@@ -133,7 +133,7 @@ void main() {
 
       // Sheet đóng — TextField mất, collapsed bar còn nguyên emoji pills.
       expect(find.byType(TextField), findsNothing);
-      expect(find.text('🩵'), findsOneWidget);
+      expect(find.text('💙'), findsOneWidget);
     });
   });
 

--- a/apps/mobile/test/features/feed/presentation/own_post_card_test.dart
+++ b/apps/mobile/test/features/feed/presentation/own_post_card_test.dart
@@ -1,8 +1,16 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 
 import 'package:meep/features/feed/data/post.dart';
 import 'package:meep/features/feed/presentation/feed_section.dart';
+import 'package:meep/features/reaction/application/reaction_controller.dart';
+import 'package:meep/features/reaction/data/reaction_repository.dart';
+
+class MockReactionRepository extends Mock implements ReactionRepository {}
 
 Post _post({DateTime? createdAt}) => Post(
       postId: 'p1',
@@ -14,18 +22,28 @@ Post _post({DateTime? createdAt}) => Post(
     );
 
 void main() {
-  // The test font renders much wider than Nunito (Figma measures the activity
-  // pill at ~255px). Use a large physical surface so photoSize is wide enough
-  // to avoid a font-driven overflow that never happens in the real app, and
-  // scroll vertically like the real feed (SliverList) / home (scroll view).
+  setUpAll(() => registerFallbackValue(''));
+
+  ProviderScope makeScope(Widget child) {
+    final repo = MockReactionRepository();
+    when(() => repo.watchReactions(any()))
+        .thenAnswer((_) => const Stream.empty());
+    return ProviderScope(
+      overrides: [reactionRepositoryProvider.overrideWithValue(repo)],
+      child: child,
+    );
+  }
+
   Future<void> pump(WidgetTester tester, Post post) async {
     tester.view.physicalSize = const Size(900, 1600);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SingleChildScrollView(child: OwnPostCard(post: post)),
+      makeScope(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(child: OwnPostCard(post: post)),
+          ),
         ),
       ),
     );

--- a/apps/mobile/test/features/reaction/presentation/reaction_sheets_test.dart
+++ b/apps/mobile/test/features/reaction/presentation/reaction_sheets_test.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/features/reaction/application/reaction_controller.dart';
+import 'package:meep/features/reaction/data/reaction_repository.dart';
+import 'package:meep/features/reaction/presentation/emoji_picker_sheet.dart';
+import 'package:meep/features/reaction/presentation/reaction_list_sheet.dart';
+
+class MockReactionRepository extends Mock implements ReactionRepository {}
+
+Widget _makeScope(Widget child) {
+  final repo = MockReactionRepository();
+  when(() => repo.watchReactions(any()))
+      .thenAnswer((_) => const Stream.empty());
+  return ProviderScope(
+    overrides: [reactionRepositoryProvider.overrideWithValue(repo)],
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  setUpAll(() => registerFallbackValue(''));
+
+  group('EmojiPickerSheet', () {
+    testWidgets('renders emoji grid with presets', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: EmojiPickerSheet(onEmojiSelected: (_) {}),
+          ),
+        ),
+      );
+
+      expect(find.byType(GridView), findsOneWidget);
+      expect(find.text('🤣'), findsOneWidget);
+    });
+
+    testWidgets('tap emoji fires callback', (tester) async {
+      String? selected;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: EmojiPickerSheet(onEmojiSelected: (e) => selected = e),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('🤣'));
+      expect(selected, '🤣');
+    });
+  });
+
+  group('ReactionListSheet', () {
+    testWidgets('renders title "Phản ứng"', (tester) async {
+      await tester
+          .pumpWidget(_makeScope(const ReactionListSheet(postId: 'p1')));
+      expect(find.text('Phản ứng'), findsOneWidget);
+    });
+  });
+}

--- a/docs/specs/2026-05-23-reaction.md
+++ b/docs/specs/2026-05-23-reaction.md
@@ -114,15 +114,17 @@ ActText bar → tap "[N] reactions" hoặc vùng count
 
 ```
 {
-  reactorUid:   string,    // documentId = reactorUid (enforce 1 reaction/user/post)
-  reactorName:  string,    // denormalized displayName
-  emoji:        string,    // single emoji char, vd "😂"
-  createdAt:    Timestamp, // serverTimestamp() — dùng cho sort
+  reactorUid:        string,    // documentId = reactorUid (enforce 1 reaction/user/post)
+  reactorName:       string,    // denormalized displayName từ UserProfile
+  reactorAvatarUrl:  string?,   // denormalized avatarUrl từ UserProfile (optional)
+  emoji:             string,    // single emoji char, vd "😂"
+  createdAt:         Timestamp, // serverTimestamp() — dùng cho sort
 }
 ```
 
-> **Document ID = `reactorUid`** — tự enforce 1 reaction/user/post. Set (upsert) thay vì add.  
+> **Document ID = `reactorUid`** — tự enforce 1 reaction/user/post. Set (upsert) thay vì add.
 > Thay đổi emoji = overwrite cùng documentId. Bỏ react = delete document.
+> **`reactorAvatarUrl` denormalize** từ `UserProfile.avatarUrl` để ReactionListSheet không cần extra read. Null/empty → fallback initials. **Eventually consistent:** nếu user đổi avatar, reaction cũ giữ avatar URL cũ cho tới khi react lại.
 
 ---
 
@@ -183,7 +185,10 @@ match /posts/{postId}/reactions/{reactorUid} {
                 && request.auth.uid == request.resource.data.reactorUid;
   allow update: if isAuthed()
                 && request.auth.uid == reactorUid
-                && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emoji', 'createdAt']);
+                && request.resource.data.diff(resource.data).affectedKeys()
+                     .hasOnly(['emoji', 'createdAt', 'reactorName', 'reactorAvatarUrl']);
+  // reactorName + reactorAvatarUrl whitelist vì denormalize từ UserProfile
+  // — user đổi profile → react lại thì doc sẽ refresh các field này.
   allow delete: if isAuthed() && request.auth.uid == reactorUid;
 }
 ```


### PR DESCRIPTION
## Mô tả

Triển khai toàn bộ presentation layer cho Reaction module:
- **FriendMessageBar M3**: 3 emoji preset 🩵🤣🥰 + smile-plus, kết nối ReactionController, active state, error toast
- **ActivityPill M3**: 2 state (empty "Chưa có hoạt động nào!" / "Hoạt động" + stacked avatars top 3 + "+N"), tap mở ReactionListSheet
- **EmojiPickerSheet**: grid 56 emoji MVP, tap → toggleReact + auto-close
- **ReactionListSheet**: bottom sheet draggable, list [avatar][name][emoji] sort DESC, row inert MVP
- Wire `reactionRepositoryProvider` trong `main.dart`

Cross-module touch Feed module (feed_section.dart) — OK per leader.

## Refs

- Closes #124
- Epic: #121
- Spec: `docs/specs/2026-05-23-reaction.md`
- Plan: `docs/plans/2026-05-23-reaction.md` (Task T3 + T4)

## Thay đổi chính

- `apps/mobile/lib/main.dart`: wire `reactionRepositoryProvider` → `FirebaseReactionRepository`
- `apps/mobile/lib/features/feed/presentation/feed_section.dart`: update `FriendMessageBar` (ConsumerWidget, 3 emoji preset + controller) và `ActivityPill` (ConsumerWidget, 2 state + avatar stack)
- `apps/mobile/lib/features/reaction/presentation/emoji_picker_sheet.dart`: implement từ stub (grid 56 emoji, no search)
- `apps/mobile/lib/features/reaction/presentation/reaction_list_sheet.dart`: implement từ stub (draggable sheet, list reactions)
- `apps/mobile/test/features/reaction/presentation/reaction_sheets_test.dart`: 3 widget tests mới
- `apps/mobile/test/features/feed/presentation/own_post_card_test.dart`: fix test cho ActivityPill mới (ProviderScope override)

## Loại thay đổi

- [x] feat — Tính năng mới

## Test

- [x] `flutter test` (full suite) — 497/497 PASS
- [x] `flutter analyze --fatal-infos` — No issues found
- [x] `dart format --set-exit-if-changed` — 0 changed

### Cách test thủ công

1. `cd apps/mobile && flutter run`
2. Mở feed → bài của bạn: check ActText bar hiện "Gửi tin nhắn..." + 🩵🤣🥰 + smile icon
3. Tap 🩵 → emoji highlight active, count tăng (optimistic)
4. Tap lại 🩵 → un-highlight (un-react)
5. Tap smile-plus → EmojiPickerSheet opens (grid emoji), chọn emoji → sheet close + toggleReact
6. Mở bài của mình → check ActivityPill: nếu có reactions → "Hoạt động" + avatar stack + "+N"
7. Tap "Hoạt động" → ReactionListSheet opens với danh sách reactions
8. Nếu không có reactions → "Chưa có hoạt động nào!" + no tap action

## Lưu ý cho reviewer

1. **M2 fallback:** FriendMessageBar + ActivityPill dùng `ref.watch(reactionControllerProvider(postId))` — nếu provider chưa wire, app crash. Đã wire trong main.dart. Trong M2 (trước T1 merge), ActText là no-op `SizedBox.shrink()`.

2. **"Gửi tin nhắn..." no-op M3:** FriendMessageBar giữ text input placeholder, tap không mở keyboard. Chat 1-1 từ ảnh thuộc Tier 1 (Chat module).

3. **ReactionListSheet row inert:** không nav `FriendProfileScreen` khi tap avatar (quyết định A của leader). Sẽ add sau.

4. **Cross-module touch:** Feed module (feed_section.dart) — leader `@manhthien2005` đã cho phép.

## Self-review checklist

- [x] Branch name `feature/NganTNK/reaction-ui`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] No secret, no debug print, no dead code
- [x] Cross-module touch: allowed
- [x] `/review` passed — no 🔴/🟡