### PR TITLE
fix(diary): avatar topbar + loading timeout + inline image (#126)

### DIFF
--- a/apps/mobile/lib/features/diary/application/diary_controller.dart
+++ b/apps/mobile/lib/features/diary/application/diary_controller.dart
@@ -94,7 +94,7 @@ class DiaryController extends _$DiaryController {
   /// Upload fail bất kỳ bước → KHÔNG tạo/update Firestore doc.
   Future<void> saveEntry({
     required DiaryEntry draft,
-    required Uint8List coverBytes,
+    Uint8List? coverBytes,
     List<Uint8List> inlineImageBytes = const [],
   }) async {
     state = state.copyWith(isSaving: true, errorMessage: null);
@@ -111,19 +111,21 @@ class DiaryController extends _$DiaryController {
           ? repo.reserveEntryId()
           : draft.entryId;
 
-      // Bước 1 — upload cover
-      String coverUrl;
-      try {
-        coverUrl = await storage.upload(
-          uid: uid,
-          entryId: entryId,
-          fileName: 'cover.jpg',
-          bytes: coverBytes,
-          contentType: 'image/jpeg',
-        );
-      } catch (e) {
-        state = _afterFailure(e, fallback: 'Tải ảnh bìa thất bại');
-        return;
+      // Bước 1 — upload cover (skip nếu không đổi ảnh cover)
+      String coverUrl = draft.coverImageUrl;
+      if (coverBytes != null) {
+        try {
+          coverUrl = await storage.upload(
+            uid: uid,
+            entryId: entryId,
+            fileName: 'cover.jpg',
+            bytes: coverBytes,
+            contentType: 'image/jpeg',
+          );
+        } catch (e) {
+          state = _afterFailure(e, fallback: 'Tải ảnh bìa thất bại');
+          return;
+        }
       }
 
       // Bước 2 — upload inline images tuần tự

--- a/apps/mobile/lib/features/diary/application/diary_controller.dart
+++ b/apps/mobile/lib/features/diary/application/diary_controller.dart
@@ -148,9 +148,9 @@ class DiaryController extends _$DiaryController {
 
       // Bước 3 — build entry với URLs thật + Firestore write.
       //
-      // Inline image URL mapping: controller replace ImageBlock placeholder
-      // theo thứ tự — block ảnh thứ N nhận `inlineUrls[N-1]`. PR4 wire UI
-      // sẽ define convention rõ ràng cho UI gọi.
+      // Inline image URL mapping: chỉ replace ImageBlock có sentinel
+      // `placeholder:` (UI mới pick). ImageBlock với URL Firestore cũ giữ
+      // nguyên — tránh edit mode ghi đè URL hợp lệ bằng URL mới (mất ảnh).
       var inlineIdx = 0;
       final contentBlocks = draft.content.map((b) {
         return b.when(
@@ -158,10 +158,14 @@ class DiaryController extends _$DiaryController {
             value: value,
             style: style,
           ),
-          image: (_) {
-            final url =
-                inlineIdx < inlineUrls.length ? inlineUrls[inlineIdx++] : '';
-            return DiaryContentBlock.image(imageUrl: url);
+          image: (existingUrl) {
+            if (existingUrl.startsWith('placeholder:')) {
+              final url =
+                  inlineIdx < inlineUrls.length ? inlineUrls[inlineIdx++] : '';
+              return DiaryContentBlock.image(imageUrl: url);
+            }
+            // URL Firestore cũ — giữ nguyên.
+            return DiaryContentBlock.image(imageUrl: existingUrl);
           },
         );
       }).toList();

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
@@ -103,10 +103,9 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
   bool _underline = false;
   bool _strikethrough = false;
 
-  /// Cover image bytes — user pick từ gallery qua `ImagePickerService`.
-  /// Null trước khi pick; sau khi pick lưu để gửi vào `controller.saveEntry`.
-  /// Read mode KHÔNG dùng (cover render từ `widget.initialImageUrl`).
-  Uint8List? _coverBytes;
+  /// Inline image bytes — user pick từ gallery qua `ImagePickerService`.
+  /// Mỗi entry = 1 ảnh inline trong content. Max 5 entries.
+  final List<Uint8List> _inlineImageBytes = [];
 
   bool get _isReadOnly => widget.mode == DiaryCanvasMode.read;
 
@@ -203,17 +202,13 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
         MoodTemplate.sad => 'Buồn bã',
       };
 
-  /// Save handler — tap check ở topbar (create mode only ở PR4a).
+  /// Save handler — tap check ở topbar.
   ///
-  /// Validate: phải có mood + cover bytes + content text non-empty.
-  /// Build `DiaryEntry` draft → `controller.saveEntry(draft, coverBytes)`.
-  /// Stream `watchEntries` sẽ tự đẩy entry mới về list khi pop về.
-  ///
-  /// T9b (PR4b) sẽ wire edit mode đầy đủ — hiện tại edit pop trực tiếp.
+  /// Create mode: cover = '' (mood asset là visual, không upload).
+  /// Inline images — upload tuần tự nếu user đã pick.
   Future<void> _handleSave() async {
     final mood = _loadedMood ?? widget.moodTemplate;
     if (mood == null) {
-      // Defensive — create flow phải pass mood từ picker.
       unawaited(Navigator.of(context).maybePop());
       return;
     }
@@ -237,12 +232,10 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
     final caption = _captionController.text.trim().isEmpty
         ? _moodLabel(mood)
         : _captionController.text.trim();
-    final coverBytes = _coverBytes;
     final isEdit = widget.mode == DiaryCanvasMode.edit;
     final existingEntry = ref.read(diaryControllerProvider).currentEntry;
 
     if (isEdit) {
-      // Edit mode — phải có entry loaded để giữ createdAt + entryId.
       if (existingEntry == null || existingEntry.entryId != widget.entryId) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -252,14 +245,13 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
         return;
       }
 
-      if (coverBytes != null) {
-        // Đổi ảnh → dùng saveEntry path để upload + update Firestore với
-        // coverUrl mới (controller.state.mode = edit → repo.updateEntry).
+      final hasNewImages = _inlineImageBytes.isNotEmpty;
+
+      if (hasNewImages) {
         final draft = existingEntry.copyWith(
           moodCaption: caption,
-          content: [DiaryContentBlock.text(value: contentText)],
+          content: _buildContentBlocks(contentText),
           privacy: _privacy,
-          moodTemplate: mood,
           updatedAt: DateTime.now(),
         );
         ref
@@ -267,30 +259,22 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
             .setMode(DiaryCanvasMode.edit);
         await ref.read(diaryControllerProvider.notifier).saveEntry(
               draft: draft,
-              coverBytes: coverBytes,
+              coverBytes: null,
+              inlineImageBytes: _inlineImageBytes,
             );
       } else {
-        // Không đổi ảnh → updateEntryNoImage (qua controller, không bypass).
         final updated = existingEntry.copyWith(
           moodCaption: caption,
-          content: [DiaryContentBlock.text(value: contentText)],
+          content: _buildContentBlocks(contentText),
           privacy: _privacy,
           updatedAt: DateTime.now(),
         );
         await ref
             .read(diaryControllerProvider.notifier)
             .updateEntryNoImage(updated);
-        // ErrorMessage handled bởi ref.listen trong build → SnackBar.
       }
     } else {
-      // Create mode — cần coverBytes.
-      if (coverBytes == null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Vui lòng chọn ảnh bìa')),
-        );
-        return;
-      }
-
+      // Create mode — cover = '' (no upload), inline images from picker.
       final placeholderTs = DateTime.now();
       final draft = DiaryEntry(
         entryId: '',
@@ -298,7 +282,7 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
         moodTemplate: mood,
         coverImageUrl: '',
         moodCaption: caption,
-        content: [DiaryContentBlock.text(value: contentText)],
+        content: _buildContentBlocks(contentText),
         privacy: _privacy,
         createdAt: placeholderTs,
         updatedAt: placeholderTs,
@@ -309,7 +293,8 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
           .setMode(DiaryCanvasMode.create);
       await ref.read(diaryControllerProvider.notifier).saveEntry(
             draft: draft,
-            coverBytes: coverBytes,
+            coverBytes: null,
+            inlineImageBytes: _inlineImageBytes,
           );
     }
 
@@ -324,16 +309,32 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
       return;
     }
 
-    // Success — pop về list. Stream tự đẩy entry mới vào state.entries.
     unawaited(Navigator.of(context).maybePop());
   }
 
-  /// Open gallery → pick + compress → lưu bytes vào `_coverBytes`.
-  Future<void> _pickCoverImage() async {
+  /// Build content blocks: text block + ImageBlock cho mỗi inline ảnh đã pick.
+  List<DiaryContentBlock> _buildContentBlocks(String text) {
+    final blocks = <DiaryContentBlock>[
+      DiaryContentBlock.text(value: text),
+    ];
+    for (var i = 0; i < _inlineImageBytes.length; i++) {
+      blocks.add(DiaryContentBlock.image(imageUrl: 'placeholder:$i'));
+    }
+    return blocks;
+  }
+
+  /// Open gallery → pick + compress → lưu bytes vào `_inlineImageBytes`.
+  Future<void> _pickInlineImage() async {
+    if (_inlineImageBytes.length >= 5) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Tối đa 5 ảnh inline')),
+      );
+      return;
+    }
     try {
       final bytes = await ref.read(imagePickerServiceProvider).pickImage();
       if (bytes == null || !mounted) return;
-      setState(() => _coverBytes = bytes);
+      setState(() => _inlineImageBytes.add(bytes));
     } catch (_) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -488,7 +489,7 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
       _ToolMode.content => _ContentToolbar(
           onType: () => setState(() => _toolMode = _ToolMode.style),
           onAlign: () => setState(() => _toolMode = _ToolMode.align),
-          onImage: () => unawaited(_pickCoverImage()),
+          onImage: () => unawaited(_pickInlineImage()),
         ),
     };
   }
@@ -589,19 +590,14 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
     );
   }
 
-  // ── Mood zone: cover (mood image) + caption highlight ──
+  // ── Mood zone: mood asset (luôn cố định) + caption highlight ──
   Widget _buildMoodZone() {
-    // Priority: user-picked bytes (chưa save) > loaded URL (read/edit) >
-    // mood asset (create mode default).
     final mood = _loadedMood ?? widget.moodTemplate;
-    final coverBytes = _coverBytes;
     final coverUrl = _loadedCoverUrl;
-    final canPick = !_isReadOnly;
 
     Widget coverChild;
-    if (coverBytes != null) {
-      coverChild = Image.memory(coverBytes, fit: BoxFit.contain);
-    } else if (coverUrl != null && coverUrl.isNotEmpty) {
+    if (coverUrl != null && coverUrl.isNotEmpty) {
+      // Read mode: cover URL từ Firestore (nếu có).
       coverChild = Image.network(
         coverUrl,
         fit: BoxFit.contain,
@@ -623,19 +619,8 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
 
     return Column(
       children: [
-        // Cover — tap để chọn ảnh trong create/edit mode.
-        SizedBox(
-          height: 102,
-          child: Semantics(
-            label: canPick ? 'Chọn ảnh bìa' : 'Ảnh bìa',
-            button: canPick,
-            child: GestureDetector(
-              onTap: canPick ? () => unawaited(_pickCoverImage()) : null,
-              behavior: HitTestBehavior.opaque,
-              child: coverChild,
-            ),
-          ),
-        ),
+        // Cover — mood asset, không tương tác.
+        SizedBox(height: 102, child: coverChild),
         const SizedBox(height: 16),
 
         // Mood caption — highlight nền turquoise (thay line xanh), editable
@@ -686,17 +671,19 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (_isReadOnly)
+        if (_isReadOnly) ...[
           Text(
             _contentController.text,
             textAlign: _contentAlign,
             style: _contentStyle,
-          )
-        else
+          ),
+          // Read mode: render ImageBlock từ entry.content.
+          ..._buildReadInlineImages(),
+        ] else ...[
           TextField(
             controller: _contentController,
             focusNode: _contentFocus,
-            autofocus: true, // bật keyboard ngay khi vào canvas
+            autofocus: true,
             maxLines: null,
             textAlign: _contentAlign,
             style: _contentStyle,
@@ -706,12 +693,62 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
               hintStyle: TextStyle(color: AppColors.bw500),
             ),
           ),
-        if (widget.initialImageUrl != null) ...[
-          const SizedBox(height: 24),
-          PolaroidImageBlock(imageUrl: widget.initialImageUrl!),
+          // Edit/Create: hiển thị inline ảnh đã pick (chưa save).
+          ..._buildPickedInlinePreviews(),
         ],
       ],
     );
+  }
+
+  /// Render ImageBlock items từ entry đã load (read mode).
+  List<Widget> _buildReadInlineImages() {
+    final entry = ref.watch(
+      diaryControllerProvider.select((s) => s.currentEntry),
+    );
+    if (entry == null) return const [];
+    return entry.content
+        .where((b) => b.maybeWhen(image: (_) => true, orElse: () => false))
+        .map(
+          (b) => b.maybeWhen(
+            image: (url) => Column(
+              children: [
+                const SizedBox(height: 24),
+                PolaroidImageBlock(imageUrl: url),
+              ],
+            ),
+            orElse: () => const SizedBox.shrink(),
+          ),
+        )
+        .toList();
+  }
+
+  /// Preview ảnh inline đã pick (create/edit, trước save).
+  List<Widget> _buildPickedInlinePreviews() {
+    return _inlineImageBytes.asMap().entries.map((e) {
+      return Column(
+        children: [
+          const SizedBox(height: 24),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(5.33),
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                Image.memory(
+                  e.value,
+                  fit: BoxFit.contain,
+                  width: double.infinity,
+                ),
+                // Polaroid frame overlay
+                Image.asset(
+                  'assets/frames/frame_polaroid.png',
+                  fit: BoxFit.contain,
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+    }).toList();
   }
 
   static const _contentStyle = TextStyle(

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
@@ -250,7 +250,10 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
       if (hasNewImages) {
         final draft = existingEntry.copyWith(
           moodCaption: caption,
-          content: _buildContentBlocks(contentText),
+          content: _buildContentBlocks(
+            contentText,
+            existingEntry: existingEntry,
+          ),
           privacy: _privacy,
           updatedAt: DateTime.now(),
         );
@@ -265,7 +268,10 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
       } else {
         final updated = existingEntry.copyWith(
           moodCaption: caption,
-          content: _buildContentBlocks(contentText),
+          content: _buildContentBlocks(
+            contentText,
+            existingEntry: existingEntry,
+          ),
           privacy: _privacy,
           updatedAt: DateTime.now(),
         );
@@ -309,14 +315,38 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
       return;
     }
 
+    // Clear inline bytes sau success — tránh re-upload nếu user back gesture
+    // cancel pop rồi tap check lại (duplicate upload + content blocks).
+    _inlineImageBytes.clear();
     unawaited(Navigator.of(context).maybePop());
   }
 
-  /// Build content blocks: text block + ImageBlock cho mỗi inline ảnh đã pick.
-  List<DiaryContentBlock> _buildContentBlocks(String text) {
+  /// Build content blocks: text block + ImageBlock cho mỗi inline ảnh.
+  ///
+  /// Edit mode: preserve existing ImageBlocks từ `existingEntry.content`
+  /// (URL đã có trên Firestore), append placeholder cho ảnh mới pick.
+  /// Create mode: chỉ text + placeholder ảnh mới.
+  ///
+  /// Lý do tách: `_syncFromEntry` chỉ load text + caption, image blocks
+  /// không đẩy vào controllers — nếu rebuild blocks chỉ từ text, image
+  /// cũ sẽ bị mất khi save edit.
+  List<DiaryContentBlock> _buildContentBlocks(
+    String text, {
+    DiaryEntry? existingEntry,
+  }) {
     final blocks = <DiaryContentBlock>[
       DiaryContentBlock.text(value: text),
     ];
+    // Preserve existing image blocks (edit mode).
+    if (existingEntry != null) {
+      for (final b in existingEntry.content) {
+        b.maybeWhen(
+          image: (url) => blocks.add(DiaryContentBlock.image(imageUrl: url)),
+          orElse: () {},
+        );
+      }
+    }
+    // Append placeholder cho ảnh mới pick.
     for (var i = 0; i < _inlineImageBytes.length; i++) {
       blocks.add(DiaryContentBlock.image(imageUrl: 'placeholder:$i'));
     }
@@ -324,8 +354,18 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
   }
 
   /// Open gallery → pick + compress → lưu bytes vào `_inlineImageBytes`.
+  /// Max 5 ảnh tổng (existing entry image blocks + new picks) — tránh vượt
+  /// Firestore rule cap (content.size() ≤ 20 mixed blocks, 5 images per spec).
   Future<void> _pickInlineImage() async {
-    if (_inlineImageBytes.length >= 5) {
+    final existing = ref
+            .read(diaryControllerProvider)
+            .currentEntry
+            ?.content
+            .where((b) => b.maybeWhen(image: (_) => true, orElse: () => false))
+            .length ??
+        0;
+    final total = existing + _inlineImageBytes.length;
+    if (total >= 5) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Tối đa 5 ảnh inline')),
       );

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen_toolbar.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen_toolbar.dart
@@ -27,7 +27,7 @@ class _ContentToolbar extends StatelessWidget {
         children: [
           _SvgIconBtn(
             asset: 'assets/icons/ic_diary_image.svg',
-            semanticLabel: 'Chọn ảnh bìa',
+            semanticLabel: 'Chèn ảnh',
             onTap: onImage,
           ),
           const SizedBox(width: 22),

--- a/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -11,6 +13,8 @@ import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
 import 'package:meep/features/diary/presentation/diary_search_screen.dart';
 import 'package:meep/features/diary/presentation/widgets/diary_list_card.dart';
 import 'package:meep/features/diary/presentation/widgets/diary_mood_card.dart';
+import 'package:meep/features/settings/presentation/settings_sheet.dart';
+import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 
 part 'diary_list_screen_mood_picker.dart';
@@ -45,6 +49,11 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
   /// nhiều lần (vd auth state stream replay).
   String? _loadedForUid;
 
+  /// Track thời điểm `loadEntries` được gọi — nếu loading kéo dài > 5s
+  /// (vd indexes chưa deploy → Firestore reject silent), hiển thị retry
+  /// button thay vì spinner vĩnh cửu.
+  DateTime? _loadingStartAt;
+
   @override
   void initState() {
     super.initState();
@@ -57,10 +66,19 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
         final uid = next.valueOrNull;
         if (uid == null || _loadedForUid == uid) return;
         _loadedForUid = uid;
+        _loadingStartAt = DateTime.now();
         ref.read(diaryControllerProvider.notifier).loadEntries(uid);
       },
       fireImmediately: true,
     );
+  }
+
+  void _retryLoad() {
+    final uid = ref.read(currentUidProvider).valueOrNull;
+    if (uid == null) return;
+    setState(() {}); // force rebuild, reset timeout visual
+    _loadingStartAt = DateTime.now();
+    ref.read(diaryControllerProvider.notifier).loadEntries(uid);
   }
 
   void _togglePicker() => setState(() => _pickerOpen = !_pickerOpen);
@@ -231,14 +249,24 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
             ),
           ),
 
-          // Avatar placeholder
-          Container(
-            width: 40,
-            height: 40,
-            decoration: const BoxDecoration(
-              shape: BoxShape.circle,
-              color:
-                  AppColors.bw600, // Avatar placeholder — match Figma BW dark
+          // Avatar — load từ profile, tap → SettingsSheet
+          Semantics(
+            button: true,
+            label: 'Cài đặt',
+            child: GestureDetector(
+              onTap: () => showModalBottomSheet<void>(
+                context: context,
+                isScrollControlled: true,
+                backgroundColor: Colors.transparent,
+                builder: (_) => const SettingsSheet(),
+              ),
+              child: AppAvatar(
+                imageUrl: ref
+                    .watch(currentUserProfileProvider)
+                    .valueOrNull
+                    ?.avatarUrl,
+                size: 40,
+              ),
             ),
           ),
         ],
@@ -302,9 +330,49 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
     final state = ref.watch(diaryControllerProvider);
 
     if (state.isLoading && state.entries.isEmpty) {
+      // Sau 5s loading không response → timeout (vd indexes chưa deploy).
+      final elapsed = _loadingStartAt != null
+          ? DateTime.now().difference(_loadingStartAt!).inSeconds
+          : 0;
+      if (elapsed >= 5) {
+        return Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'Không thể tải nhật ký',
+                style: TextStyle(
+                  fontFamily: 'Nunito',
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.bw500,
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextButton(
+                onPressed: _retryLoad,
+                child: const Text(
+                  'Thử lại',
+                  style: TextStyle(
+                    fontFamily: 'Nunito',
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.turquoise500,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      }
       return const Center(
         child: CircularProgressIndicator(color: AppColors.turquoise500),
       );
+    }
+
+    // Reset timeout khi load done.
+    if (_loadingStartAt != null && !state.isLoading) {
+      _loadingStartAt = null;
     }
 
     if (state.errorMessage != null && state.entries.isEmpty) {

--- a/apps/mobile/test/features/diary/application/diary_controller_test.dart
+++ b/apps/mobile/test/features/diary/application/diary_controller_test.dart
@@ -273,6 +273,58 @@ void main() {
     });
   });
 
+  group('saveEntry — preserve existing image URLs (edit)', () {
+    test(
+      'image block với URL Firestore cũ KHÔNG bị ghi đè bởi inlineUrls',
+      () async {
+        storage.urls = ['https://cdn/new_img.jpg'];
+        when(() => repo.updateEntry(any())).thenAnswer((_) async {});
+
+        final c = makeContainer();
+        c.read(diaryControllerProvider.notifier).setMode(DiaryCanvasMode.edit);
+
+        // Draft: 1 text + 1 image cũ (URL) + 1 placeholder (ảnh mới pick).
+        await c.read(diaryControllerProvider.notifier).saveEntry(
+          draft: draftEntry(
+            entryId: 'e-existing',
+            content: const [
+              DiaryContentBlock.text(value: 'Nội dung'),
+              DiaryContentBlock.image(imageUrl: 'https://cdn/old_img.jpg'),
+              DiaryContentBlock.image(imageUrl: 'placeholder:0'),
+            ],
+          ),
+          inlineImageBytes: [Uint8List(50)],
+        );
+
+        // Verify chỉ 1 upload (cho placeholder), không upload cho URL cũ.
+        expect(storage.uploadCount, 1);
+
+        // Verify updateEntry nhận đúng content: URL cũ giữ + placeholder
+        // thay bằng URL mới.
+        final captured = verify(() => repo.updateEntry(captureAny()))
+            .captured
+            .single as DiaryEntry;
+        expect(captured.content.length, 3);
+        expect(
+          captured.content[1].maybeWhen(
+            image: (url) => url,
+            orElse: () => '',
+          ),
+          'https://cdn/old_img.jpg',
+          reason: 'URL cũ giữ nguyên',
+        );
+        expect(
+          captured.content[2].maybeWhen(
+            image: (url) => url,
+            orElse: () => '',
+          ),
+          'https://cdn/new_img.jpg',
+          reason: 'placeholder được thay bằng URL mới upload',
+        );
+      },
+    );
+  });
+
   group('saveEntry — edit mode', () {
     test('mode=edit → gọi updateEntry, KHÔNG gọi createEntry', () async {
       storage.urls = ['https://cdn/cover.jpg'];

--- a/apps/mobile/test/features/diary/application/diary_controller_test.dart
+++ b/apps/mobile/test/features/diary/application/diary_controller_test.dart
@@ -194,6 +194,31 @@ void main() {
       expect(state.currentEntry?.entryId, 'e-new');
     });
 
+    test('coverBytes null → skip cover upload, chỉ upload inline', () async {
+      storage.urls = ['https://cdn/img1.jpg'];
+      when(() => repo.createEntry(any()))
+          .thenAnswer((_) async => savedEntry('e-new'));
+
+      final c = makeContainer();
+      await c.read(diaryControllerProvider.notifier).saveEntry(
+        draft: draftEntry(
+          content: const [DiaryContentBlock.image(imageUrl: 'placeholder:0')],
+        ),
+        coverBytes: null,
+        inlineImageBytes: [Uint8List.fromList(List.filled(50, 0xCD))],
+      );
+
+      expect(storage.uploadCount, 1);
+      expect(
+        storage.uploads[0]['fileName'],
+        'img_1.jpg',
+        reason: 'cover upload bị skip, chỉ upload inline',
+      );
+      verify(() => repo.createEntry(any())).called(1);
+      final state = c.read(diaryControllerProvider);
+      expect(state.currentEntry?.entryId, 'e-new');
+    });
+
     test('cover upload fail → KHÔNG gọi inline upload, KHÔNG tạo Firestore doc',
         () async {
       storage.urls = const [null]; // cover fail


### PR DESCRIPTION
## Mô tả

3 UX fixes sau review của anh.

## Changes

### 1. Avatar topbar (AppAvatar + SettingsSheet)

Thay placeholder gray circle bằng avatar thật từ `currentUserProfile.avatarUrl`, tap → mở SettingsSheet (giống tab Chat).

### 2. Loading timeout

Nếu `loadEntries` > 5s không response (vd indexes chưa deploy → Firestore reject silent), hiển thị "Không thể tải nhật ký" + nút "Thử lại" (retry fire loadEntries). Fix bug stuck spinner vĩnh cửu.

Logic: Track `_loadingStartAt` khi fire loadEntries. Trong `_buildBody()`, nếu `isLoading && entries.isEmpty` đã > 5s → hiển thị timeout state thay vì CircularProgressIndicator.

### 3. Inline image thay vì pick cover

Bỏ cover pick từ MoodZone — cover luôn là mood asset PNG (`bg_${mood}.png`) cố định. Image button trong toolbar giờ pick ảnh inline vào thân bài.

Flow:
- Tap image button → `ImagePickerService.pickImage()` → `_inlineImageBytes.add(bytes)`
- Preview: ảnh + polaroid frame overlay trong content area (create/edit)
- Save: upload tuần tự qua `controller.saveEntry(coverBytes: null, inlineImageBytes: _inlineImageBytes)`
- Max 5 inline images
- Read mode: render `ImageBlock` từ `entry.content` qua `PolaroidImageBlock`
- MoodZone: luôn mood asset, không tương tác

Code changes:
- `saveEntry`: `coverBytes` nay nullable (null = skip cover upload, giữ draft.coverImageUrl)
- `_handleSave` create: không validate coverBytes, build content blocks với `_buildContentBlocks()` (text + ImageBlock slots)
- `_buildContentArea`: tách read mode (`_buildReadInlineImages`) + edit/create (`_buildPickedInlinePreviews`)

## Files

| File | Δ | Mô tả |
|---|---|---|
| `lib/features/diary/presentation/diary_list_screen.dart` | +84 | Avatar + SettingsSheet + loading timeout |
| `lib/features/diary/presentation/diary_canvas_screen.dart` | ±167 | Remove cover pick, add inline pick + preview + polaroid read |
| `lib/features/diary/presentation/diary_canvas_screen_toolbar.dart` | ±2 | Label "Chọn ảnh bìa" → "Chèn ảnh" |
| `lib/features/diary/application/diary_controller.dart` | ±5 | saveEntry: coverBytes nullable |
| `test/features/diary/application/diary_controller_test.dart` | +25 | Test coverBytes null flow |

## Test plan

- [x] `flutter test test/features/diary/` — 57/57 pass
- [x] `flutter test` full suite — 671/671 pass, không break
- [x] `flutter analyze` — 0 issues
- [x] `dart format --set-exit-if-changed` — clean
- [ ] Manual smoke: avatar tap → SettingsSheet; loading > 5s → retry; canvas image button → pick → polaroid preview → save → read hiện polaroid

## Note cho anh test

- **Đã deploy indexes chưa?** Nếu chưa, loading sẽ timeout 5s → hiện retry button (behavior mới từ fix này).
- Canvas: cover là mood asset cố định (không cần pick nữa). Image button trong toolbar phía dưới giờ là "Chèn ảnh".
- Sau khi pick ảnh → hiển thị ảnh + khung polaroid ngay dưới text.
- Read mode: ảnh inline hiển thị với PolaroidImageBlock (frame polaroid chính thức).

Refs #126

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>