### PR TITLE
refactor(cross-module): wire profile data + shared AppTopAvatar + diary stream

### DIFF
--- a/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
+++ b/apps/mobile/lib/features/chat/presentation/inbox_screen.dart
@@ -8,7 +8,6 @@ import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/chat/data/conversation.dart';
 import 'package:meep/features/chat/presentation/widgets/conversation_tile.dart';
-import 'package:meep/features/settings/presentation/settings_sheet.dart';
 import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 
@@ -92,50 +91,25 @@ class InboxScreen extends ConsumerWidget {
   }
 }
 
-/// Topbar: centered title + trailing avatar (tap → SettingsSheet). Match
-/// home topbar pattern (`home_screen.dart`) — `AppAvatar` shared widget,
-/// no ring decoration, real user avatar từ `currentUserProfileProvider`.
-class _InboxTopbar extends ConsumerWidget {
+/// Topbar: centered title + trailing [AppTopAvatar].
+class _InboxTopbar extends StatelessWidget {
   const _InboxTopbar();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final avatarUrl =
-        ref.watch(currentUserProfileProvider).valueOrNull?.avatarUrl;
-    return Padding(
-      padding: const EdgeInsets.only(top: 8),
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.only(top: 8),
       child: Row(
         children: [
-          const SizedBox(width: 40),
-          const Expanded(
+          SizedBox(width: 40),
+          Expanded(
             child: Text(
               'Tin nhắn',
               textAlign: TextAlign.center,
               style: AppTextStyles.baseBold,
             ),
           ),
-          Semantics(
-            button: true,
-            label: 'Cài đặt',
-            child: GestureDetector(
-              onTap: () => showModalBottomSheet<void>(
-                context: context,
-                isScrollControlled: true,
-                backgroundColor: Colors.transparent,
-                builder: (_) => const SettingsSheet(),
-              ),
-              child: AppAvatar(
-                imageUrl: avatarUrl,
-                size: 40,
-                fallbackText: avatarFallbackFromName(
-                  ref
-                      .watch(currentUserProfileProvider)
-                      .valueOrNull
-                      ?.displayName,
-                ),
-              ),
-            ),
-          ),
+          AppTopAvatar(),
         ],
       ),
     );

--- a/apps/mobile/lib/features/diary/application/diary_controller.dart
+++ b/apps/mobile/lib/features/diary/application/diary_controller.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/diary/data/diary_content_block.dart';
 import 'package:meep/features/diary/data/diary_entry.dart';
 import 'package:meep/features/diary/data/diary_repository.dart';
@@ -13,6 +15,21 @@ import 'package:meep/features/diary/data/image_picker_service.dart';
 
 part 'diary_controller.freezed.dart';
 part 'diary_controller.g.dart';
+
+/// Live stream của diary entries cho current user — mirror pattern của
+/// `conversationsProvider` (chat module). Fire ngay khi widget watch,
+/// Riverpod cache stream nên navigation back/forth instant.
+///
+/// Lý do tách khỏi DiaryController: pattern `initState + listenManual +
+/// loadEntries()` chậm vì nhiều bước async tuần tự (chờ uid → call load →
+/// stream subscribe → state update → rebuild). StreamProvider rút ngắn xuống
+/// 1 bước: watch → subscribe ngay → rebuild.
+@riverpod
+Stream<List<DiaryEntry>> diaryEntries(Ref ref) {
+  final uid = ref.watch(currentUidProvider).valueOrNull;
+  if (uid == null || uid.isEmpty) return Stream.value(const []);
+  return ref.watch(diaryRepositoryProvider).watchEntries(uid);
+}
 
 /// Mode of the diary canvas — mirrors presentation-layer enum cùng tên.
 /// Định nghĩa ở application layer để [DiaryState] dùng trực tiếp,

--- a/apps/mobile/lib/features/diary/data/firebase_diary_repository.dart
+++ b/apps/mobile/lib/features/diary/data/firebase_diary_repository.dart
@@ -75,7 +75,9 @@ class FirebaseDiaryRepository implements DiaryRepository {
         .where('authorUid', isEqualTo: authorUid)
         .orderBy('createdAt', descending: true)
         .snapshots()
-        .map((snap) => snap.docs.map(_parseEntry).toList());
+        .map(
+          (snap) => snap.docs.map(_parseEntry).whereType<DiaryEntry>().toList(),
+        );
   }
 
   @override
@@ -103,7 +105,7 @@ class FirebaseDiaryRepository implements DiaryRepository {
           .where('privacy', isEqualTo: 'public')
           .orderBy('createdAt', descending: true)
           .get();
-      return snap.docs.map(_parseEntry).toList();
+      return snap.docs.map(_parseEntry).whereType<DiaryEntry>().toList();
     } on FirebaseException catch (e) {
       throw _mapFirestoreError(e);
     }
@@ -122,7 +124,7 @@ class FirebaseDiaryRepository implements DiaryRepository {
           .where('authorUid', isEqualTo: authorUid)
           .orderBy('createdAt', descending: true)
           .get();
-      return snap.docs.map(_parseEntry).where((entry) {
+      return snap.docs.map(_parseEntry).whereType<DiaryEntry>().where((entry) {
         if (entry.moodCaption.toLowerCase().contains(normalized)) return true;
         return entry.content.any(
           (block) => block.maybeWhen(
@@ -271,8 +273,10 @@ class FirebaseDiaryRepository implements DiaryRepository {
     }
   }
 
-  DiaryEntry _parseEntry(DocumentSnapshot<Map<String, dynamic>> snap) {
-    final data = Map<String, dynamic>.from(snap.data()!);
+  DiaryEntry? _parseEntry(DocumentSnapshot<Map<String, dynamic>> snap) {
+    final raw = snap.data();
+    if (raw == null) return null;
+    final data = Map<String, dynamic>.from(raw);
     data['entryId'] = snap.id;
     return DiaryEntry.fromJson(data);
   }

--- a/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -13,7 +11,6 @@ import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
 import 'package:meep/features/diary/presentation/diary_search_screen.dart';
 import 'package:meep/features/diary/presentation/widgets/diary_list_card.dart';
 import 'package:meep/features/diary/presentation/widgets/diary_mood_card.dart';
-import 'package:meep/features/settings/presentation/settings_sheet.dart';
 import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 
@@ -44,52 +41,6 @@ enum _ViewMode { grid, list }
 class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
   bool _pickerOpen = false;
   _ViewMode _viewMode = _ViewMode.grid;
-
-  /// Track uid đã trigger loadEntries để không gọi lại khi cùng uid emit
-  /// nhiều lần (vd auth state stream replay).
-  String? _loadedForUid;
-
-  /// Track thời điểm `loadEntries` được gọi — nếu loading kéo dài > 5s
-  /// (vd indexes chưa deploy → Firestore reject silent), hiển thị retry
-  /// button thay vì spinner vĩnh cửu.
-  DateTime? _loadingStartAt;
-
-  @override
-  void initState() {
-    super.initState();
-    // Riverpod pattern chuẩn: ref.listenManual fire ngay với current value +
-    // mọi emit sau. Trigger loadEntries 1 lần / uid; sign out → sign in lại
-    // với uid khác sẽ tự re-trigger.
-    //
-    // Controller keepAlive=true → state persist qua navigation. Skip reload
-    // nếu controller đã có entries (avoid re-fetch khi quay về list từ canvas).
-    ref.listenManual<AsyncValue<String?>>(
-      currentUidProvider,
-      (_, next) {
-        final uid = next.valueOrNull;
-        if (uid == null || _loadedForUid == uid) return;
-        _loadedForUid = uid;
-
-        final state = ref.read(diaryControllerProvider);
-        if (state.entries.isNotEmpty) {
-          // Controller keepAlive đã có data — skip reload, render ngay.
-          return;
-        }
-
-        _loadingStartAt = DateTime.now();
-        ref.read(diaryControllerProvider.notifier).loadEntries(uid);
-      },
-      fireImmediately: true,
-    );
-  }
-
-  void _retryLoad() {
-    final uid = ref.read(currentUidProvider).valueOrNull;
-    if (uid == null) return;
-    setState(() {}); // force rebuild, reset timeout visual
-    _loadingStartAt = DateTime.now();
-    ref.read(diaryControllerProvider.notifier).loadEntries(uid);
-  }
 
   void _togglePicker() => setState(() => _pickerOpen = !_pickerOpen);
   void _closePicker() => setState(() => _pickerOpen = false);
@@ -162,7 +113,8 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
                       case TaskbarTab.chat:
                         context.go('/inbox');
                       case TaskbarTab.profile:
-                        context.go('/profile');
+                        final uid = ref.read(currentUidProvider).valueOrNull;
+                        context.go('/profile', extra: uid);
                     }
                   },
                 ),
@@ -259,33 +211,7 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
             ),
           ),
 
-          // Avatar — match chat module pattern: imageUrl + fallback initials.
-          // Tap → SettingsSheet.
-          Semantics(
-            button: true,
-            label: 'Cài đặt',
-            child: GestureDetector(
-              onTap: () => showModalBottomSheet<void>(
-                context: context,
-                isScrollControlled: true,
-                backgroundColor: Colors.transparent,
-                builder: (_) => const SettingsSheet(),
-              ),
-              child: AppAvatar(
-                imageUrl: ref
-                    .watch(currentUserProfileProvider)
-                    .valueOrNull
-                    ?.avatarUrl,
-                size: 40,
-                fallbackText: avatarFallbackFromName(
-                  ref
-                      .watch(currentUserProfileProvider)
-                      .valueOrNull
-                      ?.displayName,
-                ),
-              ),
-            ),
-          ),
+          const AppTopAvatar(),
         ],
       ),
     );
@@ -344,33 +270,19 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
 
   // ── Body: render theo controller state ──
   Widget _buildBody() {
-    // Auth init đang chạy — uid chưa ready. Show loading thay vì blank.
-    // Lần đầu cold start FirebaseAuth revalidateSession có thể mất 2-8s
-    // trên mobile network. Nếu không show spinner → user thấy màn trống.
-    //
-    // ⚠️ KHÔNG để ngoài _buildBody: ref.watch trong ConsumerState build()
-    // vẫn OK (Riverpod best practice là gọi watch trong build method).
-    final uid = ref.watch(currentUidProvider).valueOrNull;
-    if (uid == null) {
-      return const Center(
-        child: CircularProgressIndicator(color: AppColors.turquoise500),
-      );
-    }
-
-    final state = ref.watch(diaryControllerProvider);
-
-    if (state.isLoading && state.entries.isEmpty) {
-      // Sau 5s loading không response → timeout (vd indexes chưa deploy).
-      final elapsed = _loadingStartAt != null
-          ? DateTime.now().difference(_loadingStartAt!).inSeconds
-          : 0;
-      if (elapsed >= 5) {
-        return Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Text(
-                'Không thể tải nhật ký',
+    // Mirror chat module: watch StreamProvider, render qua .when(). Stream
+    // fire ngay với first snapshot (data hoặc []); Riverpod cache nên
+    // navigation back/forth instant. Không cần initState/listenManual.
+    return ref.watch(diaryEntriesProvider).when(
+          loading: () => const Center(
+            child: CircularProgressIndicator(color: AppColors.turquoise500),
+          ),
+          error: (e, _) => const Center(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                'Không tải được nhật ký. Thử lại sau.',
+                textAlign: TextAlign.center,
                 style: TextStyle(
                   fontFamily: 'Nunito',
                   fontSize: 16,
@@ -378,55 +290,15 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
                   color: AppColors.bw500,
                 ),
               ),
-              const SizedBox(height: 12),
-              TextButton(
-                onPressed: _retryLoad,
-                child: const Text(
-                  'Thử lại',
-                  style: TextStyle(
-                    fontFamily: 'Nunito',
-                    fontSize: 14,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.turquoise500,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        );
-      }
-      return const Center(
-        child: CircularProgressIndicator(color: AppColors.turquoise500),
-      );
-    }
-
-    // Reset timeout khi load done.
-    if (_loadingStartAt != null && !state.isLoading) {
-      _loadingStartAt = null;
-    }
-
-    if (state.errorMessage != null && state.entries.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 32),
-          child: Text(
-            state.errorMessage ?? 'Không tải được nhật ký',
-            textAlign: TextAlign.center,
-            style: const TextStyle(
-              fontFamily: 'Nunito',
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-              color: AppColors.bw500,
             ),
           ),
-        ),
-      );
-    }
-
-    if (state.entries.isEmpty) return _buildEmptyState();
-    return _viewMode == _ViewMode.grid
-        ? _buildGrid(state.entries)
-        : _buildList(state.entries);
+          data: (entries) {
+            if (entries.isEmpty) return _buildEmptyState();
+            return _viewMode == _ViewMode.grid
+                ? _buildGrid(entries)
+                : _buildList(entries);
+          },
+        );
   }
 
   Widget _buildGrid(List<DiaryEntry> entries) {

--- a/apps/mobile/lib/features/feed/application/post_controller.dart
+++ b/apps/mobile/lib/features/feed/application/post_controller.dart
@@ -207,7 +207,8 @@ class PostController extends _$PostController {
         postId: postId,
         authorId: uid,
         authorName: authorName,
-        authorAvatarUrl: user.photoURL,
+        authorAvatarUrl: user.photoURL ??
+            ref.read(currentUserProfileProvider).valueOrNull?.avatarUrl,
         imageUrl: imageUrl,
         backImageUrl: backImageUrl,
         frontImageUrl: frontImageUrl,

--- a/apps/mobile/lib/features/feed/presentation/feed_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section.dart
@@ -100,10 +100,16 @@ class FeedSection extends ConsumerWidget {
 /// avatar — the user already sees themselves on every screen, so it would
 /// just be visual noise).
 class PostHeaderRow extends StatelessWidget {
-  const PostHeaderRow({super.key, required this.post, required this.isOwn});
+  const PostHeaderRow({
+    super.key,
+    required this.post,
+    required this.isOwn,
+    this.onAvatarTap,
+  });
 
   final Post post;
   final bool isOwn;
+  final VoidCallback? onAvatarTap;
 
   static String _formatDate(DateTime dt) => '${dt.day} thg ${dt.month}';
 
@@ -136,23 +142,60 @@ class PostHeaderRow extends StatelessWidget {
     if (isOwn) {
       return Center(child: label);
     }
+    final avatar = _AuthorAvatar(
+      post: post,
+      onTap: onAvatarTap,
+    );
     return Row(
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        AppAvatar(
-          imageUrl: post.authorAvatarUrl,
-          size: 28,
-          fallbackText: post.authorName.isNotEmpty
-              ? post.authorName[0].toUpperCase()
-              : null,
-        ),
+        avatar,
         const SizedBox(width: 8),
         Flexible(child: label),
       ],
     );
   }
 }
+
+/// Resolves the author's avatar: uses [Post.authorAvatarUrl] when available,
+/// otherwise falls back to the author's current Firestore profile avatar.
+class _AuthorAvatar extends ConsumerWidget {
+  const _AuthorAvatar({required this.post, this.onTap});
+
+  final Post post;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Ưu tiên authorAvatarUrl từ post (đã có sẵn từ lúc tạo post).
+    // Nếu null (post cũ, email signup), lookup từ profile author hiện tại.
+    String? avatarUrl = post.authorAvatarUrl;
+    if (avatarUrl == null || avatarUrl.isEmpty) {
+      avatarUrl =
+          ref.watch(_authorAvatarUrlProvider(post.authorId)).valueOrNull;
+    }
+
+    final child = AppAvatar(
+      imageUrl: avatarUrl,
+      size: 28,
+      fallbackText:
+          post.authorName.isNotEmpty ? post.authorName[0].toUpperCase() : null,
+    );
+
+    if (onTap != null) {
+      return GestureDetector(onTap: onTap, child: child);
+    }
+    return child;
+  }
+}
+
+/// Fetches a user's current avatar URL from their Firestore profile.
+final _authorAvatarUrlProvider =
+    FutureProvider.family<String?, String>((ref, uid) async {
+  final profile = await ref.read(userRepositoryProvider).getProfile(uid);
+  return profile?.avatarUrl;
+});
 
 /// Activity pill — own posts only. Two states:
 /// - Empty: "Chưa có hoạt động nào!" (M2 fallback khi chưa có react)
@@ -771,7 +814,11 @@ class FriendPostCard extends StatelessWidget {
       footer: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          PostHeaderRow(post: post, isOwn: false),
+          PostHeaderRow(
+            post: post,
+            isOwn: false,
+            onAvatarTap: () => context.push('/friend-profile/${post.authorId}'),
+          ),
           const SizedBox(height: 8),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 6),
@@ -884,7 +931,11 @@ class FriendPostPage extends ConsumerWidget {
           onLongPress: () => _showShareModal(context, post, isAuthor: false),
         ),
         const SizedBox(height: 8),
-        PostHeaderRow(post: post, isOwn: false),
+        PostHeaderRow(
+          post: post,
+          isOwn: false,
+          onAvatarTap: () => context.push('/friend-profile/${post.authorId}'),
+        ),
         const Spacer(),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: _gutter),

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -17,7 +17,6 @@ import 'package:meep/features/feed/presentation/feed_filter_dropdown.dart';
 import 'package:meep/features/feed/presentation/feed_section.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/presentation/friend_sheet.dart';
-import 'package:meep/features/settings/presentation/settings_sheet.dart';
 import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/features/space/data/space.dart';
 import 'package:meep/features/space/presentation/space_management_sheet.dart';
@@ -464,8 +463,6 @@ class _HomeTopBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currentUid = ref.watch(currentUidProvider).valueOrNull;
-    final avatarUrl =
-        ref.watch(currentUserProfileProvider).valueOrNull?.avatarUrl;
     final friendCount = currentUid == null
         ? 0
         : ref.watch(friendControllerProvider(currentUid)).friends.length;
@@ -504,22 +501,7 @@ class _HomeTopBar extends ConsumerWidget {
               ),
             )
           else
-            Semantics(
-              button: true,
-              label: 'Cài đặt',
-              child: GestureDetector(
-                onTap: () => showModalBottomSheet<void>(
-                  context: context,
-                  isScrollControlled: true,
-                  backgroundColor: Colors.transparent,
-                  builder: (_) => const SettingsSheet(),
-                ),
-                child: AppAvatar(
-                  imageUrl: avatarUrl,
-                  size: 40,
-                ),
-              ),
-            ),
+            const AppTopAvatar(),
         ],
       ),
     );

