### PR TITLE
feat(diary): T9b rewire CanvasRead + Search + Menu (#272)

### DIFF
--- a/apps/mobile/lib/features/diary/application/diary_controller.dart
+++ b/apps/mobile/lib/features/diary/application/diary_controller.dart
@@ -232,6 +232,45 @@ class DiaryController extends _$DiaryController {
     }
   }
 
+  /// Update entry fields KHÔNG đổi ảnh — dùng bởi `DiaryCanvasScreen` edit
+  /// mode khi user chỉ đổi text/caption/privacy. Tránh upload sequence
+  /// (caller path saveEntry yêu cầu coverBytes).
+  Future<void> updateEntryNoImage(DiaryEntry entry) async {
+    state = state.copyWith(isSaving: true, errorMessage: null);
+    try {
+      await ref.read(diaryRepositoryProvider).updateEntry(entry);
+      state = state.copyWith(
+        isSaving: false,
+        currentEntry: entry,
+      );
+    } catch (e) {
+      state = _afterFailure(e);
+    }
+  }
+
+  /// Fetch entry theo entryId → set vào [state.currentEntry].
+  /// Dùng bởi `DiaryCanvasScreen` read/edit mode khi push qua entryId.
+  Future<void> loadEntry(String entryId) async {
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      final entry = await ref.read(diaryRepositoryProvider).getEntry(entryId);
+      if (entry == null) {
+        state = state.copyWith(
+          isLoading: false,
+          currentEntry: null,
+          errorMessage: 'Không tìm thấy nhật ký',
+        );
+        return;
+      }
+      state = state.copyWith(
+        isLoading: false,
+        currentEntry: entry,
+      );
+    } catch (e) {
+      state = _afterFailure(e);
+    }
+  }
+
   /// Xoá entry + Storage assets (gọi repository.deleteEntry).
   Future<void> deleteEntry(String entryId) async {
     state = state.copyWith(isSaving: true, errorMessage: null);
@@ -249,6 +288,14 @@ class DiaryController extends _$DiaryController {
   void clearError() {
     if (state.errorMessage != null) {
       state = state.copyWith(errorMessage: null);
+    }
+  }
+
+  /// Reset `searchResults` về empty mà không qua repo. Dùng khi user xoá
+  /// query trong DiarySearchScreen — tránh Firestore round-trip thừa.
+  void clearSearchResults() {
+    if (state.searchResults.isNotEmpty) {
+      state = state.copyWith(searchResults: const []);
     }
   }
 

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
@@ -110,6 +110,20 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
 
   bool get _isReadOnly => widget.mode == DiaryCanvasMode.read;
 
+  /// Cover URL từ Firestore (read/edit mode). Khác `widget.initialImageUrl`:
+  /// initial là hint từ caller (list screen) — `_loadedEntry` sync khi
+  /// controller fetch xong; cover URL có thể đổi sau khi user edit.
+  String? _loadedCoverUrl;
+
+  /// Mood loaded từ Firestore (read/edit mode) — khác `widget.moodTemplate`
+  /// (cũng là hint). Sau khi loadEntry xong, dùng cái này để render mood.
+  MoodTemplate? _loadedMood;
+
+  /// Guard sync — chỉ ghi đè `_captionController` + `_contentController`
+  /// 1 lần khi loadEntry hoàn thành. Tránh re-emit stream đè text user
+  /// vừa gõ trong edit mode.
+  bool _hasSyncedFromEntry = false;
+
   @override
   void initState() {
     super.initState();
@@ -123,6 +137,49 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
         TextEditingController(text: widget.initialContent ?? '');
     // Date hiển thị topbar: entryDate (read/edit) hoặc hôm nay (create).
     _displayDate = widget.entryDate ?? DateTime.now();
+    _loadedCoverUrl = widget.initialImageUrl;
+    _loadedMood = widget.moodTemplate;
+
+    // Read/edit mode + có entryId → fetch entry thật + sync state.
+    final entryId = widget.entryId;
+    if (entryId != null &&
+        entryId.isNotEmpty &&
+        widget.mode != DiaryCanvasMode.create) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        ref.read(diaryControllerProvider.notifier).loadEntry(entryId);
+      });
+    }
+  }
+
+  /// Sync controllers + local state khi controller emit `currentEntry`.
+  /// Chỉ apply cho read/edit mode + match entryId hiện tại + chỉ sync 1 lần.
+  void _syncFromEntry(DiaryEntry entry) {
+    if (entry.entryId != widget.entryId) return;
+    if (_hasSyncedFromEntry) {
+      // Re-emit (vd sau updateEntryNoImage success) — chỉ sync cover URL +
+      // privacy, KHÔNG ghi đè text controllers (user có thể đang gõ tiếp).
+      setState(() {
+        _loadedCoverUrl =
+            entry.coverImageUrl.isNotEmpty ? entry.coverImageUrl : null;
+        _loadedMood = entry.moodTemplate;
+        _privacy = entry.privacy;
+      });
+      return;
+    }
+    _hasSyncedFromEntry = true;
+    final fullText = entry.content
+        .map((b) => b.maybeWhen(text: (v, _) => v, orElse: () => ''))
+        .where((s) => s.isNotEmpty)
+        .join('\n\n');
+    _captionController.text = entry.moodCaption;
+    _contentController.text = fullText;
+    setState(() {
+      _loadedCoverUrl =
+          entry.coverImageUrl.isNotEmpty ? entry.coverImageUrl : null;
+      _loadedMood = entry.moodTemplate;
+      _privacy = entry.privacy;
+    });
   }
 
   /// Format DateTime → "DD tháng MM" (tiếng Việt, không zero-pad).
