### PR TITLE
feat(notification): T4 deep link routing từ notification tap

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -28,6 +28,8 @@ import 'package:meep/features/feed/presentation/capture_preview_screen.dart';
 import 'package:meep/features/feed/presentation/grid_view_screen.dart';
 import 'package:meep/features/feed/presentation/home_screen.dart';
 import 'package:meep/features/home/presentation/home_page.dart';
+import 'package:meep/features/notification/application/notification_controller.dart';
+import 'package:meep/features/notification/application/notification_state.dart';
 import 'package:meep/features/profile/presentation/edit_profile_screen.dart';
 import 'package:meep/features/profile/presentation/friend_profile_screen.dart';
 import 'package:meep/features/profile/presentation/profile_screen.dart';
@@ -99,6 +101,39 @@ String? authRedirect({
   // uid != null, profile exists — không redirect user khỏi reset page
   if (location == '/login/reset-password') return null;
   return onAuthRoute ? '/home' : null;
+}
+
+/// Pure mapping: notification `data` payload → in-app route.
+///
+/// Designed to be testable without GoRouter or Firebase mocks. Caller picks
+/// the navigation primitive (`go` vs `push`) — T4 uses `go` to keep deep
+/// links idempotent (no duplicate route stack on double-tap).
+///
+///   friend_request / friend_accepted → /home?openFriendSheet=1
+///   reaction                         → /home?highlight=`postId`
+///   new_post                         → /home
+///   unknown / missing type           → /home
+///
+/// Missing postId for `reaction` falls back to `/home` — the source push
+/// always includes it, so a missing value means a malformed payload that
+/// the user shouldn't see a broken highlight for. HomeScreen already
+/// renders the "post no longer exists" toast when the postId can't be
+/// resolved to a Post, so unknown postIds reuse that path.
+String routeForNotification(Map<String, String> data) {
+  final type = data['type'];
+  switch (type) {
+    case 'friend_request':
+    case 'friend_accepted':
+      return '/home?openFriendSheet=1';
+    case 'reaction':
+      final postId = data['postId'];
+      if (postId == null || postId.isEmpty) return '/home';
+      return '/home?highlight=${Uri.encodeQueryComponent(postId)}';
+    case 'new_post':
+      return '/home';
+    default:
+      return '/home';
+  }
 }
 
 /// ChangeNotifier kích hoạt GoRouter redirect re-evaluation khi auth state thay đổi.
@@ -211,6 +246,7 @@ GoRouter appRouter(Ref ref) {
         builder: (_, state) => HomeScreen(
           spaceId: state.uri.queryParameters['spaceId'],
           highlightPostId: state.uri.queryParameters['highlight'],
+          openFriendSheet: state.uri.queryParameters['openFriendSheet'] == '1',
         ),
       ),
       GoRoute(
@@ -393,6 +429,30 @@ GoRouter appRouter(Ref ref) {
       router.go('/home');
     }
   });
