### PR TITLE
feat(streak): ST4 — StreakScreen + calendar + stats pill + empty state

### DIFF
--- a/apps/mobile/assets/icons/ic_send.svg
+++ b/apps/mobile/assets/icons/ic_send.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.5 2.5L9.16667 10.8333M17.5 2.5L12.0833 17.5L9.16667 10.8333M17.5 2.5L2.5 7.91667L9.16667 10.8333" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/mobile/lib/features/streak/application/streak_controller.dart
+++ b/apps/mobile/lib/features/streak/application/streak_controller.dart
@@ -43,7 +43,10 @@ class StreakController extends _$StreakController {
   /// Gọi từ `StreakScreen.initState` hoặc `ref.read(...notifier).init()` khi
   /// user mở Streak tab lần đầu.
   Future<void> init() async {
-    final uid = ref.read(currentUidProvider).valueOrNull;
+    // Use `.future` thay vì `.valueOrNull` để chờ Stream emit lần đầu.
+    // valueOrNull return null nếu provider chưa subscribe → race condition
+    // khi controller init trước UI watch currentUidProvider.
+    final uid = await ref.read(currentUidProvider.future);
     if (uid == null) {
       state = state.copyWith(
         errorMessage: 'Bạn cần đăng nhập để xem Kỷ niệm',
@@ -78,7 +81,7 @@ class StreakController extends _$StreakController {
   Future<void> swipePrev() async {
     final current = state.viewingMonth;
     if (current == null) return; // chưa init
-    final uid = ref.read(currentUidProvider).valueOrNull;
+    final uid = await ref.read(currentUidProvider.future);
     if (uid == null) return;
 
     final prevMonth = DateTime(current.year, current.month - 1);
@@ -95,7 +98,7 @@ class StreakController extends _$StreakController {
   Future<void> swipeNext() async {
     final current = state.viewingMonth;
     if (current == null) return;
-    final uid = ref.read(currentUidProvider).valueOrNull;
+    final uid = await ref.read(currentUidProvider.future);
     if (uid == null) return;
 
     final nowLocal = ref.read(nowProvider)();

--- a/apps/mobile/lib/features/streak/presentation/streak_screen.dart
+++ b/apps/mobile/lib/features/streak/presentation/streak_screen.dart
@@ -1,9 +1,237 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// TODO(ST/T3/TBD): implement StreakScreen per Figma
-class StreakScreen extends StatelessWidget {
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/streak/application/streak_controller.dart';
+import 'package:meep/features/streak/presentation/widgets/empty_state_overlay.dart';
+import 'package:meep/features/streak/presentation/widgets/streak_calendar.dart';
+import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart';
+import 'package:meep/shared/widgets/photo_detail_screen.dart';
+import 'package:meep/shared/widgets/share_photo_sheet.dart';
+
+/// Streak/Kỷ niệm — calendar view. Match Figma `269:1983`.
+///
+/// Layout:
+/// - Topbar: "Kỷ niệm" Nunito Bold 18 white + avatar 40 góc phải
+/// - Calendar grid (custom) → tap ngày có post → push PhotoDetailScreen
+/// - Pill stats: `[N Khoảnh khắc | Xd chuỗi]` (toàn cục, không đổi khi swipe)
+/// - Empty state: 2 arrow vector vẽ tay + subtitle CTA
+class StreakScreen extends ConsumerStatefulWidget {
   const StreakScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => const Scaffold(body: SizedBox.shrink());
+  ConsumerState<StreakScreen> createState() => _StreakScreenState();
+}
+
+class _StreakScreenState extends ConsumerState<StreakScreen> {
+  bool _initStarted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _ensureInit());
+  }
+
+  void _ensureInit() {
+    if (_initStarted) return;
+    _initStarted = true;
+    ref.read(streakControllerProvider.notifier).init();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(streakControllerProvider);
+    final profileAsync = ref.watch(currentUserProfileProvider);
+    final totalMoments =
+        profileAsync.valueOrNull?.postCount ?? state.allPostDates.length;
+    final displayName = profileAsync.valueOrNull?.displayName ?? '';
+    final avatarUrl = profileAsync.valueOrNull?.avatarUrl;
+
+    final hasNoPosts = state.allPostDates.isEmpty;
+    final viewingMonth = state.viewingMonth ?? _startOfThisMonth();
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF0D0804),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          physics: const NeverScrollableScrollPhysics(),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: MediaQuery.of(context).size.height -
+                  MediaQuery.of(context).padding.vertical,
+            ),
+            child: Column(
+              children: [
+                _Topbar(displayName: displayName, avatarUrl: avatarUrl),
+                if (state.errorMessage != null)
+                  _ErrorBanner(message: state.errorMessage!),
+                if (hasNoPosts) ...[
+                  const SizedBox(height: 36),
+                  const EmptyStateOverlay(),
+                ] else
+                  const SizedBox(height: 90),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 41),
+                  child: StreakCalendar(
+                    viewingMonth: viewingMonth,
+                    monthPosts: state.monthPosts,
+                    today: DateTime.now(),
+                    onTapDay: (index) => _openPhotoDetail(context, index),
+                    onSwipePrev: () =>
+                        ref.read(streakControllerProvider.notifier).swipePrev(),
+                    onSwipeNext: () =>
+                        ref.read(streakControllerProvider.notifier).swipeNext(),
+                  ),
+                ),
+                if (hasNoPosts) ...[
+                  const SizedBox(height: 16),
+                  const StreakArrowDown(),
+                  const SizedBox(height: 16),
+                ] else
+                  const SizedBox(height: 28),
+                StreakStatsPill(
+                  totalMoments: totalMoments,
+                  currentStreak: state.currentStreak,
+                ),
+                const SizedBox(height: 40),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openPhotoDetail(BuildContext context, int initialIndex) {
+    final state = ref.read(streakControllerProvider);
+    if (state.monthPosts.isEmpty) return;
+
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => PhotoDetailScreen(
+          postId: state.monthPosts[initialIndex].postId,
+          initialIndex: initialIndex,
+          posts: state.monthPosts,
+          captionPillColor: const Color(0x66394041),
+          timeColor: AppColors.bw600,
+          onShareTap: (p) => SharePhotoSheet.show(
+            context,
+            post: p,
+            isAuthor: true,
+          ),
+        ),
+      ),
+    );
+  }
+
+  static DateTime _startOfThisMonth() {
+    final now = DateTime.now();
+    return DateTime(now.year, now.month);
+  }
+}
+
+// ─── Topbar ───────────────────────────────────────────────────────────────────
+
+class _Topbar extends StatelessWidget {
+  const _Topbar({required this.displayName, this.avatarUrl});
+
+  final String displayName;
+  final String? avatarUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(27, 9, 27, 9),
+      child: SizedBox(
+        height: 40,
+        child: Row(
+          children: [
+            const SizedBox(width: 40), // balance avatar
+            Expanded(
+              child: Text(
+                'Kỷ niệm',
+                textAlign: TextAlign.center,
+                style: AppTextStyles.baseBold
+                    .copyWith(color: const Color(0xFFFFFFFF)),
+              ),
+            ),
+            _TopAvatar(displayName: displayName, avatarUrl: avatarUrl),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TopAvatar extends StatelessWidget {
+  const _TopAvatar({required this.displayName, this.avatarUrl});
+
+  final String displayName;
+  final String? avatarUrl;
+
+  static const _bgColor = Color(0xFF73716F);
+
+  String get _initials {
+    final parts = displayName.trim().split(' ');
+    if (parts.length >= 2 && parts[0].isNotEmpty && parts[1].isNotEmpty) {
+      return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
+    }
+    return displayName.isNotEmpty ? displayName[0].toUpperCase() : '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final url = avatarUrl;
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        color: _bgColor,
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: url != null && url.isNotEmpty
+          ? CachedNetworkImage(
+              imageUrl: url,
+              fit: BoxFit.cover,
+              errorWidget: (_, __, ___) => _initialsFallback(),
+              placeholder: (_, __) => Container(color: _bgColor),
+            )
+          : _initialsFallback(),
+    );
+  }
+
+  Widget _initialsFallback() {
+    return Center(
+      child: Text(
+        _initials,
+        style: AppTextStyles.smSemiBold.copyWith(color: AppColors.bw100),
+      ),
+    );
+  }
+}
+
+// ─── Error banner ─────────────────────────────────────────────────────────────
+
+class _ErrorBanner extends StatelessWidget {
+  const _ErrorBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      color: AppColors.error700.withValues(alpha: 0.9),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Text(
+        message,
+        textAlign: TextAlign.center,
+        style: AppTextStyles.smSemiBold.copyWith(color: AppColors.bw100),
+      ),
+    );
+  }
 }

--- a/apps/mobile/lib/features/streak/presentation/widgets/calendar_day_cell.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/calendar_day_cell.dart
@@ -1,0 +1,101 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+/// Một ô trong [StreakCalendar]. Match Figma `269:1990` cell variants.
+///
+/// 4 trạng thái (priority): empty (other month) → today+post → today → post → no-post.
+/// - `imageUrl != null`: render thumbnail (CachedNetworkImage) cornerRadius 7
+/// - `imageUrl == null && isInMonth`: render dot 11×11 ở center
+/// - `!isInMonth`: render spacer (transparent)
+/// - `isToday`: overlay stroke 1px `#656565` (over thumbnail hoặc background light)
+class CalendarDayCell extends StatelessWidget {
+  const CalendarDayCell({
+    super.key,
+    required this.isInMonth,
+    required this.isToday,
+    this.imageUrl,
+    this.onTap,
+  });
+
+  /// Day thuộc tháng đang xem (false = padding day từ tháng khác).
+  final bool isInMonth;
+
+  /// Ngày hôm nay (local timezone).
+  final bool isToday;
+
+  /// URL ảnh thumbnail nếu day có post; null = no post.
+  final String? imageUrl;
+
+  /// Tap handler. Null khi cell không tappable (empty / no-post).
+  final VoidCallback? onTap;
+
+  static const _dotColor = Color(0x6E585754);
+  static const _todayStroke = Color(0xFF656565);
+  static const _todayFill = Color(0xFFC4C4C4);
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isInMonth) {
+      return const SizedBox(width: 37, height: 35);
+    }
+
+    final hasPost = imageUrl != null && imageUrl!.isNotEmpty;
+    Widget content;
+
+    if (hasPost) {
+      content = ClipRRect(
+        borderRadius: BorderRadius.circular(7),
+        child: CachedNetworkImage(
+          imageUrl: imageUrl!,
+          fit: BoxFit.cover,
+          placeholder: (_, __) => Container(color: _todayFill),
+          errorWidget: (_, __, ___) => Container(color: _todayFill),
+        ),
+      );
+    } else if (isToday) {
+      content = Container(
+        decoration: BoxDecoration(
+          color: _todayFill,
+          borderRadius: BorderRadius.circular(7),
+        ),
+      );
+    } else {
+      content = Center(
+        child: Container(
+          width: 11,
+          height: 11,
+          decoration: BoxDecoration(
+            color: _dotColor,
+            borderRadius: BorderRadius.circular(7),
+          ),
+        ),
+      );
+    }
+
+    final cell = SizedBox(
+      width: 37,
+      height: 35,
+      child: Stack(
+        children: [
+          Positioned.fill(child: content),
+          if (isToday)
+            Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border.all(color: _todayStroke, width: 1),
+                  borderRadius: BorderRadius.circular(7),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+
+    if (onTap == null) return cell;
+    return Semantics(
+      button: true,
+      label: 'Xem ảnh ngày',
+      child: GestureDetector(onTap: onTap, child: cell),
+    );
+  }
+}

--- a/apps/mobile/lib/features/streak/presentation/widgets/empty_state_overlay.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/empty_state_overlay.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// Empty state cho StreakScreen (chưa post lần nào).
+///
+/// Match Figma `269:1985`:
+/// - Subtitle: "Gửi khoảnh khắc đầu tiên của bạn tại Meep !"
+///   (Nunito Bold 14, color `#ffffff7a`, center)
+/// - Vector 3 (curved arrow): chỉ TỪ subtitle XUỐNG → lên Taskbar send icon
+/// - Vector 4 (curved arrow): chỉ TỪ calendar XUỐNG → pill stats
+/// - 2 vectors render via CustomPainter — dashed curve stroke `#ffffff7a`
+///
+/// Widget chỉ render text + arrows; calendar + pill là phần khác của
+/// StreakScreen (vẫn render bình thường, overlay này nổi trên).
+class EmptyStateOverlay extends StatelessWidget {
+  const EmptyStateOverlay({super.key});
+
+  static const _muted = Color(0x7AFFFFFF);
+  static const _labelStyle = TextStyle(
+    fontFamily: 'Nunito',
+    fontSize: 14,
+    fontWeight: FontWeight.w700,
+    height: 18 / 14,
+    color: _muted,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const SizedBox(height: 16),
+            const Text(
+              'Gửi khoảnh khắc đầu tiên của bạn tại Meep !',
+              textAlign: TextAlign.center,
+              style: _labelStyle,
+            ),
+            const SizedBox(height: 12),
+            // Arrow lên: subtitle → Taskbar send icon (icon nhỏ ở dưới)
+            // Render send icon + curved arrow chỉ về phía Taskbar.
+            Center(
+              child: SizedBox(
+                width: 80,
+                height: 85,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    Positioned(
+                      top: 0,
+                      child: SvgPicture.asset(
+                        'assets/icons/ic_send.svg',
+                        width: 24,
+                        height: 24,
+                        colorFilter: const ColorFilter.mode(
+                          _muted,
+                          BlendMode.srcIn,
+                        ),
+                      ),
+                    ),
+                    CustomPaint(
+                      size: const Size(40, 85),
+                      painter: _CurvedArrowPainter(direction: _Direction.down),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Arrow XUỐNG (chỉ về pill stats ở dưới) — render riêng vì position
+/// khác overlay topbar (Stack alignment trong [StreakScreen]).
+class StreakArrowDown extends StatelessWidget {
+  const StreakArrowDown({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: CustomPaint(
+        size: const Size(30, 65),
+        painter: _CurvedArrowPainter(direction: _Direction.up),
+      ),
+    );
+  }
+}
+
+enum _Direction { up, down }
+
+class _CurvedArrowPainter extends CustomPainter {
+  _CurvedArrowPainter({required this.direction});
+
+  final _Direction direction;
+
+  static const _stroke = Color(0x7AFFFFFF);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = _stroke
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5
+      ..strokeCap = StrokeCap.round;
+
+    final path = Path();
+    if (direction == _Direction.down) {
+      // Curve loop xuống dưới, kết thúc bằng arrow head
+      // (mock dashed curve — vẽ đoạn cong cơ bản)
+      path.moveTo(size.width / 2, 24);
+      path.quadraticBezierTo(
+        size.width * 0.85,
+        size.height * 0.35,
+        size.width * 0.55,
+        size.height * 0.55,
+      );
+      path.quadraticBezierTo(
+        size.width * 0.15,
+        size.height * 0.78,
+        size.width * 0.5,
+        size.height - 4,
+      );
+    } else {
+      // Curve loop lên trên
+      path.moveTo(size.width / 2, size.height - 4);
+      path.quadraticBezierTo(
+        size.width * 0.85,
+        size.height * 0.65,
+        size.width * 0.55,
+        size.height * 0.45,
+      );
+      path.quadraticBezierTo(
+        size.width * 0.15,
+        size.height * 0.22,
+        size.width * 0.5,
+        4,
+      );
+    }
+
+    // Render dashed
+    _drawDashed(canvas, path, paint, dashLength: 5, gapLength: 4);
+  }
+
+  void _drawDashed(
+    Canvas canvas,
+    Path path,
+    Paint paint, {
+    required double dashLength,
+    required double gapLength,
+  }) {
+    for (final metric in path.computeMetrics()) {
+      var distance = 0.0;
+      while (distance < metric.length) {
+        final next = distance + dashLength;
+        canvas.drawPath(
+          metric.extractPath(distance, next.clamp(0, metric.length)),
+          paint,
+        );
+        distance = next + gapLength;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _CurvedArrowPainter old) =>
+      old.direction != direction;
+}

--- a/apps/mobile/lib/features/streak/presentation/widgets/streak_calendar.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/streak_calendar.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/streak/presentation/widgets/calendar_day_cell.dart';
+
+/// Custom calendar grid 7 cols × 6 rows. Match Figma `269:1990`.
+///
+/// - Container: cornerRadius 22, fill `#5857546e`
+/// - Month header: bg `#8383836e`, "tháng MM YYYY" Inter SemiBold 14 white
+/// - Cell: 37×35 cornerRadius 7, column gap 8, row gap 4
+/// - Tuần bắt đầu CN (col 0 = Sunday) — match Figma layout
+///
+/// Swipe horizontal:
+/// - Right→Left (drag end velocity > 0) = swipePrev → tháng cũ hơn
+/// - Left→Right = swipeNext → tháng mới hơn (controller cap tại tháng hiện tại)
+class StreakCalendar extends StatelessWidget {
+  const StreakCalendar({
+    super.key,
+    required this.viewingMonth,
+    required this.monthPosts,
+    required this.today,
+    this.onTapDay,
+    this.onSwipePrev,
+    this.onSwipeNext,
+  });
+
+  /// Start-of-month (year/month/1) đang xem.
+  final DateTime viewingMonth;
+
+  /// Posts thuộc tháng này, dùng để map day → coverImageUrl.
+  /// Caller phải đảm bảo posts đều thuộc viewingMonth.
+  final List<Post> monthPosts;
+
+  /// Ngày hôm nay (local timezone) — dùng để highlight ô today.
+  final DateTime today;
+
+  /// Tap handler khi user tap ô có post. Receives index trong [monthPosts]
+  /// (sort theo createdAt ASC). Null = no-op.
+  final ValueChanged<int>? onTapDay;
+
+  final VoidCallback? onSwipePrev;
+  final VoidCallback? onSwipeNext;
+
+  static const _bgFill = Color(0x6E585754);
+  static const _headerFill = Color(0x6E838383);
+  static const _columnGap = 8.0;
+  static const _rowGap = 4.0;
+  static const _columns = 7;
+  static const _rows = 6;
+
+  @override
+  Widget build(BuildContext context) {
+    // Map dayOfMonth → first post của ngày đó (1 post / ngày để render
+    // thumbnail; nếu user post nhiều lần/ngày, hiển thị ảnh đầu tiên).
+    // Index trong monthPosts dùng cho onTapDay callback.
+    final Map<int, int> dayToPostIndex = {};
+    for (var i = 0; i < monthPosts.length; i++) {
+      final d = monthPosts[i].createdAt.toLocal();
+      // Chỉ map ngày đầu tiên gặp — Streak tap → carousel open tại ảnh đó,
+      // PhotoDetailScreen sẽ swipe qua các ảnh khác cùng ngày.
+      dayToPostIndex.putIfAbsent(d.day, () => i);
+    }
+
+    final firstWeekday =
+        DateTime(viewingMonth.year, viewingMonth.month).weekday;
+    // Dart weekday: Mon=1...Sun=7. Convert sang Sun=0...Sat=6.
+    final leadingEmpty = firstWeekday % 7;
+    final daysInMonth =
+        DateTime(viewingMonth.year, viewingMonth.month + 1, 0).day;
+
+    final todayInMonth =
+        today.year == viewingMonth.year && today.month == viewingMonth.month;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onHorizontalDragEnd: (details) {
+        final v = details.primaryVelocity ?? 0;
+        if (v < -200) {
+          // swipe right→left = next month (controller cap)
+          onSwipeNext?.call();
+        } else if (v > 200) {
+          // swipe left→right = prev month
+          onSwipePrev?.call();
+        }
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          color: _bgFill,
+          borderRadius: BorderRadius.circular(22),
+        ),
+        padding: const EdgeInsets.only(bottom: 10),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _MonthHeader(
+              month: viewingMonth,
+              fill: _headerFill,
+            ),
+            const SizedBox(height: 10),
+            _Grid(
+              leadingEmpty: leadingEmpty,
+              daysInMonth: daysInMonth,
+              todayDay: todayInMonth ? today.day : null,
+              dayToPostIndex: dayToPostIndex,
+              postsForDay: (day) {
+                final i = dayToPostIndex[day];
+                if (i == null) return null;
+                return monthPosts[i].coverImageUrl;
+              },
+              onTapDay: onTapDay,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MonthHeader extends StatelessWidget {
+  const _MonthHeader({required this.month, required this.fill});
+
+  final DateTime month;
+  final Color fill;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: fill,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(22)),
+      ),
+      padding: const EdgeInsets.fromLTRB(16, 11, 16, 11),
+      child: Text(
+        _format(month),
+        style: const TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          color: Color(0xFFFFFFFF),
+          height: 17 / 14,
+        ),
+      ),
+    );
+  }
+
+  String _format(DateTime month) {
+    final mm = month.month.toString().padLeft(2, '0');
+    return 'tháng $mm ${month.year}';
+  }
+}
+
+class _Grid extends StatelessWidget {
+  const _Grid({
+    required this.leadingEmpty,
+    required this.daysInMonth,
+    required this.todayDay,
+    required this.dayToPostIndex,
+    required this.postsForDay,
+    required this.onTapDay,
+  });
+
+  final int leadingEmpty;
+  final int daysInMonth;
+  final int? todayDay;
+  final Map<int, int> dayToPostIndex;
+  final String? Function(int day) postsForDay;
+  final ValueChanged<int>? onTapDay;
+
+  @override
+  Widget build(BuildContext context) {
+    final cells = <Widget>[];
+
+    for (var i = 0; i < StreakCalendar._rows; i++) {
+      final row = <Widget>[];
+      for (var j = 0; j < StreakCalendar._columns; j++) {
+        final slotIndex = i * StreakCalendar._columns + j;
+        final dayNumber = slotIndex - leadingEmpty + 1;
+        final isInMonth = dayNumber >= 1 && dayNumber <= daysInMonth;
+        final url = isInMonth ? postsForDay(dayNumber) : null;
+        final postIndex = isInMonth ? dayToPostIndex[dayNumber] : null;
+
+        row.add(
+          CalendarDayCell(
+            isInMonth: isInMonth,
+            isToday: isInMonth && todayDay == dayNumber,
+            imageUrl: url,
+            onTap: postIndex != null ? () => onTapDay?.call(postIndex) : null,
+          ),
+        );
+        if (j < StreakCalendar._columns - 1) {
+          row.add(const SizedBox(width: StreakCalendar._columnGap));
+        }
+      }
+      cells.add(Row(mainAxisSize: MainAxisSize.min, children: row));
+      if (i < StreakCalendar._rows - 1) {
+        cells.add(const SizedBox(height: StreakCalendar._rowGap));
+      }
+    }
+
+    return Column(mainAxisSize: MainAxisSize.min, children: cells);
+  }
+}

--- a/apps/mobile/lib/features/streak/presentation/widgets/streak_stats_pill.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/streak_stats_pill.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+/// Pill stats bottom của StreakScreen — match Figma `269:1992`.
+///
+/// Layout: " N Khoảnh khắc | Xd chuỗi"
+/// - Số (N / Xd): WHITE Nunito Bold 12
+/// - Chữ (Khoảnh khắc / chuỗi): WHITE 48% alpha Nunito Bold 12
+/// - Separator "|": Inter SemiBold 10 WHITE 48% alpha
+/// - Container: bg `#5857546e`, cornerRadius 12, padding 8/11
+class StreakStatsPill extends StatelessWidget {
+  const StreakStatsPill({
+    super.key,
+    required this.totalMoments,
+    required this.currentStreak,
+  });
+
+  final int totalMoments;
+  final int currentStreak;
+
+  static const _bgFill = Color(0x6E585754);
+  static const _muted = Color(0x7AFFFFFF); // white 48%
+
+  static const _numberStyle = TextStyle(
+    fontFamily: 'Nunito',
+    fontSize: 12,
+    fontWeight: FontWeight.w700,
+    height: 16 / 12,
+    color: Color(0xFFFFFFFF),
+  );
+
+  static const _labelStyle = TextStyle(
+    fontFamily: 'Nunito',
+    fontSize: 12,
+    fontWeight: FontWeight.w700,
+    height: 16 / 12,
+    color: _muted,
+  );
+
+  static const _sepStyle = TextStyle(
+    fontFamily: 'Inter',
+    fontSize: 10,
+    fontWeight: FontWeight.w600,
+    color: _muted,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '$totalMoments khoảnh khắc, chuỗi $currentStreak ngày',
+      child: Container(
+        decoration: BoxDecoration(
+          color: _bgFill,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 8),
+        child: RichText(
+          text: TextSpan(
+            style: _numberStyle,
+            children: [
+              TextSpan(text: ' $totalMoments'),
+              const TextSpan(text: ' Khoảnh khắc ', style: _labelStyle),
+              const TextSpan(text: '|', style: _sepStyle),
+              TextSpan(text: ' ${currentStreak}d'),
+              const TextSpan(text: ' chuỗi ', style: _labelStyle),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/streak/presentation/streak_screen_test.dart
+++ b/apps/mobile/test/features/streak/presentation/streak_screen_test.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/streak/application/streak_controller.dart';
+import 'package:meep/features/streak/data/streak_repository.dart';
+import 'package:meep/features/streak/presentation/streak_screen.dart';
+import 'package:meep/features/streak/presentation/widgets/empty_state_overlay.dart';
+import 'package:meep/features/streak/presentation/widgets/streak_calendar.dart';
+import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart';
+
+class FakeStreakRepo implements StreakRepository {
+  FakeStreakRepo({this.allDates = const [], this.monthPostsMap = const {}});
+
+  final List<DateTime> allDates;
+  final Map<DateTime, List<Post>> monthPostsMap;
+
+  @override
+  Future<List<DateTime>> getUserAllDates(String uid) async => allDates;
+
+  @override
+  Stream<List<Post>> watchUserMonth(String uid, DateTime month) {
+    final key = DateTime(month.year, month.month);
+    return Stream.value(monthPostsMap[key] ?? const []);
+  }
+}
+
+UserProfile fakeProfile({int postCount = 0, String? avatar}) => UserProfile(
+      uid: 'uid-alice',
+      email: 'a@b.com',
+      displayName: 'Alice Doe',
+      username: 'alice',
+      avatarUrl: avatar,
+      postCount: postCount,
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+    );
+
+Widget host({
+  required FakeStreakRepo repo,
+  String? uid = 'uid-alice',
+  UserProfile? profile,
+  DateTime? now,
+}) {
+  return ProviderScope(
+    overrides: [
+      streakRepositoryProvider.overrideWithValue(repo),
+      // Sync Stream — emit value ngay lập tức trong cùng frame để
+      // controller.init() đọc valueOrNull thấy uid non-null.
+      currentUidProvider.overrideWith(
+        (ref) async* {
+          yield uid;
+        },
+      ),
+      currentUserProfileProvider.overrideWith(
+        (ref) async* {
+          yield profile;
+        },
+      ),
+      nowProvider.overrideWithValue(
+        () => now ?? DateTime(2026, 5, 22, 14, 30),
+      ),
+    ],
+    child: const MaterialApp(home: StreakScreen()),
+  );
+}
+
+/// Helper: pump enough frames để init() chạy xong + stream emit.
+Future<void> pumpUntilSettled(WidgetTester tester) async {
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  testWidgets('topbar render "Kỷ niệm" title', (tester) async {
+    await tester.pumpWidget(
+      host(repo: FakeStreakRepo(), profile: fakeProfile()),
+    );
+    await pumpUntilSettled(tester);
+    expect(find.text('Kỷ niệm'), findsOneWidget);
+  });
+
+  testWidgets('empty state visible khi chưa có post nào', (tester) async {
+    await tester.pumpWidget(
+      host(repo: FakeStreakRepo(), profile: fakeProfile()),
+    );
+    await pumpUntilSettled(tester);
+
+    expect(find.byType(EmptyStateOverlay), findsOneWidget);
+    expect(
+      find.text('Gửi khoảnh khắc đầu tiên của bạn tại Meep !'),
+      findsOneWidget,
+    );
+    expect(find.byType(StreakArrowDown), findsOneWidget);
+  });
+
+  testWidgets('empty state ẩn khi có ít nhất 1 post', (tester) async {
+    final now = DateTime(2026, 5, 22, 14, 30);
+    await tester.pumpWidget(
+      host(
+        repo: FakeStreakRepo(
+          allDates: [DateTime(2026, 5, 22)],
+          monthPostsMap: {
+            DateTime(2026, 5): [
+              Post(
+                postId: 'p1',
+                authorId: 'uid-alice',
+                authorName: 'Alice',
+                imageUrl: 'https://cdn/p1.jpg',
+                audienceType: AudienceType.all,
+                createdAt: DateTime(2026, 5, 22, 8),
+              ),
+            ],
+          },
+        ),
+        profile: fakeProfile(postCount: 1),
+        now: now,
+      ),
+    );
+    await pumpUntilSettled(tester);
+
+    expect(find.byType(EmptyStateOverlay), findsNothing);
+    expect(find.byType(StreakArrowDown), findsNothing);
+  });
+
+  testWidgets('calendar + pill stats luôn render', (tester) async {
+    await tester.pumpWidget(
+      host(repo: FakeStreakRepo(), profile: fakeProfile()),
+    );
+    await pumpUntilSettled(tester);
+
+    expect(find.byType(StreakCalendar), findsOneWidget);
+    expect(find.byType(StreakStatsPill), findsOneWidget);
+  });
+
+  testWidgets('pill render postCount từ UserProfile (denormalized)',
+      (tester) async {
+    await tester.pumpWidget(
+      host(
+        repo: FakeStreakRepo(),
+        profile: fakeProfile(postCount: 42),
+      ),
+    );
+    await pumpUntilSettled(tester);
+
+    final pill = tester.widget<StreakStatsPill>(find.byType(StreakStatsPill));
+    expect(pill.totalMoments, 42);
+  });
+
+  testWidgets('profile null (chưa load) → fallback allPostDates length',
+      (tester) async {
+    final now = DateTime(2026, 5, 22);
+    await tester.pumpWidget(
+      host(
+        repo: FakeStreakRepo(
+          allDates: [DateTime(2026, 5, 22), DateTime(2026, 5, 21)],
+        ),
+        profile: null,
+        now: now,
+      ),
+    );
+    await pumpUntilSettled(tester);
+
+    final pill = tester.widget<StreakStatsPill>(find.byType(StreakStatsPill));
+    expect(pill.totalMoments, 2);
+  });
+}

--- a/apps/mobile/test/features/streak/presentation/widgets/calendar_day_cell_test.dart
+++ b/apps/mobile/test/features/streak/presentation/widgets/calendar_day_cell_test.dart
@@ -1,0 +1,93 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/streak/presentation/widgets/calendar_day_cell.dart';
+
+void main() {
+  Widget host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+  testWidgets('isInMonth=false → spacer 37×35, không render gì',
+      (tester) async {
+    await tester.pumpWidget(
+      host(const CalendarDayCell(isInMonth: false, isToday: false)),
+    );
+    expect(find.byType(CachedNetworkImage), findsNothing);
+    expect(find.byType(GestureDetector), findsNothing);
+    expect(find.byType(DecoratedBox), findsNothing);
+  });
+
+  testWidgets('isInMonth + no post + no today → render dot 11×11',
+      (tester) async {
+    await tester.pumpWidget(
+      host(const CalendarDayCell(isInMonth: true, isToday: false)),
+    );
+    expect(find.byType(CachedNetworkImage), findsNothing);
+    // Dot là Container width: 11, height: 11 + decoration. Match Container
+    // có width/height = 11 (constraints set qua Container shortcut).
+    final dot = find.byWidgetPredicate(
+      (w) =>
+          w is Container &&
+          w.constraints?.maxWidth == 11 &&
+          w.constraints?.maxHeight == 11,
+    );
+    expect(dot, findsAtLeast(1));
+  });
+
+  testWidgets('imageUrl non-null → render CachedNetworkImage', (tester) async {
+    await tester.pumpWidget(
+      host(
+        const CalendarDayCell(
+          isInMonth: true,
+          isToday: false,
+          imageUrl: 'https://cdn/p1.jpg',
+        ),
+      ),
+    );
+    expect(find.byType(CachedNetworkImage), findsOneWidget);
+  });
+
+  testWidgets('isToday=true → render outline border', (tester) async {
+    await tester.pumpWidget(
+      host(const CalendarDayCell(isInMonth: true, isToday: true)),
+    );
+    // CalendarDayCell wrap content trong Stack với DecoratedBox overlay
+    // chứa Border. Tìm bất kỳ widget nào có border non-null.
+    final hasBorder = find.byWidgetPredicate((w) {
+      if (w is DecoratedBox) {
+        final dec = w.decoration;
+        return dec is BoxDecoration && dec.border != null;
+      }
+      if (w is Container) {
+        final dec = w.decoration;
+        return dec is BoxDecoration && dec.border != null;
+      }
+      return false;
+    });
+    expect(hasBorder, findsAtLeast(1));
+  });
+
+  testWidgets('onTap fire khi có post', (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      host(
+        CalendarDayCell(
+          isInMonth: true,
+          isToday: false,
+          imageUrl: 'https://cdn/p1.jpg',
+          onTap: () => tapped = true,
+        ),
+      ),
+    );
+    await tester.tap(find.byType(GestureDetector));
+    expect(tapped, isTrue);
+  });
+
+  testWidgets('onTap null khi no post → không có GestureDetector wrapper',
+      (tester) async {
+    await tester.pumpWidget(
+      host(const CalendarDayCell(isInMonth: true, isToday: false)),
+    );
+    // CalendarDayCell có GestureDetector chỉ khi onTap != null
+    expect(find.byType(GestureDetector), findsNothing);
+  });
+}

--- a/apps/mobile/test/features/streak/presentation/widgets/streak_calendar_test.dart
+++ b/apps/mobile/test/features/streak/presentation/widgets/streak_calendar_test.dart
@@ -1,0 +1,162 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/feed/data/post.dart';
+import 'package:meep/features/streak/presentation/widgets/calendar_day_cell.dart';
+import 'package:meep/features/streak/presentation/widgets/streak_calendar.dart';
+
+void main() {
+  Post makePost(String id, DateTime createdAt) => Post(
+        postId: id,
+        authorId: 'uid-alice',
+        authorName: 'Alice',
+        imageUrl: 'https://cdn/$id.jpg',
+        audienceType: AudienceType.all,
+        createdAt: createdAt,
+      );
+
+  Widget host(Widget child) => MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(width: 330, child: child),
+          ),
+        ),
+      );
+
+  testWidgets('header render đúng format "tháng MM YYYY"', (tester) async {
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 4),
+          monthPosts: const [],
+          today: DateTime(2026, 5, 22),
+        ),
+      ),
+    );
+    expect(find.text('tháng 04 2026'), findsOneWidget);
+  });
+
+  testWidgets('grid render 42 cells (6 rows × 7 cols)', (tester) async {
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 5),
+          monthPosts: const [],
+          today: DateTime(2026, 5, 22),
+        ),
+      ),
+    );
+    expect(find.byType(CalendarDayCell), findsNWidgets(42));
+  });
+
+  testWidgets('ngày có post → render CachedNetworkImage', (tester) async {
+    final posts = [
+      makePost('p1', DateTime(2026, 5, 10, 14)),
+      makePost('p2', DateTime(2026, 5, 22, 8)),
+    ];
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 5),
+          monthPosts: posts,
+          today: DateTime(2026, 5, 22),
+        ),
+      ),
+    );
+    expect(find.byType(CachedNetworkImage), findsNWidgets(2));
+  });
+
+  testWidgets('tap ngày có post → onTapDay fires với đúng index',
+      (tester) async {
+    int? tappedIndex;
+    final posts = [
+      makePost('p1', DateTime(2026, 5, 10, 14)),
+      makePost('p2', DateTime(2026, 5, 22, 8)),
+    ];
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 5),
+          monthPosts: posts,
+          today: DateTime(2026, 5, 22),
+          onTapDay: (i) => tappedIndex = i,
+        ),
+      ),
+    );
+    final tappableCells = find.byWidgetPredicate(
+      (w) => w is CalendarDayCell && w.imageUrl != null,
+    );
+    await tester.tap(tappableCells.first);
+    expect(tappedIndex, isIn([0, 1]));
+  });
+
+  testWidgets('swipe trái → phải = swipePrev fires', (tester) async {
+    var prevCalled = false;
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 5),
+          monthPosts: const [],
+          today: DateTime(2026, 5, 22),
+          onSwipePrev: () => prevCalled = true,
+        ),
+      ),
+    );
+    final container = find.byType(StreakCalendar);
+    await tester.fling(container, const Offset(300, 0), 800);
+    await tester.pumpAndSettle();
+    expect(prevCalled, isTrue);
+  });
+
+  testWidgets('swipe phải → trái = swipeNext fires', (tester) async {
+    var nextCalled = false;
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 5),
+          monthPosts: const [],
+          today: DateTime(2026, 5, 22),
+          onSwipeNext: () => nextCalled = true,
+        ),
+      ),
+    );
+    final container = find.byType(StreakCalendar);
+    await tester.fling(container, const Offset(-300, 0), 800);
+    await tester.pumpAndSettle();
+    expect(nextCalled, isTrue);
+  });
+
+  testWidgets('today highlight chỉ khi viewingMonth chứa today',
+      (tester) async {
+    // viewingMonth khác today's month → KHÔNG có ô isToday
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 3),
+          monthPosts: const [],
+          today: DateTime(2026, 5, 22),
+        ),
+      ),
+    );
+    final todayCells = find.byWidgetPredicate(
+      (w) => w is CalendarDayCell && w.isToday,
+    );
+    expect(todayCells, findsNothing);
+  });
+
+  testWidgets('today highlight khi viewingMonth = today month', (tester) async {
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 5),
+          monthPosts: const [],
+          today: DateTime(2026, 5, 22),
+        ),
+      ),
+    );
+    final todayCells = find.byWidgetPredicate(
+      (w) => w is CalendarDayCell && w.isToday,
+    );
+    expect(todayCells, findsOneWidget);
+  });
+}

