### PR TITLE
feat(notification): T5+6+7 — 3 Cloud Functions push notification

### DIFF
--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -1,6 +1,5 @@
 import { setGlobalOptions } from 'firebase-functions/v2';
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
-import { onDocumentCreated } from 'firebase-functions/v2/firestore';
 import { initializeApp } from 'firebase-admin/app';
 import { z } from 'zod';
 
@@ -17,6 +16,7 @@ initializeApp();
 setGlobalOptions({
   region: 'asia-southeast1',
   maxInstances: 10,
+  timeoutSeconds: 60,
 });
 
 // ===== Schemas =====
@@ -75,25 +75,11 @@ export { onFriendshipDeleted } from './friend/onFriendshipDeleted.js';
 
 // onPostCreated + onPostDeleted implemented in ./feed/ — exported above
 
-// ===== Notification module stubs =====
+// ===== Notification module =====
 
-/** TODO(N/impl): send FCM to receiver + persist /notifications doc */
-export const onFriendRequestCreated = onDocumentCreated(
-  { document: 'friend_requests/{requestId}', region: 'asia-southeast1' },
-  (_event) => { /* TODO(N/impl) */ },
-);
-
-/** TODO(N/impl): send FCM to original sender + persist /notifications doc */
-export const onFriendRequestAccepted = onDocumentCreated(
-  { document: 'friendships/{pairId}', region: 'asia-southeast1' },
-  (_event) => { /* TODO(N/impl) */ },
-);
-
-/** TODO(N/impl): send FCM to post owner + persist /notifications doc */
-export const onReactionCreated = onDocumentCreated(
-  { document: 'posts/{postId}/reactions/{reactionId}', region: 'asia-southeast1' },
-  (_event) => { /* TODO(N/impl) */ },
-);
+export { onFriendRequestCreated } from './notification/onFriendRequestCreated.js';
+export { onFriendRequestAccepted } from './notification/onFriendRequestAccepted.js';
+export { onReactionCreated } from './notification/onReactionCreated.js';
 
 // ===== Space module =====
 

--- a/firebase/functions/src/notification/_fcm.ts
+++ b/firebase/functions/src/notification/_fcm.ts
@@ -1,0 +1,95 @@
+import { logger } from 'firebase-functions/v2';
+
+export interface FcmPayload {
+  title: string;
+  body: string;
+  /// FCM data payload — keys MUST mirror what the Flutter deep-link router
+  /// reads (`type`, `requestId`, `postId`...). Values are stringified by FCM.
+  data: Record<string, string>;
+  /// Android notification channel — must exist client-side. Channels declared
+  /// in Flutter NotificationController.initFCM().
+  channelId: string;
+}
+
+/**
+ * Send one FCM notification to every token under `/users/{uid}/fcmTokens`,
+ * then prune tokens that FCM flags as permanently invalid.
+ *
+ * Skips gracefully (no throw) when:
+ *  - the recipient has no `fcmTokens` docs (logged out, never logged in)
+ *  - every token doc is missing/empty the `token` field
+ *
+ * The 1-token/user policy is enforced client-side
+ * ([apps/mobile/lib/features/notification/data/firebase_notification_repository.dart](../../../../apps/mobile/lib/features/notification/data/firebase_notification_repository.dart)),
+ * but this helper still iterates the collection in case of a transient
+ * multi-device race — the multicast is safe either way.
+ *
+ * Errors thrown by FCM (network, quota) are caught and logged. We do NOT
+ * rethrow because the notification doc has already been written; letting the
+ * trigger retry would duplicate the doc on the next invocation.
+ */
+export async function sendFcmToUser(
+  db: FirebaseFirestore.Firestore,
+  uid: string,
+  payload: FcmPayload,
+): Promise<void> {
+  const tokenSnap = await db.collection(`users/${uid}/fcmTokens`).get();
+  if (tokenSnap.empty) return;
+
+  const tokens: string[] = [];
+  const tokenRefs: FirebaseFirestore.DocumentReference[] = [];
+  for (const doc of tokenSnap.docs) {
+    const raw: unknown = doc.data().token;
+    if (typeof raw === 'string' && raw !== '') {
+      tokens.push(raw);
+      tokenRefs.push(doc.ref);
+    }
+  }
+  if (tokens.length === 0) return;
+
+  // Lazy-import to keep cold-start light (firebase/functions/CLAUDE.md).
+  const { getMessaging } = await import('firebase-admin/messaging');
+
+  try {
+    const response = await getMessaging().sendEachForMulticast({
+      tokens,
+      notification: { title: payload.title, body: payload.body },
+      data: payload.data,
+      android: { notification: { channelId: payload.channelId } },
+    });
+
+    const invalidRefs: FirebaseFirestore.DocumentReference[] = [];
+    response.responses.forEach((r, i) => {
+      if (r.success) return;
+      if (isPermanentTokenError(r.error?.code)) {
+        const ref = tokenRefs[i];
+        if (ref) invalidRefs.push(ref);
+      }
+    });
+
+    if (invalidRefs.length > 0) {
+      const batch = db.batch();
+      invalidRefs.forEach((ref) => batch.delete(ref));
+      await batch.commit();
+    }
+  } catch (e) {
+    logger.error('FCM multicast failed', { uid, error: e });
+  }
+}
+
+/**
+ * FCM error codes that mean the token is permanently dead — the device
+ * either uninstalled the app, disabled notifications, or rotated tokens.
+ * Retrying these will never succeed; the only correct action is to delete
+ * the token doc so the next push attempt skips it.
+ *
+ * Transient codes (quota, internal, unavailable) are NOT in this list — we
+ * keep those tokens and let the next event try again.
+ */
+export function isPermanentTokenError(code: string | undefined): boolean {
+  return (
+    code === 'messaging/registration-token-not-registered' ||
+    code === 'messaging/invalid-registration-token' ||
+    code === 'messaging/invalid-argument'
+  );
+}