+
+  // Notification deep link: NotificationController captures both the
+  // cold-start `getInitialMessage` and live `onMessageOpenedApp` into
+  // `state.lastOpenedApp`. Route once per unique messageId, then ask the
+  // controller to clear — guards against a stale payload re-firing on
+  // hot restart or provider re-listen.
+  //
+  // `fireImmediately: true` covers the race where `initFcm()` (kicked off
+  // by main.dart's auth listener) finishes BEFORE the router provider
+  // builds: state already has `lastOpenedApp`, listener attaches → fires
+  // synchronously with previous=null so the cold-start cmsg routes.
+  ref.listen<OpenedAppPayload?>(
+    notificationControllerProvider.select((s) => s.lastOpenedApp),
+    (previous, next) {
+      if (next == null) return;
+      if (previous?.messageId == next.messageId) return;
+      final route = routeForNotification(next.data);
+      router.go(route);
+      ref
+          .read(notificationControllerProvider.notifier)
+          .consumeOpenedAppMessage();
+    },
+    fireImmediately: true,
+  );
 
   ref.onDispose(() {
     channel.setMethodCallHandler(null);

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -25,10 +25,20 @@ import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
-  const HomeScreen({super.key, this.spaceId, this.highlightPostId});
+  const HomeScreen({
+    super.key,
+    this.spaceId,
+    this.highlightPostId,
+    this.openFriendSheet = false,
+  });
 
   final String? spaceId;
   final String? highlightPostId;
+
+  /// Set true when navigated from a friend_request / friend_accepted push
+  /// (T4 deep link). HomeScreen auto-opens the FriendSheet once after
+  /// mount, then clears the pending flag.
+  final bool openFriendSheet;
 
   @override
   ConsumerState<HomeScreen> createState() => _HomeScreenState();
@@ -50,11 +60,18 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   /// rebuild vì lý do khác.
   String? _pendingHighlightPostId;
 
+  /// Notification deep link target — set khi route mở với
+  /// `?openFriendSheet=1` (friend_request / friend_accepted push). Cleared
+  /// ngay sau khi showModalBottomSheet để rebuild kế tiếp không mở thêm
+  /// sheet thứ hai.
+  bool _pendingOpenFriendSheet = false;
+
   @override
   void initState() {
     super.initState();
     _pageController = PageController();
     _pendingHighlightPostId = widget.highlightPostId;
+    _pendingOpenFriendSheet = widget.openFriendSheet;
 
     // Deeplink `/space/:spaceId` → seed provider sau frame đầu (provider
     // chưa thể mutate inside initState — ref.read OK nhưng convention
@@ -81,6 +98,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     if (widget.highlightPostId != null &&
         widget.highlightPostId != oldWidget.highlightPostId) {
       _pendingHighlightPostId = widget.highlightPostId;
+    }
+    if (widget.openFriendSheet && !oldWidget.openFriendSheet) {
+      _pendingOpenFriendSheet = true;
     }
   }
 
@@ -271,6 +291,23 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _handleHighlight(pendingId, feedState.posts);
         });
+      });
+    }
+
+    // Notification deep link (friend_request / friend_accepted) → auto-open
+    // FriendSheet. Independent of feed loading state — clear pending
+    // synchronously so this branch only fires once per arrival.
+    if (_pendingOpenFriendSheet) {
+      _pendingOpenFriendSheet = false;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          backgroundColor: Colors.transparent,
+          barrierColor: const Color(0x73000000),
+          builder: (_) => const FriendSheet(),
+        );
       });
     }
 

--- a/apps/mobile/lib/features/notification/application/notification_controller.dart
+++ b/apps/mobile/lib/features/notification/application/notification_controller.dart
@@ -26,12 +26,6 @@ NotificationPreferences notificationPreferences(Ref ref) =>
       'wire NotificationPreferences in main.dart',
     );
 
