### PR TITLE
fix(diary): keepAlive + cached reload + avatar fallback + polaroid + overflow (#126)

### DIFF
--- a/apps/mobile/lib/features/diary/application/diary_controller.dart
+++ b/apps/mobile/lib/features/diary/application/diary_controller.dart
@@ -53,7 +53,7 @@ ImagePickerService imagePickerService(ImagePickerServiceRef ref) =>
       'wire FlutterImagePickerService in main.dart',
     );
 
-@riverpod
+@Riverpod(keepAlive: true)
 class DiaryController extends _$DiaryController {
   StreamSubscription<List<DiaryEntry>>? _entriesSub;
 

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
@@ -763,27 +763,46 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
   }
 
   /// Preview ảnh inline đã pick (create/edit, trước save).
+  /// Layout match `PolaroidImageBlock` — ảnh nằm trong "Picture Window"
+  /// region (5.69% left, 4.53% top, 88.6% width, 73% height) của frame.
   List<Widget> _buildPickedInlinePreviews() {
-    return _inlineImageBytes.asMap().entries.map((e) {
+    // Tỉ lệ Picture Window trong frame Polaroid (Figma 769:5116).
+    const picLeft = 15.79 / 277.63;
+    const picTop = 15.36 / 339;
+    const picWidth = 246.02 / 277.63;
+    const picHeight = 247.4 / 339;
+    const aspect = 277.63 / 339;
+
+    return _inlineImageBytes.map((bytes) {
       return Column(
         children: [
           const SizedBox(height: 24),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(5.33),
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                Image.memory(
-                  e.value,
-                  fit: BoxFit.contain,
-                  width: double.infinity,
-                ),
-                // Polaroid frame overlay
-                Image.asset(
-                  'assets/frames/frame_polaroid.png',
-                  fit: BoxFit.contain,
-                ),
-              ],
+          AspectRatio(
+            aspectRatio: aspect,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final w = constraints.maxWidth;
+                final h = constraints.maxHeight;
+                return Stack(
+                  children: [
+                    // 1. Frame asset background (white border + textured lattice).
+                    Positioned.fill(
+                      child: Image.asset(
+                        'assets/frames/frame_polaroid.png',
+                        fit: BoxFit.fill,
+                      ),
+                    ),
+                    // 2. User image positioned vào Picture Window region.
+                    Positioned(
+                      left: w * picLeft,
+                      top: h * picTop,
+                      width: w * picWidth,
+                      height: h * picHeight,
+                      child: Image.memory(bytes, fit: BoxFit.cover),
+                    ),
+                  ],
+                );
+              },
             ),
           ),
         ],

--- a/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
@@ -60,12 +60,22 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
     // Riverpod pattern chuẩn: ref.listenManual fire ngay với current value +
     // mọi emit sau. Trigger loadEntries 1 lần / uid; sign out → sign in lại
     // với uid khác sẽ tự re-trigger.
+    //
+    // Controller keepAlive=true → state persist qua navigation. Skip reload
+    // nếu controller đã có entries (avoid re-fetch khi quay về list từ canvas).
     ref.listenManual<AsyncValue<String?>>(
       currentUidProvider,
       (_, next) {
         final uid = next.valueOrNull;
         if (uid == null || _loadedForUid == uid) return;
         _loadedForUid = uid;
+
+        final state = ref.read(diaryControllerProvider);
+        if (state.entries.isNotEmpty) {
+          // Controller keepAlive đã có data — skip reload, render ngay.
+          return;
+        }
+
         _loadingStartAt = DateTime.now();
         ref.read(diaryControllerProvider.notifier).loadEntries(uid);
       },
@@ -249,7 +259,8 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
             ),
           ),
 
-          // Avatar — load từ profile, tap → SettingsSheet
+          // Avatar — match chat module pattern: imageUrl + fallback initials.
+          // Tap → SettingsSheet.
           Semantics(
             button: true,
             label: 'Cài đặt',
@@ -266,6 +277,12 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
                     .valueOrNull
                     ?.avatarUrl,
                 size: 40,
+                fallbackText: avatarFallbackFromName(
+                  ref
+                      .watch(currentUserProfileProvider)
+                      .valueOrNull
+                      ?.displayName,
+                ),
               ),
             ),
           ),
@@ -406,7 +423,9 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
         crossAxisCount: 2,
         mainAxisSpacing: 32,
         crossAxisSpacing: 32,
