### PR TITLE
fix: grid view detail + UI fixes profile/friend + counter clamp

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -22,16 +22,19 @@ import 'package:meep/dev/widget_catalog_page.dart';
 import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
 import 'package:meep/features/diary/presentation/diary_create_screen.dart';
 import 'package:meep/features/diary/presentation/diary_list_screen.dart';
+import 'package:meep/core/theme/hex_color.dart';
 import 'package:meep/features/feed/data/post.dart';
 import 'package:meep/features/feed/presentation/capture_preview_args.dart';
 import 'package:meep/features/feed/presentation/capture_preview_screen.dart';
 import 'package:meep/features/feed/presentation/grid_view_screen.dart';
 import 'package:meep/features/feed/presentation/home_screen.dart';
+import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/features/home/presentation/home_page.dart';
 import 'package:meep/features/profile/presentation/edit_profile_screen.dart';
 import 'package:meep/features/profile/presentation/friend_profile_screen.dart';
 import 'package:meep/features/profile/presentation/profile_screen.dart';
 import 'package:meep/shared/widgets/photo_detail_screen.dart';
+import 'package:meep/shared/widgets/share_modal.dart';
 import 'package:meep/features/space/presentation/space_create_sheet.dart';
 import 'package:meep/features/streak/presentation/streak_screen.dart';
 
@@ -333,6 +336,30 @@ GoRouter appRouter(Ref ref) {
           );
         },
       ),
+      // Grid view (HomeScreen Taskbar) → tap photo → mở PhotoDetailScreen với
+      // viền màu Space khi post thuộc Space. Khác `/profile/photo/:postId` ở
+      // chỗ: compute borderColor từ spaceByIdProvider — Profile route giữ
+      // nguyên không border (Profile feed mixed, không có Space context).
+      GoRoute(
+        path: '/grid/photo/:postId',
+        builder: (_, state) {
+          final extra = state.extra;
+          if (extra is Map<String, dynamic>) {
+            final posts = extra['posts'];
+            final index = (extra['index'] as int?) ?? 0;
+            return _GridPhotoDetailRoute(
+              postId: state.pathParameters['postId'] ?? '',
+              posts: posts is List<Post> ? posts : const [],
+              initialIndex: index,
+            );
+          }
+          return _GridPhotoDetailRoute(
+            postId: state.pathParameters['postId'] ?? '',
+            posts: const [],
+            initialIndex: (extra as int?) ?? 0,
+          );
+        },
+      ),
       GoRoute(
         path: '/friend-profile/:uid',
         builder: (_, state) =>
@@ -399,4 +426,51 @@ GoRouter appRouter(Ref ref) {
     notifier.dispose();
   });
   return router;
+}
+
+/// Route widget cho `/grid/photo/:postId`. Compute border color per-post từ
+/// Space đầu tiên (pattern `_postBorderColor` feed_section). Share button mở
+/// [ShareModal] với `isAuthor` tính từ `currentUidProvider`, match behavior
+/// cũ của `_PostDetailSheet` trong [GridViewScreen].
+class _GridPhotoDetailRoute extends ConsumerWidget {
+  const _GridPhotoDetailRoute({
+    required this.postId,
+    required this.posts,
+    required this.initialIndex,
+  });
+
+  final String postId;
+  final List<Post> posts;
+  final int initialIndex;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (posts.isEmpty) {
+      return PhotoDetailScreen(postId: postId, initialIndex: initialIndex);
+    }
+    final currentUid = ref.watch(currentUidProvider).valueOrNull;
+
+    return PhotoDetailScreen(
+      postId: postId,
+      posts: posts,
+      initialIndex: initialIndex,
+      borderColorFor: (post, itemRef) {
+        if (post.spaceIds.isEmpty) return null;
+        final space =
+            itemRef.watch(spaceByIdProvider(post.spaceIds.first)).valueOrNull;
+        if (space == null) return null;
+        return hexToColor(space.colorHex);
+      },
+      onShareTap: (post) {
+        showModalBottomSheet<void>(
+          context: context,
+          backgroundColor: Colors.transparent,
+          builder: (_) => ShareModal(
+            post: post,
+            isAuthor: post.authorId == currentUid,
+          ),
+        );
+      },
+    );
+  }
 }

