### PR TITLE
feat(diary): T1 FirebaseDiaryRepository — CRUD + getPublicEntries + searchEntries (#127)

### DIFF
--- a/apps/mobile/lib/features/diary/data/firebase_diary_repository.dart
+++ b/apps/mobile/lib/features/diary/data/firebase_diary_repository.dart
@@ -1,0 +1,354 @@
+import 'dart:typed_data';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
+import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/data/diary_repository.dart';
+
+/// Firebase-backed implementation of [DiaryRepository].
+///
+/// Storage upload/delete tách qua [DiaryStorageClient] để test inject stub —
+/// `firebase_storage` upload trả `UploadTask extends Future`, khó mock.
+/// Pattern mirror với `FirebaseProfileRepository` (avatars).
+class FirebaseDiaryRepository implements DiaryRepository {
+  FirebaseDiaryRepository({
+    required FirebaseFirestore firestore,
+    required DiaryStorageClient storageClient,
+  })  : _firestore = firestore,
+        _storageClient = storageClient;
+
+  /// Convenience factory: wire FirebaseStorage trực tiếp. main.dart dùng
+  /// factory này; tests dùng constructor với stub.
+  factory FirebaseDiaryRepository.firebase({
+    required FirebaseFirestore firestore,
+    required FirebaseStorage storage,
+  }) {
+    return FirebaseDiaryRepository(
+      firestore: firestore,
+      storageClient: _FirebaseDiaryStorageClient(storage),
+    );
+  }
+
+  final FirebaseFirestore _firestore;
+  final DiaryStorageClient _storageClient;
+
+  static const _collection = 'diary';
+  static const int _maxBlocks = 20;
+  static const int _maxMoodCaptionChars = 50;
+
+  CollectionReference<Map<String, dynamic>> get _col =>
+      _firestore.collection(_collection);
+
+  @override
+  Future<DiaryEntry> createEntry(DiaryEntry entry) async {
+    _validateMoodCaption(entry.moodCaption);
+    _validateBlockCount(entry.content);
+
+    final docRef = _col.doc();
+    final entryWithId = entry.copyWith(entryId: docRef.id);
+    final data = _serializeEntry(entryWithId)
+      ..['createdAt'] = FieldValue.serverTimestamp()
+      ..['updatedAt'] = FieldValue.serverTimestamp();
+
+    try {
+      await docRef.set(data);
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+    return entryWithId;
+  }
+
+  @override
+  Stream<List<DiaryEntry>> watchEntries(String authorUid) {
+    return _col
+        .where('authorUid', isEqualTo: authorUid)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snap) => snap.docs.map(_parseEntry).toList());
+  }
+
+  @override
+  Future<DiaryEntry?> getEntry(String entryId) async {
+    if (entryId.isEmpty) {
+      throw const ValidationError(
+        message: 'Thiếu mã nhật ký',
+        code: 'diary/entry-id-required',
+      );
+    }
+    try {
+      final snap = await _col.doc(entryId).get();
+      if (!snap.exists) return null;
+      return _parseEntry(snap);
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+  }
+
+  @override
+  Future<List<DiaryEntry>> getPublicEntries(String authorUid) async {
+    try {
+      final snap = await _col
+          .where('authorUid', isEqualTo: authorUid)
+          .where('privacy', isEqualTo: 'public')
+          .orderBy('createdAt', descending: true)
+          .get();
+      return snap.docs.map(_parseEntry).toList();
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+  }
+
+  @override
+  Future<List<DiaryEntry>> searchEntries({
+    required String authorUid,
+    required String query,
+  }) async {
+    final normalized = query.trim().toLowerCase();
+    if (normalized.isEmpty) return const [];
+
+    try {
+      final snap = await _col
+          .where('authorUid', isEqualTo: authorUid)
+          .orderBy('createdAt', descending: true)
+          .get();
+      return snap.docs.map(_parseEntry).where((entry) {
+        if (entry.moodCaption.toLowerCase().contains(normalized)) return true;
+        return entry.content.any(
+          (block) => block.maybeWhen(
+            text: (value, _) => value.toLowerCase().contains(normalized),
+            orElse: () => false,
+          ),
+        );
+      }).toList();
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+  }
+
+  @override
+  Future<void> updateEntry(DiaryEntry entry) async {
+    if (entry.entryId.isEmpty) {
+      throw const ValidationError(
+        message: 'Thiếu mã nhật ký',
+        code: 'diary/entry-id-required',
+      );
+    }
+    _validateMoodCaption(entry.moodCaption);
+    _validateBlockCount(entry.content);
+
+    final docRef = _col.doc(entry.entryId);
+    final DocumentSnapshot<Map<String, dynamic>> snap;
+    try {
+      snap = await docRef.get();
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+    if (!snap.exists) {
+      throw NotFoundError('Nhật ký');
+    }
+    final existingAuthor = snap.data()?['authorUid'] as String?;
+    if (existingAuthor != entry.authorUid) {
+      throw const ValidationError(
+        message: 'Không được đổi tác giả của nhật ký',
+        code: 'diary/author-immutable',
+      );
+    }
+
+    final data = _serializeEntry(entry)
+      ..remove('createdAt')
+      ..['updatedAt'] = FieldValue.serverTimestamp();
+
+    try {
+      await docRef.update(data);
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+  }
+
+  @override
+  Future<void> updatePrivacy({
+    required String entryId,
+    required DiaryPrivacy privacy,
+  }) async {
+    if (entryId.isEmpty) {
+      throw const ValidationError(
+        message: 'Thiếu mã nhật ký',
+        code: 'diary/entry-id-required',
+      );
+    }
+    try {
+      await _col.doc(entryId).update({
+        'privacy': privacy.name,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+  }
+
+  @override
+  Future<void> deleteEntry(String entryId) async {
+    if (entryId.isEmpty) {
+      throw const ValidationError(
+        message: 'Thiếu mã nhật ký',
+        code: 'diary/entry-id-required',
+      );
+    }
+
+    final docRef = _col.doc(entryId);
+    final DocumentSnapshot<Map<String, dynamic>> snap;
+    try {
+      snap = await docRef.get();
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+    if (!snap.exists) {
+      throw NotFoundError('Nhật ký');
+    }
+    final ownerUid = snap.data()?['authorUid'] as String?;
+
+    try {
+      await docRef.delete();
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e);
+    }
+
+    if (ownerUid != null && ownerUid.isNotEmpty) {
+      try {
+        await _storageClient.deletePrefix('diary/$ownerUid/$entryId');
+      } on FirebaseException catch (e) {
+        throw _mapStorageError(e);
+      }
+    }
+  }
+
+  /// Convert entry → Firestore-ready map. Phải tự flatten `content` vì
+  /// `json_serializable` generate cho freezed union để raw `_$TextBlockImpl`
+  /// (không call `toJson()` từng phần tử), Firestore reject object lạ.
+  ///
+  /// KHÔNG lưu `entryId` vào doc field — `snap.id` là source of truth, mirror
+  /// `FirebasePostRepository` pattern. `_parseEntry` inject `snap.id` lại khi
+  /// đọc.
+  Map<String, dynamic> _serializeEntry(DiaryEntry entry) {
+    return <String, dynamic>{
+      'authorUid': entry.authorUid,
+      'moodTemplate': entry.moodTemplate.name,
+      'coverImageUrl': entry.coverImageUrl,
+      'moodCaption': entry.moodCaption,
+      'content': entry.content.map((b) => b.toJson()).toList(),
+      'privacy': entry.privacy.name,
+      'createdAt': const TimestampConverter().toJson(entry.createdAt),
+      'updatedAt': const TimestampConverter().toJson(entry.updatedAt),
+    };
+  }
+
+  void _validateMoodCaption(String caption) {
+    if (caption.length > _maxMoodCaptionChars) {
+      throw const ValidationError(
+        message: 'Tiêu đề nhật ký tối đa 50 ký tự',
+        code: 'diary/mood-caption-too-long',
+      );
+    }
+  }
+
+  void _validateBlockCount(List<DiaryContentBlock> content) {
+    if (content.length > _maxBlocks) {
+      throw const ValidationError(
+        message: 'Nhật ký tối đa 20 khối nội dung',
+        code: 'diary/too-many-blocks',
+      );
+    }
+  }
+
+  DiaryEntry _parseEntry(DocumentSnapshot<Map<String, dynamic>> snap) {
+    final data = Map<String, dynamic>.from(snap.data()!);
+    data['entryId'] = snap.id;
+    return DiaryEntry.fromJson(data);
+  }
+
+  AppError _mapFirestoreError(FirebaseException e) => switch (e.code) {
+        'permission-denied' => ForbiddenError('truy cập nhật ký'),
+        'not-found' => NotFoundError('Nhật ký'),
+        'unavailable' ||
+        'cancelled' ||
+        'deadline-exceeded' =>
+          NetworkError(message: 'Không có kết nối mạng', cause: e),
+        _ => UnexpectedError(
+            message: e.message ?? e.code,
+            code: e.code,
+            cause: e,
+          ),
+      };
+
+  AppError _mapStorageError(FirebaseException e) => switch (e.code) {
+        'unauthorized' ||
+        'permission-denied' =>
+          ForbiddenError('xoá ảnh nhật ký'),
+        'object-not-found' => NotFoundError('Ảnh nhật ký'),
+        'retry-limit-exceeded' ||
+        'unavailable' ||
+        'canceled' ||
+        'cancelled' =>
+          NetworkError(message: 'Không có kết nối mạng', cause: e),
+        _ => UnexpectedError(
+            message: e.message ?? e.code,
+            code: e.code,
+            cause: e,
+          ),
+      };
+}
+
+/// Storage boundary cho diary assets. Tách interface để test inject stub —
+/// `UploadTask` implement `Future` nhưng có chain methods khó mock.
+abstract class DiaryStorageClient {
+  /// Upload `bytes` lên `diary/{uid}/{entryId}/{fileName}` và trả download URL.
+  Future<String> upload({
+    required String uid,
+    required String entryId,
+    required String fileName,
+    required Uint8List bytes,
+    required String contentType,
+  });
+
+  /// Xoá toàn bộ object dưới `prefix` (vd `diary/{uid}/{entryId}`).
+  /// No-op nếu prefix trống. Repository gọi sau khi delete Firestore doc.
+  Future<void> deletePrefix(String prefix);
+}
+
+class _FirebaseDiaryStorageClient implements DiaryStorageClient {
+  _FirebaseDiaryStorageClient(this._storage);
+
+  final FirebaseStorage _storage;
+
+  @override
+  Future<String> upload({
+    required String uid,
+    required String entryId,
+    required String fileName,
+    required Uint8List bytes,
+    required String contentType,
+  }) async {
+    final ref = _storage.ref('diary/$uid/$entryId/$fileName');
+    await ref.putData(bytes, SettableMetadata(contentType: contentType));
+    return ref.getDownloadURL();
+  }
+
+  @override
+  Future<void> deletePrefix(String prefix) async {
+    final dir = _storage.ref(prefix);
+    final ListResult listing = await dir.listAll();
+    await Future.wait([
+      for (final item in listing.items) _safeDelete(item),
+    ]);
+  }
+
+  Future<void> _safeDelete(Reference ref) async {
+    try {
+      await ref.delete();
+    } on FirebaseException catch (e) {
+      if (e.code != 'object-not-found') rethrow;
+    }
+  }
+}

--- a/apps/mobile/test/features/diary/data/firebase_diary_repository_test.dart
+++ b/apps/mobile/test/features/diary/data/firebase_diary_repository_test.dart
@@ -1,0 +1,501 @@
+import 'dart:typed_data';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
+import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/data/firebase_diary_repository.dart';
+
+void main() {
+  const ownerUid = 'uid-owner';
+  const otherUid = 'uid-other';
+
+  late FakeFirebaseFirestore firestore;
+  late _StubDiaryStorageClient storage;
+  late FirebaseDiaryRepository repo;
+
+  DiaryEntry buildEntry({
+    String entryId = '',
+    String authorUid = ownerUid,
+    MoodTemplate mood = MoodTemplate.happy,
+    String coverImageUrl = 'https://cdn/cover.jpg',
+    String moodCaption = 'Happy!',
+    List<DiaryContentBlock> content = const [],
+    DiaryPrivacy privacy = DiaryPrivacy.private,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return DiaryEntry(
+      entryId: entryId,
+      authorUid: authorUid,
+      moodTemplate: mood,
+      coverImageUrl: coverImageUrl,
+      moodCaption: moodCaption,
+      content: content.isEmpty
+          ? const [DiaryContentBlock.text(value: 'Hôm nay đi chơi')]
+          : content,
+      privacy: privacy,
+      createdAt: createdAt ?? DateTime.utc(2026, 5, 22),
+      updatedAt: updatedAt ?? DateTime.utc(2026, 5, 22),
+    );
+  }
+
+  Future<void> seedEntry(
+    String entryId, {
+    required String authorUid,
+    DiaryPrivacy privacy = DiaryPrivacy.private,
+    String moodCaption = 'Title',
+    List<DiaryContentBlock> content = const [
+      DiaryContentBlock.text(value: 'Body content'),
+    ],
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) async {
+    final entry = buildEntry(
+      entryId: entryId,
+      authorUid: authorUid,
+      privacy: privacy,
+      moodCaption: moodCaption,
+      content: content,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+    await firestore.doc('diary/$entryId').set(<String, dynamic>{
+      'entryId': entryId,
+      'authorUid': entry.authorUid,
+      'moodTemplate': entry.moodTemplate.name,
+      'coverImageUrl': entry.coverImageUrl,
+      'moodCaption': entry.moodCaption,
+      'content': entry.content.map((b) => b.toJson()).toList(),
+      'privacy': entry.privacy.name,
+      'createdAt': Timestamp.fromDate(entry.createdAt),
+      'updatedAt': Timestamp.fromDate(entry.updatedAt),
+    });
+  }
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    storage = _StubDiaryStorageClient();
+    repo = FirebaseDiaryRepository(
+      firestore: firestore,
+      storageClient: storage,
+    );
+  });
+
+  group('createEntry', () {
+    test('Firestore auto-ID + trả entry với entryId server-generated',
+        () async {
+      final draft = buildEntry();
+
+      final created = await repo.createEntry(draft);
+
+      expect(created.entryId, isNotEmpty);
+      final snap = await firestore.doc('diary/${created.entryId}').get();
+      expect(snap.exists, true);
+      expect(snap.data()!['authorUid'], ownerUid);
+      expect(snap.data()!['moodTemplate'], 'happy');
+    });
+
+    test('set createdAt + updatedAt qua serverTimestamp', () async {
+      final draft = buildEntry();
+
+      final created = await repo.createEntry(draft);
+
+      final data =
+          (await firestore.doc('diary/${created.entryId}').get()).data()!;
+      expect(data['createdAt'], isA<Timestamp>());
+      expect(data['updatedAt'], isA<Timestamp>());
+    });
+
+    test('ghi authorUid vào field document để query đọc lại', () async {
+      final draft = buildEntry();
+
+      final created = await repo.createEntry(draft);
+
+      final data =
+          (await firestore.doc('diary/${created.entryId}').get()).data()!;
+      expect(data['authorUid'], ownerUid);
+      expect(
+        data.containsKey('entryId'),
+        false,
+        reason: 'entryId là snap.id, không lưu trùng vào field',
+      );
+    });
+
+    test('throws ValidationError khi moodCaption > 50 chars', () async {
+      final draft = buildEntry(moodCaption: 'x' * 51);
+
+      await expectLater(
+        repo.createEntry(draft),
+        throwsA(
+          isA<ValidationError>()
+              .having((e) => e.code, 'code', 'diary/mood-caption-too-long'),
+        ),
+      );
+    });
+
+    test('throws ValidationError khi content > 20 blocks', () async {
+      final blocks = List.generate(
+        21,
+        (i) => DiaryContentBlock.text(value: 'block $i'),
+      );
+      final draft = buildEntry(content: blocks);
+
+      await expectLater(
+        repo.createEntry(draft),
+        throwsA(
+          isA<ValidationError>()
+              .having((e) => e.code, 'code', 'diary/too-many-blocks'),
+        ),
+      );
+    });
+  });
+
+  group('watchEntries', () {
+    test('emit chỉ entries của authorUid theo createdAt DESC', () async {
+      await seedEntry(
+        'e-old',
+        authorUid: ownerUid,
+        createdAt: DateTime.utc(2026, 5, 20),
+      );
+      await seedEntry(
+        'e-new',
+        authorUid: ownerUid,
+        createdAt: DateTime.utc(2026, 5, 22),
+      );
+      await seedEntry(
+        'e-other',
+        authorUid: otherUid,
+        createdAt: DateTime.utc(2026, 5, 21),
+      );
+
+      final first = await repo.watchEntries(ownerUid).first;
+
+      expect(first.map((e) => e.entryId).toList(), ['e-new', 'e-old']);
+    });
+
+    test('emit list rỗng khi user chưa có entry nào', () async {
+      final first = await repo.watchEntries(ownerUid).first;
+      expect(first, isEmpty);
+    });
+
+    test('emit lại khi entry mới được thêm', () async {
+      final values = <int>[];
+      final sub = repo
+          .watchEntries(ownerUid)
+          .listen((entries) => values.add(entries.length));
+
+      await Future<void>.delayed(Duration.zero);
+      await seedEntry('e-1', authorUid: ownerUid);
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(values.last, 1);
+    });
+  });
+
+  group('getEntry', () {
+    test('trả entry khi doc tồn tại', () async {
+      await seedEntry('e-1', authorUid: ownerUid, moodCaption: 'Loaded');
+
+      final entry = await repo.getEntry('e-1');
+
+      expect(entry, isNotNull);
+      expect(entry!.entryId, 'e-1');
+      expect(entry.moodCaption, 'Loaded');
+    });
+
+    test('trả null khi doc không tồn tại', () async {
+      final entry = await repo.getEntry('missing');
+      expect(entry, isNull);
+    });
+
+    test('throws ValidationError khi entryId rỗng', () async {
+      await expectLater(
+        repo.getEntry(''),
+        throwsA(
+          isA<ValidationError>()
+              .having((e) => e.code, 'code', 'diary/entry-id-required'),
+        ),
+      );
+    });
+  });
+
+  group('getPublicEntries — Profile cross-module', () {
+    test('chỉ trả entries privacy == public của authorUid', () async {
+      await seedEntry(
+        'e-pub-1',
+        authorUid: ownerUid,
+        privacy: DiaryPrivacy.public,
+        createdAt: DateTime.utc(2026, 5, 22),
+      );
+      await seedEntry(
+        'e-pub-2',
+        authorUid: ownerUid,
+        privacy: DiaryPrivacy.public,
+        createdAt: DateTime.utc(2026, 5, 20),
+      );
+      await seedEntry(
+        'e-priv',
+        authorUid: ownerUid,
+        privacy: DiaryPrivacy.private,
+      );
+      await seedEntry(
+        'e-other-pub',
+        authorUid: otherUid,
+        privacy: DiaryPrivacy.public,
+      );
+
+      final result = await repo.getPublicEntries(ownerUid);
+
+      expect(result.map((e) => e.entryId).toList(), ['e-pub-1', 'e-pub-2']);
+    });
+
+    test('trả list rỗng khi user không có public entry', () async {
+      await seedEntry('e-priv', authorUid: ownerUid);
+
+      final result = await repo.getPublicEntries(ownerUid);
+      expect(result, isEmpty);
+    });
+  });
+
+  group('searchEntries — client-side filter', () {
+    setUp(() async {
+      await seedEntry(
+        'e-1',
+        authorUid: ownerUid,
+        moodCaption: 'Đà Lạt sương mù',
+        content: const [
+          DiaryContentBlock.text(value: 'Đi cafe Tùng buổi sáng'),
+        ],
+        createdAt: DateTime.utc(2026, 5, 22),
+      );
+      await seedEntry(
+        'e-2',
+        authorUid: ownerUid,
+        moodCaption: 'Mưa Sài Gòn',
+        content: const [DiaryContentBlock.text(value: 'Nhớ Đà Lạt quá')],
+        createdAt: DateTime.utc(2026, 5, 21),
+      );
+      await seedEntry(
+        'e-3',
+        authorUid: ownerUid,
+        moodCaption: 'Bình thường',
+        content: const [DiaryContentBlock.text(value: 'Nothing special')],
+      );
+      await seedEntry(
+        'e-other',
+        authorUid: otherUid,
+        moodCaption: 'Đà Lạt',
+      );
+    });
+
+    test('match qua moodCaption', () async {
+      final result = await repo.searchEntries(
+        authorUid: ownerUid,
+        query: 'sài gòn',
+      );
+
+      expect(result.map((e) => e.entryId).toList(), ['e-2']);
+    });
+
+    test('match qua text content block', () async {
+      final result = await repo.searchEntries(
+        authorUid: ownerUid,
+        query: 'cafe tùng',
+      );
+
+      expect(result.map((e) => e.entryId).toList(), ['e-1']);
+    });
+
+    test('case-insensitive', () async {
+      final result = await repo.searchEntries(
+        authorUid: ownerUid,
+        query: 'NHỚ',
+      );
+
+      expect(result.map((e) => e.entryId).toList(), ['e-2']);
+    });
+
+    test('không match cross-user entries', () async {
+      final result = await repo.searchEntries(
+        authorUid: ownerUid,
+        query: 'Đà Lạt',
+      );
+
+      final ids = result.map((e) => e.entryId).toList();
+      expect(ids, containsAll(['e-1', 'e-2']));
+      expect(ids, isNot(contains('e-other')));
+    });
+
+    test('trả list rỗng khi query không match', () async {
+      final result = await repo.searchEntries(
+        authorUid: ownerUid,
+        query: 'không có gì',
+      );
+      expect(result, isEmpty);
+    });
+
+    test('trả list rỗng khi query toàn whitespace', () async {
+      final result = await repo.searchEntries(
+        authorUid: ownerUid,
+        query: '   ',
+      );
+      expect(result, isEmpty);
+    });
+  });
+
+  group('updateEntry', () {
+    test('cập nhật field cho phép + set updatedAt', () async {
+      await seedEntry('e-1', authorUid: ownerUid, moodCaption: 'Old');
+      final updated = buildEntry(
+        entryId: 'e-1',
+        moodCaption: 'New',
+        content: const [DiaryContentBlock.text(value: 'New body')],
+      );
+
+      await repo.updateEntry(updated);
+
+      final data = (await firestore.doc('diary/e-1').get()).data()!;
+      expect(data['moodCaption'], 'New');
+      expect(data['updatedAt'], isA<Timestamp>());
+    });
+
+    test('throws khi entryId rỗng', () async {
+      final draft = buildEntry(entryId: '');
+
+      await expectLater(
+        repo.updateEntry(draft),
+        throwsA(
+          isA<ValidationError>()
+              .having((e) => e.code, 'code', 'diary/entry-id-required'),
+        ),
+      );
+    });
+
+    test('không cho đổi authorUid', () async {
+      await seedEntry('e-1', authorUid: ownerUid);
+      final hijack = buildEntry(entryId: 'e-1', authorUid: otherUid);
+
+      await expectLater(
+        repo.updateEntry(hijack),
+        throwsA(
+          isA<ValidationError>()
+              .having((e) => e.code, 'code', 'diary/author-immutable'),
+        ),
+      );
+
+      final data = (await firestore.doc('diary/e-1').get()).data()!;
+      expect(data['authorUid'], ownerUid);
+    });
+
+    test('throws NotFoundError khi entry không tồn tại', () async {
+      final draft = buildEntry(entryId: 'missing');
+
+      await expectLater(
+        repo.updateEntry(draft),
+        throwsA(isA<NotFoundError>()),
+      );
+    });
+
+    test('throws ValidationError khi moodCaption > 50', () async {
+      await seedEntry('e-1', authorUid: ownerUid);
+      final draft = buildEntry(entryId: 'e-1', moodCaption: 'x' * 51);
+
+      await expectLater(
+        repo.updateEntry(draft),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+  });
+
+  group('updatePrivacy', () {
+    test('chỉ update field privacy + updatedAt, không đụng content', () async {
+      await seedEntry(
+        'e-1',
+        authorUid: ownerUid,
+        moodCaption: 'Keep',
+        privacy: DiaryPrivacy.private,
+      );
+
+      await repo.updatePrivacy(
+        entryId: 'e-1',
+        privacy: DiaryPrivacy.public,
+      );
+
+      final data = (await firestore.doc('diary/e-1').get()).data()!;
+      expect(data['privacy'], 'public');
+      expect(data['moodCaption'], 'Keep');
+      expect(data['updatedAt'], isA<Timestamp>());
+    });
+
+    test('throws ValidationError khi entryId rỗng', () async {
+      await expectLater(
+        repo.updatePrivacy(entryId: '', privacy: DiaryPrivacy.public),
+        throwsA(
+          isA<ValidationError>()
+              .having((e) => e.code, 'code', 'diary/entry-id-required'),
+        ),
+      );
+    });
+  });
+
+  group('deleteEntry', () {
+    test('xoá Firestore doc', () async {
+      await seedEntry('e-1', authorUid: ownerUid);
+
+      await repo.deleteEntry('e-1');
+
+      final snap = await firestore.doc('diary/e-1').get();
+      expect(snap.exists, false);
+    });
+
+    test('gọi storage clear cho diary/{uid}/{entryId}', () async {
+      await seedEntry('e-1', authorUid: ownerUid);
+
+      await repo.deleteEntry('e-1');
+
+      expect(storage.lastDeletedPrefix, 'diary/$ownerUid/e-1');
+    });
+
+    test('throws NotFoundError khi entry không tồn tại', () async {
+      await expectLater(
+        repo.deleteEntry('missing'),
+        throwsA(isA<NotFoundError>()),
+      );
+      expect(storage.lastDeletedPrefix, isNull);
+    });
+
+    test('throws ValidationError khi entryId rỗng', () async {
+      await expectLater(
+        repo.deleteEntry(''),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+  });
+}
+
+class _StubDiaryStorageClient implements DiaryStorageClient {
+  String? lastDeletedPrefix;
+  Exception? exceptionToThrow;
+
+  @override
+  Future<String> upload({
+    required String uid,
+    required String entryId,
+    required String fileName,
+    required Uint8List bytes,
+    required String contentType,
+  }) async {
+    if (exceptionToThrow != null) throw exceptionToThrow!;
+    return 'https://stub/diary/$uid/$entryId/$fileName';
+  }
+
+  @override
+  Future<void> deletePrefix(String prefix) async {
+    if (exceptionToThrow != null) throw exceptionToThrow!;
+    lastDeletedPrefix = prefix;
+  }
+}

--- a/tasks/todo-diary.md
+++ b/tasks/todo-diary.md
@@ -9,10 +9,10 @@
 
 ## Phase 1 — Data layer
 
-- [ ] **T1** — `FirebaseDiaryRepository` (createEntry + watchEntries + **getPublicEntries(authorUid)** + getEntry + updateEntry + deleteEntry + searchEntries in-memory)
+- [x] **T1** — `FirebaseDiaryRepository` (createEntry + watchEntries + **getPublicEntries(authorUid)** + getEntry + updateEntry + deleteEntry + searchEntries in-memory)
 
 ## Checkpoint: Data layer ✓
-- [ ] `flutter test test/features/diary/` — 0 failures
+- [x] `flutter test test/features/diary/` — 0 failures
 
 ---
 


### PR DESCRIPTION
## Mô tả

Implement T1 — `FirebaseDiaryRepository` cho Diary module per [Plan T1](docs/plans/2026-05-23-diary.md). Đây là PR1 trong workflow BE 3-PR (T1 data → T2 controller + wire → T8 rules).

Build trên contract LX8 (PR #159 ThienPDM): `DiaryRepository` abstract (8 method), `DiaryEntry` + `DiaryContentBlock` freezed. PR này impl 8 method với Storage boundary tách qua `DiaryStorageClient` interface (mirror `FirebaseProfileRepository` pattern — `UploadTask extends Future` khó mock thẳng).

## Refs

- Closes #127 — T1 FirebaseDiaryRepository
- Refs #126 — Epic Diary
- Spec: [docs/specs/2026-05-23-diary.md](docs/specs/2026-05-23-diary.md)
- Plan: [docs/plans/2026-05-23-diary.md](docs/plans/2026-05-23-diary.md)

## Acceptance criteria (theo issue #127)

- [x] `createEntry` dùng Firestore auto-ID, trả `entryId` server-generated
- [x] `watchEntries(uid)` ORDER BY `createdAt DESC` — chỉ entries của owner
- [x] `getPublicEntries(authorUid)` filter `privacy == 'public'` — `Future<List>` cho Profile module
- [x] `searchEntries(uid, query)` load all → filter in-memory case-insensitive (MVP <100 entries)
- [x] `updateEntry` defensive check `authorUid` immutable
- [x] `flutter test test/features/diary/data/` — 30/30 pass

## Files

| File | Δ | Mô tả |
|---|---|---|
| `lib/features/diary/data/firebase_diary_repository.dart` | +354 (new) | 8 method impl + `DiaryStorageClient` interface |
| `test/features/diary/data/firebase_diary_repository_test.dart` | +501 (new) | 30 cases qua `fake_cloud_firestore` + stub storage |
| `tasks/todo-diary.md` | ±4 | Tick T1 |

## Design choices

- **Storage boundary qua `DiaryStorageClient`** — `UploadTask` implement Future nhưng có chain methods khó mock thẳng. Pattern mirror Profile (`AvatarStorageClient`). Factory `FirebaseDiaryRepository.firebase` wire production; test inject stub.
- **`_serializeEntry` flatten content thủ công** — `json_serializable` generate cho freezed union ghi raw `_$TextBlockImpl` instead of map → Firestore reject. Tự convert `content.map((b) => b.toJson()).toList()`.
- **Không lưu `entryId` vào doc field** — `snap.id` là source of truth (mirror `FirebasePostRepository`). `_parseEntry` inject `snap.id` lại khi đọc.
- **`deleteEntry` order**: Firestore doc xoá TRƯỚC, Storage prefix clear SAU — fail giữa chừng → user retry, doc đã không còn nên không show stale data.
- **Storage delete graceful** — `_safeDelete` swallow `object-not-found` (CF có thể đã clear trước).

## Caveats / follow-ups

### 1. Compound indexes thiếu — cần leader raise PR riêng

`watchEntries` + `searchEntries` query `(authorUid asc, createdAt desc)`.
`getPublicEntries` query `(authorUid asc, privacy asc, createdAt desc)`.

`fake_cloud_firestore` không enforce index → tests pass. Production sẽ throw `failed-precondition` khi wire `diaryRepositoryProvider` vào `main.dart` (làm ở T2). Em không touch `firebase/firestore.indexes.json` vì shared infra — cần ThienPDM raise PR riêng hoặc gộp vào PR3 T8 (rules + indexes).

### 2. `_serializeEntry` workaround json_serializable

Comment explain rõ trong code. Nếu sau này upgrade `freezed`/`json_serializable` fix bug union → có thể đơn giản hoá về `entry.toJson()`.

### 3. T2 và T8 chờ PR này merge

- **T2** (#128): `DiaryController` saveEntry + wire main + rewire mock screens
- **T8** (#131 partial): Firestore + Storage rules + rules tests + indexes

## Test plan

- [x] `flutter test test/features/diary/data/firebase_diary_repository_test.dart` — 30/30 pass
- [x] `flutter test test/features/diary/` — 30/30 pass
- [x] `flutter test` full suite — 598/598 pass, không break
- [x] `flutter analyze lib/features/diary/ test/features/diary/` — 0 issue
- [x] `dart format --set-exit-if-changed` — clean
- [x] `/review` 5-axis Standard — 0 critical, 3 important findings fixed (getEntry validation + bỏ entryId redundant field + indexes deferred)

## Self-review checklist

- [x] Branch name đúng format `feature/HanDHG/diary-firebase-repo`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không file lớn vô tình (`.env`, keystore, service account)
- [x] Không `print` debug còn sót
- [x] Không `// TODO` chưa link issue
- [x] Không touch module khác (mỗi diary)
- [x] Không touch shared infra (`core/`, `firestore.rules`, `firestore.indexes.json`) — caveat #1 flag clearly