### PR TITLE
test(diary): T8 rules tests + 2 compound indexes (#131)

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -49,6 +49,23 @@
         { "fieldPath": "participantIds", "arrayConfig": "CONTAINS" },
         { "fieldPath": "lastMessageAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "diary",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "authorUid", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "diary",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "authorUid", "order": "ASCENDING" },
+        { "fieldPath": "privacy", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firebase/functions/src/firestore.rules.test.ts
+++ b/firebase/functions/src/firestore.rules.test.ts
@@ -635,6 +635,82 @@ describe('/diary/{entryId}', () => {
     await seedEntry('private');
     await assertFails(authed(stranger).firestore().doc(`diary/${ENTRY_ID}`).delete());
   });
+
+  test('content > 20 blocks rejected', async () => {
+    // Spec §Data model: max 20 content blocks per entry.
+    // Rule firestore.rules `/diary/{id}` enforce: request.resource.data.content.size() <= 20.
+    const twentyOneBlocks = Array.from({ length: 21 }, (_, i) => ({
+      type: 'text',
+      value: `block ${i}`,
+    }));
+    await assertFails(
+      authed(alice).firestore().doc(`diary/${ENTRY_ID}`).set({
+        authorUid: alice,
+        privacy: 'private',
+        moodTemplate: 'happy',
+        coverImageUrl: 'https://example.com/cover.jpg',
+        moodCaption: 'Lots of blocks',
+        content: twentyOneBlocks,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    );
+  });
+
+  test('content == 20 blocks accepted (boundary inclusive)', async () => {
+    // Rule cap là `<= 20` (inclusive). Bảo vệ off-by-one nếu rule drift sang `< 20`.
+    const twentyBlocks = Array.from({ length: 20 }, (_, i) => ({
+      type: 'text',
+      value: `block ${i}`,
+    }));
+    await assertSucceeds(
+      authed(alice).firestore().doc(`diary/${ENTRY_ID}`).set({
+        authorUid: alice,
+        privacy: 'private',
+        moodTemplate: 'happy',
+        coverImageUrl: 'https://example.com/cover.jpg',
+        moodCaption: 'Max blocks',
+        content: twentyBlocks,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    );
+  });
+
+  test('owner can update own entry (caption + content)', async () => {
+    await seedEntry('private');
+    await assertSucceeds(
+      authed(alice).firestore().doc(`diary/${ENTRY_ID}`).set({
+        authorUid: alice,
+        privacy: 'private',
+        moodTemplate: 'happy',
+        coverImageUrl: 'https://example.com/cover.jpg',
+        moodCaption: 'Updated title',
+        content: [{ type: 'text', value: 'Updated body' }],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    );
+  });
+
+  test('update cannot change authorUid (author hijack)', async () => {
+    // Rule: request.resource.data.authorUid == resource.data.authorUid
+    // → bob (logged in as bob) cannot reassign alice's entry to himself,
+    //   nor can alice flip authorUid to someone else.
+    await seedEntry('private');
+    await assertFails(
+      authed(alice).firestore().doc(`diary/${ENTRY_ID}`).set({
+        authorUid: bob, // hijack attempt
+        privacy: 'private',
+        moodTemplate: 'happy',
+        coverImageUrl: 'https://example.com/cover.jpg',
+        moodCaption: 'Hijacked',
+        content: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    );
+  });
 });
 
 // ===== /conversations/{conversationId} =====

--- a/firebase/functions/src/storage.rules.test.ts
+++ b/firebase/functions/src/storage.rules.test.ts
@@ -160,6 +160,153 @@ describe('Storage /avatars/{uid}/', () => {
   });
 });
 
+// ===== /diary/{uid}/{allPaths=**} =====
+
+describe('Storage /diary/{uid}/', () => {
+  describe('write', () => {
+    test('owner can upload valid JPEG ≤ 10MB', async () => {
+      const alice = uid('alice');
+      const ref = authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`);
+      await assertSucceeds(ref.put(fakeImage(1024)));
+    });
+
+    test('owner can upload exactly 10MB - 1 byte (under cap)', async () => {
+      const alice = uid('alice');
+      const ref = authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`);
+      await assertSucceeds(ref.put(fakeImage(10 * 1024 * 1024 - 1)));
+    });
+
+    test('owner cannot upload exactly 10MB (cap strict <)', async () => {
+      // Rule: request.resource.size < 10 * 1024 * 1024 — boundary excluded.
+      const alice = uid('alice');
+      const ref = authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`);
+      await assertFails(ref.put(fakeImage(10 * 1024 * 1024)));
+    });
+
+    test('owner cannot upload > 10MB', async () => {
+      const alice = uid('alice');
+      const ref = authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`);
+      await assertFails(ref.put(fakeImage(10 * 1024 * 1024 + 1)));
+    });
+
+    test('owner cannot upload non-image (text/plain)', async () => {
+      const alice = uid('alice');
+      const ref = authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/notes.txt`);
+      await assertFails(ref.put(fakeImage(1024, 'text/plain')));
+    });
+
+    test('owner cannot upload non-image (application/pdf)', async () => {
+      const alice = uid('alice');
+      const ref = authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/doc.pdf`);
+      await assertFails(ref.put(fakeImage(1024, 'application/pdf')));
+    });
+
+    test('owner can upload PNG (image/png matches image/.*)', async () => {
+      const alice = uid('alice');
+      const ref = authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/img_1.png`);
+      await assertSucceeds(ref.put(fakeImage(1024, 'image/png')));
+    });
+
+    test('owner can upload inline image into nested path', async () => {
+      // Pattern `{allPaths=**}` allows deeper paths than `{filename}`. Diary
+      // dùng `diary/{uid}/{entryId}/img_N.jpg` (3 segments sau uid).
+      const alice = uid('alice');
+      const ref = authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/img_2.jpg`);
+      await assertSucceeds(ref.put(fakeImage(1024)));
+    });
+
+    test('stranger cannot upload to another user prefix', async () => {
+      const alice = uid('alice');
+      const bob = uid('bob');
+      const ref = authed(bob)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`);
+      await assertFails(ref.put(fakeImage(1024)));
+    });
+
+    test('stranger cannot upload to deep nested path of another user', async () => {
+      // Rule `{allPaths=**}` cho phép path sâu — defense check để pattern match
+      // không bypass uid enforcement.
+      const alice = uid('alice');
+      const bob = uid('bob');
+      const ref = authed(bob)
+        .storage()
+        .ref(`diary/${alice}/entry-1/sub/folder/file.jpg`);
+      await assertFails(ref.put(fakeImage(1024)));
+    });
+
+    test('unauthenticated cannot upload', async () => {
+      const alice = uid('alice');
+      const ref = unauthed()
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`);
+      await assertFails(ref.put(fakeImage(1024)));
+    });
+  });
+
+  describe('read', () => {
+    test('owner can read own diary image', async () => {
+      const alice = uid('alice');
+      const ref = authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`);
+      await ref.put(fakeImage(1024));
+
+      await assertSucceeds(ref.getDownloadURL());
+    });
+
+    test('other authed user can read (Firestore rule controls visibility)', async () => {
+      // Storage rule cho phép mọi authed user read; Firestore rule
+      // `/diary/{id}` mới enforce friend + privacy. URL đã được lưu
+      // trong doc nên client KHÔNG list được prefix.
+      const alice = uid('alice');
+      const bob = uid('bob');
+      await authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`)
+        .put(fakeImage(1024));
+
+      await assertSucceeds(
+        authed(bob)
+          .storage()
+          .ref(`diary/${alice}/entry-1/cover.jpg`)
+          .getDownloadURL(),
+      );
+    });
+
+    test('unauthenticated cannot read', async () => {
+      const alice = uid('alice');
+      await authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`)
+        .put(fakeImage(1024));
+
+      await assertFails(
+        unauthed()
+          .storage()
+          .ref(`diary/${alice}/entry-1/cover.jpg`)
+          .getDownloadURL(),
+      );
+    });
+  });
+});
+
 // ===== Default deny — non-avatar paths =====
 
 describe('Storage default deny', () => {


### PR DESCRIPTION
## Mô tả

Hoàn thành **T8** của #131 — rules tests + indexes. T6+T7 FE đã done qua PR #231 (merged 2026-06-02). Đây là PR3 trong workflow BE 3-PR cho Diary module.

Rules `.rules` files đã có sẵn trên develop từ LX-RULES PR #164 (ThienPDM merge). PR3 KHÔNG đụng rules — chỉ thêm test coverage còn thiếu + 2 compound indexes cần thiết khi Diary T1 chạy production.

## Refs

- Closes #131 — T6 (#231) + T7 (#231) + T8 (this PR)
- Refs #126 — Epic Diary
- Build trên #263 (T1) + #269 (T2) đã merged
- Rules đã có từ #164 (LX-RULES) — KHÔNG đụng `.rules` files
- Spec: [docs/specs/2026-05-23-diary.md](docs/specs/2026-05-23-diary.md)
- Plan: [docs/plans/2026-05-23-diary.md](docs/plans/2026-05-23-diary.md)

## Acceptance criteria (theo issue #131 — T8)

### `/diary/{id}` Firestore rules
- [x] owner read ✓ (cả private + public) — đã có trong develop
- [x] friend read public ✓ — đã có
- [x] friend read private ✗ — đã có
- [x] stranger ✗ — đã có
- [x] create chỉ owner ✓ — đã có
- [x] `moodCaption.size() > 50` ✗ — đã có
- [x] `content.size() > 20` ✗ — **PR3 thêm**
- [x] `content.size() == 20` ✓ (boundary inclusive) — **PR3 thêm**
- [x] owner update ✓ — **PR3 thêm**
- [x] update đổi authorUid (hijack) ✗ — **PR3 thêm**

### Storage `diary/{uid}/...`
- [x] owner write ✓ — **PR3 thêm**
- [x] write >10MB ✗ — **PR3 thêm (strict <, boundary)**
- [x] write non-image ✗ — **PR3 thêm (text/plain + application/pdf)**
- [x] PNG OK — **PR3 thêm**
- [x] deep nested path owner ✓ + stranger ✗ — **PR3 thêm**
- [x] stranger write ✗ + unauth write ✗ — **PR3 thêm**
- [x] read: owner + other authed + unauth — **PR3 thêm**

## Files

| File | Δ | Mô tả |
|---|---|---|
| `firebase/functions/src/firestore.rules.test.ts` | +76 | 4 tests mới (3 AC + 1 boundary) |
| `firebase/functions/src/storage.rules.test.ts` | +147 | 14 cases mới: `Storage /diary/{uid}/` (write + read) |
| `firebase/firestore.indexes.json` | +17 | 2 indexes diary |

## Cross-module touch (cần leader review)

**`firebase/firestore.indexes.json`** — shared infra. Cần leader OK + deploy:
```bash
firebase deploy --only firestore:indexes --project <prod-or-staging>
```

2 indexes mới:
- `diary (authorUid asc, createdAt desc)` — dùng bởi `DiaryRepository.watchEntries(uid)` + `searchEntries(uid)` (PR #263)
- `diary (authorUid asc, privacy asc, createdAt desc)` — dùng bởi `DiaryRepository.getPublicEntries(authorUid)` (Profile cross-module)

Em đã flag caveat indexes này qua 2 PR trước (#263, #269). Khi T1 (FirebaseDiaryRepository) wire vào main.dart (đã làm ở T2 #269), query sẽ throw `failed-precondition` cho đến khi indexes deploy.

## Design choices

- **Theo convention `firestore.rules.test.ts` ở `src/`, KHÔNG ở `test/rules/`** — issue #131 ghi `firebase/functions/test/rules/diary.rules.test.ts` nhưng repo thực tế dùng `src/firestore.rules.test.ts` + `src/storage.rules.test.ts` (gộp all collections). Em theo pattern thật để gộp tests cùng module → dễ scan + emulator runner đã wire path đó. Profile T9 (PR #242) cũng theo pattern này.
- **Boundary inclusive test** (`content == 20`) — defense check chống off-by-one nếu rule drift sang `< 20`. Pattern mirror với avatar tests (`exactly 5MB - 1` + `exactly 5MB`).
- **Deep nested stranger test** — `{allPaths=**}` cho phép path sâu; explicit-test verify uid enforcement không bị bypass qua nested pattern.

## Caveats / follow-ups

### 1. Local emulator không chạy được — CI verify

Port 9999 trên máy em bị process khác giữ (cycle Firebase emulator). Em không kill (risk). CI workflow `firestore-rules` sẽ verify (Profile T9 PR #242 cũng skip local cùng lý do).

### 2. Indexes cần deploy trước khi user ấn Diary tab production

Khi user tap tab Diary → `DiaryController.loadEntries(uid)` fire `watchEntries` query. Không có index → `failed-precondition`. Leader merge PR này → ngay sau deploy indexes:

```bash
firebase deploy --only firestore:indexes --project <project-id>
```

## Test plan

- [x] `cd firebase/functions && npm run lint` — clean
- [x] `cd firebase/functions && npm run typecheck` — clean
- [ ] `firebase emulators:exec --only firestore,storage --project demo-meep-test "cd functions && npm run test:rules"` — **CI verify** (local port busy)
- [x] `/review` 6-axis Standard — 0 critical, 2 minor fixed (boundary inclusive + deep nested stranger)

## Self-review checklist

- [x] Branch name `feature/HanDHG/diary-rules`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không file lớn vô tình
- [x] Không `console.log` debug
- [x] Không `// TODO` chưa link issue
- [x] Không touch module khác (chỉ `firebase/` tests + indexes)
- [x] Shared infra `firestore.indexes.json` flag rõ trong Caveat #2 + cần ThienPDM review deploy