### PR TITLE
fix(notification): đồng bộ token path + push notification cho chat

### DIFF
--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -115,6 +115,7 @@ String? authRedirect({
 ///   friend_request / friend_accepted → /home?openFriendSheet=1
 ///   reaction                         → /home?highlight=`postId`
 ///   new_post                         → /home
+///   chat_message                     → /chat/`conversationId`
 ///   unknown / missing type           → /home
 ///
 /// Missing postId for `reaction` falls back to `/home` — the source push
@@ -122,6 +123,11 @@ String? authRedirect({
 /// the user shouldn't see a broken highlight for. HomeScreen already
 /// renders the "post no longer exists" toast when the postId can't be
 /// resolved to a Post, so unknown postIds reuse that path.
+///
+/// Missing conversationId for `chat_message` cũng fallback `/home` —
+/// payload từ Cloud Function (chat/onMessageCreated.ts) luôn set field này,
+/// nếu rỗng nghĩa là payload bị malformed nên đừng đưa user vào chat screen
+/// trống không load được.
 String routeForNotification(Map<String, String> data) {
   final type = data['type'];
   switch (type) {
@@ -134,6 +140,10 @@ String routeForNotification(Map<String, String> data) {
       return '/home?highlight=${Uri.encodeQueryComponent(postId)}';
     case 'new_post':
       return '/home';
+    case 'chat_message':
+      final conversationId = data['conversationId'];
+      if (conversationId == null || conversationId.isEmpty) return '/home';
+      return '/chat/${Uri.encodeComponent(conversationId)}';
     default:
       return '/home';
   }

--- a/apps/mobile/test/core/router/app_router_test.dart
+++ b/apps/mobile/test/core/router/app_router_test.dart
@@ -394,6 +394,40 @@ void main() {
       );
     });
 
+    test('chat_message with conversationId → /chat/<conversationId>', () {
+      expect(
+        routeForNotification(const {
+          'type': 'chat_message',
+          'conversationId': 'conv-abc',
+          'senderId': 'uid-sender',
+          'messageId': 'msg-1',
+        }),
+        '/chat/conv-abc',
+      );
+    });
+
+    test('chat_message with missing conversationId → /home', () {
+      // Defensive — payload từ onMessageCreated luôn set conversationId; rỗng
+      // hoặc thiếu nghĩa là malformed, đừng đẩy user vào chat screen lỗi.
+      expect(routeForNotification(const {'type': 'chat_message'}), '/home');
+      expect(
+        routeForNotification(
+          const {'type': 'chat_message', 'conversationId': ''},
+        ),
+        '/home',
+      );
+    });
+
+    test('chat_message percent-encodes conversationId', () {
+      expect(
+        routeForNotification(const {
+          'type': 'chat_message',
+          'conversationId': 'a/b c',
+        }),
+        '/chat/a%2Fb%20c',
+      );
+    });
+
     test('unknown type → /home (fallback, no crash)', () {
       expect(
         routeForNotification(const {'type': 'made_up_type'}),

--- a/firebase/functions/src/chat/onMessageCreated.ts
+++ b/firebase/functions/src/chat/onMessageCreated.ts
@@ -1,0 +1,175 @@
+import { FieldValue, getFirestore } from 'firebase-admin/firestore';
+import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+import { logger } from 'firebase-functions/v2';
+import { sendFcmToUser } from '../notification/_fcm.js';
+import { isAlreadyExists, readDisplayName } from '../notification/_helpers.js';
+
+interface MessageData {
+  senderId?: unknown;
+  text?: unknown;
+  senderDisplayName?: unknown;
+}
+
+interface ConversationData {
+  participantIds?: unknown;
+}
+
+/**
+ * Notify mọi participant khác của conversation khi có message mới.
+ *
+ * Triggers on /conversations/{conversationId}/messages/{messageId} create.
+ * Tier 1 Meep chỉ chat 1-1 nên thường chỉ 1 receiver, nhưng code path xử lý
+ * `participantIds` tổng quát để khi mở group chat sau này không phải sửa lại.
+ *
+ * Idempotent: notification doc keyed `chat_{conversationId}_{messageId}` —
+ * trigger fire 2 lần (Firestore guarantee at-least-once) collide trên
+ * `.create()` và exit clean. FCM bị skip ở lần 2.
+ *
+ * `senderDisplayName` đã được mobile denormalize vào message doc
+ * (firestore.rules:309 whitelist nó), fallback đọc /users/{senderId} cho
+ * message cũ trước denormalize.
+ */
+export const onMessageCreated = onDocumentCreated(
+  {
+    document: 'conversations/{conversationId}/messages/{messageId}',
+    region: 'asia-southeast1',
+  },
+  async (event) => {
+    const raw = event.data?.data() as MessageData | undefined;
+    if (!raw) {
+      logger.warn('[CHAT-DEBUG] event.data rỗng → bỏ qua');
+      return;
+    }
+
+    const { conversationId, messageId } = event.params;
+    const senderId = typeof raw.senderId === 'string' ? raw.senderId : '';
+    const text = typeof raw.text === 'string' ? raw.text : '';
+
+    logger.info(
+      { conversationId, messageId, senderId, textLength: text.length },
+      '[CHAT-DEBUG] Trigger onMessageCreated bắt đầu chạy',
+    );
+
+    if (!senderId) {
+      logger.warn('[CHAT-DEBUG] Message thiếu senderId → bỏ qua', {
+        conversationId,
+        messageId,
+      });
+      return;
+    }
+
+    const db = getFirestore();
+    const convSnap = await db.doc(`conversations/${conversationId}`).get();
+    if (!convSnap.exists) {
+      logger.warn('[CHAT-DEBUG] Conversation không tồn tại → bỏ qua', {
+        conversationId,
+      });
+      return;
+    }
+
+    const conv = convSnap.data() as ConversationData | undefined;
+    const recipientUids = receiversOf(conv?.participantIds, senderId);
+    if (recipientUids.length === 0) {
+      logger.info(
+        { conversationId, senderId },
+        '[CHAT-DEBUG] Không còn participant nào khác sender → không cần gửi',
+      );
+      return;
+    }
+
+    let senderName =
+      typeof raw.senderDisplayName === 'string' &&
+      raw.senderDisplayName.length > 0
+        ? raw.senderDisplayName
+        : '';
+    if (!senderName) {
+      const senderSnap = await db.doc(`users/${senderId}`).get();
+      senderName = readDisplayName(senderSnap.data());
+    }
+
+    const payload = {
+      title: senderName,
+      body: bodyPreview(text),
+      data: {
+        type: 'chat_message',
+        conversationId,
+        senderId,
+        messageId,
+      } as Record<string, string>,
+      channelId: 'chat',
+    };
+
+    await Promise.all(
+      recipientUids.map(async (receiverUid) => {
+        const notifRef = db.doc(
+          `users/${receiverUid}/notifications/chat_${conversationId}_${messageId}`,
+        );
+        try {
+          await notifRef.create({
+            type: 'chatMessage',
+            title: payload.title,
+            body: payload.body,
+            data: payload.data,
+            read: false,
+            createdAt: FieldValue.serverTimestamp(),
+          });
+          logger.info(
+            { receiverUid, conversationId, messageId },
+            '[CHAT-DEBUG] Đã tạo notification doc cho receiver',
+          );
+        } catch (e) {
+          if (isAlreadyExists(e)) {
+            logger.info(
+              '[CHAT-DEBUG] Notification đã tồn tại (trigger fire 2 lần) → bỏ qua FCM',
+              { receiverUid, messageId },
+            );
+            return;
+          }
+          logger.error('[CHAT-DEBUG] Lỗi tạo notification doc cho receiver', {
+            receiverUid,
+            messageId,
+            error: e,
+          });
+          throw e;
+        }
+
+        await sendFcmToUser(db, receiverUid, payload);
+        logger.info(
+          { receiverUid, messageId },
+          '[CHAT-DEBUG] Đã gọi xong sendFcmToUser cho receiver',
+        );
+      }),
+    );
+  },
+);
+
+/**
+ * Lọc participants chỉ giữ những uid khác sender — dùng cho fan-out FCM +
+ * notif doc. Defensive: accept `unknown` rồi narrow vì Firestore data type
+ * lúc runtime không enforce shape.
+ *
+ * Exported cho unit test.
+ */
+export function receiversOf(
+  participantIds: unknown,
+  senderId: string,
+): string[] {
+  if (!Array.isArray(participantIds)) return [];
+  return participantIds.filter(
+    (uid): uid is string => typeof uid === 'string' && uid !== senderId,
+  );
+}
+
+/**
+ * Cắt nội dung tin nhắn thành đoạn preview ngắn cho notification body.
+ * FCM android cho ≈ 240 char nhưng UI Android system tray hiển thị ≈ 2
+ * dòng — 100 char là ngưỡng an toàn cho text Việt có dấu (UTF-16 nhân đôi
+ * dài hơn dấu ASCII).
+ *
+ * Exported cho unit test.
+ */
+export function bodyPreview(text: string): string {
+  if (text.length === 0) return 'Đã gửi tin nhắn mới';
+  if (text.length <= 100) return text;
+  return `${text.substring(0, 97)}...`;
+}

--- a/firebase/functions/src/feed/onPostCreated.ts
+++ b/firebase/functions/src/feed/onPostCreated.ts
@@ -1,7 +1,6 @@
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
-import { getMessaging } from 'firebase-admin/messaging';
 import { onDocumentCreated } from 'firebase-functions/v2/firestore';
-import { logger } from 'firebase-functions/v2';
+import { sendFcmToUser } from '../notification/_fcm.js';
 import { spacePostFanOut } from '../space/spacePostFanOut.js';
 
 interface PostData {
@@ -125,6 +124,14 @@ async function _getFriendUids(
   });
 }
 
+/**
+ * Delegate per-recipient FCM dispatch sang `sendFcmToUser`, vốn đọc token từ
+ * `/users/{uid}/fcmTokens` — đúng path mobile save vào
+ * (firebase_notification_repository.dart:saveFcmToken). Trước đây hàm này tự
+ * đọc `/users/{uid}/private/fcm` → token luôn rỗng → post notification không
+ * bao giờ tới friend. Để 1 helper duy nhất quản lý token lookup + prune token
+ * chết, tránh path bị lệch khi mobile đổi format trong tương lai.
+ */
 async function _sendFcmToRecipients(
   db: FirebaseFirestore.Firestore,
   recipientUids: string[],
@@ -132,38 +139,18 @@ async function _sendFcmToRecipients(
   authorName: string,
   postId: string,
 ): Promise<void> {
-  // Batch load FCM tokens
-  const tokenPromises = recipientUids.map((uid) =>
-    db.collection(`users/${uid}/private`).doc('fcm').get(),
+  if (recipientUids.length === 0) return;
+  const payload = {
+    title: authorName,
+    body: 'Vừa đăng một ảnh mới',
+    data: {
+      type: 'new_post',
+      postId,
+      authorId,
+    },
+    channelId: 'posts',
+  };
+  await Promise.all(
+    recipientUids.map((uid) => sendFcmToUser(db, uid, payload)),
   );
-  const tokenDocs = await Promise.all(tokenPromises);
-
-  const tokens: string[] = [];
-  for (const doc of tokenDocs) {
-    if (!doc.exists) continue;
-    const t = doc.data()?.token as string | undefined;
-    if (t != null && t !== '') tokens.push(t);
-  }
-
-  if (tokens.length === 0) return;
-
-  try {
-    await getMessaging().sendEachForMulticast({
-      tokens,
-      notification: {
-        title: authorName,
-        body: 'Vừa đăng một ảnh mới',
-      },
-      data: {
-        type: 'new_post',
-        postId,
-        authorId,
-      },
-      android: {
-        notification: { channelId: 'posts' },
-      },
-    });
-  } catch (e) {
-    logger.error('FCM multicast failed', e);
-  }
 }

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -81,6 +81,10 @@ export { onFriendRequestCreated } from './notification/onFriendRequestCreated.js
 export { onFriendRequestAccepted } from './notification/onFriendRequestAccepted.js';
 export { onReactionCreated } from './notification/onReactionCreated.js';
 
+// ===== Chat module =====
+
+export { onMessageCreated } from './chat/onMessageCreated.js';
+
 // ===== Space module =====
 
 export { createSpace } from './space/createSpace.js';

--- a/firebase/functions/src/space/spacePostFanOut.ts
+++ b/firebase/functions/src/space/spacePostFanOut.ts
@@ -1,6 +1,6 @@
 import { FieldValue, getFirestore } from 'firebase-admin/firestore';
-import { getMessaging } from 'firebase-admin/messaging';
 import { logger } from 'firebase-functions/v2';
+import { sendFcmToUser } from '../notification/_fcm.js';
 
 interface SpacePost {
   postId: string;
@@ -109,6 +109,12 @@ export async function spacePostFanOut(post: SpacePost): Promise<void> {
   );
 }
 
+/**
+ * Cùng lý do với feed/onPostCreated._sendFcmToRecipients: trước đây hàm này
+ * tự đọc `/users/{uid}/private/fcm` trong khi mobile save token vào
+ * `/users/{uid}/fcmTokens`. Đẩy hết FCM dispatch về `sendFcmToUser` để 1
+ * helper duy nhất giữ ownership chuyện token lookup + prune.
+ */
 async function sendFcmToSpaceMembers(
   db: FirebaseFirestore.Firestore,
   recipientUids: string[],
@@ -118,38 +124,19 @@ async function sendFcmToSpaceMembers(
   spaceId: string,
   spaceName: string,
 ): Promise<void> {
-  const tokenDocs = await Promise.all(
-    recipientUids.map((uid) =>
-      db.collection(`users/${uid}/private`).doc('fcm').get(),
-    ),
+  if (recipientUids.length === 0) return;
+  const payload = {
+    title: `${authorName} → ${spaceName}`,
+    body: 'Vừa chia sẻ ảnh mới trong Space',
+    data: {
+      type: 'new_space_post',
+      postId,
+      authorId,
+      spaceId,
+    },
+    channelId: 'posts',
+  };
+  await Promise.all(
+    recipientUids.map((uid) => sendFcmToUser(db, uid, payload)),
   );
-
-  const tokens: string[] = [];
-  for (const doc of tokenDocs) {
-    if (!doc.exists) continue;
-    const t: unknown = doc.data()?.token;
-    if (typeof t === 'string' && t.length > 0) tokens.push(t);
-  }
-  if (tokens.length === 0) return;
-
-  try {
-    await getMessaging().sendEachForMulticast({
-      tokens,
-      notification: {
-        title: `${authorName} → ${spaceName}`,
-        body: 'Vừa chia sẻ ảnh mới trong Space',
-      },
-      data: {
-        type: 'new_space_post',
-        postId,
-        authorId,
-        spaceId,
-      },
-      android: {
-        notification: { channelId: 'posts' },
-      },
-    });
-  } catch (e) {
-    logger.error('spacePostFanOut FCM failed', e);
-  }
 }

--- a/firebase/functions/test/chat/onMessageCreated.test.ts
+++ b/firebase/functions/test/chat/onMessageCreated.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bodyPreview,
+  receiversOf,
+} from '../../src/chat/onMessageCreated.js';
+
+describe('receiversOf', () => {
+  it('returns participants excluding sender', () => {
+    expect(receiversOf(['uid-a', 'uid-b'], 'uid-a')).toEqual(['uid-b']);
+  });
+
+  it('returns empty when sender is the only participant', () => {
+    expect(receiversOf(['uid-a'], 'uid-a')).toEqual([]);
+  });
+
+  it('returns empty when participantIds is missing', () => {
+    expect(receiversOf(undefined, 'uid-a')).toEqual([]);
+  });
+
+  it('returns empty when participantIds is not an array', () => {
+    expect(receiversOf('uid-a,uid-b', 'uid-a')).toEqual([]);
+  });
+
+  it('skips non-string entries defensively', () => {
+    expect(receiversOf(['uid-a', 42, null, 'uid-c'], 'uid-a')).toEqual([
+      'uid-c',
+    ]);
+  });
+
+  it('supports group conversations — all non-sender participants returned', () => {
+    expect(
+      receiversOf(['uid-a', 'uid-b', 'uid-c', 'uid-d'], 'uid-b'),
+    ).toEqual(['uid-a', 'uid-c', 'uid-d']);
+  });
+});
+
+describe('bodyPreview', () => {
+  it('falls back to default copy for empty message', () => {
+    expect(bodyPreview('')).toBe('Đã gửi tin nhắn mới');
+  });
+
+  it('returns text unchanged when ≤ 100 chars', () => {
+    const text = 'Tin nhắn ngắn nè';
+    expect(bodyPreview(text)).toBe(text);
+  });
+
+  it('truncates to 97 chars + "..." when > 100 chars', () => {
+    const text = 'a'.repeat(150);
+    const out = bodyPreview(text);
+    expect(out.length).toBe(100);
+    expect(out.endsWith('...')).toBe(true);
+    expect(out.startsWith('a'.repeat(97))).toBe(true);
+  });
+
+  it('preserves UTF-8 Vietnamese characters in short text', () => {
+    const text = 'Mai mình đi cà phê nhé, có cả Khoa với Hân nữa.';
+    expect(bodyPreview(text)).toBe(text);
+  });
+});


### PR DESCRIPTION
## Tóm tắt

Fix 3 vấn đề khiến push notification không hoạt động + 1 vấn đề tap chat noti không redirect:

1. **Post notification (friend feed)** — `onPostCreated._sendFcmToRecipients` đọc token từ `/users/{uid}/private/fcm` nhưng mobile save vào `/users/{uid}/fcmTokens` → 100% miss.
2. **Space post notification** — `spacePostFanOut.sendFcmToSpaceMembers` cùng bug, cùng path sai.
3. **Chat 1-1 notification** — chưa có Cloud Function trigger cho `/conversations/{cid}/messages/{mid}` → message mới không sinh push noti.
4. **Tap chat notification không redirect** — `routeForNotification` thiếu case `chat_message` nên fallback `/home` thay vì mở `/chat/<conversationId>`.

## Thay đổi

### Cloud Functions

- **`onPostCreated.ts` + `spacePostFanOut.ts`**: delegate FCM dispatch sang `sendFcmToUser` (đọc đúng path `fcmTokens` + prune token chết) thay vì inline `getMessaging().sendEachForMulticast`. 1 helper duy nhất quản lý token lookup → tránh path bị lệch khi mobile đổi format trong tương lai.
- **`chat/onMessageCreated.ts` (NEW)**: listen `/conversations/{conversationId}/messages/{messageId}`:
  - Read conversation → lấy `participantIds`, filter exclude sender
  - Sender name: prefer `senderDisplayName` denormalize trong message (firestore.rules:309 whitelist), fallback `/users/{senderId}`
  - Truncate body ≤ 100 chars cho Android tray
  - Notif doc `chat_{cid}_{mid}` idempotent + `sendFcmToUser`
  - Multi-receiver ready cho group chat sau này
- **`index.ts`**: register `onMessageCreated` dưới section Chat module.

### Mobile

- **`app_router.dart`**: thêm case `'chat_message'` trong `routeForNotification` → `/chat/<conversationId>` (percent-encoded). Missing/empty `conversationId` fallback `/home` cùng pattern reaction.

## Không sửa

- **Reaction notification** — code hiện đã đi qua `sendFcmToUser` đúng path. Nếu vẫn fail sau deploy, xem log `[REACTION-DEBUG]` + `[FCM-DEBUG]` (từ PR debug log song song) để pin point. Có thể là token chưa save (mobile log `MEEP-NOTI-REPO`) hoặc permission denied.
- **Tap banner foreground** — banner trong app chưa wire `handleOpenedApp`. Để PR riêng nếu cần.

## Test plan

- [x] Gate 1 — branch name regex pass (`fix/KhoaLND/push-notification`)
- [x] Gate 2 — commitlint 2 commits, 0 problems, 0 warnings
- [x] Gate 3 — Flutter: build_runner regen no new file, dart format clean, `flutter analyze --fatal-infos` clean, `flutter test --coverage` **721/721 pass** (+3 test mới cho `routeForNotification` chat_message)
- [x] Gate 4 — Functions: `npm ci` + `lint` + `typecheck` + `npm test` **121/121 pass** (+10 test mới cho `receiversOf` + `bodyPreview`)
- [ ] Gate 5 — Firestore rules: SKIP (không chạm `.rules`)
- [ ] Anh deploy + verify trên device thật

## Sau khi merge: deploy + verify

```bash
# Deploy chỉ 2 function có thay đổi
firebase deploy --only functions:onPostCreated,functions:onMessageCreated --project meep-staging

# Watch log
firebase functions:log --since 2m