--- a/apps/mobile/test/features/streak/presentation/widgets/streak_stats_pill_test.dart
+++ b/apps/mobile/test/features/streak/presentation/widgets/streak_stats_pill_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart';
+
+void main() {
+  Widget host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+  testWidgets('render N Khoảnh khắc + Xd chuỗi', (tester) async {
+    await tester.pumpWidget(
+      host(const StreakStatsPill(totalMoments: 12, currentStreak: 7)),
+    );
+    // Có RichText với cả " 12" và "7d"
+    final richText = tester.widget<RichText>(find.byType(RichText));
+    final fullText = richText.text.toPlainText();
+    expect(fullText, contains('12'));
+    expect(fullText, contains('Khoảnh khắc'));
+    expect(fullText, contains('7d'));
+    expect(fullText, contains('chuỗi'));
+  });
+
+  testWidgets('0 moments + 0 streak vẫn render đúng', (tester) async {
+    await tester.pumpWidget(
+      host(const StreakStatsPill(totalMoments: 0, currentStreak: 0)),
+    );
+    final richText = tester.widget<RichText>(find.byType(RichText));
+    final fullText = richText.text.toPlainText();
+    expect(fullText, contains('0 Khoảnh khắc'));
+    expect(fullText, contains('0d chuỗi'));
+  });
+}