-        childAspectRatio: 150.5 / 182,
+        // Buffer 4px height: tránh overflow 1-2px do font/scale rounding
+        // (text line-height float làm DiaryMoodCard cao hơn 182 logical px).
+        childAspectRatio: 150.5 / 186,
       ),
       itemCount: entries.length,
       itemBuilder: (context, index) {


### PR DESCRIPTION
## Mô tả

4 issues phát hiện qua test thực tế sau khi PR #279 merge — không gộp vào PR cũ kịp.

## Refs

- Refs #126
- Build trên develop sau PR #279 (#126 fix) + PR #280 (notification T4) + PR #281 (profile UI fixes)

## 4 Issues + Fixes

### 1. Critical: Loading chậm + sai "Không tải được" sau tạo + out app

**User reproduce path:**
1. Vào Diary tab → load entries OK
2. Tạo entry mới → save → pop về list (entry hiện qua stream)
3. Out app
4. Mở lại Diary tab → loading 5s → "Không tải được" + retry
5. Bấm retry → load OK

**Root cause:** `DiaryController` autoDispose. Khi navigate sang Canvas, listener bị cancel → controller dispose → state reset về `const DiaryState()`. Khi quay về list, `listenManual fireImmediately` fire lại + `_loadedForUid` không match (state widget mới) → fire `loadEntries` race với recreate sub → spinner timeout.

**Fix:**
- `@Riverpod(keepAlive: true)` cho `DiaryController` → state persist qua navigation.
- Listener skip `loadEntries` nếu `state.entries.isNotEmpty` (controller cache đã có).
- Match pattern với 3 providers diary khác (đều keepAlive).

### 2. Avatar topbar diary không như chat

**Bug:** AppAvatar không có `fallbackText` → khi `avatarUrl == null` hiện shape rỗng.

**Fix:** Match `InboxTopbar` pattern (`chat/presentation/inbox_screen.dart:127`):
```dart
AppAvatar(
  imageUrl: profile?.avatarUrl,
  size: 40,
  fallbackText: avatarFallbackFromName(profile?.displayName),
)
```

### 3. Bottom overflowed by 1px (Diary list grid)

**Bug:** `childAspectRatio: 150.5 / 182` quá chật. `DiaryMoodCard` render height = 120 (image) + 9 (gap) + ~28 (title) + ~18 (date) + text line-height float gây rounding > 182.

**Fix:** Buffer 4px → `150.5 / 186`. Layout chính xác theo Figma vẫn được giữ vì 4px nằm trong text line-height tolerance.

### 4. Ảnh chèn nằm NGOÀI polaroid frame (preview create/edit)

**Bug:** `_buildPickedInlinePreviews` dùng `ClipRRect + Stack` overlay `Image.memory(fit: contain)` full + `Image.asset frame` overlay → ảnh hiển thị toàn phần, frame chỉ là overlay decoration, không clip ảnh vào region.

`PolaroidImageBlock` thật (`presentation/widgets/polaroid_image_block.dart`) dùng `AspectRatio + LayoutBuilder + Positioned` đặt ảnh chính xác vào "Picture Window" region (5.69% left, 4.53% top, 88.6% width, 73% height).

**Fix:** Copy pattern PolaroidImageBlock cho preview, đổi `Image.network → Image.memory`. Save flow vẫn dùng `PolaroidImageBlock` (read mode) — không bị bug.

## Files

| File | Δ | Mô tả |
|---|---|---|
| `lib/features/diary/application/diary_controller.dart` | ±2 | `@riverpod` → `@Riverpod(keepAlive: true)` |
| `lib/features/diary/presentation/diary_list_screen.dart` | ±25 | Avatar fallbackText + skip-reload-if-cached + aspectRatio buffer |
| `lib/features/diary/presentation/diary_canvas_screen.dart` | ±31 | `_buildPickedInlinePreviews` Picture Window positioning |

## Test plan

- [x] `flutter test test/features/diary/` — 58/58 pass
- [x] `flutter test` full suite — 711/711 pass, không break
- [x] `flutter analyze` — 0 issues
- [x] `dart format --set-exit-if-changed` — clean

## Test sau merge (anh)

| Scenario | Expected |
|---|---|
| Mở Diary tab lần đầu | Load nhanh < 1s (indexes deployed) |
| Tạo entry → save → out app → mở lại Diary | **Render ngay** từ controller cache, không spinner |
| Navigate Canvas → back về list | List entries vẫn giữ (không re-fetch) |
| Avatar topbar | Ảnh hoặc initials (giống Inbox/Home) |
| Grid card | **Không còn overflow 1px** |
| Chèn ảnh trong canvas create | **Ảnh nằm GỌN trong frame polaroid** |
| Save xong xem read mode | Ảnh hiển thị đúng (đã correct từ trước) |