### PR TITLE
feat(streak): ST1 — FirebaseStreakRepository (watchUserMonth + getUserAllDates)

### DIFF
--- a/apps/mobile/lib/features/streak/data/firebase_streak_repository.dart
+++ b/apps/mobile/lib/features/streak/data/firebase_streak_repository.dart
@@ -1,0 +1,86 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/streak/data/streak_repository.dart';
+
+/// Firestore implementation of [StreakRepository].
+///
+/// Streak module read-only từ `/posts` — không có collection riêng, không
+/// có Cloud Function. Filter `spaceId == null` server-side (Firestore null
+/// equality match docs có explicit null hoặc field absent). Convert
+/// `createdAt` về local timezone trước khi tính `dayKey` (timezone contract
+/// spec §Data model).
+class FirebaseStreakRepository implements StreakRepository {
+  FirebaseStreakRepository(this._db);
+
+  final FirebaseFirestore _db;
+
+  static const _posts = 'posts';
+
+  @override
+  Stream<List<Post>> watchUserMonth(String uid, DateTime month) {
+    final startOfMonth = DateTime(month.year, month.month);
+    final startOfNextMonth = DateTime(month.year, month.month + 1);
+
+    return _db
+        .collection(_posts)
+        .where('authorId', isEqualTo: uid)
+        .where('spaceId', isNull: true)
+        .where(
+          'createdAt',
+          isGreaterThanOrEqualTo: Timestamp.fromDate(startOfMonth),
+        )
+        .where('createdAt', isLessThan: Timestamp.fromDate(startOfNextMonth))
+        .orderBy('createdAt')
+        .snapshots()
+        .map(
+          (snap) => snap.docs
+              .map((doc) => Post.fromJson({...doc.data(), 'postId': doc.id}))
+              .toList(),
+        )
+        .handleError(_mapAndThrow);
+  }
+
+  @override
+  Future<List<DateTime>> getUserAllDates(String uid) async {
+    try {
+      final snap = await _db
+          .collection(_posts)
+          .where('authorId', isEqualTo: uid)
+          .where('spaceId', isNull: true)
+          .orderBy('createdAt', descending: true)
+          .get();
+
+      final dayKeys = <DateTime>{};
+      for (final doc in snap.docs) {
+        final raw = doc.data()['createdAt'];
+        if (raw is! Timestamp) continue;
+        final local = raw.toDate().toLocal();
+        dayKeys.add(DateTime(local.year, local.month, local.day));
+      }
+      // Sort DESC để controller dùng trực tiếp cho calculateStreak (newest first).
+      final sorted = dayKeys.toList()..sort((a, b) => b.compareTo(a));
+      return sorted;
+    } on FirebaseException catch (e) {
+      throw _mapStreakError(e);
+    }
+  }
+
+  Never _mapAndThrow(Object e, [StackTrace? _]) {
+    if (e is FirebaseException) throw _mapStreakError(e);
+    throw AppError.fromUnknown(e, fallback: 'Không thể tải Kỷ niệm');
+  }
+
+  AppError _mapStreakError(FirebaseException e) => switch (e.code) {
+        'permission-denied' => ForbiddenError('đọc bài viết'),
+        'unavailable' || 'network-request-failed' => NetworkError(
+            message: 'Không có kết nối mạng',
+            cause: e,
+          ),
+        _ => UnexpectedError(
+            message: e.message ?? 'Không thể tải Kỷ niệm',
+            code: e.code,
+            cause: e,
+          ),
+      };
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -38,6 +38,8 @@ import 'package:meep/features/notification/data/notification_preferences.dart';
 import 'package:meep/features/notification/presentation/widgets/notification_banner.dart';
 import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/features/space/data/firebase_space_repository.dart';
+import 'package:meep/features/streak/application/streak_controller.dart';
+import 'package:meep/features/streak/data/firebase_streak_repository.dart';
 import 'package:meep/features/widget/application/widget_data_service.dart';
 import 'package:meep/firebase_options.dart';
 
@@ -127,6 +129,9 @@ void main() async {
         ),
         diaryStorageClientProvider.overrideWithValue(
           FirebaseDiaryStorageClient(FirebaseStorage.instance),
+        ),
+        streakRepositoryProvider.overrideWithValue(
+          FirebaseStreakRepository(FirebaseFirestore.instance),
         ),
       ],
       child: const MeepApp(),