--- a/firebase/functions/src/notification/_helpers.ts
+++ b/firebase/functions/src/notification/_helpers.ts
@@ -1,0 +1,26 @@
+/**
+ * Cross-CF helpers for the notification module. Kept separate from `_fcm.ts`
+ * so FCM concerns stay isolated from generic Firestore/user-doc utilities.
+ */
+
+/**
+ * Pull `displayName` out of a /users/{uid} doc payload defensively — the
+ * user might not have set one yet, in which case we fall back to a generic
+ * label rather than rendering "undefined muốn kết bạn".
+ */
+export function readDisplayName(userData: unknown): string {
+  if (userData == null || typeof userData !== 'object') return 'Một người dùng';
+  const name = (userData as { displayName?: unknown }).displayName;
+  if (typeof name === 'string' && name.length > 0) return name;
+  return 'Một người dùng';
+}
+
+/**
+ * Firestore admin SDK throws gRPC errors with `code: 6` (ALREADY_EXISTS)
+ * when `.create()` hits an existing doc. We use this to make triggers
+ * idempotent against the documented "triggers may fire twice" risk
+ * (firebase/functions/CLAUDE.md).
+ */
+export function isAlreadyExists(e: unknown): boolean {
+  return typeof e === 'object' && e !== null && (e as { code?: unknown }).code === 6;
+}