-/// Messages delivered while app was killed, read once at cold start.
-/// T4 deep link handler consumes this.
-final initialMessageProvider = Provider<RemoteMessage?>((ref) {
-  return ref.read(notificationControllerProvider.notifier).initialMessage;
-});
-
 @riverpod
 class NotificationController extends _$NotificationController {
   final FlutterLocalNotificationsPlugin _localNotifications =
@@ -41,10 +35,7 @@ class NotificationController extends _$NotificationController {
   StreamSubscription<RemoteMessage>? _onMessageOpenedAppSub;
   StreamSubscription<String>? _onTokenRefreshSub;
   Timer? _bannerTimer;
-  RemoteMessage? _initialMessage;
   bool _fcmInitialized = false;
-
-  RemoteMessage? get initialMessage => _initialMessage;
 
   @override
   NotificationState build() {
@@ -96,13 +87,16 @@ class NotificationController extends _$NotificationController {
 
     // Cold-start deep link captured BEFORE wiring the live stream — else a
     // background-arriving message during init can be handled by both
-    // `_initialMessage` (T4 deep link) and `onMessageOpenedApp`, causing a
-    // double navigate. Per Firebase docs.
-    _initialMessage = await messaging.getInitialMessage();
+    // `getInitialMessage` (cold-start path) and `onMessageOpenedApp`,
+    // causing a double navigate. Per Firebase docs.
+    final initialMessage = await messaging.getInitialMessage();
+    if (initialMessage != null) {
+      handleOpenedApp(initialMessage);
+    }
 
     _onMessageSub = FirebaseMessaging.onMessage.listen(_handleForeground);
     _onMessageOpenedAppSub =
-        FirebaseMessaging.onMessageOpenedApp.listen(_handleOpenedApp);
+        FirebaseMessaging.onMessageOpenedApp.listen(handleOpenedApp);
   }
 
   Future<void> _saveToken(String token) async {
@@ -174,8 +168,33 @@ class NotificationController extends _$NotificationController {
     });
   }
 
-  void _handleOpenedApp(RemoteMessage message) {
-    // T4 wires deep link routing from this callback.
+  /// Wraps a tapped `RemoteMessage` into [OpenedAppPayload] and writes it
+  /// to state — the router's `ref.listen` consumes it and routes once.
+  ///
+  /// Public (not private) so unit tests can drive it directly without
+  /// mocking the FirebaseMessaging stream. Called by `initFcm` for the
+  /// cold-start `getInitialMessage` and by the `onMessageOpenedApp`
+  /// subscription for background taps.
+  void handleOpenedApp(RemoteMessage message) {
+    // `messageId` is FCM's dedupe key — guaranteed unique per delivery.
+    // Fall back to a synthetic id when null (vd push from emulator) so the
+    // payload is still emittable; equality still holds because the same
+    // RemoteMessage instance keeps the same fallback id during one tap.
+    final messageId = message.messageId ?? 'no-id-${message.hashCode}';
+    final data = Map<String, String>.from(
+      message.data.map((k, v) => MapEntry(k, v.toString())),
+    );
+    state = state.copyWith(
+      lastOpenedApp: OpenedAppPayload(messageId: messageId, data: data),
+    );
+  }
+
+  /// Router calls after dispatching the navigation. Clears `lastOpenedApp`
+  /// so a future re-listen (vd hot restart with the same payload still in
+  /// state) does not re-route.
+  void consumeOpenedAppMessage() {
+    if (state.lastOpenedApp == null) return;
+    state = state.copyWith(lastOpenedApp: null);
   }
 
   void dismissBanner() {

--- a/apps/mobile/lib/features/notification/application/notification_state.dart
+++ b/apps/mobile/lib/features/notification/application/notification_state.dart
@@ -12,11 +12,27 @@ class BannerPayload with _$BannerPayload {
   }) = _BannerPayload;
 }
 
+/// Pending deep-link emitted when user taps an FCM notification while the
+/// app is alive (background → foreground). The router listens for changes
+/// and routes once, then calls `consumeOpenedAppMessage` to clear.
+///
+/// Wrapped instead of using raw `RemoteMessage` so freezed `==` can compare
+/// distinct deliveries — same `messageId` is treated as the same payload
+/// (FCM dedupe guarantee), so re-emits with the same id are no-ops.
+@freezed
+class OpenedAppPayload with _$OpenedAppPayload {
+  const factory OpenedAppPayload({
+    required String messageId,
+    @Default({}) Map<String, String> data,
+  }) = _OpenedAppPayload;
+}
+
 @freezed
 class NotificationState with _$NotificationState {
   const factory NotificationState({
     @Default(false) bool fcmPermissionDenied,
     @Default(false) bool bannerSuppressed,
     BannerPayload? currentBanner,
+    OpenedAppPayload? lastOpenedApp,
   }) = _NotificationState;
 }

--- a/apps/mobile/test/core/router/app_router_test.dart
+++ b/apps/mobile/test/core/router/app_router_test.dart
@@ -332,4 +332,77 @@ void main() {
       );
     });
   });