--- a/apps/mobile/lib/core/theme/app_text_styles.dart
+++ b/apps/mobile/lib/core/theme/app_text_styles.dart
@@ -38,6 +38,12 @@ abstract final class AppTextStyles {
   );
 
   // text-base — 18px
+  static const baseSemiBold = TextStyle(
+    fontFamily: _family,
+    fontSize: 18,
+    fontWeight: FontWeight.w600,
+    height: 24 / 18,
+  );
   static const baseBold = TextStyle(
     fontFamily: _family,
     fontSize: 18,
@@ -66,6 +72,12 @@ abstract final class AppTextStyles {
   );
 
   // text-lg — 20px
+  static const lgSemiBold = TextStyle(
+    fontFamily: _family,
+    fontSize: 20,
+    fontWeight: FontWeight.w600,
+    height: 28 / 20,
+  );
   static const lgBold = TextStyle(
     fontFamily: _family,
     fontSize: 20,

--- a/apps/mobile/lib/features/feed/presentation/grid_view_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/grid_view_screen.dart
@@ -1,6 +1,6 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_proportions.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
@@ -9,10 +9,8 @@ import 'package:meep/features/feed/application/feed_controller.dart';
 import 'package:meep/features/feed/application/feed_filter_controller.dart';
 import 'package:meep/features/feed/data/post.dart';
 import 'package:meep/features/feed/presentation/feed_filter_dropdown.dart';
-import 'package:meep/features/feed/presentation/feed_section.dart';
 import 'package:meep/features/feed/presentation/grid_photo_tile.dart';
 import 'package:meep/features/space/application/space_controller.dart';
-import 'package:meep/shared/widgets/share_modal.dart';
 
 /// Grid view 3-cột tất cả ảnh đã post của filter hiện tại. Mở từ nút
 /// grid trên Taskbar feed (HomeScreen embedded). Filter (Mọi người / Bạn /
@@ -114,17 +112,22 @@ class _Grid extends StatelessWidget {
       itemCount: posts.length,
       itemBuilder: (_, i) => GridPhotoTile(
         post: posts[i],
-        onTap: () => _showDetail(context, posts[i]),
+        onTap: () => _openDetail(context, i),
       ),
     );
   }
 
-  void _showDetail(BuildContext context, Post post) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (_) => _PostDetailSheet(post: post),
+  // Push sang PhotoDetailScreen full-screen (shared widget). Route
+  // `/grid/photo/:postId` wire borderColor từ Space + onShareTap mở
+  // ShareModal — xem `_GridPhotoDetailRoute` trong app_router.dart.
+  void _openDetail(BuildContext context, int index) {
+    final post = posts[index];
+    context.push(
+      '/grid/photo/${post.postId}',
+      extra: <String, Object>{
+        'posts': posts,
+        'index': index,
+      },
     );
   }
 }
@@ -217,81 +220,6 @@ class _GridTopBar extends ConsumerWidget {
           // Symmetric spacer — same width as back icon (24) + room for tap area.
           const SizedBox(width: 36),
         ],
