### PR TITLE
fix(feed/android/notification): sửa 3 module sau review

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/dev/meep/meep/WidgetSyncWorker.kt
+++ b/apps/mobile/android/app/src/main/kotlin/dev/meep/meep/WidgetSyncWorker.kt
@@ -177,17 +177,30 @@ class WidgetSyncWorker(
      * Synchronous Glide bitmap fetch — safe on [Dispatchers.IO].
      * Glide consults memory + disk cache before going to the network, so an
      * offline run with a populated cache returns the previously cached bitmap.
+     *
+     * `.override(width, height)` caps the decoded bitmap to widget render size.
+     * Without it, Glide decodes at the source resolution (full-resolution
+     * captures from camera = several MB per bitmap) → RemoteViews bundle hits
+     * the 1MB IPC limit and OOM risk grows with each periodic refresh.
+     *
+     * `.get(timeout)` guards the WorkManager IO dispatcher from an indefinite
+     * hang if the network stalls past the connectivity constraint check.
      */
     private fun loadBitmap(url: String, circular: Boolean): Bitmap {
-        val request = Glide.with(applicationContext)
+        val targetSize = if (circular) AVATAR_TARGET_PX else PHOTO_TARGET_PX
+        return Glide.with(applicationContext)
             .asBitmap()
             .load(url)
             .apply(
-                RequestOptions().diskCacheStrategy(DiskCacheStrategy.ALL).let {
-                    if (circular) it.transform(CircleCrop()) else it
-                },
+                RequestOptions()
+                    .diskCacheStrategy(DiskCacheStrategy.ALL)
+                    .override(targetSize, targetSize)
+                    .let {
+                        if (circular) it.transform(CircleCrop()) else it
+                    },
             )
-        return request.submit().get()
+            .submit(targetSize, targetSize)
+            .get(BITMAP_LOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS)
     }
 
     private fun renderPlaceholder() {
@@ -261,6 +274,18 @@ class WidgetSyncWorker(
         private const val PERIODIC_WORK_NAME = "meep.widget.sync.periodic"
         private const val ONE_TIME_WORK_NAME = "meep.widget.sync.oneshot"
         private const val PERIODIC_INTERVAL_MINUTES = 15L
+
+        // Bitmap targets — match max widget render size. Photo cap chosen so a
+        // 4×2 widget at xxxhdpi (~640px wide) renders sharp; avatar at 24dp
+        // ≈ 96px (xxhdpi). Glide downsamples source bitmaps to these bounds
+        // before decoding → memory + bundle stay under RemoteViews 1MB limit.
+        private const val PHOTO_TARGET_PX = 720
+        private const val AVATAR_TARGET_PX = 128
+
+        // Cap on Glide's blocking `.get()` — WorkManager IO dispatcher must not
+        // sit on a hung future when the network constraint passed but the
+        // connection stalled mid-fetch.
+        private const val BITMAP_LOAD_TIMEOUT_SECONDS = 20L
 
         /** Format unread count badge: 1–9 verbatim, ≥10 collapses to "9+". */
         internal fun formatCount(count: Int): String =

--- a/apps/mobile/android/app/src/test/kotlin/dev/meep/meep/WidgetSyncWorkerTest.kt
+++ b/apps/mobile/android/app/src/test/kotlin/dev/meep/meep/WidgetSyncWorkerTest.kt
@@ -338,13 +338,16 @@ class WidgetSyncWorkerTest {
     private fun givenGlideBitmap() {
         val bitmap = mockk<Bitmap>(relaxed = true)
         val futureTarget = mockk<FutureTarget<Bitmap>>(relaxed = true)
-        every { futureTarget.get() } returns bitmap
+        // Loader now caps target size via submit(w, h) and adds a timeout to
+        // get(timeout, unit) — mock the args-bearing overloads so the new
+        // signature in WidgetSyncWorker.loadBitmap resolves.
+        every { futureTarget.get(any(), any()) } returns bitmap
 
         @Suppress("UNCHECKED_CAST")
         val requestBuilder = mockk<RequestBuilder<Bitmap>>(relaxed = true)
         every { requestBuilder.load(any<String>()) } returns requestBuilder
         every { requestBuilder.apply(any()) } returns requestBuilder
-        every { requestBuilder.submit() } returns futureTarget
+        every { requestBuilder.submit(any(), any()) } returns futureTarget
 
         val requestManager = mockk<RequestManager>(relaxed = true)
         every { requestManager.asBitmap() } returns requestBuilder

--- a/apps/mobile/lib/features/feed/application/app_camera_controller.dart
+++ b/apps/mobile/lib/features/feed/application/app_camera_controller.dart
@@ -5,7 +5,8 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:meep/features/feed/application/camera_state.dart';
-import 'package:meep/features/feed/data/image_flip.dart';
+import 'package:meep/features/feed/data/image_flip.dart'
+    show fixOrientationInPlace, flipImageHorizontallyInPlace;
 
 part 'app_camera_controller.g.dart';
 
@@ -109,11 +110,13 @@ class AppCameraController extends _$AppCameraController {
       state = state.copyWith(isCapturing: true);
       try {
         final file = await _cameraCtrl!.takePicture();
-        // Android lưu file cam trước un-mirror — flip lại để khớp với preview
-        // (selfie-mirror mặc định Android). Người dùng thấy "đúng mặt mình"
-        // ở cả live preview lẫn ảnh đã chụp.
+        debugPrint(
+          '[CameraCapture] takePicture done → ${file.path} | front=${state.isFrontCamera}',
+        );
         if (state.isFrontCamera) {
           await flipImageHorizontallyInPlace(file.path);
+        } else {
+          await fixOrientationInPlace(file.path);
         }
         return file.path;
       } catch (e) {
@@ -134,9 +137,10 @@ class AppCameraController extends _$AppCameraController {
       final file = await _cameraCtrl!.takePicture();
       final path = file.path;
 
-      // Flip mirror cho lens trước (cùng lý do với single mode).
       if (state.activeLens == CameraLens.front) {
         await flipImageHorizontallyInPlace(path);
+      } else {
+        await fixOrientationInPlace(path);
       }
 
       // Save photo to the appropriate slot

--- a/apps/mobile/lib/features/feed/application/feed_controller.dart
+++ b/apps/mobile/lib/features/feed/application/feed_controller.dart
@@ -137,16 +137,30 @@ class FeedController extends _$FeedController {
   }
 
   void _updateWidget(Ref ref, Post post) {
+    // Fire-and-forget. Sync `try` ngoài chỉ catch lỗi đồng bộ của
+    // `ref.read` (vd provider scope sai) — async error trong Future của
+    // `updateWidgetData` cần `.catchError`, nếu không sẽ trở thành
+    // unhandled async exception. `_safePoke` bên trong đã nuốt
+    // PlatformException/MissingPluginException, nên `.catchError` chỉ là
+    // safety net cho future-proof.
     try {
-      ref.read(widgetDataServiceProvider).updateWidgetData(
-            postId: post.postId,
-            imageUrl: post.coverImageUrl,
-            authorAvatarUrl: post.authorAvatarUrl,
-            caption: post.caption,
-            captionType: post.captionType?.name,
-          );
-    } catch (_) {
+      unawaited(
+        ref
+            .read(widgetDataServiceProvider)
+            .updateWidgetData(
+              postId: post.postId,
+              imageUrl: post.coverImageUrl,
+              authorAvatarUrl: post.authorAvatarUrl,
+              caption: post.caption,
+              captionType: post.captionType?.name,
+            )
+            .catchError((Object e, StackTrace st) {
+          debugPrint('[FeedController] widget update failed: $e\n$st');
+        }),
+      );
+    } catch (e, st) {
       // Best-effort — widget update must not crash the feed stream.
+      debugPrint('[FeedController] widget update sync error: $e\n$st');
     }
   }
 }

--- a/apps/mobile/lib/features/feed/application/post_controller.dart
+++ b/apps/mobile/lib/features/feed/application/post_controller.dart
@@ -196,19 +196,23 @@ class PostController extends _$PostController {
         }
       }
 
-      // authorName: chữ đầu tiên trong displayName, tối đa 6 ký tự.
-      // Dài hơn → cắt còn 6 + "...".
-      final rawName = user.displayName?.trim() ?? '';
-      final firstName = rawName.split(' ').first;
-      final authorName =
-          firstName.length <= 6 ? firstName : '${firstName.substring(0, 6)}...';
+      // authorName: lưu full displayName. UI tự handle ellipsis (xem
+      // `feed_section.dart` _AuthorLabel: maxLines 1 + ellipsis + Flexible).
+      // Ưu tiên Firestore profile (source of truth, luôn sync với
+      // /users/{uid}.displayName) — FirebaseAuth currentUser.displayName có
+      // thể null/empty với user đăng ký bằng email/phone trước khi sync về
+      // Auth.
+      final profile = ref.read(currentUserProfileProvider).valueOrNull;
+      final profileName = profile?.displayName.trim() ?? '';
+      final authorName = profileName.isNotEmpty
+          ? profileName
+          : (user.displayName?.trim() ?? '');
 
       final post = Post(
         postId: postId,
         authorId: uid,
         authorName: authorName,
-        authorAvatarUrl: user.photoURL ??
-            ref.read(currentUserProfileProvider).valueOrNull?.avatarUrl,
+        authorAvatarUrl: user.photoURL ?? profile?.avatarUrl,
         imageUrl: imageUrl,
         backImageUrl: backImageUrl,
         frontImageUrl: frontImageUrl,

--- a/apps/mobile/lib/features/feed/data/image_flip.dart
+++ b/apps/mobile/lib/features/feed/data/image_flip.dart
@@ -3,27 +3,85 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
 
-/// Lật ngang (mirror) ảnh tại [path] in-place, ghi đè file gốc bằng
-/// PNG đã flip.
-///
-/// Dùng cho ảnh chụp cam trước: Android `CameraController.takePicture()`
-/// lưu file un-mirror (đúng physical scene), trong khi preview lại
-/// selfie-mirror. Để file khớp với preview ng user thấy, flip lại bằng
-/// `dart:ui` Canvas — KHÔNG cần `image` package.
-///
-/// File output là PNG (không phải JPEG). Pipeline `PostController.submit`
-/// sau đó sẽ re-encode JPEG qua `flutter_image_compress`, nên format trung
-/// gian PNG không ảnh hưởng output cuối.
-///
-/// Returns true nếu flip thành công, false nếu decode/encode fail (gọi
-/// vẫn tiếp tục flow với file gốc un-mirror).
-Future<bool> flipImageHorizontallyInPlace(String path) async {
+const _tag = '[ImageOrientation]';
+
+Future<bool> fixOrientationInPlace(String path) async {
+  debugPrint('$_tag fixOrientation START');
   try {
-    final bytes = await File(path).readAsBytes();
+    // keepExif: true so Flutter's codec can read orientation and rotate pixels.
+    // keepExif: false strips the tag without guaranteeing pixel rotation on Android.
+    final compressed = await FlutterImageCompress.compressWithFile(
+      path,
+      minWidth: 1080,
+      minHeight: 1080,
+      quality: 100,
+      keepExif: true,
+      format: CompressFormat.jpeg,
+    );
+    if (compressed == null) {
+      debugPrint('$_tag fixOrientation: compress returned null');
+      return false;
+    }
+    debugPrint('$_tag fixOrientation: compress OK (${compressed.length}B)');
+
+    // Decode with Flutter's EXIF-aware codec → pixels are already rotated
+    // to the correct portrait orientation at this point.
+    final codec = await ui.instantiateImageCodec(compressed);
+    final frame = await codec.getNextFrame();
+    final src = frame.image;
+    debugPrint('$_tag fixOrientation: decoded ${src.width}x${src.height}');
+
+    // Re-render onto a canvas to bake the orientation into the pixel data
+    // so the saved file needs no EXIF tag for correct display.
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.drawImage(src, Offset.zero, Paint());
+    final picture = recorder.endRecording();
+    final baked = await picture.toImage(src.width, src.height);
+    final png = await baked.toByteData(format: ui.ImageByteFormat.png);
+    src.dispose();
+    baked.dispose();
+    picture.dispose();
+
+    if (png == null) {
+      debugPrint('$_tag fixOrientation: toByteData null');
+      return false;
+    }
+    await File(path).writeAsBytes(png.buffer.asUint8List());
+    debugPrint('$_tag fixOrientation DONE ✓');
+    return true;
+  } catch (e) {
+    debugPrint('$_tag fixOrientation FAILED: $e');
+    return false;
+  }
+}
+
+Future<bool> flipImageHorizontallyInPlace(String path) async {
+  debugPrint('$_tag flipHorizontal START');
+  try {
+    // keepExif: true so instantiateImageCodec can apply EXIF rotation before
+    // we flip. With keepExif: false the tag is stripped and the codec gets
+    // raw sensor pixels (landscape), making the flip direction wrong.
+    final oriented = await FlutterImageCompress.compressWithFile(
+      path,
+      minWidth: 1080,
+      minHeight: 1080,
+      quality: 100,
+      keepExif: true,
+      format: CompressFormat.jpeg,
+    );
+    if (oriented == null) {
+      debugPrint('$_tag flipHorizontal: compress returned null, using raw');
+    }
+    final bytes = oriented ?? await File(path).readAsBytes();
+    debugPrint('$_tag flipHorizontal: orient bytes=${bytes.length}');
+
     final codec = await ui.instantiateImageCodec(bytes);
     final frame = await codec.getNextFrame();
     final src = frame.image;
+    debugPrint('$_tag flipHorizontal after orient: ${src.width}x${src.height}');
 
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
@@ -38,11 +96,15 @@ Future<bool> flipImageHorizontallyInPlace(String path) async {
     flipped.dispose();
     picture.dispose();
 
-    if (png == null) return false;
+    if (png == null) {
+      debugPrint('$_tag flipHorizontal: toByteData null');
+      return false;
+    }
     await File(path).writeAsBytes(png.buffer.asUint8List());
+    debugPrint('$_tag flipHorizontal DONE ✓');
     return true;
   } catch (e) {
-    debugPrint('[flipImageHorizontallyInPlace] failed: $e');
+    debugPrint('$_tag flipHorizontal FAILED: $e');
     return false;
   }
 }

--- a/apps/mobile/lib/features/feed/presentation/grid_view_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/grid_view_screen.dart
@@ -183,7 +183,7 @@ class _GridTopBar extends ConsumerWidget {
             button: true,
             label: 'Quay lại',
             child: GestureDetector(
-              onTap: () => Navigator.of(context).pop(),
+              onTap: () => context.pop(),
               child: const Icon(Icons.arrow_back, color: AppColors.bw100),
             ),
           ),

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -238,7 +238,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           activeTab: TaskbarTab.home,
           chatBadgeCount: chatBadgeCount,
           onTabSelected: _onTaskbarTab,
-          onGridTap: () => context.go('/grid-view'),
+          onGridTap: () => context.push('/grid-view'),
           onUploadTap: _onShareTap,
           ringColor: ringColor,
         ),

--- a/apps/mobile/lib/features/notification/application/notification_controller.dart
+++ b/apps/mobile/lib/features/notification/application/notification_controller.dart
@@ -101,7 +101,14 @@ class NotificationController extends _$NotificationController {
   }
 
   Future<void> _saveToken(String token) async {
-    final uid = ref.read(currentUidProvider).valueOrNull;
+    // `valueOrNull` alone silently drops the token when the uid stream
+    // hasn't settled yet — happens during `initFcm()` if `getToken()`
+    // resolves before the auth stream emits, or when `onTokenRefresh`
+    // fires immediately after a fresh install. Await the next emission
+    // (resolves to the current value if already cached) so we save under
+    // the real uid. Stream emits null while signed-out → still drop.
+    var uid = ref.read(currentUidProvider).valueOrNull;
+    uid ??= await ref.read(currentUidProvider.future);
     if (uid == null) return;
     await ref.read(notificationRepositoryProvider).saveFcmToken(uid, token);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1160,21 +1160,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",


### PR DESCRIPTION
## Tóm tắt

- **fix(feed)**: sửa xoay ảnh sau khi chụp không đúng hướng, lưu full displayName từ Firestore profile, unawaited + catchError cho widget update, `context.go` → `context.push` cho grid-view
- **fix(android)**: giới hạn kích thước bitmap Glide tránh OOM + thêm timeout cho `loadBitmap`
- **fix(notification)**: await uid future trước khi lưu FCM token tránh bỏ sót token sau fresh install

## Root cause

### feed — xoay ảnh
`keepExif: false` strip EXIF không đảm bảo rotate pixel trên Android → `Image.file()` hiển thị sai hướng. `lockCaptureOrientation(portraitUp)` force portrait cứng bất kể thiết bị cầm hướng nào.

**Fix:** `keepExif: true` + Canvas re-render để bake orientation vào pixel; bỏ lock.

### android — OOM
`Glide.submit().get()` không giới hạn kích thước → decode full-res bitmap → RemoteViews bundle vượt 1MB IPC limit.

**Fix:** `submit(targetSize, targetSize)` + `.get(timeout, unit)` với `PHOTO_TARGET_PX=720`, `AVATAR_TARGET_PX=128`.

### notification — FCM token bị bỏ sót
`valueOrNull` drop token khi auth stream chưa emit tại `initFcm()` hoặc `onTokenRefresh` fire ngay sau fresh install.

**Fix:** fallback `await ref.read(currentUidProvider.future)` để đợi uid thật.

## Test
- `flutter analyze`: no issues
- `flutter test`: 743/743 passed