@@ -154,27 +211,14 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
   ///
   /// T9b (PR4b) sẽ wire edit mode đầy đủ — hiện tại edit pop trực tiếp.
   Future<void> _handleSave() async {
-    final mood = widget.moodTemplate;
+    final mood = _loadedMood ?? widget.moodTemplate;
     if (mood == null) {
       // Defensive — create flow phải pass mood từ picker.
       unawaited(Navigator.of(context).maybePop());
       return;
     }
-    if (widget.mode == DiaryCanvasMode.edit) {
-      // TODO(D/T9b/HanDHG): edit mode wire ở PR4b — issue #272.
-      unawaited(Navigator.of(context).maybePop());
-      return;
-    }
 
-    // Validate inputs (spec §Worst path).
-    final coverBytes = _coverBytes;
     final contentText = _contentController.text.trim();
-    if (coverBytes == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Vui lòng chọn ảnh bìa')),
-      );
-      return;
-    }
     if (contentText.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Vui lòng nhập nội dung')),
@@ -193,26 +237,81 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
     final caption = _captionController.text.trim().isEmpty
         ? _moodLabel(mood)
         : _captionController.text.trim();
+    final coverBytes = _coverBytes;
+    final isEdit = widget.mode == DiaryCanvasMode.edit;
+    final existingEntry = ref.read(diaryControllerProvider).currentEntry;
 
-    // Build draft — entryId rỗng để repo reserve, timestamps server-side
-    // sẽ override createdAt/updatedAt (em pass placeholder để model validate).
-    final placeholderTs = DateTime.now();
-    final draft = DiaryEntry(
-      entryId: '',
-      authorUid: uid,
-      moodTemplate: mood,
-      coverImageUrl: '', // controller replace với coverUrl thật sau upload
-      moodCaption: caption,
-      content: [DiaryContentBlock.text(value: contentText)],
-      privacy: _privacy,
-      createdAt: placeholderTs,
-      updatedAt: placeholderTs,
-    );
-
-    await ref.read(diaryControllerProvider.notifier).saveEntry(
-          draft: draft,
-          coverBytes: coverBytes,
+    if (isEdit) {
+      // Edit mode — phải có entry loaded để giữ createdAt + entryId.
+      if (existingEntry == null || existingEntry.entryId != widget.entryId) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Chưa tải được nhật ký, vui lòng thử lại'),
+          ),
         );
+        return;
+      }
+
+      if (coverBytes != null) {
+        // Đổi ảnh → dùng saveEntry path để upload + update Firestore với
+        // coverUrl mới (controller.state.mode = edit → repo.updateEntry).
+        final draft = existingEntry.copyWith(
+          moodCaption: caption,
+          content: [DiaryContentBlock.text(value: contentText)],
+          privacy: _privacy,
+          moodTemplate: mood,
+          updatedAt: DateTime.now(),
+        );
+        ref
+            .read(diaryControllerProvider.notifier)
+            .setMode(DiaryCanvasMode.edit);
+        await ref.read(diaryControllerProvider.notifier).saveEntry(
+              draft: draft,
+              coverBytes: coverBytes,
+            );
+      } else {
+        // Không đổi ảnh → updateEntryNoImage (qua controller, không bypass).
+        final updated = existingEntry.copyWith(
+          moodCaption: caption,
+          content: [DiaryContentBlock.text(value: contentText)],
+          privacy: _privacy,
+          updatedAt: DateTime.now(),
+        );
+        await ref
+            .read(diaryControllerProvider.notifier)
+            .updateEntryNoImage(updated);
+        // ErrorMessage handled bởi ref.listen trong build → SnackBar.
+      }
+    } else {
+      // Create mode — cần coverBytes.
+      if (coverBytes == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Vui lòng chọn ảnh bìa')),
+        );
+        return;
+      }
+
+      final placeholderTs = DateTime.now();
+      final draft = DiaryEntry(
+        entryId: '',
+        authorUid: uid,
+        moodTemplate: mood,
+        coverImageUrl: '',
+        moodCaption: caption,
+        content: [DiaryContentBlock.text(value: contentText)],
+        privacy: _privacy,
+        createdAt: placeholderTs,
+        updatedAt: placeholderTs,
+      );
+
+      ref
+          .read(diaryControllerProvider.notifier)
+          .setMode(DiaryCanvasMode.create);
+      await ref.read(diaryControllerProvider.notifier).saveEntry(
+            draft: draft,
+            coverBytes: coverBytes,
+          );
+    }
 
     if (!mounted) return;
 
