### PR TITLE
fix(diary): auth init spinner — tránh blank screen cold start (#126)

### DIFF
--- a/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
@@ -344,6 +344,19 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
 
   // ── Body: render theo controller state ──
   Widget _buildBody() {
+    // Auth init đang chạy — uid chưa ready. Show loading thay vì blank.
+    // Lần đầu cold start FirebaseAuth revalidateSession có thể mất 2-8s
+    // trên mobile network. Nếu không show spinner → user thấy màn trống.
+    //
+    // ⚠️ KHÔNG để ngoài _buildBody: ref.watch trong ConsumerState build()
+    // vẫn OK (Riverpod best practice là gọi watch trong build method).
+    final uid = ref.watch(currentUidProvider).valueOrNull;
+    if (uid == null) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppColors.turquoise500),
+      );
+    }
+
     final state = ref.watch(diaryControllerProvider);
 
     if (state.isLoading && state.entries.isEmpty) {


### PR DESCRIPTION
## Mô tả

Follow-up fix cho PR #283. Auth init race gây blank screen lúc cold start.

## Root cause

```
Lần đầu cold start:
  App mount → currentUidProvider = AsyncLoading (chưa emit uid)
  → listenManual fireImmediately fire → next.valueOrNull = null
  → guard skip (uid == null)
  → revalidateSession mất 2-8s trên mobile network
  → auth init hoàn thành → uid emit → listener fire → loadEntries
  → ⚠️ SUỐT 2-8s KHÔNG CÓ VISUAL FEEDBACK
  → User thấy màn trống, nghi app đơ

Lần sau (đã authed):
  App mount → currentUidProvider emit uid ngay (cache từ Firebase Auth SDK)
  → fireImmediately uid != null → fire loadEntries → stream emit → render < 1s ✅
```

## Fix

`_buildBody()` check `currentUidProvider.valueOrNull == null` **trước** các check khác → show `CircularProgressIndicator` ngay. Khi uid ready → listener fire → flow bình thường.

| Trước fix | Sau fix |
|---|---|
| Cold start: blank screen 4-8s → spinner → load | Cold start: spinner ngay → uid emit → load |
| Anh trick (tạo → out → mở lại) mới load được | Load bình thường ngay từ đầu |

## Files

| File | Δ |
|---|---|
| `lib/features/diary/presentation/diary_list_screen.dart` | +13 |

## Test

- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/features/diary/` — 58/58 pass

Refs #126

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>