### PR TITLE
feat(streak): ST5 — Taskbar wire + GoRouter E2E tests

### DIFF
--- a/apps/mobile/lib/features/streak/presentation/streak_screen.dart
+++ b/apps/mobile/lib/features/streak/presentation/streak_screen.dart
@@ -1,14 +1,17 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/streak/application/streak_controller.dart';
 import 'package:meep/features/streak/presentation/widgets/empty_state_overlay.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_calendar.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart';
+import 'package:meep/shared/widgets/app_taskbar.dart';
 import 'package:meep/shared/widgets/photo_detail_screen.dart';
 import 'package:meep/shared/widgets/share_photo_sheet.dart';
 
@@ -49,6 +52,9 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
         profileAsync.valueOrNull?.postCount ?? state.allPostDates.length;
     final displayName = profileAsync.valueOrNull?.displayName ?? '';
     final avatarUrl = profileAsync.valueOrNull?.avatarUrl;
+    final unreadCounts = ref.watch(unreadCountsProvider);
+    final totalUnread =
+        unreadCounts.values.fold<int>(0, (sum, val) => sum + val);
 
     final hasNoPosts = state.allPostDates.isEmpty;
     final viewingMonth = state.viewingMonth ?? _startOfThisMonth();
@@ -56,53 +62,92 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
     return Scaffold(
       backgroundColor: const Color(0xFF0D0804),
       body: SafeArea(
-        child: SingleChildScrollView(
-          physics: const NeverScrollableScrollPhysics(),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(
-              minHeight: MediaQuery.of(context).size.height -
-                  MediaQuery.of(context).padding.vertical,
-            ),
-            child: Column(
-              children: [
-                _Topbar(displayName: displayName, avatarUrl: avatarUrl),
-                if (state.errorMessage != null)
-                  _ErrorBanner(message: state.errorMessage!),
-                if (hasNoPosts) ...[
-                  const SizedBox(height: 36),
-                  const EmptyStateOverlay(),
-                ] else
-                  const SizedBox(height: 90),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 41),
-                  child: StreakCalendar(
-                    viewingMonth: viewingMonth,
-                    monthPosts: state.monthPosts,
-                    today: DateTime.now(),
-                    onTapDay: (index) => _openPhotoDetail(context, index),
-                    onSwipePrev: () =>
-                        ref.read(streakControllerProvider.notifier).swipePrev(),
-                    onSwipeNext: () =>
-                        ref.read(streakControllerProvider.notifier).swipeNext(),
-                  ),
+        child: Stack(
+          children: [
+            SingleChildScrollView(
+              physics: const NeverScrollableScrollPhysics(),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: MediaQuery.of(context).size.height -
+                      MediaQuery.of(context).padding.vertical,
                 ),
-                if (hasNoPosts) ...[
-                  const SizedBox(height: 16),
-                  const StreakArrowDown(),
-                  const SizedBox(height: 16),
-                ] else
-                  const SizedBox(height: 28),
-                StreakStatsPill(
-                  totalMoments: totalMoments,
-                  currentStreak: state.currentStreak,
+                child: Column(
+                  children: [
+                    _Topbar(displayName: displayName, avatarUrl: avatarUrl),
+                    if (state.errorMessage != null)
+                      _ErrorBanner(message: state.errorMessage!),
+                    if (hasNoPosts) ...[
+                      const SizedBox(height: 36),
+                      const EmptyStateOverlay(),
+                    ] else
+                      const SizedBox(height: 90),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 41),
+                      child: StreakCalendar(
+                        viewingMonth: viewingMonth,
+                        monthPosts: state.monthPosts,
+                        today: DateTime.now(),
+                        onTapDay: (index) => _openPhotoDetail(context, index),
+                        onSwipePrev: () => ref
+                            .read(streakControllerProvider.notifier)
+                            .swipePrev(),
+                        onSwipeNext: () => ref
+                            .read(streakControllerProvider.notifier)
+                            .swipeNext(),
+                      ),
+                    ),
+                    if (hasNoPosts) ...[
+                      const SizedBox(height: 16),
+                      const StreakArrowDown(),
+                      const SizedBox(height: 16),
+                    ] else
+                      const SizedBox(height: 28),
+                    StreakStatsPill(
+                      totalMoments: totalMoments,
+                      currentStreak: state.currentStreak,
+                    ),
+                    // Spacer cuối để Taskbar floating không đè lên pill
+                    const SizedBox(height: 100),
+                  ],
                 ),
-                const SizedBox(height: 40),
-              ],
+              ),
             ),
-          ),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Padding(
+                padding: EdgeInsets.only(
+                  bottom: MediaQuery.of(context).size.height * 0.045,
+                ),
+                child: AppTaskbar(
+                  activeTab: TaskbarTab.streak,
+                  chatBadgeCount: totalUnread,
+                  onTabSelected: _onTabSelected,
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
+  }
+
+  void _onTabSelected(TaskbarTab tab) {
+    switch (tab) {
+      case TaskbarTab.streak:
+        // Đã ở Streak → no-op
+        break;
+      case TaskbarTab.diary:
+        context.go('/diary');
+      case TaskbarTab.home:
+        context.go('/home');
+      case TaskbarTab.chat:
+        context.go('/inbox');
+      case TaskbarTab.profile:
+        final uid = ref.read(currentUidProvider).valueOrNull;
+        if (uid != null) {
+          context.go('/profile', extra: uid);
+        }
+    }
   }
 
   void _openPhotoDetail(BuildContext context, int initialIndex) {

--- a/apps/mobile/lib/features/streak/presentation/streak_screen.dart
+++ b/apps/mobile/lib/features/streak/presentation/streak_screen.dart
@@ -57,7 +57,9 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
         unreadCounts.values.fold<int>(0, (sum, val) => sum + val);
 
     final hasNoPosts = state.allPostDates.isEmpty;
-    final viewingMonth = state.viewingMonth ?? _startOfThisMonth();
+    final nowLocal = ref.watch(nowProvider)();
+    final viewingMonth =
+        state.viewingMonth ?? DateTime(nowLocal.year, nowLocal.month);
 
     return Scaffold(
       backgroundColor: const Color(0xFF0D0804),
@@ -86,7 +88,7 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
                       child: StreakCalendar(
                         viewingMonth: viewingMonth,
                         monthPosts: state.monthPosts,
-                        today: DateTime.now(),
+                        today: nowLocal,
                         onTapDay: (index) => _openPhotoDetail(context, index),
                         onSwipePrev: () => ref
                             .read(streakControllerProvider.notifier)
@@ -153,12 +155,15 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
   void _openPhotoDetail(BuildContext context, int initialIndex) {
     final state = ref.read(streakControllerProvider);
     if (state.monthPosts.isEmpty) return;
+    // Clamp index: monthPosts có thể đã thay đổi giữa lúc render cell và lúc
+    // tap (stream emit lại, hoặc delete xảy ra song song). Tránh OOB crash.
+    final safeIndex = initialIndex.clamp(0, state.monthPosts.length - 1);
 
     Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (_) => PhotoDetailScreen(
-          postId: state.monthPosts[initialIndex].postId,
-          initialIndex: initialIndex,
+          postId: state.monthPosts[safeIndex].postId,
+          initialIndex: safeIndex,
           posts: state.monthPosts,
           captionPillColor: const Color(0x66394041),
           timeColor: AppColors.bw600,
@@ -170,11 +175,6 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
         ),
       ),
     );
-  }
-
-  static DateTime _startOfThisMonth() {
-    final now = DateTime.now();
-    return DateTime(now.year, now.month);
   }
 }
 

--- a/apps/mobile/test/features/streak/presentation/streak_screen_test.dart
+++ b/apps/mobile/test/features/streak/presentation/streak_screen_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/feed/data/post.dart';
@@ -12,6 +13,7 @@ import 'package:meep/features/streak/presentation/streak_screen.dart';
 import 'package:meep/features/streak/presentation/widgets/empty_state_overlay.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_calendar.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart';
+import 'package:meep/shared/widgets/app_taskbar.dart';
 
 class FakeStreakRepo implements StreakRepository {
   FakeStreakRepo({this.allDates = const [], this.monthPostsMap = const {}});
@@ -168,5 +170,94 @@ void main() {
 
     final pill = tester.widget<StreakStatsPill>(find.byType(StreakStatsPill));
     expect(pill.totalMoments, 2);
+  });
+
+  // ── E2E: Taskbar wired ──────────────────────────────────────────────────
+
+  testWidgets('Taskbar visible với active tab = streak', (tester) async {
+    await tester.pumpWidget(
+      host(repo: FakeStreakRepo(), profile: fakeProfile()),
+    );
+    await pumpUntilSettled(tester);
+
+    final taskbar = tester.widget<AppTaskbar>(find.byType(AppTaskbar));
+    expect(taskbar.activeTab, TaskbarTab.streak);
+  });
+
+  // Navigate từ Taskbar trong GoRouter — verify onTabSelected dispatch.
+  // Chỉ test navigation logic, không test render màn destination (dest cần
+  // providers module khác → out-of-scope).
+  testWidgets('tap Taskbar home tab → navigate /home (không còn ở Streak)',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation: '/streak',
+      routes: [
+        GoRoute(path: '/streak', builder: (_, __) => const StreakScreen()),
+        GoRoute(
+          path: '/home',
+          builder: (_, __) => const Scaffold(body: Text('HOME_MARKER')),
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          streakRepositoryProvider.overrideWithValue(FakeStreakRepo()),
+          currentUidProvider.overrideWith((ref) async* {
+            yield 'uid-alice';
+          }),
+          currentUserProfileProvider.overrideWith((ref) async* {
+            yield fakeProfile();
+          }),
+          nowProvider.overrideWithValue(
+            () => DateTime(2026, 5, 22),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await pumpUntilSettled(tester);
+
+    await tester.tap(find.bySemanticsLabel('Trang chủ'));
+    await pumpUntilSettled(tester);
+
+    expect(find.text('HOME_MARKER'), findsOneWidget);
+  });
+
+  testWidgets(
+      'tap Taskbar streak tab khi đang ở /streak → no-op (vẫn ở Streak)',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation: '/streak',
+      routes: [
+        GoRoute(path: '/streak', builder: (_, __) => const StreakScreen()),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          streakRepositoryProvider.overrideWithValue(FakeStreakRepo()),
+          currentUidProvider.overrideWith((ref) async* {
+            yield 'uid-alice';
+          }),
+          currentUserProfileProvider.overrideWith((ref) async* {
+            yield fakeProfile();
+          }),
+          nowProvider.overrideWithValue(
+            () => DateTime(2026, 5, 22),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await pumpUntilSettled(tester);
+
+    // Tap streak tab (Semantics label "Kỷ niệm" trên Taskbar)
+    // .last vì topbar title cũng có text "Kỷ niệm"
+    await tester.tap(find.bySemanticsLabel('Kỷ niệm').last);
+    await pumpUntilSettled(tester);
+
+    // Vẫn ở StreakScreen
+    expect(find.byType(StreakScreen), findsOneWidget);
   });
 }

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -17,6 +17,24 @@
       ]
     },
     {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "authorId", "order": "ASCENDING" },
+        { "fieldPath": "spaceId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "authorId", "order": "ASCENDING" },
+        { "fieldPath": "spaceId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "friend_requests",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Summary

ST5 — task cuối cùng của Streak module. Wire AppTaskbar vào StreakScreen + E2E navigation tests.

### Changes

- **StreakScreen**: thêm `AppTaskbar` floating variant dưới bottom (Stack overlay)
  - `activeTab: TaskbarTab.streak`
  - `chatBadgeCount` từ `unreadCountsProvider` (match pattern Profile)
  - `onTabSelected` dispatch → `context.go('/diary'|'/home'|'/inbox'|'/profile')`

### Tests bổ sung (3 E2E)

- Taskbar visible với active tab = streak
- Tap home tab → navigate `/home`, không còn ở StreakScreen
- Tap streak tab khi đang ở /streak → no-op (vẫn ở Streak)

### Existing wire (đã có từ trước)

Các module khác (Profile, Diary, Inbox, Home) đã wire `streak` tab → `go('/streak')` từ các PR trước. Route `/streak` đã có trong router từ LX12 contract.

## Refs

Closes #262

## Test plan

- [x] `flutter analyze apps/mobile --no-pub` → No issues found
- [x] **47/47 streak tests pass** (8 calculate_streak + 9 controller + 6 repo + 6 cell + 8 calendar + 2 pill + 9 screen)
- [ ] Manual smoke test: cold start → login → Taskbar tab streak → calendar → swipe + tap → photo detail → share → save → delete → back → pill update

## Module complete checklist

- [x] ST1 — FirebaseStreakRepository (#268 MERGED)
- [x] ST2 — StreakController (#275 MERGED)
- [x] ST3 — Shared widgets move (#273 MERGED)
- [x] ST4 — StreakScreen UI (#277 MERGED)
- [x] ST5 — Taskbar wire + E2E tests (this PR)
- [ ] `dart format --set-exit-if-changed .` clean
- [ ] `flutter analyze --no-pub` clean
- [ ] Manual smoke test full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)