@@ -280,34 +379,68 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
       case DiaryMenuAction.edit:
         // Push Canvas edit mode với content hiện tại prefilled. Dùng
         // pushReplacement để back nút trở về Diary list (skip read mode).
-        await Navigator.of(context).pushReplacement(
-          MaterialPageRoute<void>(
-            builder: (_) => DiaryCanvasScreen(
-              mode: DiaryCanvasMode.edit,
-              entryId: widget.entryId,
-              moodTemplate: widget.moodTemplate,
-              initialCaption: _captionController.text,
-              initialContent: _contentController.text,
-              initialImageUrl: widget.initialImageUrl,
-              entryDate: _displayDate,
+        // entry đã loaded vào state.currentEntry — edit screen sẽ tự re-fetch
+        // qua loadEntry (initState fire).
+        unawaited(
+          Navigator.of(context).pushReplacement(
+            MaterialPageRoute<void>(
+              builder: (_) => DiaryCanvasScreen(
+                mode: DiaryCanvasMode.edit,
+                entryId: widget.entryId,
+                moodTemplate: _loadedMood ?? widget.moodTemplate,
+                initialCaption: _captionController.text,
+                initialContent: _contentController.text,
+                initialImageUrl: _loadedCoverUrl,
+                entryDate: _displayDate,
+              ),
             ),
           ),
         );
       case DiaryMenuAction.delete:
         final confirmed = await DeleteDiaryDialog.show(context);
-        if (confirmed == true && mounted) {
-          // TODO(D/T6/HanDHG): gọi DiaryController.deleteEntry(entryId).
-          // ignore: unawaited_futures
-          Navigator.of(context).maybePop();
+        if (confirmed != true || !mounted) return;
+        final entryId = widget.entryId;
+        if (entryId == null || entryId.isEmpty) {
+          unawaited(Navigator.of(context).maybePop());
+          return;
+        }
+        await ref.read(diaryControllerProvider.notifier).deleteEntry(entryId);
+        if (!mounted) return;
+        // Error handled bởi ref.listen errorMessage SnackBar.
+        // Success → pop về list (stream tự loại entry).
+        if (ref.read(diaryControllerProvider).errorMessage == null) {
+          unawaited(Navigator.of(context).maybePop());
         }
       case DiaryMenuAction.share:
-        // TODO(D/T7/HanDHG): native share sheet (share_plus với text + cover image).
+        // TODO(D/T-share/HanDHG): native share sheet (share_plus) — defer Tier 1.
         break;
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    // Read/edit mode: listen currentEntry → sync controllers + local state
+    // khi loadEntry hoàn thành (initState fire postFrame).
+    if (widget.mode != DiaryCanvasMode.create) {
+      ref.listen<DiaryEntry?>(
+        diaryControllerProvider.select((s) => s.currentEntry),
+        (prev, next) {
+          if (next != null && next != prev) _syncFromEntry(next);
+        },
+      );
+    }
+    // ErrorMessage listener — show SnackBar khi error fire.
+    ref.listen<String?>(
+      diaryControllerProvider.select((s) => s.errorMessage),
+      (prev, next) {
+        if (next == null || next == prev) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next)),
+        );
+        ref.read(diaryControllerProvider.notifier).clearError();
+      },
+    );
+
     return Scaffold(
       backgroundColor: _canvasBg,
       body: SafeArea(
@@ -458,13 +591,26 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
 
   // ── Mood zone: cover (mood image) + caption highlight ──
   Widget _buildMoodZone() {
-    final mood = widget.moodTemplate;
+    // Priority: user-picked bytes (chưa save) > loaded URL (read/edit) >
+    // mood asset (create mode default).
+    final mood = _loadedMood ?? widget.moodTemplate;
     final coverBytes = _coverBytes;
+    final coverUrl = _loadedCoverUrl;
     final canPick = !_isReadOnly;
 
     Widget coverChild;
     if (coverBytes != null) {
       coverChild = Image.memory(coverBytes, fit: BoxFit.contain);
+    } else if (coverUrl != null && coverUrl.isNotEmpty) {
+      coverChild = Image.network(
+        coverUrl,
+        fit: BoxFit.contain,
+        errorBuilder: (_, __, ___) => const Icon(
+          Icons.broken_image_outlined,
+          size: 48,
+          color: AppColors.bw500,
+        ),
+      );
     } else if (mood == null) {
       coverChild = const Icon(
         Icons.image_outlined,

--- a/apps/mobile/lib/features/diary/presentation/diary_search_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_search_screen.dart
@@ -1,7 +1,14 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
 import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
 import 'package:meep/features/diary/presentation/widgets/diary_filter_sheet.dart';
 
 part 'diary_search_screen_widgets.dart';
@@ -14,24 +21,29 @@ part 'diary_search_screen_widgets.dart';
 /// Layout: search bar (BW700 bg) + filter icon → "N kết quả" label →
 /// list result cards (54×53 image circular + keyword highlight + date).
 /// Client-side filter (load all entries → filter in-memory).
-class DiarySearchScreen extends StatefulWidget {
+class DiarySearchScreen extends ConsumerStatefulWidget {
   const DiarySearchScreen({super.key});
 
   @override
-  State<DiarySearchScreen> createState() => _DiarySearchScreenState();
+  ConsumerState<DiarySearchScreen> createState() => _DiarySearchScreenState();
 }
 
-class _DiarySearchScreenState extends State<DiarySearchScreen> {
+class _DiarySearchScreenState extends ConsumerState<DiarySearchScreen> {
   final _controller = TextEditingController();
   final _focusNode = FocusNode();
 
   /// Filter advanced — mood multi-select + date range. Default empty.
   DiaryFilterValue _filter = const DiaryFilterValue();
 
+  /// Debounce timer cho input — fire `controller.searchEntries` sau 300ms
+  /// kể từ lần gõ cuối (tránh spam Firestore read khi user gõ nhanh).
+  Timer? _debounce;
+  static const _debounceDuration = Duration(milliseconds: 300);
+
   @override
   void initState() {
     super.initState();
-    _controller.addListener(() => setState(() {}));
+    _controller.addListener(_onQueryChanged);
     // Autofocus + bật keyboard ngay khi mở.
     WidgetsBinding.instance.addPostFrameCallback(
       (_) => _focusNode.requestFocus(),
@@ -40,31 +52,56 @@ class _DiarySearchScreenState extends State<DiarySearchScreen> {
 
   @override
   void dispose() {
+    _debounce?.cancel();
     _controller.dispose();
     _focusNode.dispose();
     super.dispose();
   }
 
-  /// Filter mock results theo query (case-insensitive) + advanced filter
-  /// (mood + date range).
-  List<_MockResult> get _results {
-    final query = _controller.text.trim().toLowerCase();
+  /// On input change — re-render (clear button hiện/ẩn) + debounce fire
+  /// `searchEntries(uid, query)`.
+  void _onQueryChanged() {
+    setState(() {}); // refresh clear button hiển thị
+    _debounce?.cancel();
+    _debounce = Timer(_debounceDuration, _fireSearch);
+  }
+
+  void _fireSearch() {
+    final uid = ref.read(currentUidProvider).valueOrNull;
+    if (uid == null) return;
+    final query = _controller.text.trim();
+    if (query.isEmpty) {
+      // Empty query → skip Firestore round-trip, reset searchResults local.
+      _resetSearchResults();
+      return;
+    }
+    ref
+        .read(diaryControllerProvider.notifier)
+        .searchEntries(authorUid: uid, query: query);
+  }
+
+  /// Clear searchResults trong state mà không qua repo. Dùng khi query empty.
+  void _resetSearchResults() {
+    final notifier = ref.read(diaryControllerProvider.notifier);
+    // Gọi searchEntries với uid không tồn tại sẽ tốn 1 read — tránh, set
+    // trực tiếp qua public method. Controller hiện chưa có setSearchResults
+    // nên dùng cách an toàn nhất: chỉ clear khi state đang có results.
+    if (ref.read(diaryControllerProvider).searchResults.isNotEmpty) {
+      notifier.clearSearchResults();
+    }
+  }
+
+  /// Post-filter Firestore results với mood + date range (advanced filter).
+  /// Query đã được Firestore filter ở repository (case-insensitive in-memory).
+  List<DiaryEntry> _applyAdvancedFilter(List<DiaryEntry> entries) {
     final from = _filter.from;
     final to = _filter.to;
-    return _mockResults.where((r) {
-      // Query: match title hoặc preview
-      if (query.isNotEmpty &&
-          !r.title.toLowerCase().contains(query) &&
-          !r.preview.toLowerCase().contains(query)) {
+    return entries.where((e) {
+      if (_filter.moods.isNotEmpty && !_filter.moods.contains(e.moodTemplate)) {
         return false;
       }
-      // Mood filter: nếu có chọn, result phải thuộc set
-      if (_filter.moods.isNotEmpty && !_filter.moods.contains(r.mood)) {
-        return false;
-      }
-      // Date range: from/to inclusive theo day-precision
-      if (from != null && r.date.isBefore(from)) return false;
-      if (to != null && r.date.isAfter(to)) return false;
+      if (from != null && e.createdAt.isBefore(from)) return false;
+      if (to != null && e.createdAt.isAfter(to)) return false;
       return true;
     }).toList();
   }
@@ -86,7 +123,8 @@ class _DiarySearchScreenState extends State<DiarySearchScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final results = _results;
+    final state = ref.watch(diaryControllerProvider);
+    final results = _applyAdvancedFilter(state.searchResults);
 
     return Scaffold(
       backgroundColor: AppColors.bw900, // #050F10
@@ -249,7 +287,7 @@ class _DiarySearchScreenState extends State<DiarySearchScreen> {
   }
 
   // ── Result cards list ──
-  Widget _buildResultsList(List<_MockResult> results) {
+  Widget _buildResultsList(List<DiaryEntry> results) {
     if (results.isEmpty) {
       return const Center(
         child: Text(
@@ -269,52 +307,39 @@ class _DiarySearchScreenState extends State<DiarySearchScreen> {
       itemCount: results.length,
       separatorBuilder: (_, __) => const SizedBox(height: 10),
       itemBuilder: (_, i) => _ResultCard(
-        result: results[i],
+        entry: results[i],
         query: _controller.text.trim(),
+        onTap: () => _openCanvasRead(results[i]),
+      ),
+    );
+  }
+
+  /// Open Canvas read mode với entry — controller sẽ loadEntry qua initState.
+  void _openCanvasRead(DiaryEntry entry) {
+    // Lấy text content từ block đầu tiên dạng text (placeholder cho T9b
+    // render đầy đủ block list).
+    final firstText = entry.content.firstWhere(
+      (b) => b.maybeWhen(text: (_, __) => true, orElse: () => false),
+      orElse: () => const DiaryContentBlock.text(value: ''),
+    );
+    final textValue = firstText.maybeWhen(
+      text: (value, _) => value,
+      orElse: () => '',
+    );
+
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => DiaryCanvasScreen(
+          mode: DiaryCanvasMode.read,
+          entryId: entry.entryId,
+          moodTemplate: entry.moodTemplate,
+          initialCaption: entry.moodCaption,
+          initialContent: textValue,
+          initialImageUrl:
+              entry.coverImageUrl.isNotEmpty ? entry.coverImageUrl : null,
+          entryDate: entry.createdAt,
+        ),
       ),
     );
   }
 }
-
-// ── Mock data ──
-
-class _MockResult {
-  const _MockResult({
-    required this.title,
-    required this.preview,
-    required this.date,
-    required this.mood,
-  });
-
-  final String title;
-  final String preview;
-  final DateTime date;
-  final MoodTemplate mood;
-
-  /// "18 tháng 5 năm 2026" — derive từ date.
-  String get dateFull => '${date.day} tháng ${date.month} năm ${date.year}';
-
-  /// Asset path từ mood enum.
-  String get moodAsset => 'assets/icons/bg_${mood.name}.png';
-}
-
-final _mockResults = <_MockResult>[
-  _MockResult(
-    title: 'Đà lạt',
-    preview: 'Chuyến đi Đà Lạt cuối tuần đầy nắng',
-    date: DateTime(2026, 5, 18),
-    mood: MoodTemplate.happy,
-  ),
-  _MockResult(
-    title: 'Mệt mỏi quá',
-    preview: 'Hôm nay thật là một ngày dài',
-    date: DateTime(2026, 5, 20),
-    mood: MoodTemplate.tired,
-  ),
-  _MockResult(
-    title: 'Buồn vu vơ',
-    preview: 'Có những lúc chỉ muốn ở yên',
-    date: DateTime(2026, 5, 19),
-    mood: MoodTemplate.sad,
-  ),
-];

--- a/apps/mobile/lib/features/diary/presentation/diary_search_screen_widgets.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_search_screen_widgets.dart
@@ -2,20 +2,28 @@ part of 'diary_search_screen.dart';
 
 /// Result card — bg BW800 + image 54×53 + keyword highlight + date.
 class _ResultCard extends StatelessWidget {
-  const _ResultCard({required this.result, required this.query});
+  const _ResultCard({
+    required this.entry,
+    required this.query,
+    required this.onTap,
+  });
 
-  final _MockResult result;
+  final DiaryEntry entry;
   final String query;
+  final VoidCallback onTap;
+
+  String get _dateFull =>
+      '${entry.createdAt.day} tháng ${entry.createdAt.month} năm ${entry.createdAt.year}';
+
+  String get _moodAsset => 'assets/icons/bg_${entry.moodTemplate.name}.png';
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
-      label: '${result.title}, ${result.dateFull}',
+      label: '${entry.moodCaption}, $_dateFull',
       button: true,
       child: GestureDetector(
-        onTap: () {
-          // TODO(D/T5/HanDHG): navigate Canvas read mode với entryId
-        },
+        onTap: onTap,
         child: Container(
           height: 85,
           padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -31,10 +39,10 @@ class _ResultCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    _HighlightedTitle(text: result.title, query: query),
+                    _HighlightedTitle(text: entry.moodCaption, query: query),
                     const SizedBox(height: 4),
                     Text(
-                      result.dateFull,
+                      _dateFull,
                       style: const TextStyle(
                         fontFamily: 'Nunito',
                         fontSize: 12,
@@ -51,7 +59,7 @@ class _ResultCard extends StatelessWidget {
               SizedBox(
                 width: 54,
                 height: 53,
-                child: Image.asset(result.moodAsset, fit: BoxFit.contain),
+                child: Image.asset(_moodAsset, fit: BoxFit.contain),
               ),
             ],
           ),

--- a/apps/mobile/test/features/diary/application/diary_controller_test.dart
+++ b/apps/mobile/test/features/diary/application/diary_controller_test.dart
@@ -382,6 +382,78 @@ void main() {
     );
   });
 
+  group('updateEntryNoImage', () {
+    test('gọi repo.updateEntry + set currentEntry, không upload', () async {
+      when(() => repo.updateEntry(any())).thenAnswer((_) async {});
+
+      final c = makeContainer();
+      final updated = savedEntry('e-1').copyWith(moodCaption: 'New title');
+
+      await c
+          .read(diaryControllerProvider.notifier)
+          .updateEntryNoImage(updated);
+
+      verify(() => repo.updateEntry(updated)).called(1);
+      expect(storage.uploadCount, 0);
+      final state = c.read(diaryControllerProvider);
+      expect(state.currentEntry?.moodCaption, 'New title');
+      expect(state.isSaving, isFalse);
+    });
+
+    test('repo fail → errorMessage set', () async {
+      when(() => repo.updateEntry(any()))
+          .thenThrow(const NetworkError(message: 'mất mạng'));
+
+      final c = makeContainer();
+
+      await c
+          .read(diaryControllerProvider.notifier)
+          .updateEntryNoImage(savedEntry('e-1'));
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.errorMessage, 'mất mạng');
+    });
+  });
+
+  group('loadEntry', () {
+    test('fetch entry + set currentEntry', () async {
+      when(() => repo.getEntry('e-1'))
+          .thenAnswer((_) async => savedEntry('e-1'));
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).loadEntry('e-1');
+
+      verify(() => repo.getEntry('e-1')).called(1);
+      final state = c.read(diaryControllerProvider);
+      expect(state.currentEntry?.entryId, 'e-1');
+      expect(state.isLoading, isFalse);
+    });
+
+    test('entry null (not found) → currentEntry null, error set', () async {
+      when(() => repo.getEntry('missing')).thenAnswer((_) async => null);
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).loadEntry('missing');
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.currentEntry, isNull);
+      expect(state.errorMessage, 'Không tìm thấy nhật ký');
+      expect(state.isLoading, isFalse);
+    });
+
+    test('repo fail → errorMessage set', () async {
+      when(() => repo.getEntry('e-1'))
+          .thenThrow(const NetworkError(message: 'mất mạng'));
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).loadEntry('e-1');
+
+      final state = c.read(diaryControllerProvider);
+      expect(state.errorMessage, 'mất mạng');
+      expect(state.currentEntry, isNull);
+    });
+  });
+
   group('deleteEntry', () {
     test('gọi repo.deleteEntry + clear currentEntry', () async {
       when(() => repo.deleteEntry('e-1')).thenAnswer((_) async {});


### PR DESCRIPTION
## Mô tả

Implement T9b (#272) — phase 2 BE wire. Complete diary UI integration với controller cho read/edit/search/menu paths. T9a (#271) đã wire List + Create flow.

Đây là PR cuối trong workflow Diary BE (5 PR tổng cộng).

## Refs

- Closes #272 — T9b phase 2 rewire
- Closes #129 — T3 mood assets (em đã comment ở `/start 126` confirm DiaryMoodCard pattern thay MoodZoneBlock — anh có thể close manual khi review xong)
- Build trên #263 (T1) + #269 (T2) + #270 (T8) + #274 (T9a) đã merged
- Spec: [docs/specs/2026-05-23-diary.md](docs/specs/2026-05-23-diary.md)

## Acceptance criteria (theo issue #272)

### DiaryCanvasScreen — read mode
- [x] Nhận `entryId` qua route param (push từ list/search)
- [x] Initial state: prefill từ caller hints, loadEntry fire postFrame
- [x] Permission denied / network error → SnackBar tiếng Việt qua `ref.listen(errorMessage)`
- [x] Render `entry.coverImageUrl` qua `Image.network` (errorBuilder fallback)
- [x] Render text content từ `entry.content` blocks (join `\n\n`)
- [x] Privacy icon từ `entry.privacy`

### DiaryCanvasScreen — edit mode
- [x] Prefill từ `DiaryEntry` thật qua `_syncFromEntry`
- [x] Sync guard `_hasSyncedFromEntry` — re-emit chỉ sync cover/privacy, KHÔNG đè text
- [x] Save với image đổi → `setMode(edit)` + `saveEntry` (upload + repo.updateEntry)
- [x] Save không đổi image → `controller.updateEntryNoImage` (no upload, không bypass)

### DiaryCanvasScreen — Ellipsis menu
- [x] Edit → `pushReplacement` Canvas edit mode (canvas tự loadEntry lại)
- [x] Delete → `DeleteDiaryDialog` confirm → `controller.deleteEntry` → pop
- [x] Share → TODO marker `D/T-share/HanDHG` defer Tier 1

### DiarySearchScreen
- [x] Debounce 300ms cho input
- [x] Empty query → `clearSearchResults` skip Firestore (tránh tốn read)
- [x] Non-empty → `controller.searchEntries(uid, query)`
- [x] Render `state.searchResults` + post-filter `_applyAdvancedFilter` (mood + date range)
- [x] "N kết quả" label
- [x] 0 kết quả → empty state "0 kết quả"
- [x] Tap result → push canvas read mode với entryId

## Files

| File | Δ | Mô tả |
|---|---|---|
| `lib/features/diary/application/diary_controller.dart` | +47 | `loadEntry` + `updateEntryNoImage` + `clearSearchResults` |
| `lib/features/diary/presentation/diary_canvas_screen.dart` | ±244 | Read/edit loadEntry + _syncFromEntry guard + edit save 2 paths + menu wire |
| `lib/features/diary/presentation/diary_search_screen.dart` | ±153 | ConsumerStatefulWidget + Timer debounce 300ms + searchResults watch + _openCanvasRead |
| `lib/features/diary/presentation/diary_search_screen_widgets.dart` | ±26 | `_ResultCard` signature đổi DiaryEntry + onTap callback |
| `test/features/diary/application/diary_controller_test.dart` | +72 | 5 cases mới (3 loadEntry + 2 updateEntryNoImage) |

## Design choices

- **`_hasSyncedFromEntry` guard**: chỉ ghi đè text controllers 1 lần đầu sau loadEntry. Re-emit (vd sau `updateEntryNoImage` success → currentEntry cập nhật) chỉ sync cover URL + privacy, KHÔNG đè text user có thể đang gõ tiếp.
- **`updateEntryNoImage` qua controller**: tránh widget gọi `diaryRepositoryProvider` trực tiếp (bypass layering + state.isSaving management).
- **`clearSearchResults` skip Firestore**: empty query → reset local state thẳng, tránh round-trip thừa.
- **MoodZone render priority**: `_coverBytes` (user picked) > `_loadedCoverUrl` (Firestore) > mood asset (create default).

## Caveats / follow-ups

### 1. Duplicate `_openCanvasRead` code

List screen + Search screen đều có method này (build canvas push với entry hints). Defer extract helper `pushDiaryRead(context, entry)` sang polish PR — không block T9b.

### 2. Share menu action defer

TODO marker `D/T-share/HanDHG` — native share sheet (share_plus) là Tier 1, không trong M3 scope.

## Test plan

- [x] `flutter test test/features/diary/` — 56/56 pass (47 cũ + 4 ImagePicker + 5 mới)
- [x] `flutter test` full suite — 654/654 pass, không break
- [x] `flutter analyze` — 0 issue
- [x] `dart format --set-exit-if-changed` — clean
- [x] `/review` 6-axis Standard — 3 🟡 fixed (controller updateEntry + sync guard + skip empty query), 1 duplicate code deferred
- [ ] Manual smoke trên Android emulator — em chưa test real device, cần anh hoặc HanDHG test golden path:
  1. Tap card list → read mode hiện entry thật (caption + content + cover)
  2. Tap ellipsis → Chỉnh sửa → sửa text → check → entry update từ list
  3. Tap ellipsis → Xóa → confirm → entry biến mất từ list
  4. Tap search icon → gõ → 300ms sau filter realtime → tap result → read mode

## Workflow Diary BE complete

| PR | Issue | Task | Status |
|---|---|---|---|
| #263 | #127 | T1 FirebaseDiaryRepository | ✅ Merged |
| #269 | #128 | T2 DiaryController + main wire | ✅ Merged |
| #270 | #131 | T8 rules tests + indexes | ✅ Merged |
| #274 | #271 | T9a rewire List + Create | ✅ Merged |
| **THIS** | **#272** | **T9b rewire Read + Search + Menu** | 🟡 Open |

Sau khi #275 merge → Diary module ship-ready cho M3 demo.

## Self-review checklist

- [x] Branch name `feature/HanDHG/diary-rewire-read-search-menu`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không file lớn vô tình
- [x] Không `print` debug
- [x] TODO marker đúng format (D/T-share/HanDHG)
- [x] Không touch module khác (chỉ `lib/features/diary/`)
- [x] Cross-module import `currentUidProvider` (auth) explicit + cần thiết