### PR DESCRIPTION
## Summary

ST4 — UI layer cho Streak module. Match Figma `269:1983` (Streak_1 — Calendar).

### Files mới

**Widgets** (`lib/features/streak/presentation/widgets/`):
- `calendar_day_cell.dart` — 4 states (other-month / no-post / post / today)
- `streak_calendar.dart` — custom GridView 7 cols × 6 rows + month header + swipe
- `streak_stats_pill.dart` — RichText 2-color (số white + chữ white 48%)
- `empty_state_overlay.dart` — subtitle + 2 dashed curved arrows (CustomPainter)

**Screen**: `lib/features/streak/presentation/streak_screen.dart` (rewrite stub)

**Asset**: `assets/icons/ic_send.svg` (Lucide style, 20×20)

### Spec đối chiếu

| Spec | Implementation |
|---|---|
| Calendar grid 7×6, cell 37×35 cornerRadius 7 | ✅ Hardcoded measurements + gaps (col 8, row 4) |
| Cell có post = thumbnail | ✅ `CachedNetworkImage` cornerRadius 7 |
| Cell không post = dot 11×11 | ✅ Container center |
| Ngày hôm nay = outline `#656565` | ✅ DecoratedBox overlay |
| Pill stats glassy bg `#5857546e` | ✅ + RichText 2 spans (số trắng + chữ mờ 48%) |
| Empty state: subtitle + 2 arrows | ✅ CustomPainter dashed curve |
| Topbar avatar + title | ✅ "Kỷ niệm" + 40px avatar (initials fallback) |
| Photo detail open với Streak overrides | ✅ captionPillColor `#39404166`, timeColor BW600 |

### Controller fix

`init/swipePrev/swipeNext` đổi từ `ref.read(currentUidProvider).valueOrNull` → `await ref.read(currentUidProvider.future)` để tránh race condition khi controller chạy trước UI subscribe currentUidProvider (phát hiện qua widget tests).

## Refs

Closes #261
Unblocks #262 (ST5 — wiring + integration test).

## Test plan

- [x] `flutter analyze apps/mobile --no-pub` → No issues found
- [x] `dart format` clean
- [x] **44/44 streak tests pass** (8 calculate_streak + 9 controller + 6 repo + 6 cell + 8 calendar + 2 pill + 6 screen)
- [ ] Manual emulator: navigate Streak → calendar render thumbnail, dot, today border; swipe tháng cũ; tap ngày có post → photo detail mở với Streak style

## Known limitations (defer post-MVP per spec)

- Messenger/Instagram share targets chỉ pop sheet (cần `url_launcher` — leader-gated dep, ST3 đã note TODO)
- Empty state arrows mock dashed curves (không match 100% Figma stroke path — Figma free-hand vector phức tạp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)