--- a/apps/mobile/test/features/streak/data/firebase_streak_repository_test.dart
+++ b/apps/mobile/test/features/streak/data/firebase_streak_repository_test.dart
@@ -1,0 +1,161 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/streak/data/firebase_streak_repository.dart';
+
+void main() {
+  late FakeFirebaseFirestore db;
+  late FirebaseStreakRepository repo;
+
+  const uid = 'uid-alice';
+
+  setUp(() {
+    db = FakeFirebaseFirestore();
+    repo = FirebaseStreakRepository(db);
+  });
+
+  Future<void> seedPost({
+    required String postId,
+    required String authorId,
+    required DateTime createdAt,
+    String? spaceId,
+  }) {
+    return db.collection('posts').doc(postId).set({
+      'postId': postId,
+      'authorId': authorId,
+      'authorName': 'Author $authorId',
+      'imageUrl': 'https://example.com/$postId.jpg',
+      'audienceType': 'all',
+      'audienceUids': <String>[],
+      'spaceId': spaceId,
+      'createdAt': Timestamp.fromDate(createdAt),
+    });
+  }
+
+  group('watchUserMonth', () {
+    test('trả posts trong tháng + spaceId == null only', () async {
+      // Tháng đang xem: 2026-05
+      final month = DateTime(2026, 5);
+
+      // 2 in-month, spaceId null → expect
+      await seedPost(
+        postId: 'p1',
+        authorId: uid,
+        createdAt: DateTime(2026, 5, 3, 10),
+      );
+      await seedPost(
+        postId: 'p2',
+        authorId: uid,
+        createdAt: DateTime(2026, 5, 20, 14),
+      );
+
+      // 1 in-month nhưng spaceId != null → loại
+      await seedPost(
+        postId: 'p3',
+        authorId: uid,
+        createdAt: DateTime(2026, 5, 10),
+        spaceId: 'space-x',
+      );
+
+      // 1 in-month nhưng author khác → loại
+      await seedPost(
+        postId: 'p4',
+        authorId: 'uid-bob',
+        createdAt: DateTime(2026, 5, 15),
+      );
+
+      // 1 ngoài tháng → loại
+      await seedPost(
+        postId: 'p5',
+        authorId: uid,
+        createdAt: DateTime(2026, 4, 30),
+      );
+
+      final stream = repo.watchUserMonth(uid, month);
+      final posts = await stream.first;
+
+      expect(posts.length, 2);
+      expect(posts.map((p) => p.postId).toSet(), {'p1', 'p2'});
+      // ORDER BY createdAt ASC
+      expect(posts.first.postId, 'p1');
+    });
+
+    test('tháng không có post → empty list', () async {
+      final month = DateTime(2026, 5);
+      await seedPost(
+        postId: 'p1',
+        authorId: uid,
+        createdAt: DateTime(2026, 3, 15),
+      );
+
+      final posts = await repo.watchUserMonth(uid, month).first;
+      expect(posts, isEmpty);
+    });
+  });
+
+  group('getUserAllDates', () {
+    test('dedupe per day (2 posts cùng ngày → 1 entry)', () async {
+      await seedPost(
+        postId: 'p1',
+        authorId: uid,
+        createdAt: DateTime(2026, 5, 22, 8),
+      );
+      await seedPost(
+        postId: 'p2',
+        authorId: uid,
+        createdAt: DateTime(2026, 5, 22, 20),
+      );
+      await seedPost(
+        postId: 'p3',
+        authorId: uid,
+        createdAt: DateTime(2026, 5, 23, 12),
+      );
+
+      final dates = await repo.getUserAllDates(uid);
+      expect(dates.length, 2);
+      // Sort DESC (newest first) — dùng cho calculateStreak
+      expect(dates[0], DateTime(2026, 5, 23));
+      expect(dates[1], DateTime(2026, 5, 22));
+    });
+
+    test('filter spaceId == null', () async {
+      await seedPost(
+        postId: 'p1',
+        authorId: uid,
+        createdAt: DateTime(2026, 5, 22),
+      );
+      await seedPost(
+        postId: 'p2',
+        authorId: uid,
+        createdAt: DateTime(2026, 5, 23),
+        spaceId: 'space-x',
+      );
+
+      final dates = await repo.getUserAllDates(uid);
+      expect(dates.length, 1);
+      expect(dates.first, DateTime(2026, 5, 22));
+    });
+
+    test('chưa có post → empty list', () async {
+      final dates = await repo.getUserAllDates(uid);
+      expect(dates, isEmpty);
+    });
+
+    test('filter authorId — không lấy của user khác', () async {
+      await seedPost(
+        postId: 'p1',
+        authorId: uid,
+        createdAt: DateTime(2026, 5, 22),
+      );
+      await seedPost(
+        postId: 'p2',
+        authorId: 'uid-bob',
+        createdAt: DateTime(2026, 5, 23),
+      );
+
+      final dates = await repo.getUserAllDates(uid);
+      expect(dates.length, 1);
+      expect(dates.first, DateTime(2026, 5, 22));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

ST1 — Streak data layer. Implement `StreakRepository` (abstract đã có từ L1) bằng Firestore.

- `watchUserMonth(uid, month)`: stream posts của user trong tháng, filter `spaceId == null`, ORDER BY createdAt ASC. Map FirebaseException → AppError tại boundary.
- `getUserAllDates(uid)`: read once toàn bộ posts của user (filter spaceId), convert `createdAt.toLocal()`, dedupe per day, sort DESC.
- Wire `streakRepositoryProvider.overrideWithValue` trong `main.dart` sau Firebase init.

## Refs

Closes #258

Unblocks #259 (ST2 controller).

## Test plan

- [x] 6 unit tests pass (`fake_cloud_firestore`)
- [x] `flutter analyze apps/mobile --no-pub` → No issues found
- [x] `dart format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)