### PR TITLE
feat(diary): T2 DiaryController + main wire (#128)

### DIFF
--- a/apps/mobile/lib/features/diary/application/diary_controller.dart
+++ b/apps/mobile/lib/features/diary/application/diary_controller.dart
@@ -1,19 +1,33 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
 import 'package:meep/features/diary/data/diary_entry.dart';
 import 'package:meep/features/diary/data/diary_repository.dart';
+import 'package:meep/features/diary/data/firebase_diary_repository.dart';
 
 part 'diary_controller.freezed.dart';
 part 'diary_controller.g.dart';
+
+/// Mode of the diary canvas — mirrors presentation-layer enum cùng tên.
+/// Định nghĩa ở application layer để [DiaryState] dùng trực tiếp,
+/// presentation import từ đây (không reverse-dependency).
+enum DiaryCanvasMode { create, read, edit }
 
 @freezed
 class DiaryState with _$DiaryState {
   const factory DiaryState({
     @Default([]) List<DiaryEntry> entries,
+    DiaryEntry? currentEntry,
     @Default(false) bool isLoading,
     @Default(false) bool isSaving,
     String? errorMessage,
+    @Default(DiaryCanvasMode.create) DiaryCanvasMode mode,
+    @Default([]) List<DiaryEntry> searchResults,
   }) = _DiaryState;
 }
 
@@ -21,42 +35,232 @@ class DiaryState with _$DiaryState {
 DiaryRepository diaryRepository(DiaryRepositoryRef ref) =>
     throw UnimplementedError(
       'diaryRepositoryProvider must be overridden — '
-      'wire FirebaseDiaryRepository in main.dart (TODO: D/T1/TBD)',
+      'wire FirebaseDiaryRepository in main.dart (TODO: D/T1/HanDHG)',
+    );
+
+@Riverpod(keepAlive: true)
+DiaryStorageClient diaryStorageClient(DiaryStorageClientRef ref) =>
+    throw UnimplementedError(
+      'diaryStorageClientProvider must be overridden — '
+      'wire FirebaseDiaryStorageClient in main.dart',
     );
 
 @riverpod
 class DiaryController extends _$DiaryController {
+  StreamSubscription<List<DiaryEntry>>? _entriesSub;
+
   @override
-  DiaryState build() => const DiaryState();
-
-  Future<void> loadEntries(String authorUid) async {
-    // TODO(D/T2/TBD): implement loadEntries
-    throw UnimplementedError('loadEntries — TODO: D/T2/TBD');
+  DiaryState build() {
+    // Single dispose registration — tránh queue grow khi loadEntries gọi
+    // nhiều lần (vd pull-to-refresh).
+    ref.onDispose(() => _entriesSub?.cancel());
+    return const DiaryState();
   }
 
-  Future<void> saveEntry(DiaryEntry entry) async {
-    // TODO(D/T3/TBD): implement saveEntry — decides create vs update by entryId
-    throw UnimplementedError('saveEntry — TODO: D/T3/TBD');
+  /// Subscribe `watchEntries(uid)` từ [DiaryRepository]. Stream emit tự động
+  /// đẩy danh sách entries mới vào [state.entries]. Lỗi → errorMessage.
+  void loadEntries(String authorUid) {
+    unawaited(_entriesSub?.cancel());
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    _entriesSub =
+        ref.read(diaryRepositoryProvider).watchEntries(authorUid).listen(
+              (entries) => state = state.copyWith(
+                entries: entries,
+                isLoading: false,
+                errorMessage: null,
+              ),
+              onError: (Object e) => state = _afterFailure(e),
+            );
   }
 
+  /// Save entry — tạo mới hoặc cập nhật tuỳ [state.mode].
+  ///
+  /// Upload sequence (spec §Lưu nhật ký):
+  /// 1. cover image → `diary/{uid}/{entryId}/cover.jpg` → coverUrl
+  /// 2. inline images tuần tự → `diary/{uid}/{entryId}/img_N.jpg` → inlineUrls
+  /// 3. TẤT CẢ URLs sẵn sàng → Firestore write với cùng entryId
+  ///
+  /// Tránh path mismatch: với create mode, controller reserve entryId TRƯỚC
+  /// upload nên Storage path khớp Firestore doc.
+  ///
+  /// Upload fail bất kỳ bước → KHÔNG tạo/update Firestore doc.
+  Future<void> saveEntry({
+    required DiaryEntry draft,
+    required Uint8List coverBytes,
+    List<Uint8List> inlineImageBytes = const [],
+  }) async {
+    state = state.copyWith(isSaving: true, errorMessage: null);
+
+    try {
+      final storage = ref.read(diaryStorageClientProvider);
+      final repo = ref.read(diaryRepositoryProvider);
+      final uid = draft.authorUid;
+      final mode = state.mode;
+
+      // Reserve entryId: create mode → repository.reserveEntryId();
+      // edit mode → dùng entryId của draft (đã có).
+      final entryId = mode == DiaryCanvasMode.create
+          ? repo.reserveEntryId()
+          : draft.entryId;
+
+      // Bước 1 — upload cover
+      String coverUrl;
+      try {
+        coverUrl = await storage.upload(
+          uid: uid,
+          entryId: entryId,
+          fileName: 'cover.jpg',
+          bytes: coverBytes,
+          contentType: 'image/jpeg',
+        );
+      } catch (e) {
+        state = _afterFailure(e, fallback: 'Tải ảnh bìa thất bại');
+        return;
+      }
+
+      // Bước 2 — upload inline images tuần tự
+      final inlineUrls = <String>[];
+      for (var i = 0; i < inlineImageBytes.length; i++) {
+        try {
+          final url = await storage.upload(
+            uid: uid,
+            entryId: entryId,
+            fileName: 'img_${i + 1}.jpg',
+            bytes: inlineImageBytes[i],
+            contentType: 'image/jpeg',
+          );
+          inlineUrls.add(url);
+        } catch (e) {
+          state = _afterFailure(e, fallback: 'Tải ảnh thứ ${i + 1} thất bại');
+          return;
+        }
+      }
+
+      // Bước 3 — build entry với URLs thật + Firestore write.
+      //
+      // Inline image URL mapping: controller replace ImageBlock placeholder
+      // theo thứ tự — block ảnh thứ N nhận `inlineUrls[N-1]`. PR4 wire UI
+      // sẽ define convention rõ ràng cho UI gọi.
+      var inlineIdx = 0;
+      final contentBlocks = draft.content.map((b) {
+        return b.when(
+          text: (value, style) => DiaryContentBlock.text(
+            value: value,
+            style: style,
+          ),
+          image: (_) {
+            final url =
+                inlineIdx < inlineUrls.length ? inlineUrls[inlineIdx++] : '';
+            return DiaryContentBlock.image(imageUrl: url);
+          },
+        );
+      }).toList();
+
+      final realEntry = draft.copyWith(
+        entryId: entryId,
+        coverImageUrl: coverUrl,
+        content: contentBlocks,
+      );
+
+      if (mode == DiaryCanvasMode.create) {
+        final created = await repo.createEntry(realEntry);
+        state = state.copyWith(
+          isSaving: false,
+          currentEntry: created,
+        );
+      } else {
+        await repo.updateEntry(realEntry);
+        state = state.copyWith(
+          isSaving: false,
+          currentEntry: realEntry,
+        );
+      }
+    } catch (e) {
+      state = _afterFailure(e);
+    }
+  }
+
+  /// Update chỉ field `privacy` + `updatedAt` — không kéo cả doc.
   Future<void> updatePrivacy({
     required String entryId,
     required DiaryPrivacy privacy,
   }) async {
-    // TODO(D/T4/TBD): implement updatePrivacy
-    throw UnimplementedError('updatePrivacy — TODO: D/T4/TBD');
+    state = state.copyWith(isSaving: true, errorMessage: null);
+    try {
+      await ref
+          .read(diaryRepositoryProvider)
+          .updatePrivacy(entryId: entryId, privacy: privacy);
+      // Cập nhật local state nếu currentEntry đang mở
+      if (state.currentEntry?.entryId == entryId) {
+        state = state.copyWith(
+          isSaving: false,
+          currentEntry: state.currentEntry?.copyWith(privacy: privacy),
+        );
+      } else {
+        state = state.copyWith(isSaving: false);
+      }
+    } catch (e) {
+      state = _afterFailure(e);
+    }
   }
 
-  Future<List<DiaryEntry>> searchEntries({
+  /// Search entries của [authorUid] — delegate sang repository, lưu kết quả
+  /// vào [state.searchResults].
+  Future<void> searchEntries({
     required String authorUid,
     required String query,
   }) async {
-    // TODO(D/T5/TBD): implement searchEntries
-    throw UnimplementedError('searchEntries — TODO: D/T5/TBD');
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      final results = await ref
+          .read(diaryRepositoryProvider)
+          .searchEntries(authorUid: authorUid, query: query);
+      state = state.copyWith(
+        isLoading: false,
+        searchResults: results,
+      );
+    } catch (e) {
+      state = _afterFailure(e);
+    }
   }
 
+  /// Xoá entry + Storage assets (gọi repository.deleteEntry).
   Future<void> deleteEntry(String entryId) async {
-    // TODO(D/T6/TBD): implement deleteEntry
-    throw UnimplementedError('deleteEntry — TODO: D/T6/TBD');
+    state = state.copyWith(isSaving: true, errorMessage: null);
+    try {
+      await ref.read(diaryRepositoryProvider).deleteEntry(entryId);
+      state = state.copyWith(
+        isSaving: false,
+        currentEntry: null,
+      );
+    } catch (e) {
+      state = _afterFailure(e);
+    }
+  }
+
+  void clearError() {
+    if (state.errorMessage != null) {
+      state = state.copyWith(errorMessage: null);
+    }
+  }
+
+  void setMode(DiaryCanvasMode mode) {
+    state = state.copyWith(mode: mode);
+  }
+
+  void setCurrentEntry(DiaryEntry? entry) {
+    state = state.copyWith(currentEntry: entry);
+  }
+
+  DiaryState _afterFailure(
+    Object e, {
+    String fallback = 'Đã có lỗi xảy ra',
+  }) {
+    final err = AppError.fromUnknown(e, fallback: fallback);
+    return state.copyWith(
+      isLoading: false,
+      isSaving: false,
+      errorMessage: err is OperationCancelledError ? null : err.message,
+    );
   }
 }

--- a/apps/mobile/lib/features/diary/data/diary_repository.dart
+++ b/apps/mobile/lib/features/diary/data/diary_repository.dart
@@ -16,7 +16,13 @@ abstract class DiaryRepository {
     required String query,
   });
 
+  /// Reserve a new entry ID without writing — controller dùng trước upload
+  /// Storage để Storage path `diary/{uid}/{entryId}/...` khớp Firestore doc.
+  String reserveEntryId();
+
   /// Create a new entry. Returns the created entry with server timestamps.
+  /// If [entry.entryId] is non-empty, the value is used (e.g. ID reserved
+  /// via [reserveEntryId]). If empty, an auto-generated ID is assigned.
   Future<DiaryEntry> createEntry(DiaryEntry entry);
 
   /// Update an existing entry.

--- a/apps/mobile/lib/features/diary/data/firebase_diary_repository.dart
+++ b/apps/mobile/lib/features/diary/data/firebase_diary_repository.dart
@@ -27,7 +27,7 @@ class FirebaseDiaryRepository implements DiaryRepository {
   }) {
     return FirebaseDiaryRepository(
       firestore: firestore,
-      storageClient: _FirebaseDiaryStorageClient(storage),
+      storageClient: FirebaseDiaryStorageClient(storage),
     );
   }
 
@@ -46,7 +46,10 @@ class FirebaseDiaryRepository implements DiaryRepository {
     _validateMoodCaption(entry.moodCaption);
     _validateBlockCount(entry.content);
 
-    final docRef = _col.doc();
+    // Tôn trọng entryId nếu caller pre-generate (ví dụ Controller reserve ID
+    // trước khi upload Storage để path khớp `diary/{uid}/{entryId}/...`).
+    // Empty → Firestore auto-gen, mirror behavior cũ.
+    final docRef = entry.entryId.isEmpty ? _col.doc() : _col.doc(entry.entryId);
     final entryWithId = entry.copyWith(entryId: docRef.id);
     final data = _serializeEntry(entryWithId)
       ..['createdAt'] = FieldValue.serverTimestamp()
@@ -59,6 +62,12 @@ class FirebaseDiaryRepository implements DiaryRepository {
     }
     return entryWithId;
   }
+
+  /// Reserve a new Firestore document ID without writing — controller dùng
+  /// trước upload Storage để Storage path `diary/{uid}/{entryId}/...` khớp
+  /// với Firestore doc ID, tránh path mismatch + collision.
+  @override
+  String reserveEntryId() => _col.doc().id;
 
   @override
   Stream<List<DiaryEntry>> watchEntries(String authorUid) {
@@ -317,8 +326,8 @@ abstract class DiaryStorageClient {
   Future<void> deletePrefix(String prefix);
 }
 
-class _FirebaseDiaryStorageClient implements DiaryStorageClient {
-  _FirebaseDiaryStorageClient(this._storage);
+class FirebaseDiaryStorageClient implements DiaryStorageClient {
+  FirebaseDiaryStorageClient(this._storage);
 
   final FirebaseStorage _storage;
 

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/features/diary/application/diary_controller.dart';
 import 'package:meep/features/diary/data/diary_entry.dart';
 import 'package:meep/features/diary/presentation/discard_changes_dialog.dart';
 import 'package:meep/features/diary/presentation/privacy_sheet.dart';
@@ -10,11 +11,14 @@ import 'package:meep/features/diary/presentation/widgets/diary_menu_sheet.dart';
 import 'package:meep/features/diary/presentation/widgets/polaroid_image_block.dart';
 import 'package:meep/features/diary/presentation/widgets/text_style_picker.dart';
 
+/// Re-export [DiaryCanvasMode] để các screen khác (`diary_list_screen`,...)
+/// import từ canvas screen như cũ, không phải đổi imports loạt.
+/// Definition canonical ở application/diary_controller.dart.
+export 'package:meep/features/diary/application/diary_controller.dart'
+    show DiaryCanvasMode;
+
 part 'diary_canvas_screen_toolbar.dart';
 part 'diary_canvas_screen_dot_grid.dart';
-
-/// Mode of the diary canvas screen.
-enum DiaryCanvasMode { create, read, edit }
 
 /// Payload pop về khi user tap check ở Canvas (create mode).
 ///

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -22,6 +22,8 @@ import 'package:meep/features/chat/application/chat_controller.dart';
 import 'package:meep/features/reaction/application/reaction_controller.dart';
 import 'package:meep/features/reaction/data/firebase_reaction_repository.dart';
 import 'package:meep/features/chat/data/firebase_conversation_repository.dart';
+import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/firebase_diary_repository.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/firebase_friend_repository.dart';
 import 'package:meep/features/friend/data/firebase_friend_request_repository.dart';
@@ -116,6 +118,15 @@ void main() async {
         ),
         notificationPreferencesProvider.overrideWithValue(
           NotificationPreferences(prefs: prefs),
+        ),
+        diaryRepositoryProvider.overrideWithValue(
+          FirebaseDiaryRepository.firebase(
+            firestore: FirebaseFirestore.instance,
+            storage: FirebaseStorage.instance,
+          ),
+        ),
+        diaryStorageClientProvider.overrideWithValue(
+          FirebaseDiaryStorageClient(FirebaseStorage.instance),
         ),
       ],
       child: const MeepApp(),

--- a/apps/mobile/test/features/diary/application/diary_controller_test.dart
+++ b/apps/mobile/test/features/diary/application/diary_controller_test.dart
@@ -1,0 +1,438 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
+import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/data/diary_repository.dart';
+import 'package:meep/features/diary/data/firebase_diary_repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockDiaryRepository extends Mock implements DiaryRepository {}
+
+class _FakeDiaryEntry extends Fake implements DiaryEntry {}
+
+class _StubStorageClient implements DiaryStorageClient {
+  /// Predefined URLs trả về theo thứ tự upload. `null` slot → throw.
+  List<String?> urls = const [];
+  int uploadCount = 0;
+  final uploads = <Map<String, dynamic>>[];
+  String? lastDeletedPrefix;
+
+  @override
+  Future<String> upload({
+    required String uid,
+    required String entryId,
+    required String fileName,
+    required Uint8List bytes,
+    required String contentType,
+  }) async {
+    final idx = uploadCount;
+    uploadCount++;
+    uploads.add({
+      'uid': uid,
+      'entryId': entryId,
+      'fileName': fileName,
+      'bytes': bytes.length,
+    });
+    if (idx >= urls.length || urls[idx] == null) {
+      throw FirebaseException(
+        plugin: 'storage',
+        code: 'unavailable',
+      );
+    }
+    return urls[idx]!;
+  }
+
+  @override
+  Future<void> deletePrefix(String prefix) async {
+    lastDeletedPrefix = prefix;
+  }
+}
+
+void main() {
+  const uid = 'uid-owner';
+
+  late _MockDiaryRepository repo;
+  late _StubStorageClient storage;
+
+  DiaryEntry draftEntry({
+    String entryId = '',
+    String moodCaption = 'Hôm nay',
+    List<DiaryContentBlock> content = const [
+      DiaryContentBlock.text(value: 'Body'),
+    ],
+    DiaryPrivacy privacy = DiaryPrivacy.private,
+  }) {
+    return DiaryEntry(
+      entryId: entryId,
+      authorUid: uid,
+      moodTemplate: MoodTemplate.happy,
+      coverImageUrl: '', // placeholder, controller sẽ replace
+      moodCaption: moodCaption,
+      content: content,
+      privacy: privacy,
+      createdAt: DateTime.utc(2026, 5, 22),
+      updatedAt: DateTime.utc(2026, 5, 22),
+    );
+  }
+
+  DiaryEntry savedEntry(String id) => draftEntry().copyWith(
+        entryId: id,
+        coverImageUrl: 'https://cdn/cover',
+      );
+
+  setUpAll(() {
+    registerFallbackValue(_FakeDiaryEntry());
+  });
+
+  setUp(() {
+    repo = _MockDiaryRepository();
+    storage = _StubStorageClient();
+    // Default reserve ID — tests có thể override khi cần verify cụ thể.
+    when(() => repo.reserveEntryId()).thenReturn('reserved-id');
+  });
+
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer(
+      overrides: [
+        diaryRepositoryProvider.overrideWithValue(repo),
+        diaryStorageClientProvider.overrideWithValue(storage),
+      ],
+    );
+    // Giữ provider alive xuyên suốt test — autoDispose tear-down giữa các
+    // c.read() làm mất state (giống profile_controller_test pattern).
+    final sub = c.listen(diaryControllerProvider, (_, __) {});
+    addTearDown(sub.close);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('build — initial state', () {
+    test('default state: empty entries, isLoading=false, mode=create', () {
+      final c = makeContainer();
+      final state = c.read(diaryControllerProvider);
+
+      expect(state.entries, isEmpty);
+      expect(state.isLoading, isFalse);
+      expect(state.isSaving, isFalse);
+      expect(state.currentEntry, isNull);
+      expect(state.mode, DiaryCanvasMode.create);
+      expect(state.searchResults, isEmpty);
+      expect(state.errorMessage, isNull);
+    });
+  });
+
+  group('loadEntries', () {
+    test('subscribe stream + emit entries vào state', () async {
+      final ctrl = StreamController<List<DiaryEntry>>();
+      when(() => repo.watchEntries(uid)).thenAnswer((_) => ctrl.stream);
+
+      final c = makeContainer();
+      c.read(diaryControllerProvider.notifier).loadEntries(uid);
+
+      // isLoading=true ngay lập tức
+      expect(c.read(diaryControllerProvider).isLoading, isTrue);
+
+      ctrl.add([savedEntry('e-1'), savedEntry('e-2')]);
+      await Future<void>.delayed(Duration.zero);
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.entries.map((e) => e.entryId), ['e-1', 'e-2']);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+      await ctrl.close();
+    });
+
+    test('stream error → errorMessage set, isLoading=false', () async {
+      when(() => repo.watchEntries(uid)).thenAnswer(
+        (_) => Stream.error(const NetworkError(message: 'mất mạng')),
+      );
+
+      final c = makeContainer();
+      c.read(diaryControllerProvider.notifier).loadEntries(uid);
+      await Future<void>.delayed(Duration.zero);
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.errorMessage, 'mất mạng');
+      expect(state.isLoading, isFalse);
+    });
+  });
+
+  group('saveEntry — create mode', () {
+    test('upload cover → upload inline → createEntry (đúng sequence)',
+        () async {
+      storage.urls = ['https://cdn/cover.jpg', 'https://cdn/img1.jpg'];
+      when(() => repo.createEntry(any()))
+          .thenAnswer((_) async => savedEntry('e-new'));
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).saveEntry(
+        draft: draftEntry(
+          content: const [
+            DiaryContentBlock.text(value: 'Mở đầu'),
+            DiaryContentBlock.image(imageUrl: 'placeholder:0'),
+          ],
+        ),
+        coverBytes: Uint8List.fromList(List.filled(100, 0xAB)),
+        inlineImageBytes: [Uint8List.fromList(List.filled(50, 0xCD))],
+      );
+
+      expect(storage.uploadCount, 2);
+      expect(storage.uploads[0]['fileName'], 'cover.jpg');
+      expect(storage.uploads[0]['entryId'], 'reserved-id');
+      expect(storage.uploads[1]['fileName'], 'img_1.jpg');
+      expect(storage.uploads[1]['entryId'], 'reserved-id');
+      verify(() => repo.createEntry(any())).called(1);
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.isSaving, isFalse);
+      expect(state.currentEntry?.entryId, 'e-new');
+    });
+
+    test('cover upload fail → KHÔNG gọi inline upload, KHÔNG tạo Firestore doc',
+        () async {
+      storage.urls = const [null]; // cover fail
+      when(() => repo.createEntry(any()))
+          .thenAnswer((_) async => savedEntry('e-new'));
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).saveEntry(
+        draft: draftEntry(),
+        coverBytes: Uint8List(100),
+        inlineImageBytes: [Uint8List(50)],
+      );
+
+      expect(storage.uploadCount, 1, reason: 'fail ở cover, không gọi inline');
+      verifyNever(() => repo.createEntry(any()));
+      final state = c.read(diaryControllerProvider);
+      expect(state.errorMessage, contains('Tải ảnh bìa thất bại'));
+      expect(state.isSaving, isFalse);
+    });
+
+    test('inline upload fail giữa chừng → KHÔNG tạo Firestore doc', () async {
+      storage.urls = ['https://cdn/cover.jpg', null]; // cover OK, inline fail
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).saveEntry(
+        draft: draftEntry(),
+        coverBytes: Uint8List(100),
+        inlineImageBytes: [Uint8List(50)],
+      );
+
+      expect(storage.uploadCount, 2);
+      verifyNever(() => repo.createEntry(any()));
+      final state = c.read(diaryControllerProvider);
+      expect(state.errorMessage, contains('thất bại'));
+    });
+
+    test('Firestore createEntry fail → state.errorMessage set', () async {
+      storage.urls = ['https://cdn/cover.jpg'];
+      when(() => repo.createEntry(any())).thenThrow(
+        const NetworkError(message: 'Firestore down'),
+      );
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).saveEntry(
+            draft: draftEntry(),
+            coverBytes: Uint8List(100),
+          );
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.errorMessage, 'Firestore down');
+      expect(state.isSaving, isFalse);
+    });
+  });
+
+  group('saveEntry — edit mode', () {
+    test('mode=edit → gọi updateEntry, KHÔNG gọi createEntry', () async {
+      storage.urls = ['https://cdn/cover.jpg'];
+      when(() => repo.updateEntry(any())).thenAnswer((_) async {});
+
+      final c = makeContainer();
+      c.read(diaryControllerProvider.notifier).setMode(DiaryCanvasMode.edit);
+
+      await c.read(diaryControllerProvider.notifier).saveEntry(
+            draft: draftEntry(entryId: 'e-existing'),
+            coverBytes: Uint8List(100),
+          );
+
+      verify(() => repo.updateEntry(any())).called(1);
+      verifyNever(() => repo.createEntry(any()));
+    });
+  });
+
+  group('updatePrivacy', () {
+    test('gọi repo.updatePrivacy + cập nhật currentEntry nếu match entryId',
+        () async {
+      when(
+        () => repo.updatePrivacy(
+          entryId: 'e-1',
+          privacy: DiaryPrivacy.public,
+        ),
+      ).thenAnswer((_) async {});
+
+      final c = makeContainer();
+      c
+          .read(diaryControllerProvider.notifier)
+          .setCurrentEntry(savedEntry('e-1'));
+
+      await c.read(diaryControllerProvider.notifier).updatePrivacy(
+            entryId: 'e-1',
+            privacy: DiaryPrivacy.public,
+          );
+
+      verify(
+        () => repo.updatePrivacy(
+          entryId: 'e-1',
+          privacy: DiaryPrivacy.public,
+        ),
+      ).called(1);
+      final state = c.read(diaryControllerProvider);
+      expect(state.currentEntry?.privacy, DiaryPrivacy.public);
+      expect(state.isSaving, isFalse);
+    });
+
+    test('KHÔNG đổi currentEntry nếu entryId khác', () async {
+      when(
+        () => repo.updatePrivacy(
+          entryId: 'e-2',
+          privacy: DiaryPrivacy.public,
+        ),
+      ).thenAnswer((_) async {});
+
+      final c = makeContainer();
+      c
+          .read(diaryControllerProvider.notifier)
+          .setCurrentEntry(savedEntry('e-1'));
+
+      await c.read(diaryControllerProvider.notifier).updatePrivacy(
+            entryId: 'e-2',
+            privacy: DiaryPrivacy.public,
+          );
+
+      final state = c.read(diaryControllerProvider);
+      // currentEntry e-1 không bị đụng (vẫn private)
+      expect(state.currentEntry?.entryId, 'e-1');
+      expect(state.currentEntry?.privacy, DiaryPrivacy.private);
+    });
+
+    test('repo fail → errorMessage set', () async {
+      when(
+        () => repo.updatePrivacy(
+          entryId: 'e-1',
+          privacy: DiaryPrivacy.public,
+        ),
+      ).thenThrow(const NetworkError(message: 'mất mạng'));
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).updatePrivacy(
+            entryId: 'e-1',
+            privacy: DiaryPrivacy.public,
+          );
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.errorMessage, 'mất mạng');
+    });
+  });
+
+  group('searchEntries', () {
+    test('delegate sang repo + lưu kết quả vào state.searchResults', () async {
+      when(
+        () => repo.searchEntries(
+          authorUid: uid,
+          query: 'đà lạt',
+        ),
+      ).thenAnswer((_) async => [savedEntry('e-1')]);
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).searchEntries(
+            authorUid: uid,
+            query: 'đà lạt',
+          );
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.searchResults.map((e) => e.entryId), ['e-1']);
+      expect(state.isLoading, isFalse);
+    });
+
+    test(
+      'repo fail → errorMessage set, searchResults giữ giá trị cũ',
+      () async {
+        when(
+          () => repo.searchEntries(
+            authorUid: uid,
+            query: any(named: 'query'),
+          ),
+        ).thenThrow(const NetworkError(message: 'mất mạng'));
+
+        final c = makeContainer();
+        await c.read(diaryControllerProvider.notifier).searchEntries(
+              authorUid: uid,
+              query: 'x',
+            );
+
+        final state = c.read(diaryControllerProvider);
+        expect(state.errorMessage, 'mất mạng');
+      },
+    );
+  });
+
+  group('deleteEntry', () {
+    test('gọi repo.deleteEntry + clear currentEntry', () async {
+      when(() => repo.deleteEntry('e-1')).thenAnswer((_) async {});
+
+      final c = makeContainer();
+      c
+          .read(diaryControllerProvider.notifier)
+          .setCurrentEntry(savedEntry('e-1'));
+
+      await c.read(diaryControllerProvider.notifier).deleteEntry('e-1');
+
+      verify(() => repo.deleteEntry('e-1')).called(1);
+      final state = c.read(diaryControllerProvider);
+      expect(state.currentEntry, isNull);
+      expect(state.isSaving, isFalse);
+    });
+
+    test('repo fail → errorMessage set, currentEntry giữ nguyên', () async {
+      when(() => repo.deleteEntry('e-1'))
+          .thenThrow(const NetworkError(message: 'mất mạng'));
+
+      final c = makeContainer();
+      c
+          .read(diaryControllerProvider.notifier)
+          .setCurrentEntry(savedEntry('e-1'));
+
+      await c.read(diaryControllerProvider.notifier).deleteEntry('e-1');
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.errorMessage, 'mất mạng');
+      expect(state.currentEntry?.entryId, 'e-1');
+    });
+  });
+
+  group('clearError + setMode + setCurrentEntry', () {
+    test('clearError reset errorMessage về null', () async {
+      when(() => repo.deleteEntry(any()))
+          .thenThrow(const NetworkError(message: 'X'));
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).deleteEntry('e-1');
+      expect(c.read(diaryControllerProvider).errorMessage, isNotNull);
+
+      c.read(diaryControllerProvider.notifier).clearError();
+      expect(c.read(diaryControllerProvider).errorMessage, isNull);
+    });
+
+    test('setMode update state.mode', () {
+      final c = makeContainer();
+      c.read(diaryControllerProvider.notifier).setMode(DiaryCanvasMode.read);
+      expect(c.read(diaryControllerProvider).mode, DiaryCanvasMode.read);
+    });
+  });
+}