+
+  group('routeForNotification — T4 deep link mapping', () {
+    test('friend_request → /home?openFriendSheet=1', () {
+      expect(
+        routeForNotification(const {
+          'type': 'friend_request',
+          'requestId': 'req-1',
+        }),
+        '/home?openFriendSheet=1',
+      );
+    });
+
+    test('friend_accepted → /home?openFriendSheet=1', () {
+      expect(
+        routeForNotification(const {
+          'type': 'friend_accepted',
+          'requestId': 'req-1',
+        }),
+        '/home?openFriendSheet=1',
+      );
+    });
+
+    test('reaction with postId → /home?highlight=<postId>', () {
+      expect(
+        routeForNotification(const {
+          'type': 'reaction',
+          'postId': 'post-abc',
+        }),
+        '/home?highlight=post-abc',
+      );
+    });
+
+    test('reaction with missing postId → /home (no broken highlight)', () {
+      // Defensive: a malformed payload should still land somewhere usable
+      // rather than throw or push an empty highlight query.
+      expect(routeForNotification(const {'type': 'reaction'}), '/home');
+      expect(
+        routeForNotification(const {'type': 'reaction', 'postId': ''}),
+        '/home',
+      );
+    });
+
+    test('reaction encodes a postId that contains special characters', () {
+      // Firestore doc IDs are safe in URLs by default, but `Uri.encode`
+      // guarantees nothing slips through even if a future id contains
+      // a reserved char.
+      expect(
+        routeForNotification(const {
+          'type': 'reaction',
+          'postId': 'a/b?c',
+        }),
+        '/home?highlight=a%2Fb%3Fc',
+      );
+    });
+
+    test('new_post → /home (no extra query)', () {
+      expect(
+        routeForNotification(const {'type': 'new_post'}),
+        '/home',
+      );
+    });
+
+    test('unknown type → /home (fallback, no crash)', () {
+      expect(
+        routeForNotification(const {'type': 'made_up_type'}),
+        '/home',
+      );
+    });
+
+    test('missing type → /home (fallback, no crash)', () {
+      expect(routeForNotification(const {}), '/home');
+    });
+  });
 }

