### PR TITLE
feat(streak): sửa avatar→settings, today CTA turquoise, pill Meep

### DIFF
--- a/apps/mobile/lib/features/streak/presentation/streak_screen.dart
+++ b/apps/mobile/lib/features/streak/presentation/streak_screen.dart
@@ -8,6 +8,7 @@ import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/streak/application/streak_controller.dart';
+import 'package:meep/features/settings/presentation/settings_sheet.dart';
 import 'package:meep/features/streak/presentation/widgets/empty_state_overlay.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_calendar.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart';
@@ -90,6 +91,7 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
                         monthPosts: state.monthPosts,
                         today: nowLocal,
                         onTapDay: (index) => _openPhotoDetail(context, index),
+                        onTapToday: () => context.go('/home'),
                         onSwipePrev: () => ref
                             .read(streakControllerProvider.notifier)
                             .swipePrev(),
@@ -230,7 +232,7 @@ class _TopAvatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final url = avatarUrl;
-    return Container(
+    final avatar = Container(
       width: 40,
       height: 40,
       decoration: const BoxDecoration(
@@ -246,6 +248,19 @@ class _TopAvatar extends StatelessWidget {
               placeholder: (_, __) => Container(color: _bgColor),
             )
           : _initialsFallback(),
+    );
+    return Semantics(
+      button: true,
+      label: 'Cài đặt',
+      child: GestureDetector(
+        onTap: () => showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          backgroundColor: Colors.transparent,
+          builder: (_) => const SettingsSheet(),
+        ),
+        child: avatar,
+      ),
     );
   }
 

--- a/apps/mobile/lib/features/streak/presentation/widgets/calendar_day_cell.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/calendar_day_cell.dart
@@ -1,13 +1,19 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
+import 'package:meep/core/theme/app_colors.dart';
+
 /// Một ô trong [StreakCalendar]. Match Figma `269:1990` cell variants.
 ///
-/// 4 trạng thái (priority): empty (other month) → today+post → today → post → no-post.
+/// Priority render: empty (other month) → post thumbnail → today CTA
+/// (turquoise + dấu cộng nếu hôm nay chưa chụp) → today no-CTA highlight →
+/// dot (no post other day).
 /// - `imageUrl != null`: render thumbnail (CachedNetworkImage) cornerRadius 7
