### PR TITLE
feat(streak): ST2 — StreakController + pure calculateStreak (timezone-aware)

### DIFF
--- a/apps/mobile/lib/features/streak/application/calculate_streak.dart
+++ b/apps/mobile/lib/features/streak/application/calculate_streak.dart
@@ -1,0 +1,29 @@
+/// Pure function — số ngày liên tiếp post từ hôm nay trở về.
+///
+/// Quy ước (spec §Data model + §Timezone contract):
+/// - [postDatesLocal]: danh sách ngày đã post, đã convert sang **local timezone**
+///   và dedupe per day (caller responsibility — `FirebaseStreakRepository`).
+/// - [nowLocal]: thời điểm hiện tại (local timezone). Inject để test deterministic.
+///
+/// Algorithm:
+/// 1. Build dayKey set (year/month/day) từ [postDatesLocal]
+/// 2. Bắt đầu từ today: nếu có trong set → +1, lùi 1 ngày
+/// 3. Dừng khi gặp ngày không có trong set
+///
+/// Examples:
+/// - `[today]` → 1
+/// - `[today, yesterday, 2d ago]` → 3
+/// - `[today, 3d ago]` → 1 (gap ở 2d/1d ago → đứt)
+/// - `[]` → 0
+/// - `[yesterday only]` (no today) → 0
+int calculateStreak(List<DateTime> postDatesLocal, DateTime nowLocal) {
+  final daySet =
+      postDatesLocal.map((d) => DateTime(d.year, d.month, d.day)).toSet();
+  int streak = 0;
+  var day = DateTime(nowLocal.year, nowLocal.month, nowLocal.day);
+  while (daySet.contains(day)) {
+    streak++;
+    day = day.subtract(const Duration(days: 1));
+  }
+  return streak;
+}

--- a/apps/mobile/lib/features/streak/application/streak_controller.dart
+++ b/apps/mobile/lib/features/streak/application/streak_controller.dart
@@ -1,34 +1,18 @@
 import 'dart:async';
 
-import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/streak/application/calculate_streak.dart';
+import 'package:meep/features/streak/application/streak_state.dart';
 import 'package:meep/features/streak/data/streak_repository.dart';
 
-part 'streak_controller.freezed.dart';
+export 'package:meep/features/streak/application/streak_state.dart';
+
 part 'streak_controller.g.dart';
