### PR TITLE
feat(widget): T4 widget + T5 sync worker + deeplink scroll tới post

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/dev/meep/meep/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/dev/meep/meep/MainActivity.kt
@@ -1,5 +1,69 @@
 package dev.meep.meep
 
+import android.annotation.TargetApi
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Build
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private var widgetChannel: MethodChannel? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        widgetChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "meep/widget",
+        )
+        widgetChannel?.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "updateWidget" -> {
+                    // Flutter just wrote new data to SharedPreferences —
+                    // kick an immediate one-time refresh so the widget
+                    // picks up the latest post photo + badge count.
+                    WidgetSyncWorker.enqueueOneTime(this@MainActivity)
+                    result.success(null)
+                }
+                "requestPinAppWidget" -> {
+                    val appWidgetManager = AppWidgetManager.getInstance(this@MainActivity)
+                    if (appWidgetManager.isRequestPinAppWidgetSupported) {
+                        pinWidgetViaLauncher(appWidgetManager)
+                        result.success(true)
+                    } else {
+                        // Launcher không hỗ trợ (Android < 8.0, custom ROM
+                        // như Xiaomi MIUI cũ) — Dart sẽ hiện toast manual.
+                        result.success(false)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // Cold start from widget tap — forward extras to Flutter.
+        // MethodChannel buffers the call until Flutter registers its handler.
+        forwardWidgetTap(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        forwardWidgetTap(intent)
+    }
+
+    private fun forwardWidgetTap(intent: Intent) {
+        val action = intent.getStringExtra("action") ?: return
+        widgetChannel?.invokeMethod("onWidgetTap", mapOf(
+            "action" to action,
+            "postId" to intent.getStringExtra("postId"),
+        ))
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    private fun pinWidgetViaLauncher(appWidgetManager: AppWidgetManager) {
+        val componentName = ComponentName(this@MainActivity, MeepWidget::class.java)
+        appWidgetManager.requestPinAppWidget(componentName, null, null)
+    }
+}

--- a/apps/mobile/android/app/src/main/kotlin/dev/meep/meep/MeepWidget.kt
+++ b/apps/mobile/android/app/src/main/kotlin/dev/meep/meep/MeepWidget.kt
@@ -1,8 +1,10 @@
 package dev.meep.meep
 
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
+import android.content.Intent
 import android.view.View
 import android.widget.RemoteViews
 
@@ -60,6 +62,7 @@ class MeepWidget : AppWidgetProvider() {
         } else {
             applyData(views, data)
         }
+        applyTapIntent(context, views, data?.postId)
         return views
     }
 
@@ -87,6 +90,36 @@ class MeepWidget : AppWidgetProvider() {
             views.setViewVisibility(R.id.widget_caption, View.VISIBLE)
         } else {
             views.setViewVisibility(R.id.widget_caption, View.GONE)
+        }
+    }
+
+    companion object {
+        /**
+         * Apply the tap-to-open PendingIntent on the widget root.
+         *
+         * When [postId] is non-null the intent carries extras so
+         * [MainActivity] deep-links to the corresponding post. When null
+         * (placeholder) the app opens at Home.
+         *
+         * Also called by [WidgetSyncWorker] so the PendingIntent is present
+         * on every RemoteViews update (not just the initial [onUpdate]).
+         */
+        fun applyTapIntent(context: Context, views: RemoteViews, postId: String?) {
+            val intent = Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                if (postId != null) {
+                    putExtra("action", "OPEN_POST")
+                    putExtra("postId", postId)
+                }
+            }
+            val requestCode = postId?.hashCode() ?: 0
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                requestCode,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+            views.setOnClickPendingIntent(R.id.meep_widget_root, pendingIntent)
         }
     }
 }

