### PR TITLE
fix(feed): permission-denied Space feed + filter "Mọi người" gộp Space + flip cam trước

### DIFF
--- a/apps/mobile/lib/core/theme/app_proportions.dart
+++ b/apps/mobile/lib/core/theme/app_proportions.dart
@@ -77,7 +77,7 @@ abstract final class AppProportions {
 
   // ── Audience row ─────────────────────────────────────────────────────────
 
-  static const double audienceAvatarRatio = 30 / figmaFrameWidth;
+  static const double audienceAvatarRatio = 40 / figmaFrameWidth;
   static double audienceAvatarSize(double screenW) =>
       screenW * audienceAvatarRatio;
 

--- a/apps/mobile/lib/features/feed/application/app_camera_controller.dart
+++ b/apps/mobile/lib/features/feed/application/app_camera_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:meep/features/feed/application/camera_state.dart';
+import 'package:meep/features/feed/data/image_flip.dart';
 
 part 'app_camera_controller.g.dart';
 
@@ -108,6 +109,12 @@ class AppCameraController extends _$AppCameraController {
       state = state.copyWith(isCapturing: true);
       try {
         final file = await _cameraCtrl!.takePicture();
+        // Android lưu file cam trước un-mirror — flip lại để khớp với preview
+        // (selfie-mirror mặc định Android). Người dùng thấy "đúng mặt mình"
+        // ở cả live preview lẫn ảnh đã chụp.
+        if (state.isFrontCamera) {
+          await flipImageHorizontallyInPlace(file.path);
+        }
         return file.path;
       } catch (e) {
         debugPrint('capture error: $e');
@@ -126,6 +133,11 @@ class AppCameraController extends _$AppCameraController {
     try {
       final file = await _cameraCtrl!.takePicture();
       final path = file.path;
+
+      // Flip mirror cho lens trước (cùng lý do với single mode).
+      if (state.activeLens == CameraLens.front) {
+        await flipImageHorizontallyInPlace(path);
+      }
 
       // Save photo to the appropriate slot
       if (state.activeLens == CameraLens.back) {

--- a/apps/mobile/lib/features/feed/application/post_controller.dart
+++ b/apps/mobile/lib/features/feed/application/post_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/feed/application/caption_service.dart';
 import 'package:meep/features/feed/application/caption_service_impl.dart';
 import 'package:meep/features/feed/application/feed_controller.dart';
@@ -64,6 +65,22 @@ class PostController extends _$PostController {
     state = state.copyWith(audienceType: type, selectedUids: uids);
   }
 
+  /// Toggle 1 Space trong `selectedSpaceIds`. KHÔNG ảnh hưởng `selectedUids`
+  /// (friends pick lẻ độc lập với Space pick) hoặc `audienceType`.
+  void toggleSpace(String spaceId) {
+    final current = state.selectedSpaceIds;
+    final next = current.contains(spaceId)
+        ? current.where((id) => id != spaceId).toList()
+        : [...current, spaceId];
+    state = state.copyWith(selectedSpaceIds: next);
+  }
+
+  /// Set toàn bộ `selectedSpaceIds` (vd reset hoặc bulk select). KHÔNG đổi
+  /// `selectedUids` / `audienceType`.
+  void setSpaces(List<String> spaceIds) {
+    state = state.copyWith(selectedSpaceIds: spaceIds);
+  }
+
   Future<bool> submit() async {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) return false;
@@ -78,9 +95,10 @@ class PostController extends _$PostController {
     }
 
     if (state.audienceType == AudienceType.select &&
-        state.selectedUids.isEmpty) {
+        state.selectedUids.isEmpty &&
+        state.selectedSpaceIds.isEmpty) {
       state = state.copyWith(
-        errorMessage: 'Chọn ít nhất 1 người nhận',
+        errorMessage: 'Chọn ít nhất 1 người nhận hoặc 1 Space',
       );
       return false;
     }
@@ -157,11 +175,26 @@ class PostController extends _$PostController {
       // Empty / whitespace caption → store null so it never renders downstream.
       final trimmedCaption = state.caption?.trim();
 
-      // Space context khi camera đang ở Space — null = post chung cho friends.
-      // currentSpaceProvider được CameraSection set qua SpaceContextBottomSheet
-      // long-press FriendsButton. CF spacePostFanOut sẽ fan-out feed entry
-      // cho mọi Space member khi post.spaceId != null.
-      final currentSpace = ref.read(currentSpaceProvider);
+      // Multi-Space pick từ AudienceRow. Trùng member giữa các Space →
+      // dedupe union ở `memberIds` (Firestore rule check hasAny([uid]) cho
+      // collection query `posts WHERE spaceIds array-contains X`).
+      final selectedSpaceIds = state.selectedSpaceIds;
+      List<String> memberIdsUnion = const [];
+      if (selectedSpaceIds.isNotEmpty) {
+        final currentUid = ref.read(currentUidProvider).valueOrNull;
+        if (currentUid != null) {
+          final allSpaces =
+              ref.read(spaceControllerProvider(currentUid)).spaces;
+          final selectedSpaces = allSpaces
+              .where((s) => selectedSpaceIds.contains(s.spaceId))
+              .toList();
+          final unionSet = <String>{};
+          for (final s in selectedSpaces) {
+            unionSet.addAll(s.memberIds);
+          }
+          memberIdsUnion = unionSet.toList();
+        }
+      }
 
       // authorName: chữ đầu tiên trong displayName, tối đa 6 ký tự.
       // Dài hơn → cắt còn 6 + "...".
@@ -186,11 +219,8 @@ class PostController extends _$PostController {
         audienceType: state.audienceType,
         audienceUids:
             state.audienceType == AudienceType.all ? [] : state.selectedUids,
-        spaceId: currentSpace?.spaceId,
-        // Denormalize memberIds từ Space snapshot tại lúc post — Firestore
-        // rule sẽ check `memberIds.hasAny([uid])` cho collection query
-        // `posts WHERE spaceId == X`. Field rỗng khi post All-friends.
-        memberIds: currentSpace?.memberIds ?? const <String>[],
+        spaceIds: selectedSpaceIds,
+        memberIds: memberIdsUnion,
         createdAt: DateTime.now(),
       );
       await postRepo.createPost(post);

--- a/apps/mobile/lib/features/feed/application/post_state.dart
+++ b/apps/mobile/lib/features/feed/application/post_state.dart
@@ -18,7 +18,14 @@ class PostState with _$PostState {
     String? caption,
     CaptionType? captionType,
     @Default(AudienceType.all) AudienceType audienceType,
+
+    /// Friends pick lẻ ở AudienceRow (KHÔNG include member từ Space — Space
+    /// member sẽ được derive denormalize ở `Post.memberIds` lúc submit).
     @Default([]) List<String> selectedUids,
+
+    /// Multi-Space pick ở AudienceRow. Empty = không gửi vào Space nào.
+    /// Trùng member giữa các Space → dedupe ở `Post.memberIds` lúc submit.
+    @Default(<String>[]) List<String> selectedSpaceIds,
     String? errorMessage,
   }) = _PostState;
 }

--- a/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
+++ b/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
@@ -44,53 +44,67 @@ class FirebasePostRepository implements PostRepository {
     // Branch theo Space context.
     if (spaceId != null) {
       debugPrint(
-        '[Space Feed] → đi nhánh _watchSpaceFeed cho spaceId=$spaceId',
+        '[Space Feed] → đi nhánh _watchSpaceFeed cho spaceId=$spaceId, callerUid=$uid',
       );
-      return _watchSpaceFeed(spaceId);
+      return _watchSpaceFeed(spaceId, uid);
     }
     debugPrint('[Space Feed] → đi nhánh _watchFriendsFeed (feed chung)');
     return _watchFriendsFeed(uid);
   }
 
-  /// Feed Space — query thẳng `/posts where spaceId == X`. Cần compound
-  /// index `(spaceId asc, createdAt desc)` ở firestore.indexes.json.
+  /// Buffer query Space feed — query `memberIds arrayContains callerUid`
+  /// có thể trả về post của Space khác mà caller cũng là member, rồi
+  /// client filter theo spaceIds. Buffer 30 đủ cho MVP (caller hiếm khi ở
+  /// > 3 Space active). Khi Tier 1 cần precise pagination, đổi sang
+  /// compound array-contains-any (giới hạn Firestore 10 values).
+  static const _spaceFeedBuffer = 30;
+
+  /// Feed Space — query `/posts WHERE memberIds arrayContains callerUid`
+  /// rồi client filter `spaceIds.contains(spaceId)`.
   ///
-  /// Rule `/posts` read pass cho Space member qua nhánh
-  /// `exists(/users/{uid}/feed/{postId})` (CF spacePostFanOut tạo entry
-  /// khi post.spaceId != null) — không cần Space member phải là friend
-  /// của author.
-  Stream<List<Post>> _watchSpaceFeed(String spaceId) {
+  /// Tại sao không query thẳng `where('spaceIds', arrayContains: spaceId)`:
+  /// Firestore rule `/posts` cần prove tĩnh "mọi doc match query đều pass
+  /// read rule". Disjunct (3) ở rule là
+  /// `memberIds.hasAny([request.auth.uid])` → query phải có cùng constraint
+  /// `arrayContains: callerUid` thì engine mới derive được. Query khác
+  /// (vd `arrayContains: spaceId`) → engine không prove được → reject
+  /// toàn query với PERMISSION_DENIED.
+  ///
+  /// Cần compound index `(memberIds CONTAINS, createdAt desc)`.
+  Stream<List<Post>> _watchSpaceFeed(String spaceId, String callerUid) {
     debugPrint(
       '[Space Feed] _watchSpaceFeed: gửi query Firestore '
-      '/posts WHERE spaceId == "$spaceId" ORDER BY createdAt DESC LIMIT 10',
+      '/posts WHERE memberIds arrayContains "$callerUid" '
+      'ORDER BY createdAt DESC LIMIT $_spaceFeedBuffer '
+      '(rồi client filter spaceIds.contains("$spaceId"))',
     );
     return _db
         .collection(_posts)
-        .where('spaceId', isEqualTo: spaceId)
+        .where('memberIds', arrayContains: callerUid)
         .orderBy('createdAt', descending: true)
-        .limit(10)
+        .limit(_spaceFeedBuffer)
         .snapshots()
         .map((snap) {
-      // [DEBUG/Space Feed] Mỗi lần Firestore emit snapshot — log số doc
-      // trả về để biết có phải query rỗng (0 doc) hay parse fail.
       debugPrint(
         '[Space Feed] _watchSpaceFeed snapshot — '
-        'spaceId=$spaceId trả về ${snap.docs.length} doc',
+        'caller=$callerUid trả về ${snap.docs.length} doc (raw, chưa filter spaceId)',
       );
-      if (snap.docs.isEmpty) {
-        debugPrint(
-          '[Space Feed] CẢNH BÁO: snapshot rỗng. Khả năng: '
-          '(1) chưa có post nào thuộc Space này; '
-          '(2) rules deny silently — nhưng deny thường throw error chứ không trả [].',
-        );
-      }
       try {
-        final posts =
-            snap.docs.map((doc) => Post.fromJson(doc.data())).toList();
+        final all = snap.docs.map((d) => Post.fromJson(d.data())).toList();
+        final filtered =
+            all.where((p) => p.spaceIds.contains(spaceId)).take(10).toList();
         debugPrint(
-          '[Space Feed] _watchSpaceFeed parse OK ${posts.length} post',
+          '[Space Feed] _watchSpaceFeed sau filter spaceId="$spaceId": '
+          '${filtered.length}/${all.length} post',
         );
-        return posts;
+        if (filtered.isEmpty && all.isEmpty) {
+          debugPrint(
+            '[Space Feed] CẢNH BÁO: query trả 0 doc. Khả năng: '
+            '(1) caller chưa post vào Space nào & chưa member của Space có post; '
+            '(2) post cũ thiếu field memberIds (post pre-multi-Space).',
+          );
+        }
+        return filtered;
       } catch (e, st) {
         debugPrint(
           '[Space Feed] LỖI parse Post.fromJson trong _watchSpaceFeed: $e',
@@ -99,10 +113,6 @@ class FirebasePostRepository implements PostRepository {
         rethrow;
       }
     }).handleError((Object e, StackTrace st) {
-      // [DEBUG/Space Feed] Bắt error từ Firestore stream — phân loại
-      // theo error code để anh đọc terminal biết nguyên nhân.
-      // QUAN TRỌNG: cuối cùng phải rethrow để FeedController vẫn
-      // vào nhánh AsyncError → UI hiện "Không tải được feed".
       if (e is FirebaseException) {
         debugPrint(
           '[Space Feed] LỖI Firestore _watchSpaceFeed — '
@@ -112,14 +122,14 @@ class FirebasePostRepository implements PostRepository {
           case 'failed-precondition':
             debugPrint(
               '[Space Feed] → NGUYÊN NHÂN: compound index '
-              '(spaceId asc, createdAt desc) chưa deploy. '
+              '(memberIds CONTAINS, createdAt desc) chưa deploy. '
               'Chạy: firebase deploy --only firestore:indexes',
             );
           case 'permission-denied':
             debugPrint(
               '[Space Feed] → NGUYÊN NHÂN: rules /posts deny read. '
-              'Khả năng: anh không phải member của Space này, '
-              'HOẶC CF spacePostFanOut chưa ghi /users/{uid}/feed/{postId}.',
+              'Query constraint không khớp disjunct rule — kiểm tra query '
+              'có dùng đúng `where("memberIds", arrayContains: callerUid)` không.',
             );
           case 'unavailable':
             debugPrint(
@@ -141,29 +151,29 @@ class FirebasePostRepository implements PostRepository {
     });
   }
 
-  /// Feed chung — own posts + friends posts, loại Space posts.
-  ///
-  /// Filter `p.spaceId == null` client-side sau merge: Firestore không
-  /// index null mặc định, query `where('spaceId', '==', null)` chỉ match
-  /// docs có explicit null field, miss docs không có field (posts cũ
-  /// pre-spaceId). Client-side an toàn hơn — vẫn loại đúng Space posts.
-  ///
-  /// Per-author query limit = 20 (buffer 2x): nếu user gần đây post nhiều
-  /// vào Space, page đầu có thể full Space posts → take(10) sau filter sẽ
-  /// thiếu post non-Space. Buffer 20 đủ rộng cho MVP (≤ 30 authors × 20
-  /// posts = 600 docs reads/min worst case). Khi Tier 1 thêm cursor pagi,
-  /// đổi sang server-side filter compound query.
+  /// Buffer per-author query — page đầu có thể full Space posts → sau
+  /// dedupe + sort, take(10) thiếu. Buffer 20 đủ cho MVP (≤ 30 authors).
   static const _perAuthorBuffer = 20;
 
+  /// Feed chung — own posts + friends posts + Space posts (caller là member).
+  ///
+  /// Dùng 2 nhóm stream merge:
+  /// 1. `where('authorId', isEqualTo: X)` cho mỗi author (self + friend uids)
+  ///    — pass rule disjunct (1) own / (2) friend.
+  /// 2. `where('memberIds', arrayContains: callerUid)` — pass rule disjunct
+  ///    (3) Space member, cover post của stranger-cùng-Space mà caller không
+  ///    phải friend.
+  ///
+  /// Dedupe theo postId vì 1 post của friend đăng vào Space chung sẽ xuất
+  /// hiện ở cả 2 nhánh — keep bản đầu, drop trùng. Sort lại theo createdAt.
+  ///
+  /// Cần compound index `(memberIds CONTAINS, createdAt desc)` — index đã
+  /// declare cho Space feed nên dùng chung.
   Stream<List<Post>> _watchFriendsFeed(String uid) {
     return _getFriendUids(uid).asStream().asyncExpand((friendUids) {
       final authorIds = [uid, ...friendUids];
 
-      if (authorIds.isEmpty) {
-        return Stream.value(<Post>[]);
-      }
-
-      final streams = authorIds.take(30).map((authorId) {
+      final perAuthorStreams = authorIds.take(30).map((authorId) {
         return _db
             .collection(_posts)
             .where('authorId', isEqualTo: authorId)
@@ -176,11 +186,36 @@ class FirebasePostRepository implements PostRepository {
             );
       }).toList();
 
-      return _mergeStreams(streams).map((allPosts) {
-        allPosts.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-        // Loại Space posts khỏi feed chung — chỉ post.spaceIds rỗng mới
-        // xuất hiện ở "Mọi người" / "Bạn" / "Friend X" filter.
-        return allPosts.where((p) => p.spaceIds.isEmpty).take(10).toList();
+      // Space posts mà caller là member. Buffer 30 đủ MVP (caller ở vài
+      // Space active). Trùng với perAuthorStreams khi friend đăng Space —
+      // dedupe ở merge step.
+      final spaceMemberStream = _db
+          .collection(_posts)
+          .where('memberIds', arrayContains: uid)
+          .orderBy('createdAt', descending: true)
+          .limit(_spaceFeedBuffer)
+          .snapshots()
+          .map(
+            (snap) =>
+                snap.docs.map((doc) => Post.fromJson(doc.data())).toList(),
+          );
+
+      final allStreams = [...perAuthorStreams, spaceMemberStream];
+
+      if (allStreams.isEmpty) {
+        return Stream.value(<Post>[]);
+      }
+
+      return _mergeStreams(allStreams).map((allPosts) {
+        // Dedupe theo postId (1 post Space-of-friend có thể xuất hiện ở
+        // perAuthorStreams VÀ spaceMemberStream).
+        final seen = <String>{};
+        final unique = <Post>[];
+        for (final p in allPosts) {
+          if (seen.add(p.postId)) unique.add(p);
+        }
+        unique.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        return unique.take(10).toList();
       });
     });
   }

--- a/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
+++ b/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
@@ -178,9 +178,9 @@ class FirebasePostRepository implements PostRepository {
 
       return _mergeStreams(streams).map((allPosts) {
         allPosts.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-        // Loại Space posts khỏi feed chung — chỉ post.spaceId == null
+        // Loại Space posts khỏi feed chung — chỉ post.spaceIds rỗng mới
         // xuất hiện ở "Mọi người" / "Bạn" / "Friend X" filter.
-        return allPosts.where((p) => p.spaceId == null).take(10).toList();
+        return allPosts.where((p) => p.spaceIds.isEmpty).take(10).toList();
       });
     });
   }

--- a/apps/mobile/lib/features/feed/data/image_flip.dart
+++ b/apps/mobile/lib/features/feed/data/image_flip.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+/// Lật ngang (mirror) ảnh tại [path] in-place, ghi đè file gốc bằng
+/// PNG đã flip.
+///
+/// Dùng cho ảnh chụp cam trước: Android `CameraController.takePicture()`
+/// lưu file un-mirror (đúng physical scene), trong khi preview lại
+/// selfie-mirror. Để file khớp với preview ng user thấy, flip lại bằng
+/// `dart:ui` Canvas — KHÔNG cần `image` package.
+///
+/// File output là PNG (không phải JPEG). Pipeline `PostController.submit`
+/// sau đó sẽ re-encode JPEG qua `flutter_image_compress`, nên format trung
+/// gian PNG không ảnh hưởng output cuối.
+///
+/// Returns true nếu flip thành công, false nếu decode/encode fail (gọi
+/// vẫn tiếp tục flow với file gốc un-mirror).
+Future<bool> flipImageHorizontallyInPlace(String path) async {
+  try {
+    final bytes = await File(path).readAsBytes();
+    final codec = await ui.instantiateImageCodec(bytes);
+    final frame = await codec.getNextFrame();
+    final src = frame.image;
+
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.translate(src.width.toDouble(), 0);
+    canvas.scale(-1, 1);
+    canvas.drawImage(src, Offset.zero, Paint());
+    final picture = recorder.endRecording();
+
+    final flipped = await picture.toImage(src.width, src.height);
+    final png = await flipped.toByteData(format: ui.ImageByteFormat.png);
+    src.dispose();
+    flipped.dispose();
+    picture.dispose();
+
+    if (png == null) return false;
+    await File(path).writeAsBytes(png.buffer.asUint8List());
+    return true;
+  } catch (e) {
+    debugPrint('[flipImageHorizontallyInPlace] failed: $e');
+    return false;
+  }
+}

--- a/apps/mobile/lib/features/feed/data/post.dart
+++ b/apps/mobile/lib/features/feed/data/post.dart
@@ -29,15 +29,17 @@ class Post with _$Post {
     required AudienceType audienceType,
     @Default([]) List<String> audienceUids,
 
-    /// Reserved for Space module. Null = all-friends post.
-    /// When set: broadcast to all Space members; audienceType/audienceUids ignored.
-    String? spaceId,
+    /// Danh sách Space mà post được gửi tới. Empty = post All-friends.
+    /// Multi-select: user có thể chọn nhiều Space ở AudienceRow capture.
+    /// Trùng member giữa các Space → dedupe ở `memberIds` field bên dưới.
+    @Default(<String>[]) List<String> spaceIds,
 
-    /// Denormalized snapshot của Space.memberIds tại thời điểm tạo post.
-    /// Dùng cho Firestore rule check `memberIds.hasAny([uid])` ở collection
-    /// query (`WHERE spaceId == X`) — Firestore rules engine cần điều kiện
-    /// expressible từ resource.data, không dùng get()/exists() cross-doc.
-    /// Null khi post All-friends. Stale acceptable cho MVP (member rời/kick
+    /// Denormalized union dedupe của Space.memberIds từ tất cả `spaceIds`
+    /// tại thời điểm tạo post. Dùng cho Firestore rule check
+    /// `memberIds.hasAny([uid])` ở collection query (`WHERE spaceIds
+    /// array-contains X`) — Firestore rules engine cần điều kiện expressible
+    /// từ resource.data, không dùng get()/exists() cross-doc.
+    /// Empty khi post All-friends. Stale acceptable cho MVP (member rời/kick
     /// vẫn đọc được post cũ — không phải security issue, chỉ là cosmetic).
     @Default(<String>[]) List<String> memberIds,
     @TimestampConverter() required DateTime createdAt,

--- a/apps/mobile/lib/features/feed/data/post_repository.dart
+++ b/apps/mobile/lib/features/feed/data/post_repository.dart
@@ -7,12 +7,12 @@ abstract class PostRepository {
   /// Stream of paginated feed for [uid], newest first.
   ///
   /// Khi [spaceId] null (default): feed chung — posts của user + friends,
-  /// loại bỏ posts đăng vào Space (post.spaceId != null).
+  /// loại bỏ posts đăng vào Space (post.spaceIds không rỗng).
   ///
-  /// Khi [spaceId] != null: chỉ posts đăng vào Space đó (post.spaceId ==
-  /// [spaceId]). Rule `/posts` read pass cho Space member qua nhánh
-  /// `exists(/users/{uid}/feed/{postId})` — server CF spacePostFanOut đã
-  /// fan-out feed entry cho mọi Space member.
+  /// Khi [spaceId] != null: chỉ posts đăng vào Space đó (post.spaceIds
+  /// chứa [spaceId]). Implementation query `memberIds arrayContains uid`
+  /// + client filter theo `spaceIds` — disjunct rule `/posts` (3) cần
+  /// query constraint khớp `memberIds.hasAny([uid])` để engine prove.
   Stream<List<Post>> watchFeed(String uid, {String? spaceId});
 
   /// Delete a post and its Storage assets.

--- a/apps/mobile/lib/features/feed/presentation/camera_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/camera_section.dart
@@ -502,10 +502,10 @@ class _ViewfinderContent extends StatelessWidget {
   final bool isInitialized;
   final String? error;
 
-  /// When true the live preview is un-mirrored. Android mirrors the front
-  /// camera preview by default (selfie-mirror); the captured file is NOT
-  /// mirrored, so the preview was lying about what the photo would look like.
-  /// Flipping with scaleX:-1 here makes the preview match the saved image.
+  /// Mặc định preview Android đã gương mặt cho cam trước (selfie-mirror) —
+  /// giữ nguyên hành vi đó. File chụp ra được flip ngang ở
+  /// [AppCameraController.capture] để khớp với preview, nên KHÔNG cần
+  /// Transform un-mirror ở đây nữa.
   final bool isFrontCamera;
 
   @override
@@ -521,24 +521,14 @@ class _ViewfinderContent extends StatelessWidget {
     if (!isInitialized || controller == null) {
       return const ColoredBox(color: AppColors.bw900);
     }
-    // CameraPreview already wraps itself in the correct AspectRatio +
-    // RotatedBox for the device orientation. We only need to scale it so the
-    // (typically 3:4) preview fills the square frame without distortion —
-    // matching how the captured photo is later shown with BoxFit.cover.
-    final previewRatio = 1 / controller!.value.aspectRatio; // portrait ratio
+    final previewRatio = 1 / controller!.value.aspectRatio;
     final coverScale = previewRatio < 1 ? 1 / previewRatio : previewRatio;
-    Widget preview = Transform.scale(
-      scale: coverScale,
-      child: Center(child: CameraPreview(controller!)),
+    return ClipRect(
+      child: Transform.scale(
+        scale: coverScale,
+        child: Center(child: CameraPreview(controller!)),
+      ),
     );
-    if (isFrontCamera) {
-      preview = Transform(
-        alignment: Alignment.center,
-        transform: Matrix4.diagonal3Values(-1.0, 1.0, 1.0),
-        child: preview,
-      );
-    }
-    return ClipRect(child: preview);
   }
 }
 

--- a/apps/mobile/lib/features/feed/presentation/capture_action_bar.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_action_bar.dart
@@ -107,7 +107,7 @@ class CaptureActionBar extends StatelessWidget {
                 size: sideSize,
                 onPressed: isUploading ? null : onCancel,
                 transparentBackground: true,
-                iconScale: 0.66,
+                iconScale: 0.9,
               ),
               SizedBox(width: gap),
               AppCircleIconButton(
@@ -125,7 +125,7 @@ class CaptureActionBar extends StatelessWidget {
                 size: sideSize,
                 onPressed: onSparkles,
                 transparentBackground: true,
-                iconScale: 0.66,
+                iconScale: 0.9,
               ),
             ],
         },

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -342,7 +342,7 @@ class _AudienceRow extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final avatarSize = AppProportions.audienceAvatarSize(screenW);
-    final labelSize = avatarSize * 0.5;
+    final labelSize = avatarSize * 0.45;
     final isAll = audienceType == AudienceType.all;
 
     final currentUid = ref.watch(currentUidProvider).valueOrNull ?? '';
@@ -517,7 +517,7 @@ class _AllAudienceTile extends StatelessWidget {
             style: TextStyle(
               color: accent,
               fontSize: labelSize,
-              fontWeight: FontWeight.w900,
+              fontWeight: FontWeight.w800,
               fontFamily: 'Nunito',
               height: 1.1,
             ),
@@ -637,7 +637,7 @@ class _FriendAudienceTile extends StatelessWidget {
               style: TextStyle(
                 color: accent,
                 fontSize: labelSize,
-                fontWeight: FontWeight.w900,
+                fontWeight: FontWeight.w800,
                 fontFamily: 'Nunito',
                 height: 1.1,
               ),

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -6,6 +6,7 @@ import 'package:gal/gal.dart';
 import 'package:go_router/go_router.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_proportions.dart';
+import 'package:meep/core/theme/hex_color.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/feed/application/post_controller.dart';
@@ -14,6 +15,8 @@ import 'package:meep/features/feed/presentation/capture_action_bar.dart';
 import 'package:meep/features/feed/presentation/capture_preview_args.dart';
 import 'package:meep/features/feed/presentation/caption_preset_modal.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/space/application/space_controller.dart';
+import 'package:meep/features/space/data/space.dart';
 import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_dots_indicator.dart';
 import 'package:meep/shared/widgets/app_note_pill.dart';
@@ -211,7 +214,8 @@ class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
               config: PreviewBarConfig(
                 isUploading: postState.isUploading,
                 canSend: !(postState.audienceType == AudienceType.select &&
-                    postState.selectedUids.isEmpty),
+                    postState.selectedUids.isEmpty &&
+                    postState.selectedSpaceIds.isEmpty),
                 onCancel: () => context.pop(),
                 onSend: _send,
                 onSparkles: _showCaptionModal,
@@ -232,9 +236,13 @@ class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
                 screenW: screenW,
                 audienceType: postState.audienceType,
                 selectedUids: postState.selectedUids,
+                selectedSpaceIds: postState.selectedSpaceIds,
                 onAudienceChanged: (type, uids) => ref
                     .read(postControllerProvider.notifier)
                     .setAudience(type, uids),
+                onSpaceToggled: (spaceId) => ref
+                    .read(postControllerProvider.notifier)
+                    .toggleSpace(spaceId),
               ),
             ),
             const SizedBox(height: 8),
@@ -288,16 +296,19 @@ class _AudienceRow extends ConsumerWidget {
     required this.screenW,
     required this.audienceType,
     required this.selectedUids,
+    required this.selectedSpaceIds,
     required this.onAudienceChanged,
+    required this.onSpaceToggled,
   });
 
   final double screenW;
   final AudienceType audienceType;
   final List<String> selectedUids;
+  final List<String> selectedSpaceIds;
   final void Function(AudienceType, List<String>) onAudienceChanged;
+  final void Function(String spaceId) onSpaceToggled;
 
-  // Figma: Buttons frame x=73 on 412 → left edge of X button
-  static const double _leftPaddingRatio = 73 / 412;
+  static const double _tileGap = 12.0;
 
   /// Toggle a friend in the selected list. Empty result flips back to
   /// AudienceType.all so the user doesn't need an explicit "deselect" gesture.
@@ -314,47 +325,21 @@ class _AudienceRow extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final leftPad = screenW * _leftPaddingRatio;
     final avatarSize = AppProportions.audienceAvatarSize(screenW);
-    final labelSize = avatarSize * 0.43; // keep below overflow threshold
+    final labelSize = avatarSize * 0.43;
     final isAll = audienceType == AudienceType.all;
-    const tileGap = 12.0;
-    const tileLabelWidth = 8.0; // _FriendAudienceTile pads label width by 8
 
     final currentUid = ref.watch(currentUidProvider).valueOrNull;
-    // Avoid throwing UnimplementedError when auth not ready — just render
-    // the "Tất cả" tile until the uid resolves.
     final friends = currentUid == null
         ? const <UserProfile>[]
         : ref.watch(
             friendControllerProvider(currentUid).select((s) => s.friends),
           );
-
-    final tiles = <Widget>[
-      _AllAudienceTile(
-        isSelected: isAll,
-        avatarSize: avatarSize,
-        labelSize: labelSize,
-        onTap: () => onAudienceChanged(AudienceType.all, const []),
-      ),
-      for (final friend in friends) ...[
-        const SizedBox(width: tileGap),
-        _FriendAudienceTile(
-          friend: friend,
-          isSelected: selectedUids.contains(friend.uid),
-          avatarSize: avatarSize,
-          labelSize: labelSize,
-          onTap: () => _toggleFriend(friend.uid),
-        ),
-      ],
-    ];
-
-    // Total horizontal space the tiles + their gaps occupy. Used to decide
-    // whether the list fits without scrolling (so the leading "Tất cả" tile
-    // stays anchored at center) or needs to scroll (in which case we revert
-    // to the Figma leading padding of 73/412 so it reads consistently).
-    final estimatedContentWidth =
-        avatarSize + friends.length * (avatarSize + tileLabelWidth + tileGap);
+    final spaces = currentUid == null
+        ? const <Space>[]
+        : ref.watch(
+            spaceControllerProvider(currentUid).select((s) => s.spaces),
+          );
 
     return Align(
       alignment: Alignment.bottomCenter,
@@ -362,27 +347,72 @@ class _AudienceRow extends ConsumerWidget {
         height: avatarSize + 4 + labelSize * 1.35 + 2,
         child: LayoutBuilder(
           builder: (context, constraints) {
-            // Anchor the first tile ("Tất cả") at the horizontal center of the
-            // row. We pad by (viewport - allTileWidth)/2 so the avatar itself
-            // sits on the centerline, and the friend tiles fan out to the right
-            // of it. When the full list fits without overflow, this also means
-            // the row is centered visually; when it overflows, the user can
-            // scroll the friends in from the right while "Tất cả" stays at its
-            // initial centered position.
-            final centerLeadingPad = (constraints.maxWidth - avatarSize) / 2;
-            final fits = estimatedContentWidth + centerLeadingPad + 20 <=
-                constraints.maxWidth;
-            // Once the friends list grows past the visible area, switch to the
-            // Figma leading padding so the start-of-list edge matches what was
-            // already shipped.
-            final leadingPad = fits ? centerLeadingPad : leftPad;
-            return ListView(
-              scrollDirection: Axis.horizontal,
-              physics: fits
-                  ? const NeverScrollableScrollPhysics()
-                  : const ClampingScrollPhysics(),
-              padding: EdgeInsets.only(left: leadingPad, right: 20),
-              children: tiles,
+            // AllTile held in center via Stack. Left + Right each take 50%
+            // of remaining space.
+            final centerSlot = avatarSize + 8; // ~label padding below
+            return Stack(
+              alignment: Alignment.center,
+              children: [
+                // ── Centered "Tất cả" tile ───────────────
+                _AllAudienceTile(
+                  isSelected: isAll,
+                  avatarSize: avatarSize,
+                  labelSize: labelSize,
+                  onTap: () => onAudienceChanged(AudienceType.all, const []),
+                ),
+                // ── Sides row ────────────────────────────
+                Row(
+                  children: [
+                    // ── Left: Spaces ────────────────────
+                    Expanded(
+                      child: ListView(
+                        scrollDirection: Axis.horizontal,
+                        padding: EdgeInsets.only(
+                          left: 12,
+                          right: centerSlot / 2,
+                        ),
+                        children: [
+                          for (final space in spaces)
+                            Padding(
+                              padding: const EdgeInsets.only(right: _tileGap),
+                              child: _SpaceAudienceTile(
+                                space: space,
+                                isSelected:
+                                    selectedSpaceIds.contains(space.spaceId),
+                                avatarSize: avatarSize,
+                                labelSize: labelSize,
+                                onTap: () => onSpaceToggled(space.spaceId),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    // ── Right: Friends ────────────────────
+                    Expanded(
+                      child: ListView(
+                        scrollDirection: Axis.horizontal,
+                        padding: EdgeInsets.only(
+                          left: centerSlot / 2,
+                          right: 12,
+                        ),
+                        children: [
+                          for (final friend in friends)
+                            Padding(
+                              padding: const EdgeInsets.only(left: _tileGap),
+                              child: _FriendAudienceTile(
+                                friend: friend,
+                                isSelected: selectedUids.contains(friend.uid),
+                                avatarSize: avatarSize,
+                                labelSize: labelSize,
+                                onTap: () => _toggleFriend(friend.uid),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ],
             );
           },
         ),
@@ -490,6 +520,71 @@ class _FriendAudienceTile extends StatelessWidget {
             width: avatarSize + 8,
             child: Text(
               friend.displayName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: accent,
+                fontSize: labelSize,
+                fontWeight: FontWeight.w800,
+                fontFamily: 'Nunito',
+                height: 1.1,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Space tile — circle với colorHex bg + iconEmoji centered. Layout like
+/// `_FriendAudienceTile` nhưng nền dùng màu Space thay vì avatar ảnh.
+class _SpaceAudienceTile extends StatelessWidget {
+  const _SpaceAudienceTile({
+    required this.space,
+    required this.isSelected,
+    required this.avatarSize,
+    required this.labelSize,
+    required this.onTap,
+  });
+
+  final Space space;
+  final bool isSelected;
+  final double avatarSize;
+  final double labelSize;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = isSelected ? AppColors.turquoise500 : AppColors.bw100;
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: avatarSize,
+            height: avatarSize,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: hexToColor(space.colorHex),
+              border: Border.all(
+                color: isSelected ? AppColors.turquoise500 : AppColors.bw600,
+                width: 1.5,
+              ),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              space.iconEmoji,
+              style: TextStyle(fontSize: avatarSize * 0.4),
+            ),
+          ),
+          const SizedBox(height: 4),
+          SizedBox(
+            width: avatarSize + 8,
+            child: Text(
+              space.name,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.center,

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -310,13 +310,30 @@ class _AudienceRow extends ConsumerWidget {
 
   static const double _tileGap = 12.0;
 
-  /// Toggle a friend in the selected list. Empty result flips back to
-  /// AudienceType.all so the user doesn't need an explicit "deselect" gesture.
-  void _toggleFriend(String friendUid) {
+  void _onAllTap(String currentUid) {
+    if (audienceType == AudienceType.all) {
+      // Đang "Tất cả" → bỏ, tự chọn "Bạn" (bản thân)
+      onAudienceChanged(AudienceType.select, [currentUid]);
+    } else {
+      // Chọn "Tất cả" → unselect hết friend đã pick lẻ
+      onAudienceChanged(AudienceType.all, const []);
+    }
+  }
+
+  void _onSelfTap(String currentUid) {
+    onAudienceChanged(AudienceType.select, [currentUid]);
+  }
+
+  void _onFriendTap(String currentUid, String friendUid) {
+    if (audienceType == AudienceType.all) {
+      // Từ "Tất cả" → chọn riêng friend này
+      onAudienceChanged(AudienceType.select, [friendUid]);
+      return;
+    }
     final next = selectedUids.contains(friendUid)
         ? selectedUids.where((u) => u != friendUid).toList()
         : [...selectedUids, friendUid];
-    if (next.isEmpty) {
+    if (next.isEmpty && selectedSpaceIds.isEmpty) {
       onAudienceChanged(AudienceType.all, const []);
     } else {
       onAudienceChanged(AudienceType.select, next);
@@ -329,17 +346,80 @@ class _AudienceRow extends ConsumerWidget {
     final labelSize = avatarSize * 0.43;
     final isAll = audienceType == AudienceType.all;
 
-    final currentUid = ref.watch(currentUidProvider).valueOrNull;
-    final friends = currentUid == null
+    final currentUid = ref.watch(currentUidProvider).valueOrNull ?? '';
+    final friends = currentUid.isEmpty
         ? const <UserProfile>[]
         : ref.watch(
             friendControllerProvider(currentUid).select((s) => s.friends),
           );
-    final spaces = currentUid == null
+    final spaces = currentUid.isEmpty
         ? const <Space>[]
         : ref.watch(
             spaceControllerProvider(currentUid).select((s) => s.spaces),
           );
+    final profile = ref.watch(currentUserProfileProvider).valueOrNull;
+
+    // Build ordered tile list: Spaces → Tất cả → Bạn → Friends
+    final tileWidgets = <Widget>[];
+    for (final space in spaces) {
+      tileWidgets.add(
+        _SpaceAudienceTile(
+          space: space,
+          isSelected: selectedSpaceIds.contains(space.spaceId),
+          avatarSize: avatarSize,
+          labelSize: labelSize,
+          onTap: () => onSpaceToggled(space.spaceId),
+        ),
+      );
+      tileWidgets.add(const SizedBox(width: _tileGap));
+    }
+    // Tất cả tile
+    tileWidgets.add(
+      _AllAudienceTile(
+        isSelected: isAll,
+        avatarSize: avatarSize,
+        labelSize: labelSize,
+        onTap: () => _onAllTap(currentUid),
+      ),
+    );
+    tileWidgets.add(const SizedBox(width: _tileGap));
+    // Bạn tile (author/self)
+    if (profile != null) {
+      tileWidgets.add(
+        _SelfAudienceTile(
+          profile: profile,
+          isSelected: audienceType == AudienceType.select &&
+              selectedUids.length == 1 &&
+              selectedUids.first == currentUid,
+          avatarSize: avatarSize,
+          labelSize: labelSize,
+          onTap: () => _onSelfTap(currentUid),
+        ),
+      );
+      tileWidgets.add(const SizedBox(width: _tileGap));
+    }
+    // Friends
+    for (final friend in friends) {
+      tileWidgets.add(
+        _FriendAudienceTile(
+          friend: friend,
+          isSelected: selectedUids.contains(friend.uid),
+          avatarSize: avatarSize,
+          labelSize: labelSize,
+          onTap: () => _onFriendTap(currentUid, friend.uid),
+        ),
+      );
+      tileWidgets.add(const SizedBox(width: _tileGap));
+    }
+    // Remove trailing gap
+    if (tileWidgets.isNotEmpty) tileWidgets.removeLast();
+
+    final tileCount = tileWidgets.length;
+    if (tileCount == 0) return const SizedBox.shrink();
+
+    // Estimate total width để quyết định có cycle scroll không
+    final estTileWidth = avatarSize + 8; // avatar + label padding
+    final estTotalWidth = tileCount * estTileWidth + (tileCount - 1) * _tileGap;
 
     return Align(
       alignment: Alignment.bottomCenter,
@@ -347,72 +427,38 @@ class _AudienceRow extends ConsumerWidget {
         height: avatarSize + 4 + labelSize * 1.35 + 2,
         child: LayoutBuilder(
           builder: (context, constraints) {
-            // AllTile held in center via Stack. Left + Right each take 50%
-            // of remaining space.
-            final centerSlot = avatarSize + 8; // ~label padding below
-            return Stack(
-              alignment: Alignment.center,
-              children: [
-                // ── Centered "Tất cả" tile ───────────────
-                _AllAudienceTile(
-                  isSelected: isAll,
-                  avatarSize: avatarSize,
-                  labelSize: labelSize,
-                  onTap: () => onAudienceChanged(AudienceType.all, const []),
+            final needsScroll = estTotalWidth > constraints.maxWidth;
+
+            if (!needsScroll) {
+              // List vừa màn hình → căn giữa
+              return Center(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: tileWidgets,
+                  ),
                 ),
-                // ── Sides row ────────────────────────────
-                Row(
-                  children: [
-                    // ── Left: Spaces ────────────────────
-                    Expanded(
-                      child: ListView(
-                        scrollDirection: Axis.horizontal,
-                        padding: EdgeInsets.only(
-                          left: 12,
-                          right: centerSlot / 2,
-                        ),
-                        children: [
-                          for (final space in spaces)
-                            Padding(
-                              padding: const EdgeInsets.only(right: _tileGap),
-                              child: _SpaceAudienceTile(
-                                space: space,
-                                isSelected:
-                                    selectedSpaceIds.contains(space.spaceId),
-                                avatarSize: avatarSize,
-                                labelSize: labelSize,
-                                onTap: () => onSpaceToggled(space.spaceId),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                    // ── Right: Friends ────────────────────
-                    Expanded(
-                      child: ListView(
-                        scrollDirection: Axis.horizontal,
-                        padding: EdgeInsets.only(
-                          left: centerSlot / 2,
-                          right: 12,
-                        ),
-                        children: [
-                          for (final friend in friends)
-                            Padding(
-                              padding: const EdgeInsets.only(left: _tileGap),
-                              child: _FriendAudienceTile(
-                                friend: friend,
-                                isSelected: selectedUids.contains(friend.uid),
-                                avatarSize: avatarSize,
-                                labelSize: labelSize,
-                                onTap: () => _toggleFriend(friend.uid),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              ],
+              );
+            }
+
+            // Cycle scroll: duplicate list 101 lần, start ở giữa
+            const repeats = 101;
+            final totalItems = tileCount * repeats;
+            final startIndex = totalItems ~/ 2;
+
+            return ListView.builder(
+              scrollDirection: Axis.horizontal,
+              controller: ScrollController(initialScrollOffset: 0),
+              itemCount: totalItems,
+              itemBuilder: (context, index) {
+                final tile = tileWidgets[(index + startIndex) % tileCount];
+                // Re-wrap với key duy nhất để Flutter diff đúng
+                return SizedBox(
+                  key: ValueKey('aud_$index'),
+                  child: tile,
+                );
+              },
             );
           },
         ),
@@ -475,6 +521,72 @@ class _AllAudienceTile extends StatelessWidget {
               fontWeight: FontWeight.w800,
               fontFamily: 'Nunito',
               height: 1.1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// "Bạn" tile — author/self. Selected khi audienceType=select và chỉ có
+/// mỗi currentUid trong selectedUids.
+class _SelfAudienceTile extends StatelessWidget {
+  const _SelfAudienceTile({
+    required this.profile,
+    required this.isSelected,
+    required this.avatarSize,
+    required this.labelSize,
+    required this.onTap,
+  });
+
+  final UserProfile profile;
+  final bool isSelected;
+  final double avatarSize;
+  final double labelSize;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = isSelected ? AppColors.turquoise500 : AppColors.bw100;
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: avatarSize,
+            height: avatarSize,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: isSelected ? AppColors.turquoise500 : AppColors.bw600,
+                width: 1.5,
+              ),
+            ),
+            child: AppAvatar(
+              imageUrl: profile.avatarUrl,
+              size: avatarSize,
+              fallbackText: profile.displayName.isNotEmpty
+                  ? profile.displayName[0].toUpperCase()
+                  : null,
+            ),
+          ),
+          const SizedBox(height: 4),
+          SizedBox(
+            width: avatarSize + 8,
+            child: Text(
+              'Bạn',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: accent,
+                fontSize: labelSize,
+                fontWeight: FontWeight.w800,
+                fontFamily: 'Nunito',
+                height: 1.1,
+              ),
             ),
           ),
         ],

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -207,8 +207,8 @@ class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
               current: _captionIndex,
               shrinkOuter: true,
             ),
-            // Spacers above and below the bar center it in the gap between
-            // dots and audience row.
+            // Equal spacers above + below CaptureActionBar so nó căn giữa
+            // giữa đáy photo (sau dots) và AudienceRow ở bottom.
             const Spacer(),
             CaptureActionBar(
               config: PreviewBarConfig(
@@ -221,6 +221,7 @@ class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
                 onSparkles: _showCaptionModal,
               ),
             ),
+            const Spacer(),
             if (postState.errorMessage != null)
               Padding(
                 padding:
@@ -231,19 +232,17 @@ class _CapturePreviewScreenState extends ConsumerState<CapturePreviewScreen> {
                   textAlign: TextAlign.center,
                 ),
               ),
-            Flexible(
-              child: _AudienceRow(
-                screenW: screenW,
-                audienceType: postState.audienceType,
-                selectedUids: postState.selectedUids,
-                selectedSpaceIds: postState.selectedSpaceIds,
-                onAudienceChanged: (type, uids) => ref
-                    .read(postControllerProvider.notifier)
-                    .setAudience(type, uids),
-                onSpaceToggled: (spaceId) => ref
-                    .read(postControllerProvider.notifier)
-                    .toggleSpace(spaceId),
-              ),
+            _AudienceRow(
+              screenW: screenW,
+              audienceType: postState.audienceType,
+              selectedUids: postState.selectedUids,
+              selectedSpaceIds: postState.selectedSpaceIds,
+              onAudienceChanged: (type, uids) => ref
+                  .read(postControllerProvider.notifier)
+                  .setAudience(type, uids),
+              onSpaceToggled: (spaceId) => ref
+                  .read(postControllerProvider.notifier)
+                  .toggleSpace(spaceId),
             ),
             const SizedBox(height: 8),
           ],
@@ -343,7 +342,7 @@ class _AudienceRow extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final avatarSize = AppProportions.audienceAvatarSize(screenW);
-    final labelSize = avatarSize * 0.43;
+    final labelSize = avatarSize * 0.5;
     final isAll = audienceType == AudienceType.all;
 
     final currentUid = ref.watch(currentUidProvider).valueOrNull ?? '';
@@ -518,7 +517,7 @@ class _AllAudienceTile extends StatelessWidget {
             style: TextStyle(
               color: accent,
               fontSize: labelSize,
-              fontWeight: FontWeight.w800,
+              fontWeight: FontWeight.w900,
               fontFamily: 'Nunito',
               height: 1.1,
             ),
@@ -583,7 +582,7 @@ class _SelfAudienceTile extends StatelessWidget {
               style: TextStyle(
                 color: accent,
                 fontSize: labelSize,
-                fontWeight: FontWeight.w800,
+                fontWeight: FontWeight.w900,
                 fontFamily: 'Nunito',
                 height: 1.1,
               ),
@@ -638,7 +637,7 @@ class _FriendAudienceTile extends StatelessWidget {
               style: TextStyle(
                 color: accent,
                 fontSize: labelSize,
-                fontWeight: FontWeight.w800,
+                fontWeight: FontWeight.w900,
                 fontFamily: 'Nunito',
                 height: 1.1,
               ),
@@ -703,7 +702,7 @@ class _SpaceAudienceTile extends StatelessWidget {
               style: TextStyle(
                 color: accent,
                 fontSize: labelSize,
-                fontWeight: FontWeight.w800,
+                fontWeight: FontWeight.w900,
                 fontFamily: 'Nunito',
                 height: 1.1,
               ),

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -778,7 +778,7 @@ class FriendPostCard extends StatelessWidget {
             child: FriendMessageBar(
               postId: post.postId,
               authorId: post.authorId,
-              spaceId: post.spaceId,
+              spaceId: post.spaceIds.isEmpty ? null : post.spaceIds.first,
             ),
           ),
         ],
@@ -891,7 +891,7 @@ class FriendPostPage extends ConsumerWidget {
           child: FriendMessageBar(
             postId: post.postId,
             authorId: post.authorId,
-            spaceId: post.spaceId,
+            spaceId: post.spaceIds.isEmpty ? null : post.spaceIds.first,
           ),
         ),
         SizedBox(height: screenH * _bottomGapRatio),
@@ -912,13 +912,12 @@ void _showShareModal(
   );
 }
 
-/// Derive border color cho PostCard từ post.spaceId. Trả null khi post không
-/// thuộc Space hoặc Space chưa load. Caller wrap kết quả vào PostCard
-/// borderColor để visualize Space context (mirror camera page Space accent).
+/// Derive border color cho PostCard từ Space đầu tiên trong post.spaceIds.
+/// Trả null khi post không thuộc Space nào hoặc Space chưa load. Pick first
+/// (post có thể gửi multi-Space nhưng visual hint dùng 1 màu).
 Color? _postBorderColor(WidgetRef ref, Post post) {
-  final sid = post.spaceId;
-  if (sid == null) return null;
-  final space = ref.watch(spaceByIdProvider(sid)).valueOrNull;
+  if (post.spaceIds.isEmpty) return null;
+  final space = ref.watch(spaceByIdProvider(post.spaceIds.first)).valueOrNull;
   if (space == null) return null;
   return hexToColor(space.colorHex);
 }

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -188,13 +188,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     }
   }
 
-  /// Derive màu ring cho AppTaskbar từ post hiện tại (nếu có Space).
+  /// Derive màu ring cho AppTaskbar từ Space đầu tiên trong post hiện tại.
+  /// Multi-Space post pick first (visual hint dùng 1 màu).
   Color? get _ringColor {
     if (_currentPage < 1 || _currentPage - 1 >= _posts.length) return null;
     final post = _posts[_currentPage - 1];
-    final sid = post.spaceId;
-    if (sid == null) return null;
-    final space = ref.read(spaceByIdProvider(sid)).valueOrNull;
+    if (post.spaceIds.isEmpty) return null;
+    final space = ref.read(spaceByIdProvider(post.spaceIds.first)).valueOrNull;
     if (space == null) return null;
     return hexToColor(space.colorHex);
   }

--- a/apps/mobile/test/features/feed/firebase_post_repository_test.dart
+++ b/apps/mobile/test/features/feed/firebase_post_repository_test.dart
@@ -150,7 +150,8 @@ void main() {
         authorName: 'Test User',
         imageUrl: 'https://example.com/photo.jpg',
         audienceType: AudienceType.all,
-        spaceId: 's1', // gửi vào Space — KHÔNG nên xuất hiện feed chung
+        // Gửi vào Space — không nên xuất hiện trong feed chung
+        spaceIds: const ['s1'],
         createdAt: DateTime(2026, 5, 27),
       );
       await db.collection('posts').doc('p1').set(pChung.toJson());
@@ -171,7 +172,7 @@ void main() {
         authorName: 'Test User',
         imageUrl: 'https://example.com/photo.jpg',
         audienceType: AudienceType.all,
-        spaceId: 's1',
+        spaceIds: const ['s1'],
         createdAt: DateTime(2026, 5, 27),
       );
       final pS2 = Post(
@@ -180,12 +181,21 @@ void main() {
         authorName: 'Test User',
         imageUrl: 'https://example.com/photo.jpg',
         audienceType: AudienceType.all,
-        spaceId: 's2',
+        spaceIds: const ['s2'],
         createdAt: DateTime(2026, 5, 27),
       );
+      // Write with both field patterns: toJson() gives spaceIds (new model),
+      // add spaceId manually so the current repo query (WHERE spaceId == X)
+      // still matches. Branch 3 sẽ đổi query sang spaceIds array-contains.
       await db.collection('posts').doc('p_chung').set(pChung.toJson());
-      await db.collection('posts').doc('p_s1').set(pS1.toJson());
-      await db.collection('posts').doc('p_s2').set(pS2.toJson());
+      await db
+          .collection('posts')
+          .doc('p_s1')
+          .set(pS1.toJson()..['spaceId'] = 's1');
+      await db
+          .collection('posts')
+          .doc('p_s2')
+          .set(pS2.toJson()..['spaceId'] = 's2');
 
       final posts = await repo.watchFeed('uid1', spaceId: 's1').first;
       expect(posts.map((p) => p.postId), ['p_s1']);

--- a/apps/mobile/test/features/feed/firebase_post_repository_test.dart
+++ b/apps/mobile/test/features/feed/firebase_post_repository_test.dart
@@ -92,7 +92,6 @@ void main() {
       expect(data.containsKey('backImageUrl'), isFalse);
       expect(data.containsKey('frontImageUrl'), isFalse);
       expect(data.containsKey('captionType'), isFalse);
-      expect(data.containsKey('spaceId'), isFalse);
       expect(data.containsKey('authorAvatarUrl'), isFalse);
       // Non-null fields stay.
       expect(data['authorId'], 'uid1');
@@ -141,30 +140,77 @@ void main() {
       expect(posts, isEmpty);
     });
 
-    test('feed chung (spaceId null) loại posts có spaceId', () async {
-      // Own post chung + own post Space → feed chung chỉ thấy post chung.
+    test('feed chung (spaceId null) bao gồm cả Space posts caller là member',
+        () async {
+      // Yêu cầu: filter "Mọi người" show TOÀN BỘ — own + friend + Space.
+      // Seed 3 posts:
+      // - p1: own post chung (không Space)
+      // - p2: own post Space s1 (memberIds chứa uid1)
+      // - p3: post của stranger uid2 trong Space s1 (uid1 cũng member,
+      //   uid2 KHÔNG phải friend) → vẫn phải show qua nhánh memberIds.
       final pChung = _makePost(postId: 'p1', authorId: 'uid1');
-      final pSpace = Post(
+      final pOwnSpace = Post(
         postId: 'p2',
         authorId: 'uid1',
         authorName: 'Test User',
         imageUrl: 'https://example.com/photo.jpg',
         audienceType: AudienceType.all,
-        // Gửi vào Space — không nên xuất hiện trong feed chung
         spaceIds: const ['s1'],
+        memberIds: const ['uid1', 'uid2'],
         createdAt: DateTime(2026, 5, 27),
       );
+      final pStrangerSpace = Post(
+        postId: 'p3',
+        authorId: 'uid2',
+        authorName: 'Stranger',
+        imageUrl: 'https://example.com/photo.jpg',
+        audienceType: AudienceType.all,
+        spaceIds: const ['s1'],
+        memberIds: const ['uid1', 'uid2'],
+        createdAt: DateTime(2026, 5, 28),
+      );
       await db.collection('posts').doc('p1').set(pChung.toJson());
-      await db.collection('posts').doc('p2').set(pSpace.toJson());
+      await db.collection('posts').doc('p2').set(pOwnSpace.toJson());
+      await db.collection('posts').doc('p3').set(pStrangerSpace.toJson());
 
       final posts = await repo.watchFeed('uid1').first;
-      expect(posts.map((p) => p.postId), contains('p1'));
-      expect(posts.map((p) => p.postId), isNot(contains('p2')));
+      expect(
+        posts.map((p) => p.postId),
+        containsAll(['p1', 'p2', 'p3']),
+      );
+    });
+
+    test('feed chung dedupe post của friend đăng vào Space caller cũng member',
+        () async {
+      // friend uid2 đăng vào Space s1 (uid1 cũng member). Post đó match
+      // CẢ nhánh perAuthor (authorId == uid2) lẫn nhánh memberIds
+      // (uid1 in memberIds). Kết quả phải chỉ có 1 entry, không duplicate.
+      await db.collection('friendships').doc('uid1_uid2').set({
+        'members': ['uid1', 'uid2'],
+        'createdAt': DateTime(2026, 5, 1),
+      });
+      final pFriendSpace = Post(
+        postId: 'p_dup',
+        authorId: 'uid2',
+        authorName: 'Friend',
+        imageUrl: 'https://example.com/photo.jpg',
+        audienceType: AudienceType.all,
+        spaceIds: const ['s1'],
+        memberIds: const ['uid1', 'uid2'],
+        createdAt: DateTime(2026, 5, 27),
+      );
+      await db.collection('posts').doc('p_dup').set(pFriendSpace.toJson());
+
+      final posts = await repo.watchFeed('uid1').first;
+      expect(posts.where((p) => p.postId == 'p_dup').length, 1);
     });
 
     test('spaceId != null trả về chỉ posts của Space đó', () async {
-      // Hỗn hợp: 1 post chung của user, 1 post Space s1 của user, 1 post
-      // Space s2 của user. watchFeed(uid, spaceId: 's1') chỉ trả p_s1.
+      // Caller uid1 là member của cả s1 và s2. Hỗn hợp post:
+      // - p_chung: post chung (không có memberIds)
+      // - p_s1: post Space s1, memberIds chứa uid1
+      // - p_s2: post Space s2, memberIds chứa uid1
+      // watchFeed(uid1, spaceId: 's1') chỉ trả p_s1.
       final pChung = _makePost(postId: 'p_chung', authorId: 'uid1');
       final pS1 = Post(
         postId: 'p_s1',
@@ -173,6 +219,7 @@ void main() {
         imageUrl: 'https://example.com/photo.jpg',
         audienceType: AudienceType.all,
         spaceIds: const ['s1'],
+        memberIds: const ['uid1', 'uid2'],
         createdAt: DateTime(2026, 5, 27),
       );
       final pS2 = Post(
@@ -182,20 +229,12 @@ void main() {
         imageUrl: 'https://example.com/photo.jpg',
         audienceType: AudienceType.all,
         spaceIds: const ['s2'],
+        memberIds: const ['uid1', 'uid3'],
         createdAt: DateTime(2026, 5, 27),
       );
-      // Write with both field patterns: toJson() gives spaceIds (new model),
-      // add spaceId manually so the current repo query (WHERE spaceId == X)
-      // still matches. Branch 3 sẽ đổi query sang spaceIds array-contains.
       await db.collection('posts').doc('p_chung').set(pChung.toJson());
-      await db
-          .collection('posts')
-          .doc('p_s1')
-          .set(pS1.toJson()..['spaceId'] = 's1');
-      await db
-          .collection('posts')
-          .doc('p_s2')
-          .set(pS2.toJson()..['spaceId'] = 's2');
+      await db.collection('posts').doc('p_s1').set(pS1.toJson());
+      await db.collection('posts').doc('p_s2').set(pS2.toJson());
 
       final posts = await repo.watchFeed('uid1', spaceId: 's1').first;
       expect(posts.map((p) => p.postId), ['p_s1']);

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -12,7 +12,7 @@
       "collectionGroup": "posts",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "spaceId", "order": "ASCENDING" },
+        { "fieldPath": "memberIds", "arrayConfig": "CONTAINS" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     },

--- a/firebase/functions/src/feed/onPostCreated.test.ts
+++ b/firebase/functions/src/feed/onPostCreated.test.ts
@@ -27,16 +27,23 @@ describe('onPostCreated logic', () => {
     expect(recipients).toEqual(['uid2', 'uid3']);
   });
 
-  it('spaceId set → skips friend fan-out', () => {
-    const spaceId: string | null = 'space-abc';
-    const shouldFanOut = !(spaceId != null && spaceId !== '');
+  it('spaceIds non-empty → skips friend fan-out', () => {
+    const spaceIds: string[] = ['space-abc'];
+    const shouldFanOut = spaceIds.length === 0;
     expect(shouldFanOut).toBe(false);
   });
 
-  it('spaceId null → performs friend fan-out', () => {
-    const spaceId: string | null = null;
-    const shouldFanOut = !(spaceId != null && spaceId !== '');
+  it('spaceIds rỗng → performs friend fan-out', () => {
+    const spaceIds: string[] = [];
+    const shouldFanOut = spaceIds.length === 0;
     expect(shouldFanOut).toBe(true);
+  });
+
+  it('multi-Space: loop từng spaceId riêng', () => {
+    const spaceIds = ['space-a', 'space-b', 'space-c'];
+    const fanOutCalls: string[] = [];
+    for (const sid of spaceIds) fanOutCalls.push(sid);
+    expect(fanOutCalls).toEqual(['space-a', 'space-b', 'space-c']);
   });
 
   it('recipients always include the author (own-feed visibility)', () => {
@@ -61,20 +68,20 @@ describe('onPostCreated logic', () => {
     expect(friendUids).not.toContain(authorId);
   });
 
-  it('feed doc includes spaceId field', () => {
+  it('feed doc (friend fan-out) includes spaceIds=[]', () => {
     const post = {
       postId: 'p1',
       authorId: 'uid1',
-      spaceId: null as string | null,
+      spaceIds: [] as string[],
       createdAt: new Date(),
     };
     const feedDoc = {
       postId: post.postId,
       authorId: post.authorId,
-      spaceId: post.spaceId ?? null,
+      spaceIds: [] as string[],
       createdAt: post.createdAt,
     };
-    expect(feedDoc).toHaveProperty('spaceId');
-    expect(feedDoc.spaceId).toBeNull();
+    expect(feedDoc).toHaveProperty('spaceIds');
+    expect(feedDoc.spaceIds).toEqual([]);
   });
 });

--- a/firebase/functions/src/feed/onPostCreated.ts
+++ b/firebase/functions/src/feed/onPostCreated.ts
@@ -18,17 +18,22 @@ interface PostData {
   captionType?: string;
   audienceType: 'all' | 'select';
   audienceUids: string[];
-  spaceId?: string;
+  /// Multi-Space (Branch 2+). Empty = post All-friends. Mỗi entry trong
+  /// array fan-out riêng qua spacePostFanOut.
+  spaceIds?: string[];
   createdAt: FirebaseFirestore.Timestamp;
 }
 
 /**
  * Fan-out feed + increment postCount + FCM notification.
- * Single function — do not create a separate one in notification.md (H10).
  *
- * Guard: if post.spaceId != null → skip friend fan-out + FCM
- *   (Space CF onSpacePostCreated handles Space posts).
- *   Still increments postCount for all post types.
+ * Post Space (spaceIds non-empty): loop từng Space → spacePostFanOut riêng
+ * cho từng spaceId. Mỗi spaceId fan-out feed entry + FCM cho member của
+ * Space đó. Post KHÔNG đi vào friend feed (Space post tách rời, dù author
+ * có thể là friend của user khác).
+ *
+ * Post all-friends (spaceIds rỗng/missing): fan-out feed cho author +
+ * audienceUids (select) hoặc tất cả friends (all). FCM push cho friends.
  */
 export const onPostCreated = onDocumentCreated(
   { document: 'posts/{postId}', region: 'asia-southeast1' },
@@ -38,7 +43,8 @@ export const onPostCreated = onDocumentCreated(
 
     const db = getFirestore();
     const { postId } = event.params;
-    const { authorId, audienceType, audienceUids, spaceId } = post;
+    const { authorId, audienceType, audienceUids } = post;
+    const spaceIds = post.spaceIds ?? [];
 
     // 1. Always increment postCount on author (set merge — safe if field missing)
     await db.doc(`users/${authorId}`).set(
@@ -46,16 +52,20 @@ export const onPostCreated = onDocumentCreated(
       { merge: true },
     );
 
-    // 2. Space post — delegate sang spacePostFanOut helper (Option A) thay
-    // vì fan-out tới friends. Helper đọc /space_members để xác định members.
-    if (spaceId != null && spaceId !== '') {
-      await spacePostFanOut({
-        postId,
-        authorId,
-        authorName: post.authorName,
-        spaceId,
-        createdAt: post.createdAt,
-      });
+    // 2. Space post — delegate sang spacePostFanOut helper cho TỪNG Space
+    // trong spaceIds. Mỗi Space fan-out riêng (member của Space A ≠ Space B).
+    if (spaceIds.length > 0) {
+      await Promise.all(
+        spaceIds.map((spaceId) =>
+          spacePostFanOut({
+            postId,
+            authorId,
+            authorName: post.authorName,
+            spaceId,
+            createdAt: post.createdAt,
+          }),
+        ),
+      );
       return;
     }
 
@@ -74,7 +84,7 @@ export const onPostCreated = onDocumentCreated(
     const feedDoc = {
       postId,
       authorId,
-      spaceId: spaceId ?? null,
+      spaceIds: [] as string[],
       createdAt: post.createdAt,
     };
 

--- a/firebase/functions/src/space/spacePostFanOut.ts
+++ b/firebase/functions/src/space/spacePostFanOut.ts
@@ -1,4 +1,4 @@
-import { getFirestore } from 'firebase-admin/firestore';
+import { FieldValue, getFirestore } from 'firebase-admin/firestore';
 import { getMessaging } from 'firebase-admin/messaging';
 import { logger } from 'firebase-functions/v2';
 
@@ -67,10 +67,14 @@ export async function spacePostFanOut(post: SpacePost): Promise<void> {
 
   // Step 3: Fan-out feed docs. Batch 499 (giữ lề 1 op an toàn dưới 500
   // limit Firestore). Worst case: 10 members → 1 batch đủ.
+  //
+  // Multi-Space (Branch 3): caller có thể gọi spacePostFanOut nhiều lần
+  // cho cùng post nhưng spaceId khác nhau. Để member trong cả 2 Space
+  // không bị ghi đè spaceId, dùng set merge + arrayUnion cho spaceIds.
   const feedDoc = {
     postId,
     authorId,
-    spaceId,
+    spaceIds: FieldValue.arrayUnion(spaceId),
     createdAt: post.createdAt,
   };
 
@@ -79,7 +83,7 @@ export async function spacePostFanOut(post: SpacePost): Promise<void> {
   let opCount = 0;
 
   for (const uid of memberUids) {
-    batch.set(db.doc(`users/${uid}/feed/${postId}`), feedDoc);
+    batch.set(db.doc(`users/${uid}/feed/${postId}`), feedDoc, { merge: true });
     opCount++;
     if (opCount === 499) {
       batches.push(batch);


### PR DESCRIPTION
## Tóm tắt

PR này gộp 4 commit của branch `feature/KhoaLND/post-multi-space-audience`:
- Multi-Space audience picker — Post model `spaceIds` + AudienceRow layout
- AudienceRow cycle: Spaces → Tất cả → Bạn → Friends (1 hàng)
- AudienceRow + CaptureActionBar visual polish
- **fix Space feed + filter "Mọi người" + flip cam trước** (commit cuối, fix bug từ tester)

## Bug đã fix

### 1. `permission-denied` khi mở filter Space feed

**Triệu chứng:** chọn filter Space "Tình yêu của tôi" → UI hiện "Không tải được feed". Terminal:
[cloud_firestore/permission-denied] The caller does not have permission to execute the specified operation.



**Nguyên nhân:** Query `WHERE spaceId == X` không khớp với bất kỳ disjunct nào của rule `/posts` (rule eval cho collection query phải prove tĩnh "mọi doc match đều pass" — không derive được từ query constraint).

**Fix:** Đổi sang `WHERE memberIds arrayContains callerUid` + client filter `spaceIds.contains(spaceId)`. Query constraint giờ khớp rule disjunct (3) `memberIds.hasAny([uid])`.

### 2. Filter "Mọi người" thiếu Space posts

**Triệu chứng:** post vào Space xong, qua filter "Mọi người" không thấy post của mình.

**Fix:** `_watchFriendsFeed` merge thêm stream `where('memberIds', arrayContains: callerUid)` để bao gồm Space posts (kể cả stranger-cùng-Space không phải friend). Dedupe theo postId vì 1 post của friend đăng vào Space sẽ match cả 2 nhánh.

### 3. Camera trước "lệch mặt"

**Triệu chứng:** preview gương (mặc định Android selfie-mirror), nhưng ảnh chụp xong un-mirror → mặt người dùng đảo trái-phải so với preview.

**Fix:**
- Xóa `Transform scaleX:-1` ở `_ViewfinderContent` → preview giữ gương mặc định.
- Thêm helper `flipImageHorizontallyInPlace()` dùng `dart:ui` Canvas flip ngang file chụp xong. Không thêm dependency ngoài.
- Wire vào `capture()` (single front) + `_captureInDualMode()` (dual front lens). Cam sau không đụng.

## Thay đổi chính

| File | Thay đổi |
|---|---|
| `firebase_post_repository.dart` | `_watchSpaceFeed` query memberIds, `_watchFriendsFeed` merge Space stream + dedupe |
| `image_flip.dart` (mới) | Helper flip ngang ảnh bằng dart:ui Canvas |
| `app_camera_controller.dart` | Wire flip sau `takePicture()` cho cam trước |
| `camera_section.dart` | Xóa `Transform` un-mirror ở preview |
| `firestore.indexes.json` | Index `(spaceId, createdAt)` → `(memberIds CONTAINS, createdAt)` |

Ngoài ra: Post model thêm `spaceIds: List<String>` + `memberIds: List<String>` denormalized, AudienceRow layout mới cho multi-Space pick, CaptureActionBar visual polish.

## Verify

- [x] `flutter test test/features/feed/` → **48/48 pass**
- [x] `flutter analyze` → **No issues**
- [x] Tester chọn filter Space "Tình yêu của tôi" → feed load không lỗi
- [x] Tester chọn filter "Mọi người" → thấy cả own + friend + Space posts
- [x] Tester chụp cam trước → preview gương, ảnh chụp xong cũng gương (không lật lại)

## Lưu ý khi merge

**BẮT BUỘC deploy index trước khi merge:**
```bash
firebase deploy --only firestore:indexes