### PR TITLE
feat(diary): T9a rewire ListScreen + CanvasCreate (#271)

### DIFF
--- a/apps/mobile/lib/features/diary/application/diary_controller.dart
+++ b/apps/mobile/lib/features/diary/application/diary_controller.dart
@@ -9,6 +9,7 @@ import 'package:meep/features/diary/data/diary_content_block.dart';
 import 'package:meep/features/diary/data/diary_entry.dart';
 import 'package:meep/features/diary/data/diary_repository.dart';
 import 'package:meep/features/diary/data/firebase_diary_repository.dart';
+import 'package:meep/features/diary/data/image_picker_service.dart';
 
 part 'diary_controller.freezed.dart';
 part 'diary_controller.g.dart';
@@ -43,6 +44,13 @@ DiaryStorageClient diaryStorageClient(DiaryStorageClientRef ref) =>
     throw UnimplementedError(
       'diaryStorageClientProvider must be overridden — '
       'wire FirebaseDiaryStorageClient in main.dart',
+    );
+
+@Riverpod(keepAlive: true)
+ImagePickerService imagePickerService(ImagePickerServiceRef ref) =>
+    throw UnimplementedError(
+      'imagePickerServiceProvider must be overridden — '
+      'wire FlutterImagePickerService in main.dart',
     );
 
 @riverpod

--- a/apps/mobile/lib/features/diary/data/image_picker_service.dart
+++ b/apps/mobile/lib/features/diary/data/image_picker_service.dart
@@ -1,0 +1,57 @@
+import 'dart:typed_data';
+
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:image_picker/image_picker.dart';
+
+/// Abstract image picker — wraps gallery pick + compress + return bytes.
+///
+/// Tách interface để test inject stub deterministic — `image_picker` cần
+/// platform plugin, không stub được trong unit test. Pattern mirror với
+/// `AvatarStorageClient`/`AvatarCompressor` ở Profile module.
+abstract class ImagePickerService {
+  /// Open gallery, user pick → compress → return bytes.
+  /// Returns null khi user cancel.
+  Future<Uint8List?> pickImage();
+}
+
+/// Production impl: gallery pick → `flutter_image_compress` → bytes.
+class FlutterImagePickerService implements ImagePickerService {
+  const FlutterImagePickerService();
+
+  @override
+  Future<Uint8List?> pickImage() async {
+    final picked = await ImagePicker().pickImage(source: ImageSource.gallery);
+    if (picked == null) return null;
+
+    final compressed = await FlutterImageCompress.compressWithFile(
+      picked.path,
+      minWidth: 1024,
+      minHeight: 1024,
+      quality: 85,
+      format: CompressFormat.jpeg,
+    );
+    if (compressed != null) return compressed;
+
+    // Fallback: plugin trả null khi platform không hỗ trợ — caller enforce
+    // size cap trên raw bytes.
+    return picked.readAsBytes();
+  }
+}
+
+/// Test fake: predictable behavior cho widget/controller test.
+///
+/// - `nextBytes`: trả bytes này; null mặc định = simulate cancel.
+/// - `exceptionToThrow`: throw exception nếu set (test error path).
+/// - `callCount`: track số lần `pickImage` được gọi.
+class FakeImagePickerService implements ImagePickerService {
+  Uint8List? nextBytes;
+  Exception? exceptionToThrow;
+  int callCount = 0;
+
+  @override
+  Future<Uint8List?> pickImage() async {
+    callCount++;
+    if (exceptionToThrow != null) throw exceptionToThrow!;
+    return nextBytes;
+  }
+}

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
@@ -1,7 +1,13 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
 import 'package:meep/features/diary/data/diary_entry.dart';
 import 'package:meep/features/diary/presentation/discard_changes_dialog.dart';
 import 'package:meep/features/diary/presentation/privacy_sheet.dart';
@@ -20,26 +26,6 @@ export 'package:meep/features/diary/application/diary_controller.dart'
 part 'diary_canvas_screen_toolbar.dart';
 part 'diary_canvas_screen_dot_grid.dart';
 
-/// Payload pop về khi user tap check ở Canvas (create mode).
-///
-/// FE-mock only — sau khi wire DiaryRepository, replace bằng `DiaryEntry`
-/// (data layer) hoặc gọi controller.saveDraft trực tiếp trong Canvas.
-class DiaryDraftResult {
-  const DiaryDraftResult({
-    required this.caption,
-    required this.content,
-    required this.mood,
-    required this.createdAt,
-    required this.privacy,
-  });
-
-  final String caption;
-  final String content;
-  final MoodTemplate mood;
-  final DateTime createdAt;
-  final DiaryPrivacy privacy;
-}
-
 /// Mode của toolbar dưới Canvas (edit/create only).
 ///
 /// - `content`: toolbar chính 4 icon (image / type / align / smile).
@@ -55,7 +41,7 @@ enum _ToolMode { content, style, align }
 /// Light theme intentionally — hardcode `#F9FCFC` (KHÔNG dùng Theme.of).
 /// Layout: topbar (ngoài box) → box border đen + dots bg (mood zone +
 /// content) → content toolbar (ngoài box).
-class DiaryCanvasScreen extends StatefulWidget {
+class DiaryCanvasScreen extends ConsumerStatefulWidget {
   const DiaryCanvasScreen({
     super.key,
     required this.mode,
@@ -86,10 +72,10 @@ class DiaryCanvasScreen extends StatefulWidget {
   final DateTime? entryDate;
 
   @override
-  State<DiaryCanvasScreen> createState() => _DiaryCanvasScreenState();
+  ConsumerState<DiaryCanvasScreen> createState() => _DiaryCanvasScreenState();
 }
 
-class _DiaryCanvasScreenState extends State<DiaryCanvasScreen> {
+class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
   /// Canvas light theme — alias để giữ semantic rõ ràng trong code.
   /// `bw100` (#F9FCFC) = nền canvas sáng theo spec §Technical approach.
   static const _canvasBg = AppColors.bw100;
@@ -116,6 +102,11 @@ class _DiaryCanvasScreenState extends State<DiaryCanvasScreen> {
   bool _italic = false;
   bool _underline = false;
   bool _strikethrough = false;
+
+  /// Cover image bytes — user pick từ gallery qua `ImagePickerService`.
+  /// Null trước khi pick; sau khi pick lưu để gửi vào `controller.saveEntry`.
+  /// Read mode KHÔNG dùng (cover render từ `widget.initialImageUrl`).
+  Uint8List? _coverBytes;
 
   bool get _isReadOnly => widget.mode == DiaryCanvasMode.read;
 
@@ -155,35 +146,101 @@ class _DiaryCanvasScreenState extends State<DiaryCanvasScreen> {
         MoodTemplate.sad => 'Buồn bã',
       };
 
-  /// Save handler — tap check ở topbar.
+  /// Save handler — tap check ở topbar (create mode only ở PR4a).
   ///
-  /// Create mode (FE mock): pop về list với `DiaryDraftResult` để list
-  /// insert entry mới lên đầu. Edit mode: chỉ pop (chưa wire update mock).
-  /// Sau khi wire DiaryRepository: gọi controller.save() rồi pop.
-  void _handleSave() {
+  /// Validate: phải có mood + cover bytes + content text non-empty.
+  /// Build `DiaryEntry` draft → `controller.saveEntry(draft, coverBytes)`.
+  /// Stream `watchEntries` sẽ tự đẩy entry mới về list khi pop về.
+  ///
+  /// T9b (PR4b) sẽ wire edit mode đầy đủ — hiện tại edit pop trực tiếp.
+  Future<void> _handleSave() async {
     final mood = widget.moodTemplate;
     if (mood == null) {
       // Defensive — create flow phải pass mood từ picker.
-      Navigator.of(context).maybePop();
+      unawaited(Navigator.of(context).maybePop());
       return;
     }
     if (widget.mode == DiaryCanvasMode.edit) {
-      // TODO(D/T3/HanDHG): edit mode wire khi có DiaryRepository.
-      Navigator.of(context).maybePop();
+      // TODO(D/T9b/HanDHG): edit mode wire ở PR4b — issue #272.
+      unawaited(Navigator.of(context).maybePop());
       return;
     }
+
+    // Validate inputs (spec §Worst path).
+    final coverBytes = _coverBytes;
+    final contentText = _contentController.text.trim();
+    if (coverBytes == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Vui lòng chọn ảnh bìa')),
+      );
+      return;
+    }
+    if (contentText.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Vui lòng nhập nội dung')),
+      );
+      return;
+    }
+
+    final uid = ref.read(currentUidProvider).valueOrNull;
+    if (uid == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Bạn cần đăng nhập để lưu nhật ký')),
+      );
+      return;
+    }
+
     final caption = _captionController.text.trim().isEmpty
         ? _moodLabel(mood)
         : _captionController.text.trim();
-    Navigator.of(context).pop(
-      DiaryDraftResult(
-        caption: caption,
-        content: _contentController.text,
-        mood: mood,
-        createdAt: _displayDate,
-        privacy: _privacy,
-      ),
+
+    // Build draft — entryId rỗng để repo reserve, timestamps server-side
+    // sẽ override createdAt/updatedAt (em pass placeholder để model validate).
+    final placeholderTs = DateTime.now();
+    final draft = DiaryEntry(
+      entryId: '',
+      authorUid: uid,
+      moodTemplate: mood,
+      coverImageUrl: '', // controller replace với coverUrl thật sau upload
+      moodCaption: caption,
+      content: [DiaryContentBlock.text(value: contentText)],
+      privacy: _privacy,
+      createdAt: placeholderTs,
+      updatedAt: placeholderTs,
     );
+
+    await ref.read(diaryControllerProvider.notifier).saveEntry(
+          draft: draft,
+          coverBytes: coverBytes,
+        );
+
+    if (!mounted) return;
+
+    final errorMessage = ref.read(diaryControllerProvider).errorMessage;
+    if (errorMessage != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(errorMessage)),
+      );
+      ref.read(diaryControllerProvider.notifier).clearError();
+      return;
+    }
+
+    // Success — pop về list. Stream tự đẩy entry mới vào state.entries.
+    unawaited(Navigator.of(context).maybePop());
+  }
+
+  /// Open gallery → pick + compress → lưu bytes vào `_coverBytes`.
+  Future<void> _pickCoverImage() async {
+    try {
+      final bytes = await ref.read(imagePickerServiceProvider).pickImage();
+      if (bytes == null || !mounted) return;
+      setState(() => _coverBytes = bytes);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Không thể chọn ảnh, vui lòng thử lại')),
+      );
+    }
   }
 
   /// Mood background asset (hiển thị trong cover circle).
@@ -298,6 +355,7 @@ class _DiaryCanvasScreenState extends State<DiaryCanvasScreen> {
       _ToolMode.content => _ContentToolbar(
           onType: () => setState(() => _toolMode = _ToolMode.style),
           onAlign: () => setState(() => _toolMode = _ToolMode.align),
+          onImage: () => unawaited(_pickCoverImage()),
         ),
     };
   }
@@ -401,18 +459,36 @@ class _DiaryCanvasScreenState extends State<DiaryCanvasScreen> {
   // ── Mood zone: cover (mood image) + caption highlight ──
   Widget _buildMoodZone() {
     final mood = widget.moodTemplate;
+    final coverBytes = _coverBytes;
+    final canPick = !_isReadOnly;
+
+    Widget coverChild;
+    if (coverBytes != null) {
+      coverChild = Image.memory(coverBytes, fit: BoxFit.contain);
+    } else if (mood == null) {
+      coverChild = const Icon(
+        Icons.image_outlined,
+        size: 48,
+        color: AppColors.bw500,
+      );
+    } else {
+      coverChild = Image.asset(_moodAsset(mood), fit: BoxFit.contain);
+    }
+
     return Column(
       children: [
-        // Cover — mood image thuần (không khung tròn để giữ shape gốc)
+        // Cover — tap để chọn ảnh trong create/edit mode.
         SizedBox(
           height: 102,
-          child: mood == null
-              ? const Icon(
-                  Icons.image_outlined,
-                  size: 48,
-                  color: AppColors.bw500,
-                )
-              : Image.asset(_moodAsset(mood), fit: BoxFit.contain),
+          child: Semantics(
+            label: canPick ? 'Chọn ảnh bìa' : 'Ảnh bìa',
+            button: canPick,
+            child: GestureDetector(
+              onTap: canPick ? () => unawaited(_pickCoverImage()) : null,
+              behavior: HitTestBehavior.opaque,
+              child: coverChild,
+            ),
+          ),
         ),
         const SizedBox(height: 16),
 

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen_toolbar.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen_toolbar.dart
@@ -3,10 +3,15 @@ part of 'diary_canvas_screen.dart';
 /// Content toolbar — 4 SVG icons: image, type, align, smile.
 /// Figma `658:6070` (Frame 1570, Turquoise/200 bg + Turquoise/500 border).
 class _ContentToolbar extends StatelessWidget {
-  const _ContentToolbar({required this.onType, required this.onAlign});
+  const _ContentToolbar({
+    required this.onType,
+    required this.onAlign,
+    required this.onImage,
+  });
 
   final VoidCallback onType;
   final VoidCallback onAlign;
+  final VoidCallback onImage;
 
   @override
   Widget build(BuildContext context) {
@@ -22,10 +27,8 @@ class _ContentToolbar extends StatelessWidget {
         children: [
           _SvgIconBtn(
             asset: 'assets/icons/ic_diary_image.svg',
-            semanticLabel: 'Chèn ảnh',
-            onTap: () {
-              // TODO(D/T8/HanDHG): chèn ảnh inline (Polaroid frame)
-            },
+            semanticLabel: 'Chọn ảnh bìa',
+            onTap: onImage,
           ),
           const SizedBox(width: 22),
           _SvgIconBtn(

--- a/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
 import 'package:meep/features/diary/data/diary_entry.dart';
 import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
 import 'package:meep/features/diary/presentation/diary_search_screen.dart';
@@ -20,113 +24,79 @@ part 'diary_list_screen_mood_picker.dart';
 /// Mood picker là overlay inline: tap FAB [+] → FAB xoay thành [x] + nền
 /// đổi xám, scrim mờ + 5 mood arc bao quanh nửa trên FAB. Tap [x] hoặc
 /// scrim → đóng.
-class DiaryListScreen extends StatefulWidget {
+class DiaryListScreen extends ConsumerStatefulWidget {
   const DiaryListScreen({super.key});
 
   @override
-  State<DiaryListScreen> createState() => _DiaryListScreenState();
-}
-
-// DEV mock data — chỉ dùng cho TextButton mở Canvas read demo. Xoá khi
-// wire DiaryRepository thật.
-const _devMockContent =
-    'Hôm nay là một ngày thật tuyệt vời. Mình đã đi dạo bên bờ biển '
-    'cùng các bạn thân, mặt trời lặn nhuộm cả bầu trời thành màu cam '
-    'rực rỡ. Mình ngồi đó nghe sóng vỗ, ngắm những con thuyền nhỏ '
-    'lướt trên mặt nước. Có những khoảnh khắc bình yên đến lạ thường, '
-    'khi mọi lo toan tan biến và mình chỉ còn cảm nhận được hơi thở '
-    'của biển cả.';
-const _devMockImageUrl = 'https://picsum.photos/seed/diary/600/600';
-
-// DEV mock entries cho Grid/List view — xoá khi wire DiaryRepository.
-class _MockEntry {
-  const _MockEntry({
-    required this.title,
-    required this.date,
-    required this.mood,
-    this.content = '',
-  });
-
-  final String title;
-  final DateTime date;
-  final MoodTemplate mood;
-
-  /// Body text — non-empty cho seed entries để Canvas read mode demo có
-  /// nội dung. Empty cho entry mới tạo từ Canvas (chưa nhập gì).
-  final String content;
+  ConsumerState<DiaryListScreen> createState() => _DiaryListScreenState();
 }
 
 /// Format ngắn cho card display: "DD th MM".
 String _formatShortDate(DateTime d) => '${d.day} th ${d.month}';
 
-/// Seed mock entries — khi mở app lần đầu. State sau đó mutable trong
-/// `_DiaryListScreenState._entries` để insert entry mới khi save Canvas.
-final List<_MockEntry> _seedMockEntries = [
-  _MockEntry(
-    title: 'Happy!',
-    date: DateTime(2026, 5, 22),
-    mood: MoodTemplate.happy,
-  ),
-  _MockEntry(
-    title: 'Tired',
-    date: DateTime(2026, 5, 20),
-    mood: MoodTemplate.tired,
-  ),
-  _MockEntry(
-    title: 'Title nhật ký',
-    date: DateTime(2026, 5, 19),
-    mood: MoodTemplate.bored,
-  ),
-  _MockEntry(
-    title: 'Đà lạt',
-    date: DateTime(2026, 5, 18),
-    mood: MoodTemplate.happy,
-  ),
-];
-
 /// View mode cho danh sách nhật ký — Grid 2-col vs List dọc.
 enum _ViewMode { grid, list }
 
-class _DiaryListScreenState extends State<DiaryListScreen> {
+class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
   bool _pickerOpen = false;
   _ViewMode _viewMode = _ViewMode.grid;
 
-  /// Mutable copy của seed mock — entry mới insert lên đầu khi user save
-  /// Canvas (FE mock). Khi wire DiaryRepository: bỏ list này, đổi sang
-  /// `StreamProvider` watch `/diary_entries` của user.
-  late final List<_MockEntry> _entries = [..._seedMockEntries];
+  /// Track uid đã trigger loadEntries để không gọi lại khi cùng uid emit
+  /// nhiều lần (vd auth state stream replay).
+  String? _loadedForUid;
+
+  @override
+  void initState() {
+    super.initState();
+    // Riverpod pattern chuẩn: ref.listenManual fire ngay với current value +
+    // mọi emit sau. Trigger loadEntries 1 lần / uid; sign out → sign in lại
+    // với uid khác sẽ tự re-trigger.
+    ref.listenManual<AsyncValue<String?>>(
+      currentUidProvider,
+      (_, next) {
+        final uid = next.valueOrNull;
+        if (uid == null || _loadedForUid == uid) return;
+        _loadedForUid = uid;
+        ref.read(diaryControllerProvider.notifier).loadEntries(uid);
+      },
+      fireImmediately: true,
+    );
+  }
 
   void _togglePicker() => setState(() => _pickerOpen = !_pickerOpen);
   void _closePicker() => setState(() => _pickerOpen = false);
 
-  /// Tap 1 mood trong picker — close picker, push Canvas create, đợi user
-  /// save → insert entry mới lên đầu list.
+  /// Tap 1 mood trong picker — close picker, push Canvas create.
+  /// Sau save: stream `watchEntries` tự đẩy entry mới về `state.entries` —
+  /// KHÔNG cần manual insert như mock cũ.
   Future<void> _onMoodSelected(MoodTemplate mood) async {
     _closePicker();
-    final result = await Navigator.of(context).push<DiaryDraftResult>(
-      MaterialPageRoute<DiaryDraftResult>(
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
         builder: (_) => DiaryCanvasScreen(
           mode: DiaryCanvasMode.create,
           moodTemplate: mood,
         ),
       ),
     );
-    if (result == null || !mounted) return;
-    setState(() {
-      _entries.insert(
-        0,
-        _MockEntry(
-          title: result.caption,
-          date: result.createdAt,
-          mood: result.mood,
-          content: result.content,
-        ),
-      );
-    });
   }
 
   @override
   Widget build(BuildContext context) {
+    // Listen errorMessage qua provider.select để show SnackBar khi error
+    // mới fire (kể cả khi đã có entries cũ — branch error trong _buildBody
+    // chỉ render khi empty).
+    ref.listen<String?>(
+      diaryControllerProvider.select((s) => s.errorMessage),
+      (prev, next) {
+        if (next == null || next == prev) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next)),
+        );
+        ref.read(diaryControllerProvider.notifier).clearError();
+      },
+    );
+
     return Scaffold(
       backgroundColor: AppColors.bw900, // #050F10
       body: Stack(
@@ -137,7 +107,7 @@ class _DiaryListScreenState extends State<DiaryListScreen> {
               children: [
                 _buildTopbar(),
                 _buildFilterRow(),
-                // Body co giãn: Grid / List / Empty
+                // Body co giãn: Grid / List / Empty / Loading / Error
                 Expanded(child: _buildBody()),
                 // Padding dưới chừa chỗ cho FAB + taskbar
                 const SizedBox(height: 160),
@@ -327,13 +297,41 @@ class _DiaryListScreenState extends State<DiaryListScreen> {
     );
   }
 
-  // ── Body: render theo view mode hoặc empty state ──
+  // ── Body: render theo controller state ──
   Widget _buildBody() {
-    if (_entries.isEmpty) return _buildEmptyState();
-    return _viewMode == _ViewMode.grid ? _buildGrid() : _buildList();
+    final state = ref.watch(diaryControllerProvider);
+
+    if (state.isLoading && state.entries.isEmpty) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppColors.turquoise500),
+      );
+    }
+
+    if (state.errorMessage != null && state.entries.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Text(
+            state.errorMessage ?? 'Không tải được nhật ký',
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              fontFamily: 'Nunito',
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: AppColors.bw500,
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (state.entries.isEmpty) return _buildEmptyState();
+    return _viewMode == _ViewMode.grid
+        ? _buildGrid(state.entries)
+        : _buildList(state.entries);
   }
 
-  Widget _buildGrid() {
+  Widget _buildGrid(List<DiaryEntry> entries) {
     return GridView.builder(
       padding: const EdgeInsets.symmetric(horizontal: 39),
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
@@ -342,49 +340,61 @@ class _DiaryListScreenState extends State<DiaryListScreen> {
         crossAxisSpacing: 32,
         childAspectRatio: 150.5 / 182,
       ),
-      itemCount: _entries.length,
+      itemCount: entries.length,
       itemBuilder: (context, index) {
-        final e = _entries[index];
+        final e = entries[index];
         return DiaryMoodCard(
-          title: e.title,
-          date: _formatShortDate(e.date),
-          mood: e.mood,
+          title: e.moodCaption,
+          date: _formatShortDate(e.createdAt),
+          mood: e.moodTemplate,
           onTap: () => _openCanvasRead(e),
         );
       },
     );
   }
 
-  Widget _buildList() {
+  Widget _buildList(List<DiaryEntry> entries) {
     return ListView.separated(
       padding: const EdgeInsets.symmetric(horizontal: 17),
-      itemCount: _entries.length,
+      itemCount: entries.length,
       separatorBuilder: (_, __) => const SizedBox(height: 12),
       itemBuilder: (context, index) {
-        final e = _entries[index];
+        final e = entries[index];
         return DiaryListCard(
-          title: e.title,
-          date: _formatShortDate(e.date),
-          mood: e.mood,
+          title: e.moodCaption,
+          date: _formatShortDate(e.createdAt),
+          mood: e.moodTemplate,
           onTap: () => _openCanvasRead(e),
         );
       },
     );
   }
 
-  void _openCanvasRead(_MockEntry e) {
-    // Entry mới chưa có content → dùng text user vừa nhập (có thể rỗng).
-    // Entry seed (content rỗng) → demo bằng mock content + image.
-    final isSeed = e.content.isEmpty;
+  /// Read mode — T9b sẽ wire đầy đủ (fetch entry + render content blocks).
+  /// PR4a tạm push canvas với fields hiện có; render text content + ảnh
+  /// inline sẽ bổ sung ở T9b.
+  void _openCanvasRead(DiaryEntry e) {
+    // Lấy text content từ block đầu tiên dạng text (nếu có) — placeholder
+    // tới khi T9b render đầy đủ block list.
+    final firstText = e.content.firstWhere(
+      (b) => b.maybeWhen(text: (_, __) => true, orElse: () => false),
+      orElse: () => const DiaryContentBlock.text(value: ''),
+    );
+    final textValue = firstText.maybeWhen(
+      text: (value, _) => value,
+      orElse: () => '',
+    );
+
     Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (_) => DiaryCanvasScreen(
           mode: DiaryCanvasMode.read,
-          moodTemplate: e.mood,
-          initialCaption: e.title,
-          initialContent: isSeed ? _devMockContent : e.content,
-          initialImageUrl: isSeed ? _devMockImageUrl : null,
-          entryDate: e.date,
+          entryId: e.entryId,
+          moodTemplate: e.moodTemplate,
+          initialCaption: e.moodCaption,
+          initialContent: textValue,
+          initialImageUrl: e.coverImageUrl.isNotEmpty ? e.coverImageUrl : null,
+          entryDate: e.createdAt,
         ),
       ),
     );

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:meep/features/reaction/data/firebase_reaction_repository.dart';
 import 'package:meep/features/chat/data/firebase_conversation_repository.dart';
 import 'package:meep/features/diary/application/diary_controller.dart';
 import 'package:meep/features/diary/data/firebase_diary_repository.dart';
+import 'package:meep/features/diary/data/image_picker_service.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/firebase_friend_repository.dart';
 import 'package:meep/features/friend/data/firebase_friend_request_repository.dart';
@@ -129,6 +130,9 @@ void main() async {
         ),
         diaryStorageClientProvider.overrideWithValue(
           FirebaseDiaryStorageClient(FirebaseStorage.instance),
+        ),
+        imagePickerServiceProvider.overrideWithValue(
+          const FlutterImagePickerService(),
         ),
         streakRepositoryProvider.overrideWithValue(
           FirebaseStreakRepository(FirebaseFirestore.instance),

--- a/apps/mobile/test/features/diary/data/image_picker_service_test.dart
+++ b/apps/mobile/test/features/diary/data/image_picker_service_test.dart
@@ -1,0 +1,42 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/diary/data/image_picker_service.dart';
+
+void main() {
+  group('FakeImagePickerService — test contract', () {
+    test('returns null khi cancel', () async {
+      final svc = FakeImagePickerService();
+      final result = await svc.pickImage();
+      expect(result, isNull);
+    });
+
+    test('returns predefined bytes khi set', () async {
+      final svc = FakeImagePickerService();
+      final bytes = Uint8List.fromList(List.filled(100, 0xAB));
+      svc.nextBytes = bytes;
+
+      final result = await svc.pickImage();
+
+      expect(result, isNotNull);
+      expect(result!.lengthInBytes, 100);
+    });
+
+    test('throws khi exceptionToThrow set', () async {
+      final svc = FakeImagePickerService();
+      svc.exceptionToThrow = Exception('picker fail');
+
+      expect(svc.pickImage, throwsException);
+    });
+
+    test('counts pickImage calls', () async {
+      final svc = FakeImagePickerService();
+      svc.nextBytes = Uint8List(50);
+
+      await svc.pickImage();
+      await svc.pickImage();
+
+      expect(svc.callCount, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Mô tả

Implement T9a (#271) — phase 1 BE wire cho Diary UI. Bỏ in-memory mock state, dùng `DiaryController` từ PR2 (#269). Phase 2 (T9b #272) sẽ wire read mode + search + menu.

## Refs

- Closes #271 — T9a phase 1 rewire
- Refs #272 — T9b phase 2 (read mode + search + menu)
- Build trên #263 (T1) + #269 (T2) + #270 (T8) đã merged
- Spec: [docs/specs/2026-05-23-diary.md](docs/specs/2026-05-23-diary.md)

## Acceptance criteria (theo issue #271)

### ImagePickerService
- [x] Abstract `pickImage()` trả `Uint8List?` (null = cancelled)
- [x] `FlutterImagePickerService` wraps `image_picker.pickImage(gallery)` + `flutter_image_compress` (1024×1024, q85, JPEG)
- [x] Wire `imagePickerServiceProvider` ở main.dart
- [x] `FakeImagePickerService` cho test (4 cases)

### DiaryListScreen
- [x] `ref.watch(diaryControllerProvider).entries` thay `_entries` mock
- [x] `ref.listenManual(currentUidProvider)` fire `loadEntries(uid)` 1 lần / uid
- [x] Loading: `CircularProgressIndicator` Turquoise/500
- [x] Error: text inline khi empty + `SnackBar` qua `ref.listen` khi đã có entries cũ
- [x] Empty: giữ behavior cũ "Bạn chưa có nhật ký nào"
- [x] Sau save thành công ở Canvas: stream tự đẩy entry mới lên (không insert manual)

### DiaryCanvasScreen — create mode
- [x] Tap MoodZone cover → `ImagePickerService.pickImage` → `setState(_coverBytes = bytes)`
- [x] Image button toolbar wire `_pickCoverImage`
- [x] `_handleSave` validate cover bytes + content text + uid → build `DiaryEntry` draft → `controller.saveEntry(draft, coverBytes)`
- [x] Error → `SnackBar` + `clearError`
- [x] Success → `Navigator.maybePop` (stream đẩy entry mới về list)

## Out of scope (T9b sẽ làm — #272)

- Edit mode wire đầy đủ — hiện tại pop trực tiếp với TODO marker `D/T9b/HanDHG`
- Read mode đọc entry thật từ Firestore
- `DiarySearchScreen` wire `controller.searchEntries`
- Delete + edit menu wire

## Files

| File | Δ | Mô tả |
|---|---|---|
| `lib/features/diary/data/image_picker_service.dart` | +57 (new) | abstract + Flutter impl + Fake stub |
| `test/features/diary/data/image_picker_service_test.dart` | +42 (new) | 4 cases test Fake contract |
| `lib/features/diary/application/diary_controller.dart` | +8 | `imagePickerServiceProvider` stub |
| `lib/features/diary/presentation/diary_list_screen.dart` | ±214 | ConsumerStatefulWidget + listenManual + 4 states render |
| `lib/features/diary/presentation/diary_canvas_screen.dart` | ±170 | ConsumerStatefulWidget + _coverBytes + saveEntry wire |
| `lib/features/diary/presentation/diary_canvas_screen_toolbar.dart` | ±13 | onImage callback wire |
| `lib/main.dart` | +4 | wire `imagePickerServiceProvider` |

## Design choices

- **`ref.listenManual` trong `initState`** (không `Future.microtask` trong `build`) — Riverpod pattern chuẩn, fire 1 lần per uid + auto re-trigger sign out → sign in.
- **`ref.listen(errorMessage)` trong `build`** — `provider.select` → SnackBar khi error change (kể cả đã có entries cũ).
- **`unawaited` cho `Navigator.maybePop`** — tránh lint warn unawaited Future.
- **`if (!mounted) return` sau await** — defensive guard cho widget dispose mid-flight.

## Caveats / follow-ups

### 1. UX MoodZone cover khi `_coverBytes == null` — defer polish

User thấy mood asset PNG placeholder ở cover area trước khi pick. Không có visual hint "tap to pick". `/review` flag là nice-to-have — defer polish PR sau T9b. Có thể add overlay "Tap để chọn ảnh" mờ trên mood asset.

### 2. T9b deferred items

- Edit mode `_handleSave` chỉ pop với TODO marker
- Read mode dùng `widget.initial*` props placeholder (T9b sẽ fetch entry thật qua `getEntry(entryId)`)
- Menu delete/share TODO markers giữ nguyên

## Test plan

- [x] `flutter test test/features/diary/` — 51/51 pass (47 cũ + 4 ImagePicker)
- [x] `flutter test` full suite — 639/639 pass, không break
- [x] `flutter analyze` — 0 issue
- [x] `dart format --set-exit-if-changed` — clean
- [x] `/review` 6-axis Standard — 2 🟡 fixed (listenManual + errorMessage SnackBar), 1 UX deferred
- [ ] Manual smoke trên Android emulator — em chưa test real device, cần anh hoặc HanDHG test golden path: tap diary tab → list load → FAB → mood picker → canvas → tap MoodZone pick ảnh → gõ text → check → entry mới hiện trên list (từ stream)

## Self-review checklist

- [x] Branch name `feature/HanDHG/diary-rewire-list-canvas`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không file lớn vô tình
- [x] Không `print` debug
- [x] Không `// TODO` chưa link issue (T9b TODO link đến #272)
- [x] Không touch module khác (chỉ `lib/features/diary/` + `lib/main.dart` wire)
- [x] Cross-module import `currentUidProvider` (auth) explicit + cần thiết