--- a/apps/mobile/android/app/src/main/kotlin/dev/meep/meep/WidgetSyncWorker.kt
+++ b/apps/mobile/android/app/src/main/kotlin/dev/meep/meep/WidgetSyncWorker.kt
@@ -191,7 +191,7 @@ class WidgetSyncWorker(
     }
 
     private fun renderPlaceholder() {
-        pushRemoteViews { views ->
+        pushRemoteViews(null) { views ->
             views.setViewVisibility(R.id.widget_placeholder, View.VISIBLE)
             views.setViewVisibility(R.id.widget_photo, View.GONE)
             views.setViewVisibility(R.id.widget_avatar, View.GONE)
@@ -206,7 +206,7 @@ class WidgetSyncWorker(
         avatar: Bitmap?,
         unreadCount: Int,
     ) {
-        pushRemoteViews { views ->
+        pushRemoteViews(post.postId) { views ->
             views.setViewVisibility(R.id.widget_placeholder, View.GONE)
 
             views.setImageViewBitmap(R.id.widget_photo, photo)
@@ -238,13 +238,14 @@ class WidgetSyncWorker(
         }
     }
 
-    private fun pushRemoteViews(build: (RemoteViews) -> Unit) {
+    private fun pushRemoteViews(postId: String?, build: (RemoteViews) -> Unit) {
         val manager = AppWidgetManager.getInstance(applicationContext)
         val component = ComponentName(applicationContext, MeepWidget::class.java)
         val ids = manager.getAppWidgetIds(component)
         if (ids.isEmpty()) return
         val views = RemoteViews(applicationContext.packageName, R.layout.meep_widget)
         build(views)
+        MeepWidget.applyTapIntent(applicationContext, views, postId)
         ids.forEach { id -> manager.updateAppWidget(id, views) }
     }
 

--- a/apps/mobile/android/app/src/main/res/layout/meep_widget.xml
+++ b/apps/mobile/android/app/src/main/res/layout/meep_widget.xml
@@ -21,6 +21,7 @@
 -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/meep_widget_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/widget_background"

--- a/apps/mobile/android/app/src/main/res/values/dimens.xml
+++ b/apps/mobile/android/app/src/main/res/values/dimens.xml
@@ -5,7 +5,7 @@
     <dimen name="widget_inner_padding">12dp</dimen>
 
     <!-- Avatar (bottom-left, circular) -->
-    <dimen name="widget_avatar_size">40dp</dimen>
+    <dimen name="widget_avatar_size">24dp</dimen>
 
     <!-- Caption pill -->
     <dimen name="widget_caption_pill_radius">14dp</dimen>

--- a/apps/mobile/android/app/src/main/res/xml/meep_widget_info.xml
+++ b/apps/mobile/android/app/src/main/res/xml/meep_widget_info.xml
@@ -7,8 +7,8 @@
   Real-time updates come from WidgetSyncWorker (WorkManager, 15-min cadence).
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="250dp"
-    android:minHeight="250dp"
+    android:minWidth="110dp"
+    android:minHeight="110dp"
     android:targetCellWidth="2"
     android:targetCellHeight="2"
     android:updatePeriodMillis="1800000"

--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -205,7 +206,13 @@ GoRouter appRouter(Ref ref) {
     },
     routes: [
       GoRoute(path: '/intro', builder: (_, __) => const IntroPage()),
-      GoRoute(path: '/home', builder: (_, __) => const HomeScreen()),
+      GoRoute(
+        path: '/home',
+        builder: (_, state) => HomeScreen(
+          spaceId: state.uri.queryParameters['spaceId'],
+          highlightPostId: state.uri.queryParameters['highlight'],
+        ),
+      ),
       GoRoute(
         path: '/signup/email',
         builder: (_, __) => const SignUpEmailPage(),
@@ -372,6 +379,27 @@ GoRouter appRouter(Ref ref) {
     ],
   );
 
-  ref.onDispose(notifier.dispose);
+  // Widget deep link: Kotlin MainActivity sends onWidgetTap events via
+  // this channel. Handler is registered after router creation so it can
+  // capture router in its closure — platform channels buffer calls until a
+  // handler is set, so even cold-start taps arrive correctly.
+  const channel = MethodChannel('meep/widget');
+  channel.setMethodCallHandler((call) async {
+    if (call.method != 'onWidgetTap') return;
+    final args = call.arguments as Map<String, dynamic>?;
+    final action = args?['action'] as String?;
+    final postId = args?['postId'] as String?;
+
+    if (action == 'OPEN_POST' && postId != null) {
+      router.go('/home?highlight=$postId');
+    } else {
+      router.go('/home');
+    }
+  });
+
+  ref.onDispose(() {
+    channel.setMethodCallHandler(null);
+    notifier.dispose();
+  });
   return router;
 }

--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -386,9 +386,12 @@ GoRouter appRouter(Ref ref) {
   const channel = MethodChannel('meep/widget');
   channel.setMethodCallHandler((call) async {
     if (call.method != 'onWidgetTap') return;
-    final args = call.arguments as Map<String, dynamic>?;
-    final action = args?['action'] as String?;
-    final postId = args?['postId'] as String?;
+    // StandardMethodCodec decode `mapOf(...)` từ Kotlin thành
+    // Map<Object?, Object?> — không cast trực tiếp về Map<String, dynamic>
+    // (sẽ throw _TypeError và swallow silently). Type-check Map base rồi pluck.
+    final args = call.arguments;
+    final action = args is Map ? args['action'] as String? : null;
+    final postId = args is Map ? args['postId'] as String? : null;
 
     if (action == 'OPEN_POST' && postId != null) {
       router.go('/home?highlight=$postId');

--- a/apps/mobile/lib/features/feed/application/feed_controller.dart
+++ b/apps/mobile/lib/features/feed/application/feed_controller.dart
@@ -9,8 +9,10 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:meep/features/feed/application/feed_state.dart';
 import 'package:meep/features/feed/data/firebase_post_repository.dart';
 import 'package:meep/features/feed/data/firebase_storage_repository.dart';
+import 'package:meep/features/feed/data/post.dart';
 import 'package:meep/features/feed/data/post_repository.dart';
 import 'package:meep/features/feed/data/storage_repository.dart';
+import 'package:meep/features/widget/application/widget_data_service.dart';
 
 part 'feed_controller.g.dart';
 
@@ -79,6 +81,12 @@ class FeedController extends _$FeedController {
         } else {
           completer.complete(feedState);
         }
+
+        // Update home-screen widget with latest all-friends post.
+        // Best-effort — widget failures must not crash the feed.
+        if (filter == FeedFilter.all && filtered.isNotEmpty) {
+          _updateWidget(ref, filtered.first);
+        }
       },
       onError: (Object e, StackTrace st) {
         if (!completer.isCompleted) {
@@ -100,5 +108,19 @@ class FeedController extends _$FeedController {
   void onItemVisible(int index) {
     final posts = state.valueOrNull?.posts ?? [];
     if (index >= posts.length - _prefetchAt) loadMore();
+  }
+
+  void _updateWidget(Ref ref, Post post) {
+    try {
+      ref.read(widgetDataServiceProvider).updateWidgetData(
+            postId: post.postId,
+            imageUrl: post.coverImageUrl,
+            authorAvatarUrl: post.authorAvatarUrl,
+            caption: post.caption,
+            captionType: post.captionType?.name,
+          );
+    } catch (_) {
+      // Best-effort — widget update must not crash the feed stream.
+    }
   }
 }

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -24,9 +24,10 @@ import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
-  const HomeScreen({super.key, this.spaceId});
+  const HomeScreen({super.key, this.spaceId, this.highlightPostId});
 
   final String? spaceId;
+  final String? highlightPostId;
 
   @override
   ConsumerState<HomeScreen> createState() => _HomeScreenState();

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -52,16 +52,55 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   String? _selectedSpaceId;
   String _selectedLabel = 'Mọi người';
 
+  /// Widget-tap deeplink target — postId cần scroll tới khi feed có data.
+  /// Set từ `widget.highlightPostId` ở initState/didUpdateWidget, clear ngay
+  /// sau khi handle xong (animate hoặc fallback toast) để không re-fire khi
+  /// rebuild vì lý do khác.
+  String? _pendingHighlightPostId;
+
   @override
   void initState() {
     super.initState();
     _pageController = PageController();
+    _pendingHighlightPostId = widget.highlightPostId;
+  }
+
+  @override
+  void didUpdateWidget(covariant HomeScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Warm start: cùng HomeScreen instance, GoRouter chỉ update query param
+    // → re-arm pending khi postId thay đổi (kể cả từ non-null sang null
+    // mình bỏ qua).
+    if (widget.highlightPostId != null &&
+        widget.highlightPostId != oldWidget.highlightPostId) {
+      _pendingHighlightPostId = widget.highlightPostId;
+    }
   }
 
   @override
   void dispose() {
     _pageController.dispose();
     super.dispose();
+  }
+
+  /// Scroll PageView tới page chứa [postId] (page 0 = camera, page i+1 =
+  /// posts[i]). Nếu không tìm thấy → snackbar fallback "Khoảnh khắc này
+  /// không còn tồn tại".
+  void _handleHighlight(String postId, List<Post> posts) {
+    if (!mounted) return;
+    final index = posts.indexWhere((p) => p.postId == postId);
+    if (index < 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Khoảnh khắc này không còn tồn tại')),
+      );
+      return;
+    }
+    if (!_pageController.hasClients) return;
+    _pageController.animateToPage(
+      index + 1,
+      duration: const Duration(milliseconds: 350),
+      curve: Curves.easeOut,
+    );
   }
 
   void _goToFeed() {
@@ -205,6 +244,20 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         filterSpaceId: _activeFilterSpaceId,
       ),
     );
+
+    // Widget deeplink → scroll tới post khi feed có data. Defer 1 frame để
+    // PageController kịp attach vào PageView.builder bên dưới. whenData chạy
+    // sync nếu feed đã cache; nếu chưa, rebuild kế tiếp (khi stream emit)
+    // sẽ hit lại nhánh này.
+    if (_pendingHighlightPostId != null) {
+      feedAsync.whenData((feedState) {
+        final pendingId = _pendingHighlightPostId!;
+        _pendingHighlightPostId = null;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _handleHighlight(pendingId, feedState.posts);
+        });
+      });
+    }
 
     final unreadCounts = ref.watch(unreadCountsProvider);
     final totalUnread =

--- a/apps/mobile/lib/features/settings/application/settings_controller.dart
+++ b/apps/mobile/lib/features/settings/application/settings_controller.dart
@@ -8,6 +8,7 @@ import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/notification/application/notification_controller.dart';
 import 'package:meep/features/settings/application/settings_state.dart';
 import 'package:meep/features/settings/data/block_repository.dart';
+import 'package:meep/features/widget/application/widget_data_service.dart';
 
 part 'settings_controller.g.dart';
 
@@ -88,6 +89,13 @@ class SettingsController extends _$SettingsController {
         await ref.read(notificationRepositoryProvider).deleteFcmToken(uid);
       } catch (_) {
         // Swallow: FCM cleanup là best-effort, không block logout.
+      }
+
+      // Clear widget cache — best-effort, không block logout.
+      try {
+        await ref.read(widgetDataServiceProvider).clearData();
+      } catch (_) {
+        // Swallow: widget cleanup is best-effort.
       }
     }
     try {

--- a/apps/mobile/lib/features/settings/presentation/widget_confirm_sheet.dart
+++ b/apps/mobile/lib/features/settings/presentation/widget_confirm_sheet.dart
@@ -7,6 +7,7 @@ import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_spacing.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/widget/application/widget_data_service.dart';
 import 'package:meep/shared/widgets/app_bottom_sheet.dart';
 
 class WidgetConfirmSheet extends ConsumerWidget {
@@ -46,14 +47,17 @@ class WidgetConfirmSheet extends ConsumerWidget {
                 label: 'Thêm',
                 bg: AppColors.turquoise600,
                 textColor: AppColors.turquoise900,
-                onTap: () {
+                onTap: () async {
+                  final supported = await ref
+                      .read(widgetDataServiceProvider)
+                      .requestPinAppWidget();
+                  if (!context.mounted) return;
                   Navigator.of(context).pop();
-                  // TODO(W/KhoaLND): requestPinAppWidget() Android intent.
-                  // Widget module = empty scaffold (apps/widget/ chưa tồn
-                  // tại). Button "Thêm" hiện no-op + hiện toast giả →
-                  // KhoaLND bind native Android intent khi build Widget
-                  // module.
-                  _showSuccessToast(context);
+                  if (supported) {
+                    _showSuccessToast(context);
+                  } else {
+                    _showManualToast(context);
+                  }
                 },
               ),
               const SizedBox(height: AppSpacing.sm),
@@ -200,7 +204,20 @@ class WidgetConfirmSheet extends ConsumerWidget {
     showDialog<void>(
       context: context,
       barrierColor: AppColors.bw900.withValues(alpha: 0.45),
-      builder: (_) => const _SuccessToastDialog(),
+      builder: (_) => const _SuccessToastDialog(
+        message: 'Đã thêm tiện ích vào màn hình chờ thành công!',
+      ),
+    );
+  }
+
+  void _showManualToast(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      barrierColor: AppColors.bw900.withValues(alpha: 0.45),
+      builder: (_) => const _SuccessToastDialog(
+        message: 'Launcher không hỗ trợ thêm tự động. Hãy giữ ở màn hình chờ → '
+            'chọn Widget → chọn Meep.',
+      ),
     );
   }
 }
@@ -209,7 +226,9 @@ class WidgetConfirmSheet extends ConsumerWidget {
 /// `dispose()` — nếu user tap close hoặc barrier sớm, Timer huỷ ngay,
 /// tránh pop nhầm route khác.
 class _SuccessToastDialog extends StatefulWidget {
-  const _SuccessToastDialog();
+  const _SuccessToastDialog({required this.message});
+
+  final String message;
 
   @override
   State<_SuccessToastDialog> createState() => _SuccessToastDialogState();
@@ -251,7 +270,7 @@ class _SuccessToastDialogState extends State<_SuccessToastDialog> {
               vertical: 28,
             ),
             child: Text(
-              'Đã thêm tiện ích vào màn hình chờ thành công!',
+              widget.message,
               style: AppTextStyles.mdBold.copyWith(color: Colors.white),
               textAlign: TextAlign.center,
             ),

--- a/apps/mobile/lib/features/widget/application/widget_data_service.dart
+++ b/apps/mobile/lib/features/widget/application/widget_data_service.dart
@@ -1,12 +1,119 @@
-// TODO(W/T4/TBD): implement WidgetDataService — writes latest post data
-// to SharedPreferences so WidgetSyncWorker (Kotlin) can read it.
-// Fields to write: postId, imageUrl, authorName
-abstract class WidgetDataService {
-  Future<void> saveLatestPost({
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'widget_data_service.g.dart';
+
+/// SharedPreferences keys — must match [WidgetDataStore.kt][1] contract exactly.
+///
+/// The shared_preferences plugin auto-prefixes keys with `flutter.` on Android,
+/// so the raw key `widget_post_id` becomes `flutter.widget_post_id` in the
+/// `FlutterSharedPreferences` file that WidgetDataStore.kt reads.
+///
+/// [1]: android/app/src/main/kotlin/dev/meep/meep/WidgetDataStore.kt
+class _WidgetKeys {
+  static const postId = 'widget_post_id';
+  static const imageUrl = 'widget_image_url';
+  static const authorAvatarUrl = 'widget_author_avatar_url';
+  static const caption = 'widget_caption';
+  static const captionType = 'widget_caption_type';
+  static const lastViewedAt = 'widget_last_viewed_at';
+
+  static const all = [
+    postId,
+    imageUrl,
+    authorAvatarUrl,
+    caption,
+    captionType,
+    lastViewedAt,
+  ];
+}
+
+class WidgetDataService {
+  WidgetDataService({required SharedPreferences prefs}) : _prefs = prefs;
+
+  final SharedPreferences _prefs;
+
+  static const _channel = MethodChannel('meep/widget');
+
+  /// Write latest post data to SharedPreferences so WidgetSyncWorker (Kotlin)
+  /// can pick it up on the next sync cycle.
+  ///
+  /// Nullable fields are removed from prefs when absent — Kotlin's
+  /// WidgetDataStore.read() uses `takeIf { it.isNotBlank() }` and treats
+  /// missing keys the same as empty strings.
+  Future<void> updateWidgetData({
     required String postId,
     required String imageUrl,
-    required String authorName,
-  });
+    String? authorAvatarUrl,
+    String? caption,
+    String? captionType,
+  }) async {
+    await _prefs.setString(_WidgetKeys.postId, postId);
+    await _prefs.setString(_WidgetKeys.imageUrl, imageUrl);
 
-  Future<void> clearData();
+    await _setOrRemove(_WidgetKeys.authorAvatarUrl, authorAvatarUrl);
+    await _setOrRemove(_WidgetKeys.caption, caption);
+    await _setOrRemove(_WidgetKeys.captionType, captionType);
+
+    // Reset the last-viewed clock so the new post's badge starts at 0
+    // for the user who just posted (their own post shouldn't count).
+    await _prefs.setInt(
+      _WidgetKeys.lastViewedAt,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+
+    // Poke Kotlin to enqueue an immediate one-time refresh
+    await _channel.invokeMethod('updateWidget');
+  }
+
+  /// Record the moment the user opened the app (resumed).
+  ///
+  /// On the next WidgetSyncWorker tick, posts with createdAt > this timestamp
+  /// are counted as unread. Must be called on every
+  /// [AppLifecycleState.resumed], regardless of entry point.
+  Future<void> recordLastViewedAt() async {
+    await _prefs.setInt(
+      _WidgetKeys.lastViewedAt,
+      DateTime.now().millisecondsSinceEpoch,
+    );
+    // Poke Kotlin to recalculate badge count
+    await _channel.invokeMethod('updateWidget');
+  }
+
+  /// Open Android launcher's native widget picker.
+  ///
+  /// Maps to `AppWidgetManager.requestPinAppWidget()` (API 26+). Returns
+  /// `true` when the intent was fired. Returns `false` when the launcher
+  /// doesn't support automatic pinning (Android < 8.0, some custom ROMs) —
+  /// caller should show manual instructions.
+  Future<bool> requestPinAppWidget() async {
+    final result = await _channel.invokeMethod<bool>('requestPinAppWidget');
+    return result ?? false;
+  }
+
+  /// Wipe all widget cached data from SharedPreferences.
+  ///
+  /// On the next WidgetSyncWorker tick, WidgetDataStore.read() returns null →
+  /// placeholder displayed. Call on logout.
+  Future<void> clearData() async {
+    for (final key in _WidgetKeys.all) {
+      await _prefs.remove(key);
+    }
+    await _channel.invokeMethod('updateWidget');
+  }
+
+  Future<void> _setOrRemove(String key, String? value) async {
+    if (value != null) {
+      await _prefs.setString(key, value);
+    } else {
+      await _prefs.remove(key);
+    }
+  }
 }
+
+@Riverpod(keepAlive: true)
+WidgetDataService widgetDataService(Ref ref) => throw UnimplementedError(
+      'wire WidgetDataService in main.dart — needs SharedPreferences.getInstance()',
+    );

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meep/core/config/app_config.dart';
 import 'package:meep/core/router/app_router.dart';
@@ -28,6 +29,7 @@ import 'package:meep/features/settings/application/settings_controller.dart';
 import 'package:meep/features/settings/data/firebase_block_repository.dart';
 import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/features/space/data/firebase_space_repository.dart';
+import 'package:meep/features/widget/application/widget_data_service.dart';
 import 'package:meep/firebase_options.dart';
 
 // Pass --dart-define=USE_EMULATOR=true khi dev local để trỏ vào Firebase Emulator Suite.
@@ -44,6 +46,8 @@ void main() async {
     FirebaseFirestore.instance.useFirestoreEmulator(_emulatorHost, 9999);
     await FirebaseStorage.instance.useStorageEmulator(_emulatorHost, 9199);
   }
+
+  final prefs = await SharedPreferences.getInstance();
 
   final authRepo = FirebaseAuthRepository(
     auth: FirebaseAuth.instance,
@@ -94,17 +98,44 @@ void main() async {
             storage: FirebaseStorage.instance,
           ),
         ),
+        widgetDataServiceProvider.overrideWithValue(
+          WidgetDataService(prefs: prefs),
+        ),
       ],
       child: const MeepApp(),
     ),
   );
 }
 
-class MeepApp extends ConsumerWidget {
+class MeepApp extends ConsumerStatefulWidget {
   const MeepApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<MeepApp> createState() => _MeepAppState();
+}
+
+class _MeepAppState extends ConsumerState<MeepApp> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      ref.read(widgetDataServiceProvider).recordLastViewedAt();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     // Orphaned Google auth cleanup:
     // Nếu app mở lại mà uid tồn tại nhưng Firestore không có profile VÀ không
     // đang trong active signup/login flow → orphan → sign out về /intro.

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -1187,10 +1187,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1720,10 +1720,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   timezone:
     dependency: transitive
     description:

--- a/apps/mobile/test/features/settings/widget_confirm_sheet_test.dart
+++ b/apps/mobile/test/features/settings/widget_confirm_sheet_test.dart
@@ -122,7 +122,8 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
-          find.text('Launcher không hỗ trợ thêm tự động. Hãy giữ ở màn hình chờ → '
+          find.text(
+              'Launcher không hỗ trợ thêm tự động. Hãy giữ ở màn hình chờ → '
               'chọn Widget → chọn Meep.'),
           findsOneWidget,
         );

--- a/apps/mobile/test/features/settings/widget_confirm_sheet_test.dart
+++ b/apps/mobile/test/features/settings/widget_confirm_sheet_test.dart
@@ -1,10 +1,13 @@
+import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/settings/presentation/widget_confirm_sheet.dart';
+import 'package:meep/features/widget/application/widget_data_service.dart';
 
 UserProfile _profile({int friendCount = 15}) {
   return UserProfile(
@@ -18,12 +21,39 @@ UserProfile _profile({int friendCount = 15}) {
   );
 }
 
+/// Controls what [WidgetDataService.requestPinAppWidget] returns in tests.
+bool _mockPinSupported = true;
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late final WidgetDataService testWidgetDataService;
+
   group('WidgetConfirmSheet', () {
+    setUpAll(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('meep/widget'),
+        (MethodCall methodCall) async {
+          if (methodCall.method == 'requestPinAppWidget') {
+            return _mockPinSupported;
+          }
+          return null;
+        },
+      );
+
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      testWidgetDataService = WidgetDataService(prefs: prefs);
+    });
+
     Widget harness() => ProviderScope(
           overrides: [
             currentUserProfileProvider.overrideWith(
               (ref) => Stream<UserProfile?>.value(_profile()),
+            ),
+            widgetDataServiceProvider.overrideWith(
+              (ref) => testWidgetDataService,
             ),
           ],
           child: MaterialApp(
@@ -59,22 +89,49 @@ void main() {
       expect(find.text('Huỷ'), findsOneWidget);
     });
 
-    testWidgets('tap [Thêm] → đóng sheet + hiện toast thành công',
-        (tester) async {
-      await openSheet(tester);
+    testWidgets(
+      'tap [Thêm] với launcher hỗ trợ → đóng sheet + hiện toast thành công',
+      (tester) async {
+        _mockPinSupported = true;
 
-      await tester.tap(find.text('Thêm'));
-      await tester.pump(); // đóng sheet + show toast dialog
+        await openSheet(tester);
 
-      expect(
-        find.text('Đã thêm tiện ích vào màn hình chờ thành công!'),
-        findsOneWidget,
-      );
-      expect(tester.takeException(), isNull);
+        await tester.tap(find.text('Thêm'));
+        await tester.pumpAndSettle();
 
-      // Toast tự đóng sau 3s — đẩy timer cho hết để không leak pending timer.
-      await tester.pump(const Duration(seconds: 3));
-      await tester.pumpAndSettle();
-    });
+        expect(
+          find.text('Đã thêm tiện ích vào màn hình chờ thành công!'),
+          findsOneWidget,
+        );
+        expect(tester.takeException(), isNull);
+
+        // Toast tự đóng sau 3s.
+        await tester.pump(const Duration(seconds: 3));
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'tap [Thêm] với launcher không hỗ trợ → đóng sheet + hiện toast manual',
+      (tester) async {
+        _mockPinSupported = false;
+
+        await openSheet(tester);
+
+        await tester.tap(find.text('Thêm'));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('Launcher không hỗ trợ thêm tự động. Hãy giữ ở màn hình chờ → '
+              'chọn Widget → chọn Meep.'),
+          findsOneWidget,
+        );
+        expect(tester.takeException(), isNull);
+
+        // Toast tự đóng sau 3s.
+        await tester.pump(const Duration(seconds: 3));
+        await tester.pumpAndSettle();
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

3 mảng theo plan widget Android (`docs/plans/2026-05-23-widget-android.md`):

- **T4 — Widget layout & assets** (Kotlin native): `MeepWidget` AppWidgetProvider render placeholder/data state, `WidgetDataStore` đọc SharedPreferences, `MainActivity` setup MethodChannel `meep/widget` + forward intent extras, drawable assets (background, caption pill, count badge, default avatar).
- **T5 — Sync worker & pin intent**: `WidgetSyncWorker` (WorkManager 15-min cadence) download photo/avatar/unread count → push RemoteViews update. Settings sheet thêm `WidgetConfirmSheet` + `requestPinAppWidget` invocation.
- **T4 — Deeplink scroll tới post** (commit cuối): fix MethodChannel cast Map + wire `HomeScreen.highlightPostId` → animate `PageView` tới page chứa post, fallback snackbar khi post đã xóa.

## Files thay đổi

**Android native (`apps/mobile/android/app/src/main/`):**
- `kotlin/.../MeepWidget.kt` — AppWidgetProvider + PendingIntent tap → MainActivity với `action=OPEN_POST, postId=...`
- `kotlin/.../MainActivity.kt` — MethodChannel `meep/widget`: `updateWidget`, `requestPinAppWidget`, forward widget tap
- `kotlin/.../WidgetSyncWorker.kt` — background refresh
- `kotlin/.../WidgetDataStore.kt` — SharedPreferences reader
- `AndroidManifest.xml` — receiver + INTERNET permission + launchMode singleTop
- `res/drawable/widget_*.xml` + `res/layout/meep_widget.xml` + `res/xml/meep_widget_info.xml`

**Flutter:**
- `lib/core/router/app_router.dart` — fix Map cast type + cold-start `defaultRouteName` parser (ở commit 840bc78)
- `lib/features/feed/presentation/home_screen.dart` — `_pendingHighlightPostId` + `_handleHighlight()` scroll PageView
- `lib/features/widget/application/widget_data_service.dart` (+ `.g.dart`) — WidgetDataService impl
- `lib/features/settings/presentation/widget_confirm_sheet.dart` — confirm sheet trước khi pin
- `test/features/settings/widget_confirm_sheet_test.dart` — widget test (đã format ở commit `ab8f162`)

## Test plan

**Automated (đã verify local — khớp CI):**
- [x] `dart format --set-exit-if-changed .` — 0 changed
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `flutter test` — 511/511 pass
- [x] `npm run lint` (functions) — clean
- [x] `npm run typecheck` (functions) — clean
- [x] `npm test` (functions) — 78/78 pass

**Manual smoke test (T6 acceptance — CHƯA chạy, cần làm trước khi merge):**
- [ ] Add widget Meep vào home screen Android từ widget picker
- [ ] Post ảnh mới từ app → widget hiện ảnh + avatar + caption sau ≤ 15 phút
- [ ] Badge unread count hiện đúng số, ẩn khi count = 0
- [ ] Tap widget khi app **chưa chạy** (cold start) → app mở, scroll feed tới đúng post
- [ ] Tap widget khi app **đã chạy** (warm start) → app foreground, scroll tới đúng post
- [ ] Tap widget với post đã xóa → app mở Home + snackbar "Khoảnh khắc này không còn tồn tại"
- [ ] Logout → widget revert về placeholder

## Risks & notes

- **Manual smoke chưa làm**: chỉ verify code/test, chưa build APK. Bug khả thi: PageController chưa attach khi `addPostFrameCallback` fire (em đã guard bằng `hasClients` nhưng cần verify trên device).
- **Auth race**: user chưa login mà tap widget → auth redirect đá về `/intro`, mất postId. Spec không cover case này (widget chỉ render khi đã login) — không fix.
- **T5 `recordLastViewedAt` wire vào `AppLifecycleState.resumed`** (yêu cầu thứ 2 của T5 acceptance): chưa thấy trong commit, có thể đã làm ở branch khác hoặc còn thiếu. Cần anh confirm.
- **Workflow observation** (không thuộc scope PR này): CLAUDE.md §Git Commits liệt kê 8 type, workflow + commitlint cho phép 11 type (`+build|ci|revert`). Nên đồng bộ ở PR riêng.

## Liên quan

- Spec: `docs/specs/2026-05-23-widget-android.md`
- Plan: `docs/plans/2026-05-23-widget-android.md`

Refs #140 