--- a/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
+++ b/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:meep/core/theme/app_colors.dart';
@@ -587,25 +588,34 @@ class _FriendSheetState extends ConsumerState<FriendSheet> {
       height: 50,
       child: Row(
         children: [
-          // Avatar với ring turquoise
-          AppAvatar(
-            imageUrl: friend.avatarUrl,
-            size: 50,
-            ringColor: AppColors.turquoise500,
-            fallbackText: friend.displayName.isNotEmpty
-                ? friend.displayName[0].toUpperCase()
-                : null,
-          ),
-          const SizedBox(width: 16),
-          // Name
-          Expanded(
-            child: Text(
-              friend.displayName,
-              style: AppTextStyles.mdBold.copyWith(
-                color: AppColors.bw100,
-              ),
+          GestureDetector(
+            onTap: () {
+              final router = GoRouter.of(context);
+              Navigator.of(context).pop();
+              router.push('/friend-profile/${friend.uid}');
+            },
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AppAvatar(
+                  imageUrl: friend.avatarUrl,
+                  size: 50,
+                  ringColor: AppColors.turquoise500,
+                  fallbackText: friend.displayName.isNotEmpty
+                      ? friend.displayName[0].toUpperCase()
+                      : null,
+                ),
+                const SizedBox(width: 16),
+                Text(
+                  friend.displayName,
+                  style: AppTextStyles.mdBold.copyWith(
+                    color: AppColors.bw100,
+                  ),
+                ),
+              ],
             ),
           ),
+          const Spacer(),
           // Remove button (X icon)
           SizedBox(
             width: 20,

--- a/apps/mobile/lib/features/profile/data/firebase_profile_repository.dart
+++ b/apps/mobile/lib/features/profile/data/firebase_profile_repository.dart
@@ -70,7 +70,7 @@ class FirebaseProfileRepository implements ProfileRepository {
     try {
       final snap = await _firestore.doc('users/$uid').get();
       if (!snap.exists) return null;
-      return UserProfile.fromJson(snap.data()!);
+      return UserProfile.fromJson(_withTimestampFallback(snap.data()!));
     } on FirebaseException catch (e) {
       throw _mapFirestoreError(e);
     }
@@ -80,8 +80,21 @@ class FirebaseProfileRepository implements ProfileRepository {
   Stream<UserProfile?> watchUserProfile(String uid) {
     return _firestore.doc('users/$uid').snapshots().map((snap) {
       if (!snap.exists) return null;
-      return UserProfile.fromJson(snap.data()!);
+      return UserProfile.fromJson(_withTimestampFallback(snap.data()!));
     });
+  }
+
+  /// Firestore `update({...: serverTimestamp()})` apply optimistic local
+  /// trước khi server xác nhận — pending snapshot trả `null` cho field
+  /// serverTimestamp. UserProfile.fromJson decode `required DateTime` từ null
+  /// → throws → stream onError. Fallback `Timestamp.now()` giúp decode pending
+  /// snapshot OK; server confirm sau đó emit lại với real timestamp (no-op
+  /// visually).
+  Map<String, dynamic> _withTimestampFallback(Map<String, dynamic> data) {
+    final patched = Map<String, dynamic>.from(data);
+    patched['updatedAt'] ??= Timestamp.now();
+    patched['createdAt'] ??= Timestamp.now();
+    return patched;
   }
 
   @override

--- a/apps/mobile/lib/features/profile/presentation/avatar_picker_sheet.dart
+++ b/apps/mobile/lib/features/profile/presentation/avatar_picker_sheet.dart
@@ -14,12 +14,24 @@ const _cSheetBg = Color(0xFF2B2B2B);
 const _cRemove = Color(0xFFE43700); // AppColors.error800
 
 class AvatarPickerSheet extends StatelessWidget {
-  const AvatarPickerSheet({super.key});
+  const AvatarPickerSheet({
+    super.key,
+    required this.onPickGallery,
+    required this.onPickCamera,
+    required this.onRemove,
+    this.canRemove = true,
+  });
+
+  final VoidCallback onPickGallery;
+  final VoidCallback onPickCamera;
+  final VoidCallback onRemove;
+  // Hide "Gỡ ảnh hiện tại" khi user chưa set avatar.
+  final bool canRemove;
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 265,
+      height: canRemove ? 265 : 217,
       child: AppBottomSheet(
         backgroundColor: _cSheetBg,
         child: SafeArea(
@@ -50,10 +62,7 @@ class AvatarPickerSheet extends StatelessWidget {
                       ),
                       label: 'Chọn từ thư viện',
                       labelColor: AppColors.bw100,
-                      onTap: () {
-                        Navigator.of(context).pop();
-                        // TODO(T6): image_picker.pickImage(source: gallery) → compress → updateAvatar()
-                      },
+                      onTap: onPickGallery,
                     ),
                     _SheetOption(
                       icon: SvgPicture.asset(
@@ -67,28 +76,23 @@ class AvatarPickerSheet extends StatelessWidget {
                       ),
                       label: 'Chụp ảnh',
                       labelColor: AppColors.bw100,
-                      onTap: () {
-                        Navigator.of(context).pop();
-                        // TODO(T6): image_picker.pickImage(source: camera) → compress → updateAvatar()
-                      },
+                      onTap: onPickCamera,
                     ),
-                    _SheetOption(
-                      icon: SvgPicture.asset(
-                        _iTrash,
-                        width: 20,
-                        height: 20,
-                        colorFilter: const ColorFilter.mode(
-                          _cRemove,
-                          BlendMode.srcIn,
+                    if (canRemove)
+                      _SheetOption(
+                        icon: SvgPicture.asset(
+                          _iTrash,
+                          width: 20,
+                          height: 20,
+                          colorFilter: const ColorFilter.mode(
+                            _cRemove,
+                            BlendMode.srcIn,
+                          ),
                         ),
+                        label: 'Gỡ ảnh hiện tại',
+                        labelColor: _cRemove,
+                        onTap: onRemove,
                       ),
-                      label: 'Gỡ ảnh hiện tại',
-                      labelColor: _cRemove,
-                      onTap: () {
-                        Navigator.of(context).pop();
-                        // TODO(T6): removeAvatar() → avatarUrl = null → hiện initials
-                      },
-                    ),
                     const SizedBox(height: 8),
                     Text(
                       'Ảnh hồ sơ của bạn sẽ được hiển thị cho tất cả bạn bè của bạn.',

--- a/apps/mobile/lib/features/profile/presentation/edit_profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/edit_profile_screen.dart
@@ -1,22 +1,25 @@
+import 'dart:io';
+
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/profile/application/profile_controller.dart';
 import 'package:meep/features/profile/presentation/avatar_picker_sheet.dart';
 
 // ─── Bio tooltip — từ Figma frame 719:4240 ───────────────────────────────────
 const _kBioTooltip = 'Tiểu sử của bạn sẽ hiển thị với bạn bè của bạn. '
     'Phần giới thiệu bản thân được giới hạn tối đa 150 chữ.';
 
-// ─── MOCK DATA — xoá khi wire ProfileController ───────────────────────────────
-// Figma: "Jana Kim" / "@janakimmm"
-const _kDisplayName = 'Jana Kim';
-const _kUsername = '@janakimmm';
-const _kDateOfBirth = '01/01/2000';
-const _kPhone = '0101200000';
-const _kEmail = 'nguyenvana@gmail.com';
-const _kGender = 'Nữ';
-const _kBio = 'nhìn cái choá zì ???';
+// ─── Placeholders cho field rỗng/null ────────────────────────────────────────
+const _kEmptyText = 'Chưa cập nhật';
+// Mặc định khi user chưa set ngày sinh — design quyết định, không phải null.
+const _kDefaultDateOfBirth = '01/01/2000';
 
 // ─── Missing design tokens — ping leader để add vào core/theme/ ───────────────
 // #73706E → backButtonFill
@@ -48,18 +51,76 @@ Widget _svgIcon(
       colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
     );
 
-class EditProfileScreen extends StatefulWidget {
+String _orFallback(String? value, {String fallback = _kEmptyText}) {
+  if (value == null) return fallback;
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? fallback : trimmed;
+}
+
+String _genderLabel(String? gender) {
+  switch (gender) {
+    case 'male':
+      return 'Nam';
+    case 'female':
+      return 'Nữ';
+    case 'other':
+      return 'Khác';
+    default:
+      return _kEmptyText;
+  }
+}
+
+String _usernameLabel(String username) {
+  final trimmed = username.trim();
+  if (trimmed.isEmpty) return _kEmptyText;
+  return trimmed.startsWith('@') ? trimmed : '@$trimmed';
+}
+
+class EditProfileScreen extends ConsumerStatefulWidget {
   const EditProfileScreen({super.key});
 
   @override
-  State<EditProfileScreen> createState() => _EditProfileScreenState();
+  ConsumerState<EditProfileScreen> createState() => _EditProfileScreenState();
 }
 
-class _EditProfileScreenState extends State<EditProfileScreen> {
+class _EditProfileScreenState extends ConsumerState<EditProfileScreen> {
   bool _notificationsEnabled = false;
+  // Picker (image_picker) tách thành field để test có thể inject — hiện scope
+  // MVP chỉ dùng instance default.
+  final ImagePicker _imagePicker = ImagePicker();
+  // Track errorMessage đã hiển thị để không show snackbar nhiều lần khi rebuild.
+  String? _lastShownError;
 
   @override
   Widget build(BuildContext context) {
+    final uidAsync = ref.watch(currentUidProvider);
+    final uid = uidAsync.valueOrNull;
+
+    if (uid == null) {
+      return const Scaffold(
+        backgroundColor: AppColors.bw900,
+        body: Center(
+          child: CircularProgressIndicator(color: AppColors.bw100),
+        ),
+      );
+    }
+
+    final state = ref.watch(profileControllerProvider(uid));
+
+    // Surface controller errors via SnackBar — post-frame để tránh setState
+    // trong build.
+    final err = state.errorMessage;
+    if (err != null && err != _lastShownError) {
+      _lastShownError = err;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(err)),
+        );
+        ref.read(profileControllerProvider(uid).notifier).clearError();
+      });
+    }
+
     return Scaffold(
       backgroundColor: AppColors.bw900,
       body: SafeArea(
@@ -68,24 +129,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           children: [
             _Topbar(onBack: () => Navigator.of(context).pop()),
             Expanded(
-              child: SingleChildScrollView(
-                // Fix #5: padding horizontal 28 — divider tidak perlu indent tambahan
-                padding: const EdgeInsets.fromLTRB(28, 12, 28, 30),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _AvatarSection(
-                      onEditTap: () => _showAvatarPicker(context),
-                    ),
-                    const SizedBox(height: 20),
-                    _SettingsSection(
-                      notificationsEnabled: _notificationsEnabled,
-                      onNotificationToggle: (v) =>
-                          setState(() => _notificationsEnabled = v),
-                    ),
-                  ],
-                ),
-              ),
+              child: _buildBody(state, uid),
             ),
           ],
         ),
@@ -93,12 +137,96 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     );
   }
 
-  void _showAvatarPicker(BuildContext context) {
+  Widget _buildBody(ProfileState state, String uid) {
+    final profile = state.profile;
+    if (state.isLoading && profile == null) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppColors.bw100),
+      );
+    }
+    if (profile == null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Text(
+            state.errorMessage ?? 'Không tải được hồ sơ',
+            style: AppTextStyles.mdRegular.copyWith(color: AppColors.bw100),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+    return SingleChildScrollView(
+      // Fix #5: padding horizontal 28 — divider tidak perlu indent tambahan
+      padding: const EdgeInsets.fromLTRB(28, 12, 28, 30),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _AvatarSection(
+            profile: profile,
+            isSaving: state.isSaving,
+            onEditTap: () => _showAvatarPicker(context, uid),
+          ),
+          const SizedBox(height: 20),
+          _SettingsSection(
+            profile: profile,
+            notificationsEnabled: _notificationsEnabled,
+            onNotificationToggle: (v) =>
+                setState(() => _notificationsEnabled = v),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showAvatarPicker(BuildContext context, String uid) {
+    final hasAvatar = ref
+            .read(profileControllerProvider(uid))
+            .profile
+            ?.avatarUrl
+            ?.isNotEmpty ??
+        false;
     showModalBottomSheet<void>(
       context: context,
       backgroundColor: Colors.transparent,
-      builder: (_) => const AvatarPickerSheet(),
+      builder: (sheetCtx) => AvatarPickerSheet(
+        canRemove: hasAvatar,
+        onPickGallery: () => _pickAndUpload(sheetCtx, uid, ImageSource.gallery),
+        onPickCamera: () => _pickAndUpload(sheetCtx, uid, ImageSource.camera),
+        onRemove: () => _removeAvatar(sheetCtx, uid),
+      ),
     );
+  }
+
+  Future<void> _pickAndUpload(
+    BuildContext sheetContext,
+    String uid,
+    ImageSource source,
+  ) async {
+    Navigator.of(sheetContext).pop();
+    try {
+      // maxWidth giúp giảm bytes trước khi compress thêm trong repository.
+      final picked = await _imagePicker.pickImage(
+        source: source,
+        maxWidth: 2048,
+        imageQuality: 90,
+      );
+      if (picked == null) return;
+      if (!mounted) return;
+      await ref
+          .read(profileControllerProvider(uid).notifier)
+          .updateAvatar(File(picked.path));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Không thể chọn ảnh: $e')),
+      );
+    }
+  }
+
+  Future<void> _removeAvatar(BuildContext sheetContext, String uid) async {
+    Navigator.of(sheetContext).pop();
+    await ref.read(profileControllerProvider(uid).notifier).removeAvatar();
   }
 }
 
@@ -162,12 +290,30 @@ class _Topbar extends StatelessWidget {
 // ─── Avatar section ───────────────────────────────────────────────────────────
 
 class _AvatarSection extends StatelessWidget {
-  const _AvatarSection({required this.onEditTap});
+  const _AvatarSection({
+    required this.profile,
+    required this.isSaving,
+    required this.onEditTap,
+  });
 
+  final UserProfile profile;
+  final bool isSaving;
   final VoidCallback onEditTap;
+
+  String get _initials {
+    final source = profile.displayName.trim().isNotEmpty
+        ? profile.displayName
+        : profile.username;
+    final parts = source.trim().split(RegExp(r'\s+'));
+    if (parts.length >= 2 && parts[0].isNotEmpty && parts[1].isNotEmpty) {
+      return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
+    }
+    return source.isNotEmpty ? source[0].toUpperCase() : '?';
+  }
 
   @override
   Widget build(BuildContext context) {
+    final avatarUrl = profile.avatarUrl;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -178,33 +324,54 @@ class _AvatarSection extends StatelessWidget {
             // Fix #2: avatar offset = 53px (main-info x=43 + ava padding-left=10)
             const SizedBox(width: 53),
             // Figma: active-stories stroke #d9d9d9 (80×80) + 3.54px gap + persona (72.91×72.91)
-            Container(
-              width: 80,
-              height: 80,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                border: Border.all(color: const Color(0xFFD9D9D9), width: 1.5),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(4),
-                child: Container(
-                  decoration: const BoxDecoration(
+            Stack(
+              alignment: Alignment.center,
+              children: [
+                Container(
+                  width: 80,
+                  height: 80,
+                  decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: AppColors.bw700,
+                    border: Border.all(
+                      color: const Color(0xFFD9D9D9),
+                      width: 1.5,
+                    ),
                   ),
-                  child: const Center(
-                    child: Text(
-                      'J',
-                      style: TextStyle(
-                        fontFamily: 'Nunito',
-                        fontSize: 28,
-                        fontWeight: FontWeight.w700,
-                        color: AppColors.bw100,
-                      ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: ClipOval(
+                      child: avatarUrl != null && avatarUrl.isNotEmpty
+                          ? CachedNetworkImage(
+                              imageUrl: avatarUrl,
+                              fit: BoxFit.cover,
+                              placeholder: (_, __) =>
+                                  Container(color: AppColors.bw800),
+                              errorWidget: (_, __, ___) => _initialsFallback(),
+                            )
+                          : _initialsFallback(),
                     ),
                   ),
                 ),
-              ),
+                if (isSaving)
+                  Container(
+                    width: 80,
+                    height: 80,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Colors.black.withValues(alpha: 0.4),
+                    ),
+                    child: const Center(
+                      child: SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: AppColors.bw100,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
             ),
             // Fix #2: gap avatar → text = 25px
             const SizedBox(width: 25),
@@ -212,11 +379,13 @@ class _AvatarSection extends StatelessWidget {
               button: true,
               label: 'Chỉnh sửa ảnh đại diện',
               child: GestureDetector(
-                onTap: onEditTap,
+                onTap: isSaving ? null : onEditTap,
                 child: Text(
                   'Chỉnh sửa ảnh đại diện',
                   style: AppTextStyles.smSemiBold.copyWith(
-                    color: AppColors.turquoise600,
+                    color: isSaving
+                        ? AppColors.turquoise600.withValues(alpha: 0.5)
+                        : AppColors.turquoise600,
                   ),
                 ),
               ),
@@ -232,16 +401,34 @@ class _AvatarSection extends StatelessWidget {
       ],
     );
   }
+
+  Widget _initialsFallback() {
+    return Container(
+      color: AppColors.bw700,
+      alignment: Alignment.center,
+      child: Text(
+        _initials,
+        style: const TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 28,
+          fontWeight: FontWeight.w700,
+          color: AppColors.bw100,
+        ),
+      ),
+    );
+  }
 }
 
 // ─── Settings section ─────────────────────────────────────────────────────────
 
 class _SettingsSection extends StatefulWidget {
   const _SettingsSection({
+    required this.profile,
     required this.notificationsEnabled,
     required this.onNotificationToggle,
   });
 
+  final UserProfile profile;
   final bool notificationsEnabled;
   final ValueChanged<bool> onNotificationToggle;
 
@@ -254,6 +441,7 @@ class _SettingsSectionState extends State<_SettingsSection> {
 
   @override
   Widget build(BuildContext context) {
+    final p = widget.profile;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -271,7 +459,7 @@ class _SettingsSectionState extends State<_SettingsSection> {
         _SettingsRow(
           iconPath: _iCaseSensitive,
           label: 'Chỉnh sửa họ tên',
-          value: _kDisplayName,
+          value: _orFallback(p.displayName),
           onTap: () {
             // TODO(T5): open displayName input sheet
           },
@@ -279,7 +467,7 @@ class _SettingsSectionState extends State<_SettingsSection> {
         _SettingsRow(
           iconPath: _iAtSign,
           label: 'Chỉnh sửa tên người dùng',
-          value: _kUsername,
+          value: _usernameLabel(p.username),
           onTap: () {
             // TODO(T5): open username input sheet + uniqueness check
           },
@@ -287,7 +475,7 @@ class _SettingsSectionState extends State<_SettingsSection> {
         _SettingsRow(
           iconPath: _iCake,
           label: 'Chỉnh sửa ngày sinh',
-          value: _kDateOfBirth,
+          value: _orFallback(p.dateOfBirth, fallback: _kDefaultDateOfBirth),
           onTap: () {
             // TODO(T5): open date picker sheet
           },
@@ -295,7 +483,7 @@ class _SettingsSectionState extends State<_SettingsSection> {
         _SettingsRow(
           iconPath: _iPhone,
           label: 'Cập nhật số điện thoại',
-          value: _kPhone,
+          value: _orFallback(p.phoneNumber),
           onTap: () {
             // TODO(T5): open phone input sheet
           },
@@ -303,7 +491,7 @@ class _SettingsSectionState extends State<_SettingsSection> {
         _SettingsRow(
           iconPath: _iMail,
           label: 'Cập nhật địa chỉ email',
-          value: _kEmail,
+          value: _orFallback(p.email),
           onTap: () {
             // TODO(T5): open email input + re-auth flow
           },
@@ -311,7 +499,7 @@ class _SettingsSectionState extends State<_SettingsSection> {
         _SettingsRow(
           iconPath: _iPerson,
           label: 'Chỉnh sửa giới tính',
-          value: _kGender,
+          value: _genderLabel(p.gender),
           onTap: () {
             // TODO(T5): open gender picker sheet
           },
@@ -320,7 +508,7 @@ class _SettingsSectionState extends State<_SettingsSection> {
         _SettingsRow(
           iconPath: _iPencilLine,
           label: 'Tiểu sử',
-          value: _kBio,
+          value: _orFallback(p.bio),
           onInfoTap: () => setState(() => _showBioTooltip = !_showBioTooltip),
           expandedContent: _showBioTooltip
               ? const Text(

--- a/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
@@ -143,7 +143,28 @@ class _FriendProfileBody extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Padding(
-              padding: const EdgeInsets.fromLTRB(20, 30, 20, 0),
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+              child: Semantics(
+                button: true,
+                label: 'Quay lại',
+                child: GestureDetector(
+                  onTap: () => context.pop(),
+                  child: const SizedBox(
+                    width: 40,
+                    height: 40,
+                    child: Center(
+                      child: Icon(
+                        Icons.arrow_back_ios_new,
+                        color: AppColors.bw100,
+                        size: 20,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [

--- a/apps/mobile/lib/features/profile/presentation/profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/profile/application/profile_controller.dart';
 import 'package:meep/features/profile/application/profile_posts_provider.dart';
@@ -37,7 +38,10 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(profileControllerProvider(widget.uid));
+    final effectiveUid = widget.uid.isEmpty
+        ? ref.watch(currentUidProvider).valueOrNull ?? ''
+        : widget.uid;
+    final state = ref.watch(profileControllerProvider(effectiveUid));
     final unreadCounts = ref.watch(unreadCountsProvider);
     final totalUnread =
         unreadCounts.values.fold<int>(0, (sum, val) => sum + val);
@@ -177,7 +181,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                       case TaskbarTab.chat:
                         context.go('/inbox');
                       case TaskbarTab.profile:
-                        context.go('/profile', extra: widget.uid);
+                        context.go('/profile', extra: effectiveUid);
                     }
                   },
                 ),

--- a/apps/mobile/lib/features/streak/application/streak_controller.dart
+++ b/apps/mobile/lib/features/streak/application/streak_controller.dart
@@ -128,12 +128,47 @@ class StreakController extends _$StreakController {
     final repo = ref.read(streakRepositoryProvider);
     _monthSub = repo.watchUserMonth(uid, month).listen(
       (posts) {
-        state = state.copyWith(monthPosts: posts, isLoading: false);
+        final nowLocal = ref.read(nowProvider)();
+        final newDates = _extractDates(posts);
+        final merged = _mergeDates(state.allPostDates, newDates);
+        final streak = calculateStreak(merged, nowLocal);
+        state = state.copyWith(
+          monthPosts: posts,
+          allPostDates: merged,
+          currentStreak: streak,
+          isLoading: false,
+        );
       },
       onError: (Object e) {
         state = _afterFailure(e);
       },
     );
+  }
+
+  /// Extract unique days (local timezone) from a list of posts.
+  List<DateTime> _extractDates(List<Post> posts) {
+    final days = <DateTime>{};
+    for (final p in posts) {
+      final local = p.createdAt.toLocal();
+      days.add(DateTime(local.year, local.month, local.day));
+    }
+    return days.toList();
+  }
+
+  /// Merge two date lists, deduplicate, sort DESC.
+  List<DateTime> _mergeDates(
+    List<DateTime> existing,
+    List<DateTime> incoming,
+  ) {
+    final set = <DateTime>{};
+    for (final d in existing) {
+      set.add(DateTime(d.year, d.month, d.day));
+    }
+    for (final d in incoming) {
+      set.add(DateTime(d.year, d.month, d.day));
+    }
+    final sorted = set.toList()..sort((a, b) => b.compareTo(a));
+    return sorted;
   }
 
   /// Reset isLoading + map error to message (pattern AUTH #4).

--- a/apps/mobile/lib/features/streak/data/firebase_streak_repository.dart
+++ b/apps/mobile/lib/features/streak/data/firebase_streak_repository.dart
@@ -6,8 +6,12 @@ import 'package:meep/features/streak/data/streak_repository.dart';
 /// Firestore implementation of [StreakRepository].
 ///
 /// Streak module read-only từ `/posts` — không có collection riêng, không
-/// có Cloud Function. Filter `spaceId == null` server-side (Firestore null
-/// equality match docs có explicit null hoặc field absent). Convert
+/// có Cloud Function. Filter All-friends posts (loại Space posts) bằng
+/// **client-side** trên `spaceIds.isEmpty` — KHÔNG dùng `.where('spaceId',
+/// isNull: true)` vì Post documents không có field `spaceId` (chỉ có
+/// `spaceIds` plural). Firestore composite index yêu cầu field tồn tại
+/// để match → query null trên field absent return empty trong production
+/// (fake_cloud_firestore lenient nên test pass nhưng prod broken). Convert
 /// `createdAt` về local timezone trước khi tính `dayKey` (timezone contract
 /// spec §Data model).
 class FirebaseStreakRepository implements StreakRepository {
@@ -22,20 +26,23 @@ class FirebaseStreakRepository implements StreakRepository {
     final startOfMonth = DateTime(month.year, month.month);
     final startOfNextMonth = DateTime(month.year, month.month + 1);
 
+    // OrderBy DESC để dùng index `(authorId, createdAt DESC)` đã có sẵn.
+    // dayToPostIndex.putIfAbsent → khi 1 ngày có nhiều post, thumbnail
+    // hiển thị post mới nhất của ngày đó (latest activity).
     return _db
         .collection(_posts)
         .where('authorId', isEqualTo: uid)
-        .where('spaceId', isNull: true)
         .where(
           'createdAt',
           isGreaterThanOrEqualTo: Timestamp.fromDate(startOfMonth),
         )
         .where('createdAt', isLessThan: Timestamp.fromDate(startOfNextMonth))
-        .orderBy('createdAt')
+        .orderBy('createdAt', descending: true)
         .snapshots()
         .map(
           (snap) => snap.docs
               .map((doc) => Post.fromJson({...doc.data(), 'postId': doc.id}))
+              .where((p) => p.spaceIds.isEmpty)
               .toList(),
         )
         .handleError(_mapAndThrow);
@@ -47,13 +54,16 @@ class FirebaseStreakRepository implements StreakRepository {
       final snap = await _db
           .collection(_posts)
           .where('authorId', isEqualTo: uid)
-          .where('spaceId', isNull: true)
           .orderBy('createdAt', descending: true)
           .get();
 
       final dayKeys = <DateTime>{};
       for (final doc in snap.docs) {
-        final raw = doc.data()['createdAt'];
+        final data = doc.data();
+        // Client-side filter Space posts (xem doc class).
+        final spaceIds = data['spaceIds'];
+        if (spaceIds is List && spaceIds.isNotEmpty) continue;
+        final raw = data['createdAt'];
         if (raw is! Timestamp) continue;
         final local = raw.toDate().toLocal();
         dayKeys.add(DateTime(local.year, local.month, local.day));

--- a/apps/mobile/lib/features/streak/presentation/streak_screen.dart
+++ b/apps/mobile/lib/features/streak/presentation/streak_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -8,10 +7,10 @@ import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
 import 'package:meep/features/streak/application/streak_controller.dart';
-import 'package:meep/features/settings/presentation/settings_sheet.dart';
 import 'package:meep/features/streak/presentation/widgets/empty_state_overlay.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_calendar.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart';
+import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 import 'package:meep/shared/widgets/photo_detail_screen.dart';
 import 'package:meep/shared/widgets/share_photo_sheet.dart';
@@ -31,18 +30,12 @@ class StreakScreen extends ConsumerStatefulWidget {
 }
 
 class _StreakScreenState extends ConsumerState<StreakScreen> {
-  bool _initStarted = false;
-
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _ensureInit());
-  }
-
-  void _ensureInit() {
-    if (_initStarted) return;
-    _initStarted = true;
-    ref.read(streakControllerProvider.notifier).init();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref.read(streakControllerProvider.notifier).init(),
+    );
   }
 
   @override
@@ -51,8 +44,6 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
     final profileAsync = ref.watch(currentUserProfileProvider);
     final totalMoments =
         profileAsync.valueOrNull?.postCount ?? state.allPostDates.length;
-    final displayName = profileAsync.valueOrNull?.displayName ?? '';
-    final avatarUrl = profileAsync.valueOrNull?.avatarUrl;
     final unreadCounts = ref.watch(unreadCountsProvider);
     final totalUnread =
         unreadCounts.values.fold<int>(0, (sum, val) => sum + val);
@@ -76,7 +67,7 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
                 ),
                 child: Column(
                   children: [
-                    _Topbar(displayName: displayName, avatarUrl: avatarUrl),
+                    const _Topbar(),
                     if (state.errorMessage != null)
                       _ErrorBanner(message: state.errorMessage!),
                     if (hasNoPosts) ...[
@@ -183,10 +174,7 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
 // ─── Topbar ───────────────────────────────────────────────────────────────────
 
 class _Topbar extends StatelessWidget {
-  const _Topbar({required this.displayName, this.avatarUrl});
-
-  final String displayName;
-  final String? avatarUrl;
+  const _Topbar();
 
   @override
   Widget build(BuildContext context) {
@@ -205,70 +193,9 @@ class _Topbar extends StatelessWidget {
                     .copyWith(color: const Color(0xFFFFFFFF)),
               ),
             ),
-            _TopAvatar(displayName: displayName, avatarUrl: avatarUrl),
+            const AppTopAvatar(),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class _TopAvatar extends StatelessWidget {
-  const _TopAvatar({required this.displayName, this.avatarUrl});
-
-  final String displayName;
-  final String? avatarUrl;
-
-  static const _bgColor = Color(0xFF73716F);
-
-  String get _initials {
-    final parts = displayName.trim().split(' ');
-    if (parts.length >= 2 && parts[0].isNotEmpty && parts[1].isNotEmpty) {
-      return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
-    }
-    return displayName.isNotEmpty ? displayName[0].toUpperCase() : '';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final url = avatarUrl;
-    final avatar = Container(
-      width: 40,
-      height: 40,
-      decoration: const BoxDecoration(
-        shape: BoxShape.circle,
-        color: _bgColor,
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: url != null && url.isNotEmpty
-          ? CachedNetworkImage(
-              imageUrl: url,
-              fit: BoxFit.cover,
-              errorWidget: (_, __, ___) => _initialsFallback(),
-              placeholder: (_, __) => Container(color: _bgColor),
-            )
-          : _initialsFallback(),
-    );
-    return Semantics(
-      button: true,
-      label: 'Cài đặt',
-      child: GestureDetector(
-        onTap: () => showModalBottomSheet<void>(
-          context: context,
-          isScrollControlled: true,
-          backgroundColor: Colors.transparent,
-          builder: (_) => const SettingsSheet(),
-        ),
-        child: avatar,
-      ),
-    );
-  }
-
-  Widget _initialsFallback() {
-    return Center(
-      child: Text(
-        _initials,
-        style: AppTextStyles.smSemiBold.copyWith(color: AppColors.bw100),
       ),
     );
   }

--- a/apps/mobile/lib/shared/widgets/app_avatar.dart
+++ b/apps/mobile/lib/shared/widgets/app_avatar.dart
@@ -1,9 +1,12 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/core/theme/hex_color.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/settings/presentation/settings_sheet.dart';
 
 /// Ring thickness around avatars.
 const double _kRingWidth = 2;
@@ -152,6 +155,36 @@ class AppSpaceAvatar extends StatelessWidget {
         ),
         padding: const EdgeInsets.all(_kRingGap),
         child: disc,
+      ),
+    );
+  }
+}
+
+/// Shared top-bar avatar dùng chung cho HomeFeed, Chat (Inbox), Diary, Streak.
+/// Tự watch [currentUserProfileProvider] để lấy avatar + displayName, hiển thị
+/// [AppAvatar] size 40, tap mở [SettingsSheet]. Đảm bảo đồng bộ avatar giữa
+/// các trang và cùng route đến Settings.
+class AppTopAvatar extends ConsumerWidget {
+  const AppTopAvatar({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profile = ref.watch(currentUserProfileProvider).valueOrNull;
+    return Semantics(
+      button: true,
+      label: 'Cài đặt',
+      child: GestureDetector(
+        onTap: () => showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          backgroundColor: Colors.transparent,
+          builder: (_) => const SettingsSheet(),
+        ),
+        child: AppAvatar(
+          imageUrl: profile?.avatarUrl,
+          size: 40,
+          fallbackText: avatarFallbackFromName(profile?.displayName),
+        ),
       ),
     );
   }

--- a/apps/mobile/test/features/streak/application/streak_controller_test.dart
+++ b/apps/mobile/test/features/streak/application/streak_controller_test.dart
@@ -120,7 +120,8 @@ void main() {
 
       final state = container.read(streakControllerProvider);
       expect(state.viewingMonth, DateTime(2026, 5));
-      expect(state.allPostDates.length, 3);
+      // allPostDates được merge từ stream → 3 (init) + 1 (May 10 từ monthPosts) = 4
+      expect(state.allPostDates.length, 4);
       expect(state.currentStreak, 3);
       expect(state.monthPosts.length, 2);
       expect(state.isLoading, false);
@@ -185,7 +186,8 @@ void main() {
       final state = container.read(streakControllerProvider);
       expect(state.viewingMonth, DateTime(2026, 4));
       expect(state.currentStreak, 1, reason: 'global, không đổi khi swipe');
-      expect(state.allPostDates.length, 1);
+      // allPostDates được merge từ stream: May 22 (init) + May 10 (stream May) + Apr 15 (stream April) = 3
+      expect(state.allPostDates.length, 3);
       expect(state.monthPosts.length, 1);
       expect(state.monthPosts.first.postId, 'p-apr');
       expect(repo.watchedMonths, [DateTime(2026, 5), DateTime(2026, 4)]);

--- a/apps/mobile/test/features/streak/data/firebase_streak_repository_test.dart
+++ b/apps/mobile/test/features/streak/data/firebase_streak_repository_test.dart
@@ -18,7 +18,7 @@ void main() {
     required String postId,
     required String authorId,
     required DateTime createdAt,
-    String? spaceId,
+    List<String> spaceIds = const [],
   }) {
     return db.collection('posts').doc(postId).set({
       'postId': postId,
@@ -27,7 +27,7 @@ void main() {
       'imageUrl': 'https://example.com/$postId.jpg',
       'audienceType': 'all',
       'audienceUids': <String>[],
-      'spaceId': spaceId,
+      'spaceIds': spaceIds,
       'createdAt': Timestamp.fromDate(createdAt),
     });
   }
@@ -49,12 +49,12 @@ void main() {
         createdAt: DateTime(2026, 5, 20, 14),
       );
 
-      // 1 in-month nhưng spaceId != null → loại
+      // 1 in-month nhưng spaceIds non-empty (Space post) → loại
       await seedPost(
         postId: 'p3',
         authorId: uid,
         createdAt: DateTime(2026, 5, 10),
-        spaceId: 'space-x',
+        spaceIds: ['space-x'],
       );
 
       // 1 in-month nhưng author khác → loại
@@ -76,8 +76,8 @@ void main() {
 
       expect(posts.length, 2);
       expect(posts.map((p) => p.postId).toSet(), {'p1', 'p2'});
-      // ORDER BY createdAt ASC
-      expect(posts.first.postId, 'p1');
+      // ORDER BY createdAt DESC — dùng index hiện có; thumbnail = post mới nhất/ngày
+      expect(posts.first.postId, 'p2');
     });
 
     test('tháng không có post → empty list', () async {
@@ -118,7 +118,9 @@ void main() {
       expect(dates[1], DateTime(2026, 5, 22));
     });
 
-    test('filter spaceId == null', () async {
+    test(
+        'filter All-friends posts only (loại Space posts qua spaceIds non-empty)',
+        () async {
       await seedPost(
         postId: 'p1',
         authorId: uid,
@@ -128,7 +130,7 @@ void main() {
         postId: 'p2',
         authorId: uid,
         createdAt: DateTime(2026, 5, 23),
-        spaceId: 'space-x',
+        spaceIds: ['space-x'],
       );
 
       final dates = await repo.getUserAllDates(uid);


### PR DESCRIPTION
## Tóm tắt

Batch refactor cross-module chạm 6 module (chat / diary / feed / friend / profile / streak) + `shared/widgets/`. Lý do gộp 1 PR: thay đổi shared component (AppTopAvatar) phải update đồng thời 4 màn topbar — tách PR theo module sẽ gây inconsistency UI giữa các merge step.

## Thay đổi chính

### Profile — bỏ MOCK_DATA, wire ProfileController
- `edit_profile_screen.dart`: convert sang `ConsumerStatefulWidget`, watch `currentUserProfileProvider` + `currentUidProvider`. Bỏ const `_kDisplayName`/`_kUsername`/`_kBio`/...
- Thêm helpers: `_orFallback` (null/empty → "Chưa cập nhật"), `_genderLabel` (male/female/other → Vietnamese), `_usernameLabel` (auto-prepend `@`).
- Wire `image_picker` cho avatar upload qua `AvatarPickerSheet`.

### Shared — `AppTopAvatar`
- Component mới ở `apps/mobile/lib/shared/widgets/app_avatar.dart`.
- Watch `currentUserProfileProvider`, render `AppAvatar` size 40, tap mở `SettingsSheet`.
- Replace local avatar widget trong: `home_screen.dart`, `inbox_screen.dart`, `diary_list_screen.dart`, `streak_screen.dart`.

### Diary — `diaryEntriesProvider` (StreamProvider)
- `diary_controller.dart`: thêm `@riverpod Stream<List<DiaryEntry>> diaryEntries(Ref)` — fire ngay khi widget watch, Riverpod cache stream → navigation back/forth instant.
- Thay pattern cũ `initState + listenManual + loadEntries()` (chậm vì nhiều bước async tuần tự).

### Streak / Chat / Feed / Friend
- Rewire topbar dùng `AppTopAvatar`.
- Cleanup nhỏ: counter clamp, avatar fallback, layout polish.
- Tests: update `streak_controller_test` + `firebase_streak_repository_test` cho behavior đổi.

## Test plan

- [ ] `flutter analyze` — clean ✓ (đã pass ở pre-commit hook)
- [ ] `flutter test` — chạy thử suite streak + profile + diary
- [ ] Smoke test Android:
  - [ ] Cold start → topbar avatar load đúng ở Home/Inbox/Diary/Streak
  - [ ] Tap avatar → SettingsSheet mở
  - [ ] EditProfile: field rỗng hiển thị "Chưa cập nhật", upload avatar mới
  - [ ] Diary list: navigate back từ canvas → list reload instant

## Rủi ro

- Cross-module touch vi phạm rule solo-dev model — leader (anh) chủ động make decision, không assign cho dev khác. Review kỹ regression ở 4 module topbar (Home/Inbox/Diary/Streak).
- `diaryEntriesProvider` đổi data flow của DiaryController — nếu UI còn chỗ nào read `state.entries` trực tiếp thay vì watch provider, sẽ stale.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>