-      ),
-    );
-  }
-}
-
-class _PostDetailSheet extends StatelessWidget {
-  const _PostDetailSheet({required this.post});
-
-  final Post post;
-
-  @override
-  Widget build(BuildContext context) {
-    final currentUid = FirebaseAuth.instance.currentUser?.uid;
-    return DraggableScrollableSheet(
-      initialChildSize: 0.9,
-      minChildSize: 0.5,
-      maxChildSize: 0.95,
-      builder: (_, ctrl) => Container(
-        decoration: const BoxDecoration(
-          color: AppColors.bw900,
-          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-        ),
-        child: SingleChildScrollView(
-          controller: ctrl,
-          child: Column(
-            children: [
-              const SizedBox(height: 12),
-              Container(
-                width: 36,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: AppColors.bw600,
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-              const SizedBox(height: 16),
-              post.authorId == currentUid
-                  ? OwnPostCard(post: post)
-                  : FriendPostCard(post: post),
-              const SizedBox(height: 20),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: ElevatedButton(
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                    showModalBottomSheet<void>(
-                      context: context,
-                      backgroundColor: Colors.transparent,
-                      builder: (_) => ShareModal(
-                        post: post,
-                        isAuthor: post.authorId == currentUid,
-                      ),
-                    );
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColors.bw800,
-                    minimumSize: const Size.fromHeight(48),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
-                    ),
-                  ),
-                  child: const Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(Icons.ios_share, color: AppColors.bw100, size: 18),
-                      SizedBox(width: 8),
-                      Text('Chia sẻ', style: TextStyle(color: AppColors.bw100)),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: 32),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
+++ b/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
@@ -313,12 +313,14 @@ class _FriendSheetState extends ConsumerState<FriendSheet> {
       );
     }
 
-    // Collapsed search bar
+    // Collapsed search bar — horizontal padding nhỏ để Row center tự nhiên
+    // chứa icon + text "Thêm một người bạn mới" (~210dp) không overflow trên
+    // Android 360dp. MainAxisAlignment.center đã tự căn giữa.
     return GestureDetector(
       onTap: _expandSearch,
       child: Container(
         height: 54,
-        padding: const EdgeInsets.symmetric(horizontal: 70),
+        padding: const EdgeInsets.symmetric(horizontal: 16),
         decoration: BoxDecoration(
           color: AppColors.bw700,
           borderRadius: BorderRadius.circular(15),
@@ -336,10 +338,14 @@ class _FriendSheetState extends ConsumerState<FriendSheet> {
               ),
             ),
             const SizedBox(width: 8),
-            Text(
-              'Thêm một người bạn mới',
-              style: AppTextStyles.baseBold.copyWith(
-                color: AppColors.bw200,
+            Flexible(
+              child: Text(
+                'Thêm một người bạn mới',
+                style: AppTextStyles.baseBold.copyWith(
+                  color: AppColors.bw200,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
             ),
           ],

--- a/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
@@ -157,20 +157,18 @@ class _FriendProfileBody extends ConsumerWidget {
                       const SizedBox(width: 25),
                       // Friend profile chỉ hiện Khoảnh khắc + Bạn bè per spec —
                       // Space ẩn (không gọi từ profile.spaceCount).
-                      _StatsRow(
-                        postCount: profile.postCount,
-                        friendCount: profile.friendCount,
+                      Expanded(
+                        child: _StatsRow(
+                          postCount: profile.postCount,
+                          friendCount: profile.friendCount,
+                        ),
                       ),
                     ],
                   ),
                   const SizedBox(height: 10),
                   Text(
                     profile.username,
-                    style: const TextStyle(
-                      fontFamily: 'Nunito',
-                      fontSize: 20,
-                      fontWeight: FontWeight.w600,
-                      height: 28 / 20,
+                    style: AppTextStyles.lgSemiBold.copyWith(
                       color: AppColors.bw100,
                     ),
                   ),
@@ -366,11 +364,10 @@ class _StatsRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
-      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
       children: [
-        _StatItem(count: postCount, label: 'Khoảnh khắc'),
-        const SizedBox(width: 30),
-        _StatItem(count: friendCount, label: 'Bạn bè'),
+        Flexible(child: _StatItem(count: postCount, label: 'Khoảnh khắc')),
+        Flexible(child: _StatItem(count: friendCount, label: 'Bạn bè')),
       ],
     );
   }
@@ -382,26 +379,26 @@ class _StatItem extends StatelessWidget {
   final int count;
   final String label;
 
+  // Counter trên Firestore có thể drift âm — xem note tại
+  // profile_screen.dart `_StatItem._safeCount`.
+  int get _safeCount => count < 0 ? 0 : count;
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
-          '$count',
-          style: const TextStyle(
-            fontFamily: 'Nunito',
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-            height: 24 / 18,
-            color: AppColors.bw100,
-          ),
+          '$_safeCount',
+          style: AppTextStyles.baseSemiBold.copyWith(color: AppColors.bw100),
           textAlign: TextAlign.center,
         ),
         Text(
           label,
           style: AppTextStyles.smMedium.copyWith(color: AppColors.bw100),
           textAlign: TextAlign.center,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
       ],
     );

--- a/apps/mobile/lib/features/profile/presentation/profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/profile_screen.dart
@@ -18,8 +18,6 @@ import 'package:meep/shared/widgets/share_profile_sheet.dart';
 // #363636 → actionButtonFill
 // #DDDDDD → actionButtonText
 // #D9D9D9 → avatarRingIdle
-// AppTextStyles.lgSemiBold  — 20px w600 h:28/20  (username)
-// AppTextStyles.baseSemiBold — 18px w600 h:24/18 (stats number)
 const _cBg = Color(0xFF050F10); // Black & White/900
 const _cButtonFill = Color(0xFF363636);
 const _cButtonText = Color(0xFFDDDDDD);
@@ -93,25 +91,22 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                             avatarUrl: profile.avatarUrl,
                           ),
                           const SizedBox(width: 25),
-                          _StatsRow(
-                            postCount: profile.postCount,
-                            friendCount: profile.friendCount,
-                            spaceCount: profile.spaceCount,
-                            onFriendTap: () {
-                              // TODO(P/T3/HanDHG): open FriendSheet
-                            },
+                          Expanded(
+                            child: _StatsRow(
+                              postCount: profile.postCount,
+                              friendCount: profile.friendCount,
+                              spaceCount: profile.spaceCount,
+                              onFriendTap: () {
+                                // TODO(P/T3/HanDHG): open FriendSheet
+                              },
+                            ),
                           ),
                         ],
                       ),
                       const SizedBox(height: 10),
                       Text(
                         profile.username,
-                        style: const TextStyle(
-                          fontFamily: 'Nunito',
-                          fontSize: 20,
-                          // TODO: AppTextStyles.lgSemiBold
-                          fontWeight: FontWeight.w600,
-                          height: 28 / 20,
+                        style: AppTextStyles.lgSemiBold.copyWith(
                           color: AppColors.bw100,
                         ),
                       ),
@@ -321,16 +316,16 @@ class _StatsRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
-      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
       children: [
-        _StatItem(count: postCount, label: 'Khoảnh khắc'),
-        const SizedBox(width: 30),
-        GestureDetector(
-          onTap: onFriendTap,
-          child: _StatItem(count: friendCount, label: 'Bạn bè'),
+        Flexible(child: _StatItem(count: postCount, label: 'Khoảnh khắc')),
+        Flexible(
+          child: GestureDetector(
+            onTap: onFriendTap,
+            child: _StatItem(count: friendCount, label: 'Bạn bè'),
+          ),
         ),
-        const SizedBox(width: 30),
-        _StatItem(count: spaceCount, label: 'Space'),
+        Flexible(child: _StatItem(count: spaceCount, label: 'Space')),
       ],
     );
   }
@@ -342,27 +337,27 @@ class _StatItem extends StatelessWidget {
   final int count;
   final String label;
 
+  // Counter trên Firestore có thể drift âm do CF race / miss (Task 4 — Path C
+  // fix root cause ở PR riêng). Clamp tại display layer để user không thấy
+  // "-1 Khoảnh khắc". Khi BE fix xong + backfill, clamp này thành no-op.
+  int get _safeCount => count < 0 ? 0 : count;
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
-          '$count',
-          style: const TextStyle(
-            fontFamily: 'Nunito',
-            fontSize: 18,
-            // TODO: AppTextStyles.baseSemiBold
-            fontWeight: FontWeight.w600,
-            height: 24 / 18,
-            color: AppColors.bw100,
-          ),
+          '$_safeCount',
+          style: AppTextStyles.baseSemiBold.copyWith(color: AppColors.bw100),
           textAlign: TextAlign.center,
         ),
         Text(
           label,
           style: AppTextStyles.smMedium.copyWith(color: AppColors.bw100),
           textAlign: TextAlign.center,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
       ],
     );

--- a/apps/mobile/lib/shared/widgets/photo_detail_screen.dart
+++ b/apps/mobile/lib/shared/widgets/photo_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
@@ -26,6 +27,7 @@ class PhotoDetailScreen extends StatefulWidget {
     this.captionPillColor = const Color(0x80000000),
     this.timeColor = AppColors.bw100,
     this.onShareTap,
+    this.borderColorFor,
   });
 
   final String postId;
@@ -46,6 +48,12 @@ class PhotoDetailScreen extends StatefulWidget {
   /// Share button tap handler. Default: open [SharePhotoSheet] với
   /// `isAuthor: true`. Pass override để customize behavior per caller.
   final ValueChanged<Post>? onShareTap;
+
+  /// Per-post border color resolver. Gọi với post hiện tại + ref để caller
+  /// có thể watch provider (vd `spaceByIdProvider` cho Space post). Return
+  /// `null` = no border cho post đó. `null` callback = no border bao giờ.
+  /// Pattern match [AppPhotoFrame] cho consistency với feed home.
+  final Color? Function(Post post, WidgetRef ref)? borderColorFor;
 
   @override
   State<PhotoDetailScreen> createState() => _PhotoDetailScreenState();
@@ -146,6 +154,7 @@ class _PhotoDetailScreenState extends State<PhotoDetailScreen> {
                   controller: _pageController,
                   currentIndex: _currentIndex,
                   onPageChanged: _onPageChanged,
+                  borderColorFor: widget.borderColorFor,
                 ),
                 if ((currentPost.caption ?? '').isNotEmpty)
                   Positioned(
@@ -304,12 +313,18 @@ class _PhotoCarousel extends StatelessWidget {
     required this.controller,
     required this.currentIndex,
     required this.onPageChanged,
+    this.borderColorFor,
   });
 
   final List<Post> posts;
   final PageController controller;
   final int currentIndex;
   final ValueChanged<int> onPageChanged;
+  final Color? Function(Post post, WidgetRef ref)? borderColorFor;
+
+  // Match [AppPhotoFrame] feed pattern — 3px border quanh ảnh active.
+  static const double _borderWidth = 3.0;
+  static const double _cornerRadius = 50.0;
 
   @override
   Widget build(BuildContext context) {
@@ -323,6 +338,16 @@ class _PhotoCarousel extends StatelessWidget {
           final isActive = index == currentIndex;
           final size = isActive ? 350.0 : 260.0;
           final opacity = isActive ? 1.0 : 0.15;
+          final post = posts[index];
+          final image = ClipRRect(
+            borderRadius: BorderRadius.circular(_cornerRadius),
+            child: CachedNetworkImage(
+              imageUrl: post.coverImageUrl,
+              fit: BoxFit.cover,
+              errorWidget: (_, __, ___) => Container(color: AppColors.bw700),
+              placeholder: (_, __) => Container(color: AppColors.bw800),
+            ),
+          );
           return AnimatedContainer(
             duration: const Duration(milliseconds: 200),
             margin: EdgeInsets.symmetric(
@@ -334,16 +359,32 @@ class _PhotoCarousel extends StatelessWidget {
             child: AnimatedOpacity(
               duration: const Duration(milliseconds: 200),
               opacity: opacity,
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(50),
-                child: CachedNetworkImage(
-                  imageUrl: posts[index].coverImageUrl,
-                  fit: BoxFit.cover,
-                  errorWidget: (_, __, ___) =>
-                      Container(color: AppColors.bw700),
-                  placeholder: (_, __) => Container(color: AppColors.bw800),
-                ),
-              ),
+              // Border chỉ render cho ảnh active — ảnh inactive opacity 0.15
+              // + size 260, thêm border sẽ noise. Match feed pattern. Mỗi
+              // item wrap Consumer riêng để callback ref.watch reactive theo
+              // post (vd swipe sang Space khác → border đổi màu).
+              child: (isActive && borderColorFor != null)
+                  ? Consumer(
+                      builder: (_, ref, __) {
+                        final color = borderColorFor!(post, ref);
+                        if (color == null) return image;
+                        return Container(
+                          decoration: BoxDecoration(
+                            // Outer radius = inner + borderWidth để bo trùng
+                            // (match [AppPhotoFrame]).
+                            borderRadius: BorderRadius.circular(
+                              _cornerRadius + _borderWidth,
+                            ),
+                            border: Border.all(
+                              color: color,
+                              width: _borderWidth,
+                            ),
+                          ),
+                          child: image,
+                        );
+                      },
+                    )
+                  : image,
             ),
           );
         },

--- a/apps/mobile/test/features/profile/presentation/profile_screen_test.dart
+++ b/apps/mobile/test/features/profile/presentation/profile_screen_test.dart
@@ -155,4 +155,22 @@ void main() {
     // username 'alice' single-word → first char 'A'
     expect(find.text('A'), findsOneWidget);
   });
+
+  testWidgets('counter âm (Firestore drift) → clamp về 0 trên UI',
+      (tester) async {
+    // Task 4A: postCount âm do CF race / miss. Display layer clamp về 0 để
+    // user không thấy "-1 Khoảnh khắc". Root cause fix ở Path C (PR riêng).
+    final driftProfile = aliceProfile.copyWith(
+      postCount: -2,
+      friendCount: -1,
+      spaceCount: 5,
+    );
+    await tester.pumpWidget(makeApp(profile: driftProfile));
+    await tester.pumpAndSettle();
+
+    expect(find.text('-2'), findsNothing);
+    expect(find.text('-1'), findsNothing);
+    expect(find.text('0'), findsNWidgets(2)); // postCount + friendCount
+    expect(find.text('5'), findsOneWidget); // spaceCount giữ nguyên
+  });
 }

--- a/apps/mobile/test/shared/widgets/photo_detail_screen_test.dart
+++ b/apps/mobile/test/shared/widgets/photo_detail_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meep/features/feed/data/post.dart';
 import 'package:meep/shared/widgets/photo_detail_screen.dart';
@@ -20,7 +21,7 @@ void main() {
     );
   }
 
-  Widget host(Widget child) => MaterialApp(home: child);
+  Widget host(Widget child) => ProviderScope(child: MaterialApp(home: child));
 
   testWidgets('empty posts → navigate back gracefully', (tester) async {
     final navigatorKey = GlobalKey<NavigatorState>();
@@ -91,6 +92,61 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.text('Feeling toasty!'), findsOneWidget);
+  });
+
+  testWidgets('borderColorFor non-null → render border quanh ảnh active',
+      (tester) async {
+    await tester.pumpWidget(
+      host(
+        PhotoDetailScreen(
+          postId: 'p1',
+          posts: [post(id: 'p1')],
+          borderColorFor: (_, __) => const Color(0xFFFF00FF),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Tìm Container có Border.all màu magenta — chỉ vẽ khi borderColorFor
+    // trả non-null cho post active.
+    final containers = tester.widgetList<Container>(find.byType(Container));
+    final hasBorder = containers.any((c) {
+      final dec = c.decoration;
+      if (dec is! BoxDecoration) return false;
+      final border = dec.border;
+      if (border is! Border) return false;
+      return border.top.color == const Color(0xFFFF00FF);
+    });
+    expect(
+      hasBorder,
+      isTrue,
+      reason: 'Border màu magenta phải render quanh ảnh active',
+    );
+  });
+
+  testWidgets('borderColorFor return null → không render border',
+      (tester) async {
+    await tester.pumpWidget(
+      host(
+        PhotoDetailScreen(
+          postId: 'p1',
+          posts: [post(id: 'p1')],
+          borderColorFor: (_, __) => null,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final containers = tester.widgetList<Container>(find.byType(Container));
+    final anyHasBorder = containers.any((c) {
+      final dec = c.decoration;
+      return dec is BoxDecoration && dec.border != null;
+    });
+    expect(
+      anyHasBorder,
+      isFalse,
+      reason: 'Callback null → không có Container border nào trong tree',
+    );
   });
 
   testWidgets('initialIndex selects đúng post', (tester) async {


### PR DESCRIPTION
## Tóm tắt

Fix 4 vấn đề UI mobile gộp trong 1 PR (4 commits tách rời cho dễ review):

1. **Grid view detail** — tap ảnh trong Grid view giờ mở `PhotoDetailScreen` (shared widget) full-screen thay vì bottom sheet riêng `_PostDetailSheet`. Post thuộc Space hiện viền màu Space (3px) quanh ảnh active — match feed home pattern.
2. **Overflow "Thêm một người bạn mới"** — collapsed search bar trong FriendSheet bị overflow do `horizontal: 70` padding quá lớn. Giảm xuống 16 + bọc Flexible.
3. **Profile font hardcode + StatsRow overflow** — swap hardcode `TextStyle(fontSize: 20/18, w600)` sang `AppTextStyles.lgSemiBold` / `baseSemiBold` (token mới). Fix `_StatsRow` overflow horizontal trên Android 360dp (avatar 100 + spacing 25 + 3 item cố định chiếm > width khả dụng). Apply cùng cho `FriendProfileScreen` (cùng module).
4. **Counter clamp `max(0)`** — Firestore counter trên `/users/{uid}` đang drift (postCount âm, friendCount lệch +1). Clamp UI tạm để user không thấy số âm. **Path A only — Path C (BE root cause) tách PR riêng cho leader**.

## Commits

| Commit | Scope |
|---|---|
| `chore(theme)`: thêm baseSemiBold + lgSemiBold tokens | core/theme |
| `fix(profile)`: swap hardcode font + fix StatsRow overflow + clamp counter | features/profile |
| `fix(friend)`: overflow nút "Thêm một người bạn mới" trong FriendSheet | features/friend |
| `feat(grid)`: reuse PhotoDetailScreen + viền màu Space khi tap ảnh | shared + features/feed + core/router |

## Files thay đổi (9)

- `core/theme/app_text_styles.dart` — +2 token
- `core/router/app_router.dart` — add route `/grid/photo/:postId` + `_GridPhotoDetailRoute` (ConsumerWidget)
- `features/profile/presentation/profile_screen.dart`
- `features/profile/presentation/friend_profile_screen.dart`
- `features/friend/presentation/friend_sheet.dart`
- `features/feed/presentation/grid_view_screen.dart` — bỏ `_PostDetailSheet`, push route
- `shared/widgets/photo_detail_screen.dart` — `borderColorFor: Color? Function(Post, WidgetRef)?` callback per-post, reactive qua Consumer wrap
- Tests: `photo_detail_screen_test.dart` (+2 borderColorFor cases), `profile_screen_test.dart` (+1 counter clamp case)

## Test plan

- [x] `dart format --set-exit-if-changed lib/ test/` — clean
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `flutter test` — **695/695 pass**
- [x] Manual smoke test trên emulator (anh xác nhận đã verify)
  - [x] Grid → tap ảnh → mở PhotoDetailScreen, swipe OK, share OK
  - [x] Post Space → border màu Space đúng quanh ảnh active
  - [x] FriendSheet → "Thêm một người bạn mới" không overflow trên 360dp
  - [x] Profile → 3 stat items không overflow, font 20px w600 đúng, counter âm clamp về 0

## Cross-module touches (đã flag)

- `core/theme/app_text_styles.dart` — leader đã OK ở conversation
- `core/router/app_router.dart` — **add route mới**, không sửa route hiện tại (low blast radius)
- `features/profile/presentation/friend_profile_screen.dart` — cùng module profile, cùng bug font hardcode + counter drift, fix cùng lúc để consistent

## Out of scope (cần PR riêng)

**Path C — BE counter drift fix** (Task 4 root cause):
- `postCount` đang âm (vd `-1`) cho user có post bị xóa
- `friendCount` lệch +1 (user có 3 bạn đếm 4)
- Hypothesis: `onPostCreated` early-return khi `event.data?.data() == null` → no increment, nhưng `onPostDeleted` vẫn decrement. Hoặc `acceptFriendRequest` double-fire idempotency.
- Action: leader (ThienPDM) audit `firebase/functions/src/feed/onPostCreated.ts` + `friend/acceptFriendRequest.ts` + `friend/onFriendshipDeleted.ts`, add `Math.max(0, ...)` safety + viết recompute script backfill counter. Branch riêng `fix/ThienPDM/profile-counter-drift`.