-/// - `imageUrl == null && isInMonth`: render dot 11×11 ở center
-/// - `!isInMonth`: render spacer (transparent)
-/// - `isToday`: overlay stroke 1px `#656565` (over thumbnail hoặc background light)
+/// - `isToday && imageUrl == null`: render khối turquoise + icon `add` —
+///   CTA "chụp hôm nay", tap → callback (parent điều hướng về camera).
+/// - `imageUrl == null && isInMonth && !isToday`: dot 11×11 ở center
+/// - `!isInMonth`: spacer (transparent)
+/// - Khi `isToday` có post: overlay stroke 1px `#656565` cho rõ ngày hiện tại.
 class CalendarDayCell extends StatelessWidget {
   const CalendarDayCell({
     super.key,
@@ -26,12 +32,14 @@ class CalendarDayCell extends StatelessWidget {
   /// URL ảnh thumbnail nếu day có post; null = no post.
   final String? imageUrl;
 
-  /// Tap handler. Null khi cell không tappable (empty / no-post).
+  /// Tap handler:
+  /// - Day có post → mở PhotoDetailScreen.
+  /// - Today no-post → điều hướng về `/home` (camera).
+  /// - Day khác no-post → null (cell không tappable).
   final VoidCallback? onTap;
 
   static const _dotColor = Color(0x6E585754);
   static const _todayStroke = Color(0xFF656565);
-  static const _todayFill = Color(0xFFC4C4C4);
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +48,7 @@ class CalendarDayCell extends StatelessWidget {
     }
 
     final hasPost = imageUrl != null && imageUrl!.isNotEmpty;
+    final showTodayCta = isToday && !hasPost;
     Widget content;
 
     if (hasPost) {
@@ -48,15 +57,20 @@ class CalendarDayCell extends StatelessWidget {
         child: CachedNetworkImage(
           imageUrl: imageUrl!,
           fit: BoxFit.cover,
-          placeholder: (_, __) => Container(color: _todayFill),
-          errorWidget: (_, __, ___) => Container(color: _todayFill),
+          placeholder: (_, __) =>
+              Container(color: AppColors.turquoise600.withValues(alpha: 0.2)),
+          errorWidget: (_, __, ___) =>
+              Container(color: AppColors.turquoise600.withValues(alpha: 0.2)),
         ),
       );
-    } else if (isToday) {
-      content = Container(
+    } else if (showTodayCta) {
+      content = DecoratedBox(
         decoration: BoxDecoration(
-          color: _todayFill,
+          color: AppColors.turquoise600,
           borderRadius: BorderRadius.circular(7),
+        ),
+        child: const Center(
+          child: Icon(Icons.add, size: 18, color: AppColors.bw100),
         ),
       );
     } else {
@@ -72,13 +86,17 @@ class CalendarDayCell extends StatelessWidget {
       );
     }
 
+    // Stroke chỉ vẽ khi today có post — để phân biệt ngày hôm nay trong dãy
+    // thumbnail. Today CTA đã có màu turquoise nổi bật, không cần stroke.
+    final showStroke = isToday && hasPost;
+
     final cell = SizedBox(
       width: 37,
       height: 35,
       child: Stack(
         children: [
           Positioned.fill(child: content),
-          if (isToday)
+          if (showStroke)
             Positioned.fill(
               child: DecoratedBox(
                 decoration: BoxDecoration(
@@ -92,9 +110,10 @@ class CalendarDayCell extends StatelessWidget {
     );
 
     if (onTap == null) return cell;
+    final label = showTodayCta ? 'Chụp khoảnh khắc hôm nay' : 'Xem ảnh ngày';
     return Semantics(
       button: true,
-      label: 'Xem ảnh ngày',
+      label: label,
       child: GestureDetector(onTap: onTap, child: cell),
     );
   }

--- a/apps/mobile/lib/features/streak/presentation/widgets/streak_calendar.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/streak_calendar.dart
@@ -20,6 +20,7 @@ class StreakCalendar extends StatelessWidget {
     required this.monthPosts,
     required this.today,
     this.onTapDay,
+    this.onTapToday,
     this.onSwipePrev,
     this.onSwipeNext,
   });
@@ -37,6 +38,11 @@ class StreakCalendar extends StatelessWidget {
   /// Tap handler khi user tap ô có post. Receives index trong [monthPosts]
   /// (sort theo createdAt ASC). Null = no-op.
   final ValueChanged<int>? onTapDay;
+
+  /// Tap handler cho ô today khi hôm nay chưa post (CTA turquoise + dấu cộng).
+  /// Caller thường điều hướng về `/home` để mở camera. Null = ô today CTA
+  /// không tappable.
+  final VoidCallback? onTapToday;
 
   final VoidCallback? onSwipePrev;
   final VoidCallback? onSwipeNext;
@@ -108,6 +114,7 @@ class StreakCalendar extends StatelessWidget {
                 return monthPosts[i].coverImageUrl;
               },
               onTapDay: onTapDay,
+              onTapToday: onTapToday,
             ),
           ],
         ),
@@ -158,6 +165,7 @@ class _Grid extends StatelessWidget {
     required this.dayToPostIndex,
     required this.postsForDay,
     required this.onTapDay,
+    required this.onTapToday,
   });
 
   final int leadingEmpty;
@@ -166,6 +174,7 @@ class _Grid extends StatelessWidget {
   final Map<int, int> dayToPostIndex;
   final String? Function(int day) postsForDay;
   final ValueChanged<int>? onTapDay;
+  final VoidCallback? onTapToday;
 
   @override
   Widget build(BuildContext context) {
@@ -179,13 +188,19 @@ class _Grid extends StatelessWidget {
         final isInMonth = dayNumber >= 1 && dayNumber <= daysInMonth;
         final url = isInMonth ? postsForDay(dayNumber) : null;
         final postIndex = isInMonth ? dayToPostIndex[dayNumber] : null;
+        final isTodayCell = isInMonth && todayDay == dayNumber;
+        // Priority: post → today CTA → no-op. Today cell có post vẫn mở
+        // PhotoDetailScreen (postIndex non-null), chỉ today no-post mới CTA.
+        final VoidCallback? tapHandler = postIndex != null
+            ? () => onTapDay?.call(postIndex)
+            : (isTodayCell ? onTapToday : null);
 
         row.add(
           CalendarDayCell(
             isInMonth: isInMonth,
-            isToday: isInMonth && todayDay == dayNumber,
+            isToday: isTodayCell,
             imageUrl: url,
-            onTap: postIndex != null ? () => onTapDay?.call(postIndex) : null,
+            onTap: tapHandler,
           ),
         );
         if (j < StreakCalendar._columns - 1) {

--- a/apps/mobile/lib/features/streak/presentation/widgets/streak_stats_pill.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/streak_stats_pill.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 
 /// Pill stats bottom của StreakScreen — match Figma `269:1992`.
 ///
-/// Layout: " N Khoảnh khắc | Xd chuỗi"
+/// Layout: " N Meep | Xd chuỗi"
 /// - Số (N / Xd): WHITE Nunito Bold 12
-/// - Chữ (Khoảnh khắc / chuỗi): WHITE 48% alpha Nunito Bold 12
+/// - Chữ (Meep / chuỗi): WHITE 48% alpha Nunito Bold 12
 /// - Separator "|": Inter SemiBold 10 WHITE 48% alpha
 /// - Container: bg `#5857546e`, cornerRadius 12, padding 8/11
 class StreakStatsPill extends StatelessWidget {
@@ -46,7 +46,7 @@ class StreakStatsPill extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
-      label: '$totalMoments khoảnh khắc, chuỗi $currentStreak ngày',
+      label: '$totalMoments Meep, chuỗi $currentStreak ngày',
       child: Container(
         decoration: BoxDecoration(
           color: _bgFill,
@@ -58,7 +58,7 @@ class StreakStatsPill extends StatelessWidget {
             style: _numberStyle,
             children: [
               TextSpan(text: ' $totalMoments'),
-              const TextSpan(text: ' Khoảnh khắc ', style: _labelStyle),
+              const TextSpan(text: ' Meep ', style: _labelStyle),
               const TextSpan(text: '|', style: _sepStyle),
               TextSpan(text: ' ${currentStreak}d'),
               const TextSpan(text: ' chuỗi ', style: _labelStyle),

--- a/apps/mobile/test/features/streak/presentation/widgets/calendar_day_cell_test.dart
+++ b/apps/mobile/test/features/streak/presentation/widgets/calendar_day_cell_test.dart
@@ -46,9 +46,15 @@ void main() {
     expect(find.byType(CachedNetworkImage), findsOneWidget);
   });
 
-  testWidgets('isToday=true → render outline border', (tester) async {
+  testWidgets('isToday + có post → render outline border', (tester) async {
     await tester.pumpWidget(
-      host(const CalendarDayCell(isInMonth: true, isToday: true)),
+      host(
+        const CalendarDayCell(
+          isInMonth: true,
+          isToday: true,
+          imageUrl: 'https://cdn/p1.jpg',
+        ),
+      ),
     );
     // CalendarDayCell wrap content trong Stack với DecoratedBox overlay
     // chứa Border. Tìm bất kỳ widget nào có border non-null.
@@ -64,6 +70,36 @@ void main() {
       return false;
     });
     expect(hasBorder, findsAtLeast(1));
+  });
+
+  testWidgets('isToday + no post → render CTA icon add (turquoise block)',
+      (tester) async {
+    await tester.pumpWidget(
+      host(const CalendarDayCell(isInMonth: true, isToday: true)),
+    );
+    // Today CTA mode: turquoise block + Icons.add center, NO outline border
+    expect(find.byIcon(Icons.add), findsOneWidget);
+    expect(find.byType(CachedNetworkImage), findsNothing);
+  });
+
+  testWidgets('isToday + no post + onTap != null → tappable với CTA semantics',
+      (tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      host(
+        CalendarDayCell(
+          isInMonth: true,
+          isToday: true,
+          onTap: () => tapped = true,
+        ),
+      ),
+    );
+    await tester.tap(find.byType(GestureDetector));
+    expect(tapped, isTrue);
+    expect(
+      find.bySemanticsLabel('Chụp khoảnh khắc hôm nay'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('onTap fire khi có post', (tester) async {

--- a/apps/mobile/test/features/streak/presentation/widgets/streak_calendar_test.dart
+++ b/apps/mobile/test/features/streak/presentation/widgets/streak_calendar_test.dart
@@ -159,4 +159,48 @@ void main() {
     );
     expect(todayCells, findsOneWidget);
   });
+
+  testWidgets('today no-post + onTapToday → tap fires CTA callback',
+      (tester) async {
+    var ctaCalled = false;
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 5),
+          monthPosts: const [],
+          today: DateTime(2026, 5, 22),
+          onTapToday: () => ctaCalled = true,
+        ),
+      ),
+    );
+    final todayCell = find.byWidgetPredicate(
+      (w) => w is CalendarDayCell && w.isToday,
+    );
+    await tester.tap(todayCell);
+    expect(ctaCalled, isTrue);
+  });
+
+  testWidgets('today có post → tap mở photo detail (onTapDay), không CTA',
+      (tester) async {
+    var ctaCalled = false;
+    int? tappedIndex;
+    final posts = [makePost('p1', DateTime(2026, 5, 22, 14))];
+    await tester.pumpWidget(
+      host(
+        StreakCalendar(
+          viewingMonth: DateTime(2026, 5),
+          monthPosts: posts,
+          today: DateTime(2026, 5, 22),
+          onTapDay: (i) => tappedIndex = i,
+          onTapToday: () => ctaCalled = true,
+        ),
+      ),
+    );
+    final todayCell = find.byWidgetPredicate(
+      (w) => w is CalendarDayCell && w.isToday,
+    );
+    await tester.tap(todayCell);
+    expect(tappedIndex, 0);
+    expect(ctaCalled, isFalse);
+  });
 }

--- a/apps/mobile/test/features/streak/presentation/widgets/streak_stats_pill_test.dart
+++ b/apps/mobile/test/features/streak/presentation/widgets/streak_stats_pill_test.dart
@@ -5,15 +5,14 @@ import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart
 void main() {
   Widget host(Widget child) => MaterialApp(home: Scaffold(body: child));
 
-  testWidgets('render N Khoảnh khắc + Xd chuỗi', (tester) async {
+  testWidgets('render N Meep + Xd chuỗi', (tester) async {
     await tester.pumpWidget(
       host(const StreakStatsPill(totalMoments: 12, currentStreak: 7)),
     );
-    // Có RichText với cả " 12" và "7d"
     final richText = tester.widget<RichText>(find.byType(RichText));
     final fullText = richText.text.toPlainText();
     expect(fullText, contains('12'));
-    expect(fullText, contains('Khoảnh khắc'));
+    expect(fullText, contains('Meep'));
     expect(fullText, contains('7d'));
     expect(fullText, contains('chuỗi'));
   });
@@ -24,7 +23,7 @@ void main() {
     );
     final richText = tester.widget<RichText>(find.byType(RichText));
     final fullText = richText.text.toPlainText();
-    expect(fullText, contains('0 Khoảnh khắc'));
+    expect(fullText, contains('0 Meep'));
     expect(fullText, contains('0d chuỗi'));
   });
 }


### PR DESCRIPTION
## Summary
- Avatar topbar tap mở `SettingsSheet` (copy pattern từ `home_screen`)
- Hôm nay chưa chụp → ô `turquoise600` + icon `+` trắng, tap → `/home` (camera)
- Hôm nay đã chụp → thumbnail ảnh thật + stroke `#656565`, tap mở `PhotoDetailScreen`
- Pill stats: "Khoảnh khắc" → "Meep"
- Thêm test: today CTA render + tap, today có post → onTapDay, không CTA

## Files changed
| File | Change |
|---|---|
| `calendar_day_cell.dart` | Thêm today CTA mode (turquoise + add icon), chỉ show stroke khi today có post |
| `streak_calendar.dart` | Thêm prop `onTapToday`, wire cell CTA callback |
| `streak_screen.dart` | Wire `onTapToday → /home`, avatar `GestureDetector → SettingsSheet` |
| `streak_stats_pill.dart` | Label "Khoảnh khắc" → "Meep" |
| `*_test.dart` (3 files) | Update assertions + thêm today CTA tests |

## Verification
- `flutter analyze lib` — clean
- `flutter test test/features/streak` — **51/51 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)