-
-@freezed
-class StreakState with _$StreakState {
-  const factory StreakState({
-    /// Posts của tháng đang xem (sort createdAt ASC).
-    @Default([]) List<Post> monthPosts,
-
-    /// Tất cả ngày đã post (local timezone, dedupe per day).
-    /// Dùng cho `calculateStreak` + Calendar render dot ngày có post.
-    @Default([]) List<DateTime> allPostDates,
-
-    /// Tháng đang xem (startOfMonthLocal). Null = chưa init.
-    DateTime? viewingMonth,
-
-    /// Số ngày liên tiếp từ hôm nay trở về (toàn cục, không đổi khi swipe tháng).
-    @Default(0) int currentStreak,
-    @Default(false) bool isLoading,
-    String? errorMessage,
-  }) = _StreakState;
-}
 
 @Riverpod(keepAlive: true)
 StreakRepository streakRepository(Ref ref) => throw UnimplementedError(
@@ -36,35 +20,125 @@ StreakRepository streakRepository(Ref ref) => throw UnimplementedError(
       'wire FirebaseStreakRepository in main.dart (TODO: ST/ST1/HanDHG)',
     );
 
-@riverpod
+/// Inject `DateTime.now` để test deterministic. Override trong test
+/// `nowProvider.overrideWithValue(() => fixedNow)`.
+@Riverpod(keepAlive: true)
+DateTime Function() now(Ref ref) => DateTime.now;
+
+/// `keepAlive: true` để state survive cross route transitions (user navigate
+/// Streak → Photo detail → back). Pattern AUTH #6 (keepAlive cho controllers
+/// xuyên route).
+@Riverpod(keepAlive: true)
 class StreakController extends _$StreakController {
+  StreamSubscription<List<Post>>? _monthSub;
+
   @override
   StreakState build() {
-    // TODO(ST/ST2/HanDHG): subscribe watchUserMonth, fetch allPostDates,
-    // compute currentStreak. See docs/plans/2026-05-23-streak.md §ST2.
+    ref.onDispose(() => _monthSub?.cancel());
     return const StreakState();
   }
 
-  /// Initialize: set viewingMonth = startOfCurrentMonthLocal, subscribe
-  /// watchUserMonth, fetch getUserAllDates once, compute currentStreak.
-  Future<void> init() {
-    throw UnimplementedError('init — TODO: ST/ST2/HanDHG');
+  /// Load tháng hiện tại + allPostDates + compute currentStreak.
+  ///
+  /// Gọi từ `StreakScreen.initState` hoặc `ref.read(...notifier).init()` khi
+  /// user mở Streak tab lần đầu.
+  Future<void> init() async {
+    final uid = ref.read(currentUidProvider).valueOrNull;
+    if (uid == null) {
+      state = state.copyWith(
+        errorMessage: 'Bạn cần đăng nhập để xem Kỷ niệm',
+      );
+      return;
+    }
+
+    final nowLocal = ref.read(nowProvider)();
+    final currentMonth = DateTime(nowLocal.year, nowLocal.month);
+    state = state.copyWith(
+      isLoading: true,
+      errorMessage: null,
+      viewingMonth: currentMonth,
+    );
+
+    try {
+      final repo = ref.read(streakRepositoryProvider);
+      final allDates = await repo.getUserAllDates(uid);
+      final streak = calculateStreak(allDates, nowLocal);
+      state = state.copyWith(
+        allPostDates: allDates,
+        currentStreak: streak,
+      );
+      _subscribeMonth(uid, currentMonth);
+    } catch (e) {
+      state = _afterFailure(e);
+    }
   }
 
-  /// Decrement viewingMonth 1 tháng. currentStreak + allPostDates KHÔNG đổi.
-  Future<void> swipePrev() {
-    throw UnimplementedError('swipePrev — TODO: ST/ST2/HanDHG');
+  /// Decrement viewingMonth 1 tháng. Stream re-subscribe cho tháng mới.
+  /// `currentStreak` + `allPostDates` KHÔNG đổi (toàn cục).
+  Future<void> swipePrev() async {
+    final current = state.viewingMonth;
+    if (current == null) return; // chưa init
+    final uid = ref.read(currentUidProvider).valueOrNull;
+    if (uid == null) return;
+
+    final prevMonth = DateTime(current.year, current.month - 1);
+    state = state.copyWith(
+      viewingMonth: prevMonth,
+      monthPosts: const [],
+      isLoading: true,
+      errorMessage: null,
+    );
+    _subscribeMonth(uid, prevMonth);
   }
 
-  /// Increment viewingMonth 1 tháng. Early-return (no-op) nếu đang viewing
-  /// tháng hiện tại — cap tại tháng hiện tại (UI bounce animation).
-  Future<void> swipeNext() {
-    throw UnimplementedError('swipeNext — TODO: ST/ST2/HanDHG');
+  /// Increment viewingMonth 1 tháng. Cap tại tháng hiện tại — early return.
+  Future<void> swipeNext() async {
+    final current = state.viewingMonth;
+    if (current == null) return;
+    final uid = ref.read(currentUidProvider).valueOrNull;
+    if (uid == null) return;
+
+    final nowLocal = ref.read(nowProvider)();
+    final currentMonth = DateTime(nowLocal.year, nowLocal.month);
+
+    // Cap: không vượt tháng hiện tại
+    if (!current.isBefore(currentMonth)) return;
+
+    final nextMonth = DateTime(current.year, current.month + 1);
+    state = state.copyWith(
+      viewingMonth: nextMonth,
+      monthPosts: const [],
+      isLoading: true,
+      errorMessage: null,
+    );
+    _subscribeMonth(uid, nextMonth);
   }
 
   void clearError() {
     if (state.errorMessage != null) {
       state = state.copyWith(errorMessage: null);
     }
+  }
+
+  void _subscribeMonth(String uid, DateTime month) {
+    _monthSub?.cancel();
+    final repo = ref.read(streakRepositoryProvider);
+    _monthSub = repo.watchUserMonth(uid, month).listen(
+      (posts) {
+        state = state.copyWith(monthPosts: posts, isLoading: false);
+      },
+      onError: (Object e) {
+        state = _afterFailure(e);
+      },
+    );
+  }
+
+  /// Reset isLoading + map error to message (pattern AUTH #4).
+  StreakState _afterFailure(Object e) {
+    final err = AppError.fromUnknown(e, fallback: 'Không thể tải Kỷ niệm');
+    return state.copyWith(
+      isLoading: false,
+      errorMessage: err is OperationCancelledError ? null : err.message,
+    );
   }
 }

--- a/apps/mobile/lib/features/streak/application/streak_state.dart
+++ b/apps/mobile/lib/features/streak/application/streak_state.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'package:meep/features/feed/data/post.dart';
+
+part 'streak_state.freezed.dart';
+
+@freezed
+class StreakState with _$StreakState {
+  const factory StreakState({
+    /// Posts của tháng đang xem (sort createdAt ASC).
+    @Default([]) List<Post> monthPosts,
+
+    /// Tất cả ngày đã post (local timezone, dedupe per day, sort DESC).
+    /// Dùng cho `calculateStreak` + Calendar render dot ngày có post.
+    @Default([]) List<DateTime> allPostDates,
+
+    /// Tháng đang xem (startOfMonthLocal). Null = chưa init.
+    DateTime? viewingMonth,
+
+    /// Số ngày liên tiếp từ hôm nay trở về (toàn cục, không đổi khi swipe tháng).
+    @Default(0) int currentStreak,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+  }) = _StreakState;
+}

--- a/apps/mobile/test/features/streak/application/calculate_streak_test.dart
+++ b/apps/mobile/test/features/streak/application/calculate_streak_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/streak/application/calculate_streak.dart';
+
+void main() {
+  final now = DateTime(2026, 5, 22, 14, 30); // any time of day — ignored
+
+  DateTime daysAgo(int n) => DateTime(now.year, now.month, now.day - n);
+
+  group('calculateStreak', () {
+    test('[] → 0 (chưa có post nào)', () {
+      expect(calculateStreak([], now), 0);
+    });
+
+    test('[today] → 1', () {
+      expect(calculateStreak([daysAgo(0)], now), 1);
+    });
+
+    test('[today, yesterday, 2d ago] → 3', () {
+      expect(
+        calculateStreak([daysAgo(0), daysAgo(1), daysAgo(2)], now),
+        3,
+      );
+    });
+
+    test('[today, 3d ago] → 1 (gap đứt streak)', () {
+      expect(calculateStreak([daysAgo(0), daysAgo(3)], now), 1);
+    });
+
+    test('[yesterday only] (no today) → 0', () {
+      expect(calculateStreak([daysAgo(1)], now), 0);
+    });
+
+    test('duplicates same day → count 1 lần', () {
+      // 3 posts cùng ngày → day set chỉ 1 entry → streak = 1
+      final today = DateTime(now.year, now.month, now.day, 8);
+      final today2 = DateTime(now.year, now.month, now.day, 14);
+      final today3 = DateTime(now.year, now.month, now.day, 22);
+      expect(calculateStreak([today, today2, today3], now), 1);
+    });
+
+    test('timezone: dates đã local — không drift khi date có hours/minutes',
+        () {
+      // Caller responsibility convert toLocal() trước. Fn này chỉ
+      // care year/month/day. Test verify hours/minutes bị ignore.
+      final todayMorning = DateTime(now.year, now.month, now.day, 6, 30);
+      final yesterdayEvening =
+          DateTime(now.year, now.month, now.day - 1, 23, 55);
+      expect(
+        calculateStreak([todayMorning, yesterdayEvening], now),
+        2,
+      );
+    });
+  });
+}

--- a/apps/mobile/test/features/streak/application/streak_controller_test.dart
+++ b/apps/mobile/test/features/streak/application/streak_controller_test.dart
@@ -1,0 +1,269 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/streak/application/streak_controller.dart';
+import 'package:meep/features/streak/data/streak_repository.dart';
+
+/// Fake repo — controller test không touch Firestore.
+class FakeStreakRepository implements StreakRepository {
+  FakeStreakRepository({
+    List<DateTime>? allDates,
+    Map<DateTime, List<Post>>? monthPosts,
+    this.shouldThrowOnGetAll = false,
+    this.shouldThrowOnWatch = false,
+  })  : _allDates = allDates ?? const [],
+        _monthPosts = monthPosts ?? const {};
+
+  final List<DateTime> _allDates;
+  final Map<DateTime, List<Post>> _monthPosts;
+  final bool shouldThrowOnGetAll;
+  final bool shouldThrowOnWatch;
+
+  int getAllCalls = 0;
+  final List<DateTime> watchedMonths = [];
+
+  @override
+  Future<List<DateTime>> getUserAllDates(String uid) async {
+    getAllCalls++;
+    if (shouldThrowOnGetAll) throw Exception('boom');
+    return _allDates;
+  }
+
+  @override
+  Stream<List<Post>> watchUserMonth(String uid, DateTime month) {
+    watchedMonths.add(month);
+    if (shouldThrowOnWatch) {
+      return Stream.error(Exception('watch-boom'));
+    }
+    final key = DateTime(month.year, month.month);
+    return Stream.value(_monthPosts[key] ?? const []);
+  }
+}
+
+Post makePost({
+  String id = 'p1',
+  required DateTime createdAt,
+}) =>
+    Post(
+      postId: id,
+      authorId: 'uid-alice',
+      authorName: 'Alice',
+      imageUrl: 'https://cdn/$id.jpg',
+      audienceType: AudienceType.all,
+      createdAt: createdAt,
+    );
+
+ProviderContainer makeContainer({
+  required FakeStreakRepository repo,
+  String? uid = 'uid-alice',
+  DateTime? now,
+}) {
+  return ProviderContainer(
+    overrides: [
+      streakRepositoryProvider.overrideWithValue(repo),
+      currentUidProvider.overrideWith(
+        (ref) => Stream.value(uid),
+      ),
+      nowProvider.overrideWithValue(
+        () => now ?? DateTime(2026, 5, 22, 14, 30),
+      ),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('StreakController — initial state', () {
+    test('default state: empty, isLoading=false, viewingMonth=null', () {
+      final container = makeContainer(repo: FakeStreakRepository());
+      addTearDown(container.dispose);
+
+      final state = container.read(streakControllerProvider);
+      expect(state.monthPosts, isEmpty);
+      expect(state.allPostDates, isEmpty);
+      expect(state.viewingMonth, isNull);
+      expect(state.currentStreak, 0);
+      expect(state.isLoading, false);
+      expect(state.errorMessage, isNull);
+    });
+  });
+
+  group('StreakController — init', () {
+    test('load allPostDates + compute currentStreak + subscribe tháng hiện tại',
+        () async {
+      final now = DateTime(2026, 5, 22, 14, 30);
+      final repo = FakeStreakRepository(
+        allDates: [
+          DateTime(2026, 5, 22),
+          DateTime(2026, 5, 21),
+          DateTime(2026, 5, 20),
+        ],
+        monthPosts: {
+          DateTime(2026, 5): [
+            makePost(id: 'p1', createdAt: DateTime(2026, 5, 10, 8)),
+            makePost(id: 'p2', createdAt: DateTime(2026, 5, 22, 17)),
+          ],
+        },
+      );
+      final container = makeContainer(repo: repo, now: now);
+      addTearDown(container.dispose);
+
+      // Pre-warm currentUidProvider stream
+      await container.read(currentUidProvider.future);
+      await container.read(streakControllerProvider.notifier).init();
+      // Wait stream subscription emit
+      await Future<void>.delayed(Duration.zero);
+
+      final state = container.read(streakControllerProvider);
+      expect(state.viewingMonth, DateTime(2026, 5));
+      expect(state.allPostDates.length, 3);
+      expect(state.currentStreak, 3);
+      expect(state.monthPosts.length, 2);
+      expect(state.isLoading, false);
+      expect(state.errorMessage, isNull);
+      expect(repo.getAllCalls, 1);
+      expect(repo.watchedMonths, [DateTime(2026, 5)]);
+    });
+
+    test('uid null → errorMessage, không gọi repo', () async {
+      final repo = FakeStreakRepository();
+      final container = makeContainer(repo: repo, uid: null);
+      addTearDown(container.dispose);
+
+      await container.read(currentUidProvider.future);
+      await container.read(streakControllerProvider.notifier).init();
+
+      final state = container.read(streakControllerProvider);
+      expect(state.errorMessage, contains('đăng nhập'));
+      expect(repo.getAllCalls, 0);
+    });
+
+    test('getUserAllDates throw → errorMessage set, isLoading false', () async {
+      final repo = FakeStreakRepository(shouldThrowOnGetAll: true);
+      final container = makeContainer(repo: repo);
+      addTearDown(container.dispose);
+
+      await container.read(currentUidProvider.future);
+      await container.read(streakControllerProvider.notifier).init();
+
+      final state = container.read(streakControllerProvider);
+      expect(state.isLoading, false);
+      expect(state.errorMessage, 'Không thể tải Kỷ niệm');
+    });
+  });
+
+  group('StreakController — swipePrev', () {
+    test('viewingMonth - 1, monthPosts reset, currentStreak KHÔNG đổi',
+        () async {
+      final now = DateTime(2026, 5, 22);
+      final repo = FakeStreakRepository(
+        allDates: [DateTime(2026, 5, 22)],
+        monthPosts: {
+          DateTime(2026, 5): [
+            makePost(id: 'p-may', createdAt: DateTime(2026, 5, 10)),
+          ],
+          DateTime(2026, 4): [
+            makePost(id: 'p-apr', createdAt: DateTime(2026, 4, 15)),
+          ],
+        },
+      );
+      final container = makeContainer(repo: repo, now: now);
+      addTearDown(container.dispose);
+
+      await container.read(currentUidProvider.future);
+      await container.read(streakControllerProvider.notifier).init();
+      await Future<void>.delayed(Duration.zero);
+      expect(container.read(streakControllerProvider).currentStreak, 1);
+
+      await container.read(streakControllerProvider.notifier).swipePrev();
+      await Future<void>.delayed(Duration.zero);
+
+      final state = container.read(streakControllerProvider);
+      expect(state.viewingMonth, DateTime(2026, 4));
+      expect(state.currentStreak, 1, reason: 'global, không đổi khi swipe');
+      expect(state.allPostDates.length, 1);
+      expect(state.monthPosts.length, 1);
+      expect(state.monthPosts.first.postId, 'p-apr');
+      expect(repo.watchedMonths, [DateTime(2026, 5), DateTime(2026, 4)]);
+    });
+  });
+
+  group('StreakController — swipeNext (cap tại tháng hiện tại)', () {
+    test('đang viewing tháng hiện tại → no-op, không gọi repo', () async {
+      final now = DateTime(2026, 5, 22);
+      final repo = FakeStreakRepository(
+        monthPosts: {DateTime(2026, 5): const []},
+      );
+      final container = makeContainer(repo: repo, now: now);
+      addTearDown(container.dispose);
+
+      await container.read(currentUidProvider.future);
+      await container.read(streakControllerProvider.notifier).init();
+      await Future<void>.delayed(Duration.zero);
+      final watchCountBefore = repo.watchedMonths.length;
+
+      await container.read(streakControllerProvider.notifier).swipeNext();
+      await Future<void>.delayed(Duration.zero);
+
+      final state = container.read(streakControllerProvider);
+      expect(state.viewingMonth, DateTime(2026, 5));
+      expect(repo.watchedMonths.length, watchCountBefore);
+    });
+
+    test('đang viewing tháng cũ → tăng 1 tháng', () async {
+      final now = DateTime(2026, 5, 22);
+      final repo = FakeStreakRepository(
+        monthPosts: {
+          DateTime(2026, 5): const [],
+          DateTime(2026, 4): const [],
+        },
+      );
+      final container = makeContainer(repo: repo, now: now);
+      addTearDown(container.dispose);
+
+      await container.read(currentUidProvider.future);
+      await container.read(streakControllerProvider.notifier).init();
+      await container.read(streakControllerProvider.notifier).swipePrev();
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        container.read(streakControllerProvider).viewingMonth,
+        DateTime(2026, 4),
+      );
+
+      await container.read(streakControllerProvider.notifier).swipeNext();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(streakControllerProvider).viewingMonth,
+        DateTime(2026, 5),
+      );
+    });
+  });
+
+  group('StreakController — clearError', () {
+    test('errorMessage non-null → set null', () async {
+      final repo = FakeStreakRepository(shouldThrowOnGetAll: true);
+      final container = makeContainer(repo: repo);
+      addTearDown(container.dispose);
+
+      await container.read(currentUidProvider.future);
+      await container.read(streakControllerProvider.notifier).init();
+      expect(container.read(streakControllerProvider).errorMessage, isNotNull);
+
+      container.read(streakControllerProvider.notifier).clearError();
+      expect(container.read(streakControllerProvider).errorMessage, isNull);
+    });
+
+    test('errorMessage đã null → no-op', () {
+      final container = makeContainer(repo: FakeStreakRepository());
+      addTearDown(container.dispose);
+
+      container.read(streakControllerProvider.notifier).clearError();
+      expect(container.read(streakControllerProvider).errorMessage, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

ST2 — Application layer cho Streak module.

### Files mới

| File | Purpose |
|---|---|
| `application/calculate_streak.dart` | Pure fn: số ngày liên tiếp từ today (inject `now` để test) |
| `application/streak_state.dart` | Freezed state (pattern AUTH #8) |
| `application/streak_controller.dart` | Rewrite — `init/swipePrev/swipeNext/clearError`, `_afterFailure(e)` pattern AUTH #4 |

### Quyết định thiết kế

- **`@Riverpod(keepAlive: true)`** — state survive cross route transitions (Streak → Photo detail → back). Pattern AUTH #6. Test verify: nếu không có `keepAlive`, autoDispose drop state ngay sau `init()` return → state fresh = empty.
- **`nowProvider`** — `DateTime.now()` injectable để test deterministic (override với `nowProvider.overrideWithValue(() => fixedNow)`).
- **`swipeNext` cap** — early return nếu `viewingMonth >= currentMonth` (no-op, không gọi repo). UI sẽ bounce animation.
- **Pill stats global** — `currentStreak` + `allPostDates` không đổi khi swipe tháng (test verified).

## Refs

Closes #259
Unblocks #261 (ST4 — StreakScreen).

## Test plan

- [x] `flutter analyze apps/mobile --no-pub` → No issues found
- [x] `dart format` clean
- [x] **22/22 streak tests pass**:
  - **calculate_streak_test (7)**: empty / today / 3 consecutive / gap / yesterday no today / duplicates / timezone hours-minutes ignored
  - **streak_controller_test (9)**: initial state / init success / uid null → errorMessage / repo throw / swipePrev preserves global / swipeNext cap → no-op / swipeNext old month → increment / clearError ×2
  - **firebase_streak_repository_test (6)** (already merged in ST1): verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)