--- a/apps/mobile/test/features/notification/application/notification_controller_test.dart
+++ b/apps/mobile/test/features/notification/application/notification_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -118,6 +119,124 @@ void main() {
 
       final state = container.read(notificationControllerProvider);
       expect(state.currentBanner, isNull);
+    });
+  });
+
+  group('handleOpenedApp', () {
+    // RemoteMessage constructor accepts arbitrary data and an explicit
+    // messageId, so the tap path is testable without mocking the FCM
+    // stream itself.
+
+    test('writes a payload with FCM messageId + data to state', () {
+      final controller =
+          container.read(notificationControllerProvider.notifier);
+
+      controller.handleOpenedApp(
+        const RemoteMessage(
+          messageId: 'fcm-msg-1',
+          data: {'type': 'friend_request', 'requestId': 'req-9'},
+        ),
+      );
+
+      final state = container.read(notificationControllerProvider);
+      expect(state.lastOpenedApp, isNotNull);
+      expect(state.lastOpenedApp!.messageId, 'fcm-msg-1');
+      expect(state.lastOpenedApp!.data, {
+        'type': 'friend_request',
+        'requestId': 'req-9',
+      });
+    });
+
+    test('synthesises an id when FCM did not supply messageId', () {
+      final controller =
+          container.read(notificationControllerProvider.notifier);
+
+      controller.handleOpenedApp(
+        const RemoteMessage(data: {'type': 'new_post'}),
+      );
+
+      final state = container.read(notificationControllerProvider);
+      expect(state.lastOpenedApp, isNotNull);
+      expect(
+        state.lastOpenedApp!.messageId,
+        startsWith('no-id-'),
+        reason: 'fallback id keeps the payload distinct from later taps',
+      );
+    });
+
+    test('coerces non-string data values to strings', () {
+      // FCM data payload is `Map<String, dynamic>` on the wire even though
+      // the contract is string-string. Real backends sometimes send
+      // numeric values — the wrapper must not throw a TypeError.
+      final controller =
+          container.read(notificationControllerProvider.notifier);
+
+      controller.handleOpenedApp(
+        const RemoteMessage(
+          messageId: 'm1',
+          data: {'type': 'reaction', 'postId': 12345},
+        ),
+      );
+
+      final state = container.read(notificationControllerProvider);
+      expect(state.lastOpenedApp!.data, {
+        'type': 'reaction',
+        'postId': '12345',
+      });
+    });
+
+    test('a second tap overwrites the previous payload', () {
+      final controller =
+          container.read(notificationControllerProvider.notifier);
+
+      controller.handleOpenedApp(
+        const RemoteMessage(messageId: 'm1', data: {'type': 'new_post'}),
+      );
+      controller.handleOpenedApp(
+        const RemoteMessage(
+          messageId: 'm2',
+          data: {'type': 'reaction', 'postId': 'p1'},
+        ),
+      );
+
+      final state = container.read(notificationControllerProvider);
+      expect(state.lastOpenedApp!.messageId, 'm2');
+      expect(state.lastOpenedApp!.data['type'], 'reaction');
+    });
+  });
+
+  group('consumeOpenedAppMessage', () {
+    test('clears lastOpenedApp after a tap has been routed', () {
+      final controller =
+          container.read(notificationControllerProvider.notifier);
+
+      controller.handleOpenedApp(
+        const RemoteMessage(messageId: 'm1', data: {'type': 'new_post'}),
+      );
+      expect(
+        container.read(notificationControllerProvider).lastOpenedApp,
+        isNotNull,
+      );
+
+      controller.consumeOpenedAppMessage();
+
+      expect(
+        container.read(notificationControllerProvider).lastOpenedApp,
+        isNull,
+      );
+    });
+
+    test('is a no-op when nothing is pending', () {
+      final controller =
+          container.read(notificationControllerProvider.notifier);
+
+      controller.consumeOpenedAppMessage();
+      controller.consumeOpenedAppMessage();
+
+      expect(
+        container.read(notificationControllerProvider).lastOpenedApp,
+        isNull,
+      );
     });
   });
 }


### PR DESCRIPTION
## Mô tả

T4 cho module Notification: implement deep link routing khi user tap notification (cold-start hoặc background). `NotificationController` capture tap vào `state.lastOpenedApp`; `app_router` consume qua `ref.listen`, map `data.type` sang route bằng pure function `routeForNotification`. HomeScreen handle query `openFriendSheet` để auto-open FriendSheet sau khi navigate.

## Refs

- Closes #105
- Spec: `docs/specs/2026-05-23-notification.md`
- Plan: `docs/plans/2026-05-23-notification.md` (Task T4)
- Phụ thuộc T2+T3 PR #266 (đã merge develop)

## Thay đổi chính

- `lib/features/notification/application/notification_state.dart`: thêm `OpenedAppPayload` freezed + field `lastOpenedApp` vào `NotificationState`.
- `lib/features/notification/application/notification_controller.dart`: `handleOpenedApp()` push payload vào state, `consumeOpenedAppMessage()` clear sau khi router route. Bỏ `initialMessageProvider` của T2 — gọn theo approach state-based (cold-start + background đi chung kênh).
- `lib/core/router/app_router.dart`: pure function `routeForNotification(data) → route`. `ref.listen` `lastOpenedApp` với `fireImmediately:true` cover race init/router build; `router.go` + messageId dedupe đảm bảo idempotent.
- `lib/features/feed/presentation/home_screen.dart`: param `openFriendSheet` + `_pendingOpenFriendSheet` — post-frame `showModalBottomSheet(FriendSheet)`.
- `test/features/notification/application/notification_controller_test.dart`: +8 test (`handleOpenedApp` 4 case + `consumeOpenedAppMessage` 2 case).
- `test/core/router/app_router_test.dart`: +8 test cho `routeForNotification` (friend_request, friend_accepted, reaction + empty/URL-encode case, new_post, unknown/missing).

