### PR TITLE
feat(notification): T1 FirebaseNotificationRepository — FCM token lifecycle + notifications CRUD

### DIFF
--- a/apps/mobile/lib/features/notification/data/firebase_notification_repository.dart
+++ b/apps/mobile/lib/features/notification/data/firebase_notification_repository.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:crypto/crypto.dart';
+
+import 'package:meep/features/notification/data/app_notification.dart';
+import 'package:meep/features/notification/data/notification_repository.dart';
+
+class FirebaseNotificationRepository implements NotificationRepository {
+  FirebaseNotificationRepository({required FirebaseFirestore firestore})
+      : _firestore = firestore;
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _fcmTokensRef(String uid) =>
+      _firestore.collection('users').doc(uid).collection('fcmTokens');
+
+  CollectionReference<Map<String, dynamic>> _notificationsRef(String uid) =>
+      _firestore.collection('users').doc(uid).collection('notifications');
+
+  /// 1-token/user policy [OQ3]: wipe every existing fcmToken doc, then write
+  /// the new one keyed by `tokenId = SHA-256(token)` (hex). Same device
+  /// re-login lands on the same `tokenId` — skip the delete-then-set on the
+  /// identity doc to avoid mixing delete+set for the same path inside one
+  /// batch (Firestore applies in commit order, but skipping is both safer
+  /// and one fewer write).
+  @override
+  Future<void> saveFcmToken(String uid, String token) async {
+    final tokenId = sha256.convert(utf8.encode(token)).toString();
+    final existing = await _fcmTokensRef(uid).get();
+    final batch = _firestore.batch();
+    for (final doc in existing.docs) {
+      if (doc.id == tokenId) continue;
+      batch.delete(doc.reference);
+    }
+    batch.set(_fcmTokensRef(uid).doc(tokenId), {
+      'token': token,
+      'platform': 'android',
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+    await batch.commit();
+  }
+
+  /// Logout cleanup — remove every fcmTokens doc for this uid.
+  @override
+  Future<void> deleteFcmToken(String uid) async {
+    final snap = await _fcmTokensRef(uid).get();
+    if (snap.docs.isEmpty) return;
+    final batch = _firestore.batch();
+    for (final doc in snap.docs) {
+      batch.delete(doc.reference);
+    }
+    await batch.commit();
+  }
+
+  /// Newest first. `new_post` notifications are push-only and never persisted
+  /// (spec §Data model, OQ2) so no client-side type filter is needed —
+  /// Cloud Functions simply skip the doc write for that type.
+  ///
+  /// `notifId` is populated with the full Firestore path (e.g.
+  /// `users/{uid}/notifications/{id}`) so [markAsRead] can resolve the doc
+  /// without re-passing uid through the abstract API.
+  @override
+  Future<List<AppNotification>> getNotifications(String uid) async {
+    final snap = await _notificationsRef(uid)
+        .orderBy('createdAt', descending: true)
+        .get();
+    return snap.docs
+        .map(
+          (doc) => AppNotification.fromJson({
+            ...doc.data(),
+            'notifId': doc.reference.path,
+          }),
+        )
+        .toList();
+  }
+
+  /// `notifId` is the full Firestore path produced by [getNotifications].
+  /// Single-field update keeps the Firestore rule
+  /// `affectedKeys().hasOnly(['read'])` satisfied — owner can mark read,
+  /// can't tamper with title/body/type.
+  @override
+  Future<void> markAsRead(String notifId) async {
+    await _firestore.doc(notifId).update({'read': true});
+  }
+}

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -330,7 +330,7 @@ packages:
     source: hosted
     version: "0.3.5+2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
 
   # Utility
   cached_network_image: ^3.4.1
+  crypto: ^3.0.5
   emoji_picker_flutter: ^4.4.0
   flutter_image_compress: ^2.3.0
   flutter_local_notifications: ^17.2.3

--- a/apps/mobile/test/features/notification/data/firebase_notification_repository_test.dart
+++ b/apps/mobile/test/features/notification/data/firebase_notification_repository_test.dart
@@ -1,0 +1,303 @@
+import 'dart:convert';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:crypto/crypto.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meep/features/notification/data/app_notification.dart';
+import 'package:meep/features/notification/data/firebase_notification_repository.dart';
+
+void main() {
+  late FakeFirebaseFirestore db;
+  late FirebaseNotificationRepository repo;
+
+  const uid = 'uid-alice';
+  const otherUid = 'uid-bob';
+
+  setUp(() {
+    db = FakeFirebaseFirestore();
+    repo = FirebaseNotificationRepository(firestore: db);
+  });
+
+  CollectionReference<Map<String, dynamic>> fcmTokensRef(String forUid) =>
+      db.collection('users').doc(forUid).collection('fcmTokens');
+
+  CollectionReference<Map<String, dynamic>> notificationsRef(String forUid) =>
+      db.collection('users').doc(forUid).collection('notifications');
+
+  String tokenIdOf(String token) =>
+      sha256.convert(utf8.encode(token)).toString();
+
+  group('saveFcmToken', () {
+    const token = 'fcm-token-abc123';
+
+    test('creates doc with tokenId = SHA-256(token), platform=android',
+        () async {
+      await repo.saveFcmToken(uid, token);
+
+      final expectedId = tokenIdOf(token);
+      final doc = await fcmTokensRef(uid).doc(expectedId).get();
+      expect(doc.exists, isTrue);
+      expect(doc.data()!['token'], token);
+      expect(doc.data()!['platform'], 'android');
+      expect(doc.data()!['updatedAt'], isA<Timestamp>());
+    });
+
+    test('SHA-256 tokenId is deterministic — hex, 64 chars', () async {
+      await repo.saveFcmToken(uid, token);
+
+      final snap = await fcmTokensRef(uid).get();
+      expect(snap.docs.length, 1);
+      final id = snap.docs.first.id;
+      expect(id.length, 64);
+      expect(RegExp(r'^[0-9a-f]+$').hasMatch(id), isTrue);
+    });
+
+    test('1-token/user policy: wipes existing docs then writes new one',
+        () async {
+      // Seed 2 stale token docs under different ids — simulating older sessions
+      // or hash mismatch from a prior bug.
+      await fcmTokensRef(uid).doc('stale-1').set({
+        'token': 'old-token-1',
+        'platform': 'android',
+        'updatedAt': Timestamp.now(),
+      });
+      await fcmTokensRef(uid).doc('stale-2').set({
+        'token': 'old-token-2',
+        'platform': 'android',
+        'updatedAt': Timestamp.now(),
+      });
+
+      await repo.saveFcmToken(uid, token);
+
+      final all = await fcmTokensRef(uid).get();
+      expect(all.docs.length, 1, reason: 'exactly 1 doc after replace');
+      expect(all.docs.first.id, tokenIdOf(token));
+      expect(all.docs.first.data()['token'], token);
+    });
+
+    test('re-save same token is idempotent — single doc, stable tokenId',
+        () async {
+      await repo.saveFcmToken(uid, token);
+      await repo.saveFcmToken(uid, token);
+
+      final all = await fcmTokensRef(uid).get();
+      expect(all.docs.length, 1);
+      expect(all.docs.first.id, tokenIdOf(token));
+    });
+
+    test('does not touch other users fcmTokens', () async {
+      await fcmTokensRef(otherUid).doc('other-token-id').set({
+        'token': 'other-token',
+        'platform': 'android',
+        'updatedAt': Timestamp.now(),
+      });
+
+      await repo.saveFcmToken(uid, token);
+
+      final otherSnap = await fcmTokensRef(otherUid).get();
+      expect(otherSnap.docs.length, 1);
+      expect(otherSnap.docs.first.data()['token'], 'other-token');
+    });
+  });
+
+  group('deleteFcmToken', () {
+    test('removes all docs for uid', () async {
+      await fcmTokensRef(uid).doc('t1').set({
+        'token': 't1',
+        'platform': 'android',
+        'updatedAt': Timestamp.now(),
+      });
+      await fcmTokensRef(uid).doc('t2').set({
+        'token': 't2',
+        'platform': 'android',
+        'updatedAt': Timestamp.now(),
+      });
+      await fcmTokensRef(uid).doc('t3').set({
+        'token': 't3',
+        'platform': 'android',
+        'updatedAt': Timestamp.now(),
+      });
+
+      await repo.deleteFcmToken(uid);
+
+      final snap = await fcmTokensRef(uid).get();
+      expect(snap.docs, isEmpty);
+    });
+
+    test('no-op when uid has no tokens — does not throw', () async {
+      await expectLater(repo.deleteFcmToken(uid), completes);
+    });
+
+    test('does not touch other users fcmTokens', () async {
+      await fcmTokensRef(uid).doc('mine').set({
+        'token': 'mine',
+        'platform': 'android',
+        'updatedAt': Timestamp.now(),
+      });
+      await fcmTokensRef(otherUid).doc('theirs').set({
+        'token': 'theirs',
+        'platform': 'android',
+        'updatedAt': Timestamp.now(),
+      });
+
+      await repo.deleteFcmToken(uid);
+
+      final mine = await fcmTokensRef(uid).get();
+      expect(mine.docs, isEmpty);
+      final theirs = await fcmTokensRef(otherUid).get();
+      expect(theirs.docs.length, 1);
+    });
+  });
+
+  group('getNotifications', () {
+    test('empty subcollection → empty list', () async {
+      final result = await repo.getNotifications(uid);
+      expect(result, isEmpty);
+    });
+
+    test('orders by createdAt DESC (newest first)', () async {
+      final older = Timestamp.fromDate(DateTime(2026, 1, 1, 10));
+      final middle = Timestamp.fromDate(DateTime(2026, 1, 2, 10));
+      final newest = Timestamp.fromDate(DateTime(2026, 1, 3, 10));
+
+      await notificationsRef(uid).doc('n-old').set({
+        'type': 'friendRequest',
+        'title': 'Old',
+        'body': 'old body',
+        'data': <String, String>{},
+        'read': false,
+        'createdAt': older,
+      });
+      await notificationsRef(uid).doc('n-new').set({
+        'type': 'reaction',
+        'title': 'New',
+        'body': 'new body',
+        'data': <String, String>{'postId': 'p1'},
+        'read': false,
+        'createdAt': newest,
+      });
+      await notificationsRef(uid).doc('n-mid').set({
+        'type': 'friendAccepted',
+        'title': 'Mid',
+        'body': 'mid body',
+        'data': <String, String>{},
+        'read': true,
+        'createdAt': middle,
+      });
+
+      final list = await repo.getNotifications(uid);
+
+      expect(list.length, 3);
+      expect(list.map((n) => n.title).toList(), ['New', 'Mid', 'Old']);
+      expect(list.first.type, NotificationType.reaction);
+      expect(list.first.data['postId'], 'p1');
+    });
+
+    test('notifId is populated with the full Firestore path', () async {
+      await notificationsRef(uid).doc('abc').set({
+        'type': 'friendRequest',
+        'title': 't',
+        'body': 'b',
+        'data': <String, String>{},
+        'read': false,
+        'createdAt': Timestamp.now(),
+      });
+
+      final list = await repo.getNotifications(uid);
+      expect(list.single.notifId, 'users/$uid/notifications/abc');
+    });
+
+    test('does not return notifications from other users', () async {
+      await notificationsRef(uid).doc('mine').set({
+        'type': 'friendRequest',
+        'title': 'Mine',
+        'body': '',
+        'data': <String, String>{},
+        'read': false,
+        'createdAt': Timestamp.now(),
+      });
+      await notificationsRef(otherUid).doc('theirs').set({
+        'type': 'friendRequest',
+        'title': 'Theirs',
+        'body': '',
+        'data': <String, String>{},
+        'read': false,
+        'createdAt': Timestamp.now(),
+      });
+
+      final list = await repo.getNotifications(uid);
+      expect(list.length, 1);
+      expect(list.single.title, 'Mine');
+    });
+  });
+
+  group('markAsRead', () {
+    test('flips read to true and leaves other fields untouched', () async {
+      final created = Timestamp.fromDate(DateTime(2026, 1, 1, 12));
+      await notificationsRef(uid).doc('n1').set({
+        'type': 'friendRequest',
+        'title': 'Tin nhắn kết bạn',
+        'body': 'Tap để xem',
+        'data': <String, String>{'requestId': 'req-1'},
+        'read': false,
+        'createdAt': created,
+      });
+
+      await repo.markAsRead('users/$uid/notifications/n1');
+
+      final snap = await notificationsRef(uid).doc('n1').get();
+      final data = snap.data()!;
+      expect(data['read'], isTrue);
+      expect(data['type'], 'friendRequest');
+      expect(data['title'], 'Tin nhắn kết bạn');
+      expect(data['body'], 'Tap để xem');
+      expect(data['data'], {'requestId': 'req-1'});
+      expect(data['createdAt'], created);
+    });
+
+    test('only the read field is written (single-field update)', () async {
+      await notificationsRef(uid).doc('n1').set({
+        'type': 'reaction',
+        'title': 'x',
+        'body': 'y',
+        'data': <String, String>{'postId': 'p1'},
+        'read': false,
+        'createdAt': Timestamp.now(),
+      });
+      final before = (await notificationsRef(uid).doc('n1').get()).data()!;
+
+      await repo.markAsRead('users/$uid/notifications/n1');
+
+      final after = (await notificationsRef(uid).doc('n1').get()).data()!;
+      // No new keys added.
+      expect(after.keys.toSet(), before.keys.toSet());
+      // Only `read` changed value; every other field deep-equals the snapshot
+      // (Flutter `expect` does deep equality on Map / Timestamp).
+      expect(after['read'], isTrue);
+      expect(after['type'], before['type']);
+      expect(after['title'], before['title']);
+      expect(after['body'], before['body']);
+      expect(after['data'], before['data']);
+      expect(after['createdAt'], before['createdAt']);
+    });
+
+    test('round-trip: getNotifications().notifId feeds markAsRead', () async {
+      await notificationsRef(uid).doc('rt').set({
+        'type': 'friendAccepted',
+        'title': 't',
+        'body': 'b',
+        'data': <String, String>{},
+        'read': false,
+        'createdAt': Timestamp.now(),
+      });
+
+      final list = await repo.getNotifications(uid);
+      await repo.markAsRead(list.single.notifId);
+
+      final snap = await notificationsRef(uid).doc('rt').get();
+      expect(snap.data()!['read'], isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Tóm tắt 
- Implement `FirebaseNotificationRepository` theo contract `NotificationRepository` abstract
- Thêm `crypto: ^3.0.5` vào pubspec.yaml (trước đó transitive qua firebase_core)
- 15 unit tests với `fake_cloud_firestore`

## AC checklist
- [x] `saveFcmToken`: batch xoá docs cũ → set doc mới với `tokenId = SHA-256(token)` hex, `platform = 'android'`
- [x] `deleteFcmToken`: batch xoá toàn bộ `/users/{uid}/fcmTokens/*`, no-op khi rỗng
- [x] `getNotifications`: `ORDER BY createdAt DESC`, `notifId` = full Firestore path
- [x] `markAsRead`: single-field update `read = true`, giữ nguyên mọi field khác
- [x] `flutter test test/features/notification/data/` — 15/15 pass
- [x] `flutter test` full suite — 565/565 pass, không regress

## Design decisions
1. **`notifId` = full Firestore path** (`users/{uid}/notifications/{id}`) thay vì doc id thuần — để `markAsRead(notifId)` resolve doc không cần truyền lại uid, giữ đúng signature abstract của ThienPDM. Nếu muốn `notifId` = doc id thì đổi signature thành `markAsRead(uid, notifId)`.
2. **Skip delete-then-set khi doc trùng tokenId** trong `saveFcmToken` — re-login cùng device sinh cùng tokenId, bỏ qua delete để tránh delete+set cùng path trong 1 batch. Hành vi idempotent, ít hơn 1 write không cần thiết.
3. **`new_post` notification không có doc** — đúng spec OQ2 (push only, không lưu). `AppNotification` enum không có entry `newPost` → repo không cần filter type. Cloud Functions đảm bảo không tạo doc cho type này.

## Test plan
| Test | Coverage |
|---|---|
| `saveFcmToken` — tạo doc đúng schema | token, platform, updatedAt |
| `saveFcmToken` — tokenId deterministic SHA-256 hex 64 ký tự | hash |
| `saveFcmToken` — xoá stale docs (1 token/user policy) | batch cleanup |
| `saveFcmToken` — idempotent re-save cùng token | no duplicate |
| `saveFcmToken` — cross-user isolation | không đụng user khác |
| `deleteFcmToken` — xoá toàn bộ docs uid | logout cleanup |
| `deleteFcmToken` — no-op khi rỗng | graceful |
| `deleteFcmToken` — cross-user isolation | không đụng user khác |
| `getNotifications` — empty → [] | edge case |
| `getNotifications` — orderBy createdAt DESC | newest first |
| `getNotifications` — notifId full path | round-trip với markAsRead |
| `getNotifications` — cross-user isolation | không leak user khác |
| `markAsRead` — flip read=true, giữ nguyên fields khác | single-field |
| `markAsRead` — chỉ field `read` thay đổi | Firestore rule proof |
| `markAsRead` — round-trip getNotifications → markAsRead | integration |