### PR DESCRIPTION
## Mô tả

Implement T2 `DiaryController` cho Diary module per [Plan T2](docs/plans/2026-05-23-diary.md). Đây là PR2 trong workflow BE 3-PR (T1 data ✅ → **T2 controller + wire main** → T8 rules).

Build trên T1 (PR #263 merged). PR này wire production logic cho `saveEntry`/`updatePrivacy`/`searchEntries`/`deleteEntry`/`loadEntries` + wire 2 providers (`diaryRepositoryProvider` + `diaryStorageClientProvider`) vào main.dart.

## Refs

- Closes #128 — T2 DiaryController
- Refs #126 — Epic Diary
- Build trên #263 (T1 FirebaseDiaryRepository ✅)
- Spec: [docs/specs/2026-05-23-diary.md](docs/specs/2026-05-23-diary.md)
- Plan: [docs/plans/2026-05-23-diary.md](docs/plans/2026-05-23-diary.md)

## Acceptance criteria (theo issue #128)

- [x] `saveEntry()` trong `DiaryCanvasMode.create` → `createEntry()`; trong `edit` → `updateEntry()`
- [x] Upload sequence: (1) cover → coverUrl, (2) inline tuần tự → inlineUrls, (3) TẤT CẢ URLs sẵn → Firestore write
- [x] Upload fail bất kỳ bước → `state.errorMessage` set, KHÔNG tạo/update Firestore doc
- [x] `updatePrivacy(entryId, privacy)` → update chỉ field `privacy` + `updatedAt`
- [x] `flutter test test/features/diary/application/` — 17/17 pass

## Files

| File | Δ | Mô tả |
|---|---|---|
| `lib/features/diary/application/diary_controller.dart` | +234 / -22 | DiaryState mở rộng + 7 method impl + 2 Riverpod providers |
| `lib/features/diary/data/diary_repository.dart` | +6 | Add `reserveEntryId()` abstract method |
| `lib/features/diary/data/firebase_diary_repository.dart` | ±17 | Impl `reserveEntryId` + `createEntry` tôn trọng entryId nếu pre-set |
| `lib/features/diary/presentation/diary_canvas_screen.dart` | ±10 | Remove inline DiaryCanvasMode enum, re-export từ controller |
| `lib/main.dart` | +11 | Wire `diaryRepositoryProvider` + `diaryStorageClientProvider` |
| `test/features/diary/application/diary_controller_test.dart` | +438 (new) | 17 cases qua mocktail |

## Design choices

- **`DiaryCanvasMode` moved presentation → application**: enum là state, controller cần ref. Canvas screen re-export `export ... show DiaryCanvasMode` để `diary_list_screen.dart`/code khác không phải đổi imports.
- **`reserveEntryId()` thêm vào abstract**: controller phải pre-reserve entryId trước upload để Storage path `diary/{uid}/{entryId}/...` khớp Firestore doc. Nếu không, sẽ có (a) collision concurrent users, (b) `deleteEntry` cleanup lệch path, (c) T8 Storage rule reject. Repository `createEntry` tôn trọng entryId non-empty (backward compat: empty → auto-gen).
- **`diaryStorageClientProvider` riêng**: controller orchestrate upload sequence (không thể qua repo vì repo `createEntry` chỉ nhận DiaryEntry). Storage client interface đã có sẵn từ T1.
- **`FirebaseDiaryStorageClient` đổi public**: main.dart cần instantiate.
- **`ref.onDispose` ở `build()` (single registration)**: avoid queue grow khi `loadEntries` gọi nhiều lần.
- **Inline URL mapping**: controller replace `ImageBlock` placeholder theo thứ tự — block ảnh thứ N nhận `inlineUrls[N-1]`. PR4 sẽ formalize UI calling convention.

## Caveats / follow-ups

### 1. Compound indexes vẫn thiếu (flag từ PR T1 #263)

Controller `loadEntries` gọi `watchEntries(uid)` (orderBy createdAt), `searchEntries` gọi `searchEntries(uid, query)` (orderBy createdAt). Cần index `(authorUid asc, createdAt desc)`. Khi runtime production, query sẽ throw `failed-precondition`.

→ Cần leader (ThienPDM) raise PR riêng cho `firebase/firestore.indexes.json` hoặc gộp vào PR3 (T8 rules).

### 2. UI rewire defer sang PR4

Mock screens (`DiaryListScreen` + `DiaryCanvasScreen`) vẫn chạy in-memory state cũ. PR4 sẽ rewire:
- `DiaryListScreen._entries` → `StreamProvider` watch via `DiaryController.loadEntries(uid)`
- `DiaryCanvasScreen._handleSave` → call `DiaryController.saveEntry()` thay vì pop với `DiaryDraftResult`

PR4 độc lập vì HanDHG có thể cần adjust UX khi data thật.

### 3. ImagePickerService chưa implement

Anh đã chọn "Add ImagePickerService interface" trong /start. PR2 chưa add vì:
- Controller `saveEntry` nhận `Uint8List coverBytes` + `List<Uint8List> inlineImageBytes` thẳng — UI lo pick + read bytes
- `ImagePickerService` interface sẽ thêm ở PR4 khi rewire Canvas screen (UI cần)

Em đã ghi nhận để không quên.

## Test plan

- [x] `flutter test test/features/diary/application/diary_controller_test.dart` — 17/17 pass
- [x] `flutter test test/features/diary/` — 47/47 pass (T1 30 + T2 17)
- [x] `flutter test` full suite — 615/615 pass, không break
- [x] `flutter analyze` — 0 issue
- [x] `dart format --set-exit-if-changed` — clean
- [x] `/review` 6-axis Standard — 3 🟡 fixed (entryId pre-reserve + ref.onDispose move + comment cleanup)

## Self-review checklist

- [x] Branch name `feature/HanDHG/diary-controller`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không file lớn vô tình (`.env`, keystore, service account)
- [x] Không `print` debug còn sót
- [x] Không `// TODO` chưa link issue
- [x] Không touch module khác — chỉ `lib/features/diary/` + `lib/main.dart` (wire)
- [x] Không touch shared infra (`core/`, `firestore.rules`, `firestore.indexes.json`) — indexes caveat #1 flag clearly