## Loại thay đổi

- [x] feat — Tính năng mới

## Test

- [x] Đã chạy `flutter test` PASS — **706/706 tests pass**
- [x] Đã chạy `flutter analyze --fatal-infos` clean — **0 issues**
- [x] Đã chạy `dart format --set-exit-if-changed .` PASS — **0 changed**
- [ ] (Nếu sửa Functions) — không sửa
- [ ] (Nếu sửa Firestore rules) — không sửa
- [ ] **Manual device test** — em chưa có Android device. Anh @manhthien2005 hoặc tester verify khi T5/T6/T7 (Cloud Functions) sẵn sàng gửi push thật.

### Cách test thủ công

1. Build app debug, cài Android device, login bằng 2 acc A và B.
2. Trigger `friend_request` (B add A) → A nhận notification → tap → app open → FriendSheet bottom sheet hiện trên Home.
3. Trigger `reaction` (B react post của A) → A nhận notification → tap → Home + scroll tới post + ring highlight.
4. Trigger `new_post` (B post mới) → A nhận notification → tap → Home (top feed).
5. (Cold-start) Force-kill app, gửi push → tap notification trong tray → app launch → navigate đúng route.
6. Double-tap cùng 1 notification → chỉ 1 route, không duplicate stack.
7. Post bị xoá: kill recipient app, send reaction, xoá post, restart app, tap notification → Home + toast "Khoảnh khắc này không còn tồn tại".

## Lưu ý cho reviewer

**1. Wording toast post xoá — spec nói "Bài viết không còn tồn tại", em giữ "Khoảnh khắc này không còn tồn tại"** (HomeScreen có sẵn từ Widget Android, không phải code em viết). Đổi sang "Bài viết" cần touch `home_screen.dart:121` — quyết định ở leader. Em giữ nguyên vì cross-task + "Khoảnh khắc" hợp tone Locket-style.

**2. Bỏ `initialMessageProvider` của T2.** T2 description (PR #266) ghi "expose `initialMessageProvider` + `_handleOpenedApp` callback (no-op TODO). T4 sẽ consume." Em refactor sang state-based: cold-start (`getInitialMessage`) + background (`onMessageOpenedApp`) đều push vào `state.lastOpenedApp` cùng kênh. Gọn hơn, single source of truth. Grep confirmed không file nào ngoài controller reference `initialMessageProvider`. Anh đã OK approach này.

**3. `handleOpenedApp` public (không phải `_handleOpenedApp`).** Để unit test drive trực tiếp với `RemoteMessage` instance, không cần mock `FirebaseMessaging` static singleton. Vẫn gọi từ `initFcm` cold-start path + `onMessageOpenedApp.listen` subscription.

**4. messageId dedupe.** `previous?.messageId == next.messageId → return` — tránh re-route khi state re-emit cùng payload (vd hot restart restore state). FCM guarantee `messageId` unique per delivery; fallback `no-id-<hashCode>` nếu null (đảm bảo cùng `RemoteMessage` instance giữ id ổn định trong 1 tap).

**5. `fireImmediately:true` trên `ref.listen`.** Cover race khi `initFcm()` (kicked off bởi main.dart auth listener) hoàn thành TRƯỚC khi router provider build. Khi listener attach trên state đã có `lastOpenedApp`, fire sync với `previous=null` → cold-start tap được route.

**6. `routeForNotification` là pure function.** Tách khỏi GoRouter, không cần Firebase mock. Caller (router) chọn navigation primitive — T4 dùng `router.go` (replace) thay vì `push` để idempotent.

## Self-review checklist

- [x] Branch name đúng format — `feature/KhoaLND/notification-deep-link`
- [x] Commit message Conventional Commits + tiếng Việt — `feat(notification): T4 deep link routing từ notification tap`
- [x] Không có file lớn vô tình
- [x] Không có `console.log` / `print` debug
- [x] Không có `// TODO` chưa link issue
- [x] Không comment-out dead code
- [x] Self-review qua diff một lần trước khi mở PR