--- a/firebase/functions/src/notification/onFriendRequestAccepted.ts
+++ b/firebase/functions/src/notification/onFriendRequestAccepted.ts
@@ -1,0 +1,107 @@
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { onDocumentUpdated } from 'firebase-functions/v2/firestore';
+import { logger } from 'firebase-functions/v2';
+import { sendFcmToUser } from './_fcm.js';
+import { isAlreadyExists, readDisplayName } from './_helpers.js';
+
+interface FriendRequestSnapshot {
+  senderId?: unknown;
+  receiverId?: unknown;
+  status?: unknown;
+}
+
+/**
+ * Notify the original sender once the receiver accepts the request.
+ *
+ * Triggers on every update to /friend_requests/{requestId}, then guards on
+ * the status transition pending→accepted so we don't fire on declined,
+ * cancelled, or no-op writes (createdAt touch, etc.).
+ *
+ * Receiver displayName comes from /users/{receiverId} because
+ * friend_requests does not denormalize the name (see firestore.rules:181).
+ *
+ * Same idempotent doc-id strategy as onFriendRequestCreated — keyed on
+ * requestId, .create() collides cleanly if the trigger double-fires.
+ */
+export const onFriendRequestAccepted = onDocumentUpdated(
+  { document: 'friend_requests/{requestId}', region: 'asia-southeast1' },
+  async (event) => {
+    const before = event.data?.before.data() as FriendRequestSnapshot | undefined;
+    const after = event.data?.after.data() as FriendRequestSnapshot | undefined;
+    if (!before || !after) return;
+
+    if (!isAcceptedTransition(before.status, after.status)) return;
+
+    const senderId = typeof after.senderId === 'string' ? after.senderId : '';
+    const receiverId = typeof after.receiverId === 'string' ? after.receiverId : '';
+    if (!senderId || !receiverId) {
+      logger.warn('onFriendRequestAccepted: missing sender/receiver', {
+        requestId: event.params.requestId,
+      });
+      return;
+    }
+
+    const { requestId } = event.params;
+    const db = getFirestore();
+
+    const receiverSnap = await db.doc(`users/${receiverId}`).get();
+    const receiverName = readDisplayName(receiverSnap.data());
+
+    const title = `${receiverName} đã chấp nhận lời mời kết bạn`;
+    const body = 'Các bạn giờ là bạn bè trên Meep!';
+    const data: Record<string, string> = {
+      type: 'friend_accepted',
+      friendUid: receiverId,
+    };
+
+    const notifRef = db.doc(
+      `users/${senderId}/notifications/friend_accepted_${requestId}`,
+    );
+    try {
+      await notifRef.create({
+        type: 'friendAccepted',
+        title,
+        body,
+        data,
+        read: false,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+    } catch (e) {
+      if (isAlreadyExists(e)) {
+        logger.info('onFriendRequestAccepted: notification already exists, skip', {
+          requestId,
+          senderId,
+        });
+        return;
+      }
+      throw e;
+    }
+
+    await sendFcmToUser(db, senderId, {
+      title,
+      body,
+      data,
+      channelId: 'friend',
+    });
+  },
+);
+
+/**
+ * Only fire when `status` flips from non-accepted to accepted. Catches:
+ *  - pending → accepted (the real case)
+ *  - declined → accepted (shouldn't happen, but safe if it does)
+ *
+ * Rejects:
+ *  - already-accepted → accepted (no-op update, e.g. updatedAt touch)
+ *  - pending → declined
+ *  - any non-string status (treat as no-op)
+ *
+ * Exported for unit tests.
+ */
+export function isAcceptedTransition(
+  beforeStatus: unknown,
+  afterStatus: unknown,
+): boolean {
+  if (typeof afterStatus !== 'string' || afterStatus !== 'accepted') return false;
+  return beforeStatus !== 'accepted';
+}

--- a/firebase/functions/src/notification/onFriendRequestCreated.ts
+++ b/firebase/functions/src/notification/onFriendRequestCreated.ts
@@ -1,0 +1,111 @@
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+import { logger } from 'firebase-functions/v2';
+import { sendFcmToUser } from './_fcm.js';
+import { isAlreadyExists, readDisplayName } from './_helpers.js';
+
+interface FriendRequestData {
+  senderId: string;
+  receiverId: string;
+  status: string;
+}
+
+/**
+ * Notify receiver when a new friend request is created.
+ *
+ * Flow:
+ *  1. Read senderId/receiverId from the request doc.
+ *  2. Read sender displayName from /users/{senderId} — friend_requests does
+ *     not denormalize the name (firestore.rules:181 only requires the four
+ *     id/status/timestamp fields).
+ *  3. Idempotent write of /users/{receiverId}/notifications/friend_request_{requestId}
+ *     via `.create()` — re-invocation of the trigger collides on the doc id
+ *     and we exit cleanly without re-sending FCM.
+ *  4. Multicast FCM via the shared helper; stale tokens get pruned in there.
+ *
+ * Receiver with zero fcm tokens → FCM step is a no-op (logout state). The
+ * notification doc still lands so the in-app list shows it on next open.
+ */
+export const onFriendRequestCreated = onDocumentCreated(
+  { document: 'friend_requests/{requestId}', region: 'asia-southeast1' },
+  async (event) => {
+    const raw = event.data?.data();
+    if (!raw) return;
+
+    const data = raw as Partial<FriendRequestData>;
+    const senderId = typeof data.senderId === 'string' ? data.senderId : '';
+    const receiverId = typeof data.receiverId === 'string' ? data.receiverId : '';
+    if (!senderId || !receiverId) {
+      logger.warn('onFriendRequestCreated: missing sender/receiver', {
+        requestId: event.params.requestId,
+      });
+      return;
+    }
+
+    const { requestId } = event.params;
+    const db = getFirestore();
+
+    const senderSnap = await db.doc(`users/${senderId}`).get();
+    const senderName = readDisplayName(senderSnap.data());
+
+    const payload = buildFriendRequestPayload(senderName, requestId, senderId);
+
+    const notifRef = db.doc(
+      `users/${receiverId}/notifications/friend_request_${requestId}`,
+    );
+    try {
+      await notifRef.create({
+        type: 'friendRequest',
+        title: payload.title,
+        body: payload.body,
+        data: payload.data,
+        read: false,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+    } catch (e) {
+      if (isAlreadyExists(e)) {
+        logger.info('onFriendRequestCreated: notification already exists, skip', {
+          requestId,
+          receiverId,
+        });
+        return;
+      }
+      throw e;
+    }
+
+    await sendFcmToUser(db, receiverId, {
+      title: payload.title,
+      body: payload.body,
+      data: payload.data,
+      channelId: 'friend',
+    });
+  },
+);
+
+interface FriendRequestPayload {
+  title: string;
+  body: string;
+  data: Record<string, string>;
+}
+
+/**
+ * Pure builder — exported only for unit tests. Body copy is fixed and
+ * title interpolates the sender's displayName. The FCM `data` payload
+ * uses snake_case `type` so the Flutter deep-link router (T4) can route
+ * without a translation layer.
+ */
+export function buildFriendRequestPayload(
+  senderName: string,
+  requestId: string,
+  senderId: string,
+): FriendRequestPayload {
+  return {
+    title: `${senderName} muốn kết bạn với bạn`,
+    body: 'Tap để xem và chấp nhận',
+    data: {
+      type: 'friend_request',
+      requestId,
+      senderId,
+    },
+  };
+}

--- a/firebase/functions/src/notification/onReactionCreated.ts
+++ b/firebase/functions/src/notification/onReactionCreated.ts
@@ -1,0 +1,126 @@
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+import { logger } from 'firebase-functions/v2';
+import { sendFcmToUser } from './_fcm.js';
+import { isAlreadyExists, readDisplayName } from './_helpers.js';
+
+interface ReactionData {
+  reactorName?: unknown;
+  emoji?: unknown;
+}
+
+interface PostData {
+  authorId?: unknown;
+}
+
+/**
+ * Notify the post author when someone reacts to their photo.
+ *
+ * Triggers on /posts/{postId}/reactions/{reactorUid} create. We never notify
+ * the author of their own reaction — short-circuit when reactorId equals the
+ * post's authorId.
+ *
+ * `reactorUid` comes from the path param, not the doc body — firestore.rules:154
+ * guarantees `request.auth.uid == reactorUid == doc.id`, so the path param
+ * is the canonical id.
+ *
+ * Reaction docs denormalize `reactorName` (firestore.rules:158 whitelists
+ * it as updatable), but we fall back to /users/{reactorUid}.displayName when
+ * absent — older docs written before denormalization may not have it.
+ *
+ * Idempotent doc id: `reaction_{postId}_{reactorUid}`. Twice-fired triggers
+ * collide on `.create()` and exit without re-pushing.
+ */
+export const onReactionCreated = onDocumentCreated(
+  {
+    document: 'posts/{postId}/reactions/{reactorUid}',
+    region: 'asia-southeast1',
+  },
+  async (event) => {
+    const raw = event.data?.data() as ReactionData | undefined;
+    if (!raw) return;
+
+    const { postId, reactorUid: reactorId } = event.params;
+    const emoji = typeof raw.emoji === 'string' ? raw.emoji : '';
+    if (!emoji) {
+      logger.warn('onReactionCreated: missing emoji', { postId, reactorId });
+      return;
+    }
+
+    const db = getFirestore();
+    const postSnap = await db.doc(`posts/${postId}`).get();
+    if (!postSnap.exists) {
+      // Post was deleted between reaction write and trigger fire — onPostDeleted
+      // will sweep the reactions subcollection. Nothing to notify.
+      return;
+    }
+    const post = postSnap.data() as PostData | undefined;
+    const authorId = typeof post?.authorId === 'string' ? post.authorId : '';
+    if (!authorId) {
+      logger.warn('onReactionCreated: post has no authorId', { postId });
+      return;
+    }
+
+    if (isSelfReaction(reactorId, authorId)) return;
+
+    // Denormalized name preferred; fall back to a fresh /users read.
+    let reactorName =
+      typeof raw.reactorName === 'string' && raw.reactorName.length > 0
+        ? raw.reactorName
+        : '';
+    if (!reactorName) {
+      const reactorSnap = await db.doc(`users/${reactorId}`).get();
+      reactorName = readDisplayName(reactorSnap.data());
+    }
+
+    const title = `${reactorName} đã react vào ảnh của bạn`;
+    const body = emoji;
+    const data: Record<string, string> = {
+      type: 'reaction',
+      postId,
+      reactorId,
+    };
+
+    const notifRef = db.doc(
+      `users/${authorId}/notifications/reaction_${postId}_${reactorId}`,
+    );
+    try {
+      await notifRef.create({
+        type: 'reaction',
+        title,
+        body,
+        data,
+        read: false,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+    } catch (e) {
+      if (isAlreadyExists(e)) {
+        logger.info('onReactionCreated: notification already exists, skip', {
+          postId,
+          reactorId,
+        });
+        return;
+      }
+      throw e;
+    }
+
+    await sendFcmToUser(db, authorId, {
+      title,
+      body,
+      data,
+      channelId: 'reaction',
+    });
+  },
+);
+
+/**
+ * The author shouldn't get pinged when they react to their own post. This
+ * is the only guard on the trigger — other reaction-permission checks live
+ * in firestore.rules:152 (only authenticated user matching reactorUid can
+ * create the doc) and don't need to be re-validated here.
+ *
+ * Exported for unit tests.
+ */
+export function isSelfReaction(reactorId: string, authorId: string): boolean {
+  return reactorId === authorId;
+}

--- a/firebase/functions/test/notification/_fcm.test.ts
+++ b/firebase/functions/test/notification/_fcm.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isPermanentTokenError } from '../../src/notification/_fcm.js';
+
+describe('isPermanentTokenError', () => {
+  it('flags unregistered tokens for deletion', () => {
+    expect(isPermanentTokenError('messaging/registration-token-not-registered')).toBe(true);
+  });
+
+  it('flags invalid registration tokens for deletion', () => {
+    expect(isPermanentTokenError('messaging/invalid-registration-token')).toBe(true);
+  });
+
+  it('flags invalid-argument for deletion (issue spec)', () => {
+    expect(isPermanentTokenError('messaging/invalid-argument')).toBe(true);
+  });
+
+  it('keeps token on transient quota error (NOT permanent)', () => {
+    // Quota errors retry the next event; deleting the token would lose it.
+    expect(isPermanentTokenError('messaging/quota-exceeded')).toBe(false);
+  });
+
+  it('keeps token on internal server error (NOT permanent)', () => {
+    expect(isPermanentTokenError('messaging/internal-error')).toBe(false);
+  });
+
+  it('keeps token on undefined error code (treat as transient)', () => {
+    expect(isPermanentTokenError(undefined)).toBe(false);
+  });
+
+  it('keeps token on unknown error code (conservative default)', () => {
+    expect(isPermanentTokenError('messaging/some-new-code')).toBe(false);
+  });
+});

--- a/firebase/functions/test/notification/onFriendRequestAccepted.test.ts
+++ b/firebase/functions/test/notification/onFriendRequestAccepted.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { isAcceptedTransition } from '../../src/notification/onFriendRequestAccepted.js';
+
+describe('isAcceptedTransition', () => {
+  it('fires on pending → accepted (the canonical case)', () => {
+    expect(isAcceptedTransition('pending', 'accepted')).toBe(true);
+  });
+
+  it('skips no-op update (accepted → accepted)', () => {
+    // Without this guard, every updatedAt touch on an already-accepted
+    // request would re-push the notification.
+    expect(isAcceptedTransition('accepted', 'accepted')).toBe(false);
+  });
+
+  it('skips pending → declined', () => {
+    expect(isAcceptedTransition('pending', 'declined')).toBe(false);
+  });
+
+  it('skips pending → pending (no status change)', () => {
+    expect(isAcceptedTransition('pending', 'pending')).toBe(false);
+  });
+
+  it('also fires on declined → accepted (defensive, real flow unlikely)', () => {
+    // Rule firestore.rules:188-194 only allows pending → accepted/declined,
+    // so this should never happen in prod — but if it does we still want
+    // the sender to know they're now friends.
+    expect(isAcceptedTransition('declined', 'accepted')).toBe(true);
+  });
+
+  it('skips when afterStatus is missing', () => {
+    expect(isAcceptedTransition('pending', undefined)).toBe(false);
+  });
+
+  it('skips when afterStatus is not a string', () => {
+    expect(isAcceptedTransition('pending', 123)).toBe(false);
+  });
+
+  it('treats missing beforeStatus as non-accepted (fires)', () => {
+    // Defensive: if `before` is malformed but `after` is accepted, still notify.
+    expect(isAcceptedTransition(undefined, 'accepted')).toBe(true);
+  });
+});

--- a/firebase/functions/test/notification/onFriendRequestCreated.test.ts
+++ b/firebase/functions/test/notification/onFriendRequestCreated.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { buildFriendRequestPayload } from '../../src/notification/onFriendRequestCreated.js';
+import { isAlreadyExists, readDisplayName } from '../../src/notification/_helpers.js';
+
+describe('buildFriendRequestPayload', () => {
+  it('interpolates sender name into title with Vietnamese copy', () => {
+    const payload = buildFriendRequestPayload('Khoa', 'req-1', 'sender-uid');
+    expect(payload.title).toBe('Khoa muốn kết bạn với bạn');
+    expect(payload.body).toBe('Tap để xem và chấp nhận');
+  });
+
+  it('FCM data uses snake_case type so deep-link router can route directly', () => {
+    const payload = buildFriendRequestPayload('Khoa', 'req-abc', 'uid-1');
+    expect(payload.data).toEqual({
+      type: 'friend_request',
+      requestId: 'req-abc',
+      senderId: 'uid-1',
+    });
+  });
+
+  it('data values are all strings (FCM requirement)', () => {
+    const payload = buildFriendRequestPayload('Khoa', 'r', 's');
+    for (const v of Object.values(payload.data)) {
+      expect(typeof v).toBe('string');
+    }
+  });
+});
+
+describe('readDisplayName', () => {
+  it('returns displayName when present', () => {
+    expect(readDisplayName({ displayName: 'Thien' })).toBe('Thien');
+  });
+
+  it('falls back when user data is null', () => {
+    expect(readDisplayName(null)).toBe('Một người dùng');
+  });
+
+  it('falls back when user data is undefined', () => {
+    expect(readDisplayName(undefined)).toBe('Một người dùng');
+  });
+
+  it('falls back when displayName is empty string', () => {
+    expect(readDisplayName({ displayName: '' })).toBe('Một người dùng');
+  });
+
+  it('falls back when displayName is not a string', () => {
+    expect(readDisplayName({ displayName: 123 })).toBe('Một người dùng');
+  });
+
+  it('falls back when displayName field is missing', () => {
+    expect(readDisplayName({ uid: 'x' })).toBe('Một người dùng');
+  });
+});
+
+describe('isAlreadyExists', () => {
+  it('detects gRPC ALREADY_EXISTS (code 6)', () => {
+    expect(isAlreadyExists({ code: 6, message: 'doc exists' })).toBe(true);
+  });
+
+  it('rejects other gRPC codes', () => {
+    expect(isAlreadyExists({ code: 5 })).toBe(false); // NOT_FOUND
+    expect(isAlreadyExists({ code: 7 })).toBe(false); // PERMISSION_DENIED
+  });
+
+  it('rejects non-object errors', () => {
+    expect(isAlreadyExists('error string')).toBe(false);
+    expect(isAlreadyExists(null)).toBe(false);
+    expect(isAlreadyExists(undefined)).toBe(false);
+  });
+
+  it('rejects objects without code field', () => {
+    expect(isAlreadyExists({ message: 'oops' })).toBe(false);
+  });
+});

--- a/firebase/functions/test/notification/onReactionCreated.test.ts
+++ b/firebase/functions/test/notification/onReactionCreated.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { isSelfReaction } from '../../src/notification/onReactionCreated.js';
+
+describe('isSelfReaction', () => {
+  it('returns true when reactor is the post author', () => {
+    expect(isSelfReaction('uid-1', 'uid-1')).toBe(true);
+  });
+
+  it('returns false when reactor is someone else', () => {
+    expect(isSelfReaction('reactor-uid', 'author-uid')).toBe(false);
+  });
+
+  it('treats empty strings as equal (both empty → skip)', () => {
+    // Defensive: if upstream gave us blank ids we shouldn't notify anyway.
+    expect(isSelfReaction('', '')).toBe(true);
+  });
+
+  it('uses strict equality (no whitespace tolerance)', () => {
+    // FCM/Firestore uids are opaque exact strings — never normalize.
+    expect(isSelfReaction('uid ', 'uid')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Mô tả

Implement 3 Firestore triggers cho push notification flow (T5+6+7 trong plan notification):
gửi FCM + persist notification doc khi friend request được tạo, được accept, và khi
có reaction mới trên post. Idempotent qua deterministic doc id để chịu được trigger
double-fire (per firebase/functions/CLAUDE.md).

## Refs

- Closes #106
- Spec: `docs/specs/2026-05-23-notification.md`
- Plan: `docs/plans/2026-05-23-notification.md` (T5, T6, T7)

## Thay đổi chính

- `firebase/functions/src/notification/_fcm.ts`: helper `sendFcmToUser` — đọc tất cả token
  từ `/users/{uid}/fcmTokens/*`, multicast 1 lần qua `sendEachForMulticast`, prune token
  chết khi FCM trả về 3 mã lỗi vĩnh viễn (`registration-token-not-registered`,
  `invalid-registration-token`, `invalid-argument`). Lazy-import `firebase-admin/messaging`
  để cold start nhẹ.
- `firebase/functions/src/notification/_helpers.ts`: 2 helper chung — `readDisplayName`
  (fallback "Một người dùng" khi user chưa set displayName) + `isAlreadyExists` (detect
  gRPC code 6 từ `.create()` để skip idempotent).
- `firebase/functions/src/notification/onFriendRequestCreated.ts`: onCreate
  `/friend_requests/{requestId}`. Đọc senderName từ `/users/{senderId}` (vì
  friend_requests không denormalize). Idempotent doc id `friend_request_{requestId}`.
- `firebase/functions/src/notification/onFriendRequestAccepted.ts`: **onUpdate**
  `/friend_requests/{requestId}` với transition guard
  `before.status !== 'accepted' && after.status === 'accepted'`. **Fix bug stub cũ**:
  stub wire sai sang `onCreate /friendships/{pairId}` — friendship doc tạo cùng lúc
  accept nhưng plan chỉ định fire khi `friend_requests.status → accepted`.
- `firebase/functions/src/notification/onReactionCreated.ts`: onCreate
  `/posts/{postId}/reactions/{reactorUid}`. Guard self-react (reactor == post.authorId).
  Dùng `event.params.reactorUid` trực tiếp — firestore.rules:154 guarantee
  `doc.id == auth.uid`.
- `firebase/functions/src/index.ts`: export 3 CF thay 3 stub; thêm `timeoutSeconds: 60`
  vào `setGlobalOptions` per firebase/functions/CLAUDE.md.
- `firebase/functions/test/notification/*.test.ts` × 4: 32 unit test cho pure helper
  (payload shape, transition guard, self-react, FCM error classification, displayName
  fallback, gRPC code detection).

## Loại thay đổi

- [x] feat — Tính năng mới
- [ ] fix — Sửa bug
- [ ] chore — Maintenance, deps, config
- [ ] refactor — Refactor không thêm feature/fix bug
- [ ] docs — Tài liệu
- [ ] test — Thêm/sửa test
- [ ] style — Format/lint, không ảnh hưởng logic
- [ ] perf — Cải thiện performance

## Test

- [x] Đã chạy `flutter test` PASS — _N/A, PR chỉ chạm Functions_
- [x] Đã chạy `flutter analyze` clean (0 warning) — _N/A_
- [x] Đã chạy `dart format --set-exit-if-changed .` PASS — _N/A_
- [x] (Functions) `npm test` PASS — **111 pass / 14 file** (32 mới)
- [x] (Functions) `npm run lint` clean
- [x] (Functions) `npm run typecheck` clean
- [x] (Firestore rules) Rules tests PASS — _N/A, PR không touch rules. Rules test cho
  notification + fcmTokens nằm ở task T8 riêng (chưa được giao)._
- [x] **Đã test thủ công trên Android** — _CHƯA, cần 2 device thật. Em đề nghị reviewer
  hoặc QA verify khi merge_

### Cách test thủ công (cho reviewer)

Cần 2 thiết bị Android đã login 2 account khác nhau (A và B), cả 2 đã saveFcmToken
sang `/users/{uid}/fcmTokens/*` (qua T2 NotificationController.initFCM).

**Test 1 — onFriendRequestCreated:**
1. Device A: gửi friend request tới B.
2. Device B: nhận push "{senderNameA} muốn kết bạn với bạn" trong vài giây.
3. Mở app B → in-app list có notification mới với type `friendRequest`.

**Test 2 — onFriendRequestAccepted:**
1. Device B: accept friend request.
2. Device A: nhận push "{senderNameB} đã chấp nhận lời mời kết bạn".
3. Verify `friend_requests/{requestId}.status` chỉ có 1 transition pending→accepted
   (không double-trigger).

**Test 3 — onReactionCreated:**
1. Device A: tạo post mới (qua flow đã có).
2. Device B: react ❤️ vào post của A.
3. Device A: nhận push "{reactorNameB} đã react vào ảnh của bạn" body "❤️".
4. Device B: react vào chính post của B (nếu B có post) → KHÔNG nhận push (self-react guard).

**Test 4 — token cleanup:**
1. Uninstall app trên device B (token chết).
2. Device A: gửi friend request → CF không retry, token doc bị xóa khỏi
   `/users/{uidB}/fcmTokens/*`. Verify trên Firestore console.

## Screenshot / video

_N/A — PR backend-only, không có UI thay đổi._

## Lưu ý cho reviewer

**1. Idempotency strategy.** 3 CF dùng deterministic doc id:
- `friend_request_{requestId}` cho onFriendRequestCreated
- `friend_accepted_{requestId}` cho onFriendRequestAccepted
- `reaction_{postId}_{reactorUid}` cho onReactionCreated

Trigger double-fire → `notifRef.create()` throw ALREADY_EXISTS (code 6) → catch + return
sớm, không re-push FCM. Trade-off: trigger 2 lần với cùng requestId chỉ 1 notification —
acceptable cho UX, an toàn cho idempotency.

**2. Fix stub cũ.** Stub `onFriendRequestAccepted` trong index.ts cũ wire sai sang
`onDocumentCreated('friendships/{pairId}')`. Plan yêu cầu `onDocumentUpdated('friend_requests/{requestId}')`
+ transition guard. Em đã sửa.

**3. ⚠️ Schema fcmTokens KHÔNG khớp với onPostCreated (đã merge).**
- `onPostCreated.ts` đọc token từ `/users/{uid}/private/fcm` (doc, field `token`).
- 3 CF của PR này đọc từ `/users/{uid}/fcmTokens/*` (subcollection) — match plan T1
  + [firebase_notification_repository.dart](apps/mobile/lib/features/notification/data/firebase_notification_repository.dart).

Trong manual test 2-device: nếu app đã saveFcmToken sang subcollection mới, push
`new_post` từ `onPostCreated` sẽ silent fail vì path khác. Out-of-scope #106 nhưng cần
biết khi test. **Đề xuất**: anh tạo issue follow-up để align `onPostCreated` cùng dùng
`/users/{uid}/fcmTokens/*` (đây là source of truth theo plan).

**4. timeoutSeconds=60 global.** Em thêm `timeoutSeconds: 60` vào `setGlobalOptions`
(default v2 cũng 60s, nhưng explicit per firebase/functions/CLAUDE.md). Ảnh hưởng mọi
CF hiện có — đã chạy `npm test`/`lint`/`typecheck` clean.

**5. Tests là unit pure-logic.** Em không setup emulator nên test pattern theo
`onPostCreated.test.ts`: chỉ test pure functions export (build payload, guards,
error classification). CF wrapper (Firestore I/O) chưa có integration test — bỏ ngỏ
giống các CF khác trong codebase. T8 sẽ cover rules + integration.

## Self-review checklist

- [x] Branch name đúng format `feature/KhoaLND/notification-cloud-functions`
- [x] Commit message tiếng Việt, theo Conventional Commits
- [x] Không có file lớn vô tình (.env, keystore, service account)
- [x] Không có console.log / print debug còn sót (chỉ logger.warn/info/error có cấu trúc)
- [x] Không có // TODO chưa link issue
- [x] Không có code comment-out dead code
- [x] Đã `/review` 6-axis trước khi mở PR (fix 3 🟡: timeoutSeconds explicit, tách
      `_helpers.ts`, simplify reactorUid)
- [x] Không leak infra files (`.claude/`, `CLAUDE.md`) — đã stash ra