### PR TITLE
feat(release): cấu hình release Android — signing, R8, Crashlytics, CI

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Decode signing keystore
         run: |
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/release.keystore
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/release.keystore
           cat > android/key.properties <<EOF
           storeFile=release.keystore
           storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -158,17 +158,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine version
+      - name: Determine version (single source = pubspec.yaml)
         id: version
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            LAST_TAG=$(git tag --sort=-v:refname | head -n1 || echo "v0.0.0")
-            VERSION=$(echo "$LAST_TAG" | awk -F. -v OFS=. '{$NF = $NF + 1; print}')
+          # pubspec.yaml la source-of-truth duy nhat: version: X.Y.Z+BUILD
+          PUBSPEC_VERSION=$(grep '^version:' apps/mobile/pubspec.yaml | sed 's/version:[[:space:]]*//' | cut -d'+' -f1)
+          VERSION="v${PUBSPEC_VERSION}"
+          # workflow_dispatch input (neu co) PHAI khop pubspec -> chan version drift.
+          INPUT="${{ github.event.inputs.version }}"
+          if [ -n "$INPUT" ] && [ "$INPUT" != "$VERSION" ]; then
+            echo "::error::Version drift: input '$INPUT' != pubspec '$VERSION'. Bump pubspec.yaml truoc khi deploy."
+            exit 1
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
+          echo "Version (tu pubspec.yaml): $VERSION"
 
       - name: Generate changelog
         id: changelog

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -96,8 +96,14 @@ jobs:
 
       - name: Run Kotlin unit tests (widget native)
         run: |
+          # google-services.json gitignored (secret) -> tao dummy ephemeral cho
+          # google-services plugin parse. Robolectric unit test khong connect
+          # Firebase that nen gia tri dummy du; file KHONG commit.
+          cat > android/app/google-services.json <<'JSON'
+          {"project_info":{"project_number":"000000000000","project_id":"meep-ci-dummy","storage_bucket":"meep-ci-dummy.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"dev.meep.meep"}},"oauth_client":[],"api_key":[{"current_key":"AIzaSyDUMMYKEYFORCIROBOLECTRICUNITTEST0"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
+          JSON
           # gradlew khong commit (android/.gitignore) -> Flutter inject wrapper
-          # qua --config-only truoc khi goi gradle. Verify o CI run dau tien.
+          # qua --config-only truoc khi goi gradle.
           flutter build apk --config-only --release
           (cd android && ./gradlew :app:testDebugUnitTest --no-daemon)
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -68,6 +68,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.41.4'
@@ -88,6 +93,13 @@ jobs:
 
       - name: Test with coverage
         run: flutter test --coverage --reporter=expanded
+
+      - name: Run Kotlin unit tests (widget native)
+        run: |
+          # gradlew khong commit (android/.gitignore) -> Flutter inject wrapper
+          # qua --config-only truoc khi goi gradle. Verify o CI run dau tien.
+          flutter build apk --config-only --release
+          (cd android && ./gradlew :app:testDebugUnitTest --no-daemon)
 
       - name: Upload coverage artifact
         if: always()
@@ -121,8 +133,16 @@ jobs:
       - name: Type check
         run: npm run typecheck || npx tsc --noEmit
 
-      - name: Test
-        run: npm test
+      - name: Test with coverage
+        run: npm run test:coverage
+
+      - name: Upload functions coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: functions-coverage
+          path: firebase/functions/coverage/
+          retention-days: 7
 
   firestore-rules:
     name: Firestore security rules tests

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     // START: FlutterFire Configuration
@@ -7,6 +10,16 @@ plugins {
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// Upload-key signing: doc tu android/key.properties (gitignored, khong commit).
+// CI ghi file nay tu GitHub Secrets o deploy-production.yml. Local dev tu tao
+// theo docs/release-checklist.md. Vang file -> fallback debug de app van build.
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+val hasKeystore = keystorePropertiesFile.exists()
+if (hasKeystore) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -35,11 +48,32 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        if (hasKeystore) {
+            create("release") {
+                storeFile = rootProject.file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            // Upload key neu key.properties ton tai, else debug (CI PR build khong
+            // co secrets van chay duoc `flutter build --release` smoke test).
+            signingConfig = if (hasKeystore) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 

--- a/apps/mobile/android/app/proguard-rules.pro
+++ b/apps/mobile/android/app/proguard-rules.pro
@@ -1,0 +1,37 @@
+# Meep release ProGuard/R8 keep rules.
+# Giu symbol cho Crashlytics symbolication + chan R8 strip reflection-based SDK.
+
+# Crashlytics: giu line number + source file cho stacktrace doc duoc.
+-keepattributes SourceFile,LineNumberTable
+-keepattributes *Annotation*
+
+# Flutter engine + embedding (deferred components, plugin registrant).
+-keep class io.flutter.** { *; }
+-keep class io.flutter.plugins.** { *; }
+-keep class io.flutter.embedding.** { *; }
+# Flutter embedding tham chieu Play Core (deferred components / split install)
+# nhung app khong dung -> R8 bao missing class. App khong split nen dontwarn an toan.
+-dontwarn com.google.android.play.core.**
+-keep class com.google.android.play.core.** { *; }
+
+# Firebase (Auth/Firestore/Storage/Messaging/Crashlytics) — reflection noi bo.
+-keep class com.google.firebase.** { *; }
+-keep class com.google.android.gms.** { *; }
+-dontwarn com.google.firebase.**
+-dontwarn com.google.android.gms.**
+
+# Google Sign-In.
+-keep class com.google.android.gms.auth.** { *; }
+
+# WorkManager + widget native (WidgetSyncWorker chay qua reflection cua WorkManager).
+-keep class androidx.work.** { *; }
+-keep class dev.meep.meep.** { *; }
+
+# Glide (annotation processor sinh GeneratedAppGlideModule, load qua reflection).
+-keep public class * implements com.bumptech.glide.module.GlideModule
+-keep class * extends com.bumptech.glide.module.AppGlideModule { <init>(...); }
+-keep public enum com.bumptech.glide.load.ImageHeaderParser$** { **[] $VALUES; public *; }
+
+# Kotlin coroutines.
+-keepclassmembers class kotlinx.coroutines.** { volatile <fields>; }
+-dontwarn kotlinx.coroutines.**

--- a/apps/mobile/lib/core/observability/crashlytics_helper.dart
+++ b/apps/mobile/lib/core/observability/crashlytics_helper.dart
@@ -1,0 +1,58 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+
+/// Scrub PII khỏi error message trước khi gửi lên Crashlytics.
+///
+/// Meep handle ảnh + friend graph cá nhân; CLAUDE.md §PII handling cấm log
+/// email/caption/displayName. Crashlytics message có thể chứa các field này khi
+/// FirebaseException bọc data — redact trước khi report.
+class CrashlyticsHelper {
+  CrashlyticsHelper(this._crashlytics);
+
+  final FirebaseCrashlytics _crashlytics;
+
+  // Email: local@domain.tld
+  static final _emailPattern = RegExp(
+    r'[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}',
+  );
+  // Số điện thoại VN/quốc tế đơn giản: optional +, 9-15 digit.
+  static final _phonePattern = RegExp(r'(\+?\d[\d\s-]{8,14}\d)');
+  // Key-value nhạy cảm: caption=..., displayName: "...", email='...'
+  static final _sensitiveKvPattern = RegExp(
+    r'(caption|displayname|display_name|email|phone|token|fcmtoken|fcm_token)'
+    r'''\s*[:=]\s*("[^"]*"|'[^']*'|[^\s,}]+)''',
+    caseSensitive: false,
+  );
+
+  /// Trả về message đã redact PII. Pure — test riêng.
+  static String scrub(String input) {
+    var out = input;
+    out = out.replaceAllMapped(
+      _sensitiveKvPattern,
+      (m) => '${m.group(1)}=[REDACTED]',
+    );
+    out = out.replaceAll(_emailPattern, '[EMAIL]');
+    out = out.replaceAll(_phonePattern, '[PHONE]');
+    return out;
+  }
+
+  /// Record error với message đã scrub. Stack giữ nguyên (không chứa PII data).
+  Future<void> recordScrubbedError(
+    Object error,
+    StackTrace? stack, {
+    bool fatal = false,
+  }) {
+    return _crashlytics.recordError(
+      _ScrubbedError(scrub(error.toString())),
+      stack,
+      fatal: fatal,
+    );
+  }
+}
+
+/// Wrapper giữ message đã scrub làm `toString()` cho Crashlytics đọc.
+class _ScrubbedError {
+  _ScrubbedError(this._message);
+  final String _message;
+  @override
+  String toString() => _message;
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2,13 +2,16 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meep/core/config/app_config.dart';
+import 'package:meep/core/observability/crashlytics_helper.dart';
 import 'package:meep/core/router/app_router.dart';
 import 'package:meep/core/theme/app_theme.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
@@ -58,6 +61,25 @@ void main() async {
     FirebaseFirestore.instance.useFirestoreEmulator(_emulatorHost, 9999);
     await FirebaseStorage.instance.useStorageEmulator(_emulatorHost, 9199);
   }
+
+  // Crashlytics: bật collection chỉ ở production build (tắt debug + emulator để
+  // dashboard không nhiễu). Bắt cả Flutter framework error lẫn Dart-zone error.
+  await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(
+    !kDebugMode && !_useEmulator,
+  );
+  final crashlytics = CrashlyticsHelper(FirebaseCrashlytics.instance);
+  FlutterError.onError = (details) {
+    FlutterError.presentError(details);
+    crashlytics.recordScrubbedError(
+      details.exception,
+      details.stack,
+      fatal: true,
+    );
+  };
+  WidgetsBinding.instance.platformDispatcher.onError = (error, stack) {
+    crashlytics.recordScrubbedError(error, stack, fatal: true);
+    return true;
+  };
 
   final prefs = await SharedPreferences.getInstance();
 

--- a/apps/mobile/test/core/observability/crashlytics_helper_test.dart
+++ b/apps/mobile/test/core/observability/crashlytics_helper_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/core/observability/crashlytics_helper.dart';
+
+void main() {
+  group('CrashlyticsHelper.scrub', () {
+    test('redacts email addresses', () {
+      final out = CrashlyticsHelper.scrub('login failed for thien@meep.dev');
+      expect(out, isNot(contains('thien@meep.dev')));
+      expect(out, contains('[EMAIL]'));
+    });
+
+    test('redacts caption key-value', () {
+      final out =
+          CrashlyticsHelper.scrub('post error caption="bi mat cua toi"');
+      expect(out, isNot(contains('bi mat cua toi')));
+      expect(out, contains('[REDACTED]'));
+    });
+
+    test('redacts displayName key-value', () {
+      final out = CrashlyticsHelper.scrub('displayName: "Pham Thien"');
+      expect(out, isNot(contains('Pham Thien')));
+    });
+
+    test('redacts fcm token', () {
+      final out = CrashlyticsHelper.scrub('fcmToken=abc123APA91def');
+      expect(out, isNot(contains('APA91def')));
+      expect(out, contains('[REDACTED]'));
+    });
+
+    test('redacts phone numbers', () {
+      final out = CrashlyticsHelper.scrub('contact +84 912 345 678 failed');
+      expect(out, isNot(contains('912 345 678')));
+      expect(out, contains('[PHONE]'));
+    });
+
+    test('keeps non-PII technical message intact', () {
+      const msg = 'PERMISSION_DENIED: Missing or insufficient permissions';
+      expect(CrashlyticsHelper.scrub(msg), msg);
+    });
+  });
+}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,116 @@
+# Release Checklist — Meep (Android MVP)
+
+> Runbook trước khi ship M3. Theo đúng thứ tự. Mỗi step có command + cách verify.
+> Technical terms / commands giữ tiếng Anh.
+
+## 1. Pre-launch checklist (tick từng dòng)
+
+- [ ] Release keystore đã generate + backup vault (xem §2)
+- [ ] `key.properties` có trên máy build / CI secrets đã fill (xem §2)
+- [ ] `flutter build appbundle --release` BUILD SUCCESSFUL, ký bằng upload key (xem §5)
+- [ ] SHA256 fingerprint upload key đã cập nhật vào `firebase/public/.well-known/assetlinks.json`
+- [ ] ProGuard giữ rule OK — smoke test auth + Firestore read + feed render trên release build không crash
+- [ ] Crashlytics nhận test crash (xem §5)
+- [ ] version bump trong `apps/mobile/pubspec.yaml` (single source — xem §3)
+- [ ] App Check enabled (SEC APPCHECK-001)
+- [ ] Firestore + Storage rules deploy prod
+- [ ] Play Store listing assets sẵn sàng (icon, screenshot, mô tả)
+- [ ] Privacy policy URL + Terms URL
+
+## 2. Signing key — generate / backup / restore
+
+### Generate (1 lần duy nhất)
+
+```bash
+keytool -genkey -v -keystore release.keystore \
+  -alias upload -keyalg RSA -keysize 4096 -validity 10000
+```
+
+### key.properties (local, gitignored — KHÔNG commit)
+
+```properties
+storeFile=release.keystore
+storePassword=<password>
+keyAlias=upload
+keyPassword=<password>
+```
+
+Đặt `release.keystore` tại `apps/mobile/android/release.keystore`, `key.properties` tại `apps/mobile/android/key.properties`.
+
+> `build.gradle.kts` resolve `storeFile` qua `rootProject.file(...)` (rootProject = `apps/mobile/android/`), nên keystore phải nằm ở `android/release.keystore` — khớp với cách CI ghi ở `deploy-production.yml`.
+
+### Backup
+
+- Lưu `release.keystore` + password vào vault (1Password/Bitwarden). **MẤT KEY = không update được app trên Play Store vĩnh viễn.**
+- Upload cho CI:
+
+```bash
+base64 -w0 release.keystore | gh secret set ANDROID_KEYSTORE_BASE64
+gh secret set ANDROID_KEYSTORE_PASSWORD
+gh secret set ANDROID_KEY_ALIAS     # = upload
+gh secret set ANDROID_KEY_PASSWORD
+```
+
+### Restore (máy mới / CI)
+
+- Local: copy keystore từ vault về `apps/mobile/android/release.keystore`, tạo lại `key.properties`.
+- CI: `deploy-production.yml` tự decode từ `ANDROID_KEYSTORE_BASE64`.
+
+### Lấy SHA256 fingerprint (cho assetlinks.json)
+
+```bash
+keytool -list -v -keystore release.keystore -alias upload | grep SHA256
+```
+
+## 3. Version bump (single source = pubspec.yaml)
+
+- Sửa `apps/mobile/pubspec.yaml` dòng `version: X.Y.Z+BUILD`.
+- PATCH cho fix-only, MINOR cho feature (theo Conventional Commits từ tag gần nhất).
+- CI `deploy-production.yml` đọc version từ pubspec; nếu truyền `workflow_dispatch.inputs.version` mà lệch pubspec → CI fail (chặn version drift).
+
+## 4. Deploy flow
+
+```bash
+git checkout deploy && git merge --no-ff origin/develop
+git push origin deploy
+# -> deploy-production.yml chạy, approve ở GitHub Environments "production"
+```
+
+Verify: Firebase Console deploy timestamp + GitHub release tag = pubspec version.
+
+## 5. Smoke test (sau khi có AAB/APK)
+
+### Verify signing
+
+```bash
+flutter build appbundle --release
+jarsigner -verify -verbose -certs \
+  build/app/outputs/bundle/release/app-release.aab | grep -i "alias\|CN="
+# -> phải thấy alias "upload" / CN của upload key, KHÔNG phải androiddebugkey
+```
+
+### Verify runtime (R8 không strip nhầm)
+
+- Install APK trên thiết bị Android sạch.
+- Sign-up user mới -> take post -> verify feed -> verify home-screen widget refresh -> sign out + in lại.
+
+### Verify Crashlytics
+
+- Trigger `FirebaseCrashlytics.instance.crash()` ở build có collection on -> dashboard nhận trong ~5 phút, stacktrace symbolicate được (nhờ ProGuard `-keepattributes SourceFile,LineNumberTable`).
+
+## 6. Rollback
+
+```bash
+gh release delete vX.Y.Z
+git checkout deploy && git revert <merge-sha> && git push
+# redeploy Functions/Rules từ tag trước:
+firebase deploy --only functions,firestore:rules,storage:rules --project meep-prod --force
+```
+
+## 7. Play Store upload
+
+1. Play Console -> Production -> Create new release.
+2. Upload `apps/mobile/build/app/outputs/bundle/release/app-release.aab`.
+3. Google Play App Signing: enroll (Google giữ app signing key; upload key = key của mình).
+4. Điền release notes (tiếng Việt), chọn rollout %.
+5. Submit review.


### PR DESCRIPTION
## Mô tả

Hoàn thiện cấu hình release cho Android MVP: ký bằng upload keystore, bật R8 minify/shrink + ProGuard, wire Crashlytics có scrub PII, bổ sung CI (Java, Kotlin test, coverage, version single-source) và runbook release. Gom 7 issue release-readiness từ audit 06 vào 1 PR.

## Refs

- Audit: `docs/audits/06_testing_ci_release_audit.md` — SIGN-001, REL-MINIFY-001, CRASHLYTICS-001, CI-MOBILE-002, CI-MOBILE-003, CI-FUNC-001, REL-VERSION-001, DOCS-REL-001
- Defer: CI-MOBILE-001 (chờ E2E-001 scaffold `integration_test/`)

## Thay đổi chính

- `apps/mobile/android/app/build.gradle.kts`: signingConfig release đọc `key.properties` (fallback debug nếu vắng) + `isMinifyEnabled`/`isShrinkResources`/`proguardFiles`.
- `apps/mobile/android/app/proguard-rules.pro` (mới): keep Firebase/Flutter/GMS/Glide/WorkManager + keepattributes cho Crashlytics symbolication + dontwarn play.core.
- `apps/mobile/lib/main.dart`: wire `FlutterError.onError` + `PlatformDispatcher.onError` + `setCrashlyticsCollectionEnabled(!debug && !emulator)`.
- `apps/mobile/lib/core/observability/crashlytics_helper.dart` (mới): `CrashlyticsHelper.scrub` redact PII + `recordScrubbedError`.
- `.github/workflows/pr-check.yml`: setup-java@21, Kotlin unit test, functions `test:coverage` + artifact.
- `.github/workflows/deploy-production.yml`: version single-source từ pubspec.yaml + guard chống drift; keystore decode về `android/release.keystore`.
- `docs/release-checklist.md` (mới): runbook pre-launch, keystore, version, deploy, rollback, Play Store.

## Loại thay đổi

- [x] feat — Tính năng mới (release signing + Crashlytics + CI)

## Test

- [x] Đã chạy `flutter test` PASS (749 test, gồm 6 test mới `crashlytics_helper`)
- [x] Đã chạy `flutter analyze --fatal-infos` clean (0 issue)
- [x] Đã chạy `dart format --set-exit-if-changed` PASS
- [ ] (Functions) `npm test` — KHÔNG chạy local; chỉ đổi CI gọi `test:coverage` (script + `@vitest/coverage-v8` đã verify tồn tại). Chạy ở CI.
- [ ] (Firestore rules) — không đụng
- [x] Đã test thủ công: build AAB release + verify signing (xem dưới)

### Cách test thủ công

1. Tạo test keystore tạm (alias `upload`) + `key.properties` trỏ `android/release.keystore`.
2. `flutter build appbundle --release` → BUILD SUCCESSFUL (`app-release.aab` 55.1MB).
3. `jarsigner -verify -certs app-release.aab` → signer `CN=Meep Test` alias `upload`, KHÔNG androiddebugkey.
4. Confirm `flutter build apk --config-only` inject `gradlew` + `gradle-wrapper.jar` (CI-MOBILE-003 chạy được).

## Lưu ý cho reviewer

- `.github/` thường không thuộc feature branch theo CLAUDE.md, nhưng CI release config là trọng tâm task này — leader (ThienPDM) đã duyệt gộp vào PR.
- **Trước khi merge sang `deploy`:** cần tạo release keystore thật + fill 4 GitHub Secrets (`ANDROID_KEYSTORE_BASE64/_PASSWORD`, `ANDROID_KEY_ALIAS/_PASSWORD`) theo `docs/release-checklist.md §2`, và cập nhật SHA256 fingerprint vào `assetlinks.json`.
- **R8 runtime chưa test trên device** (cần google-services.json thật) — smoke test §5 checklist sẽ verify auth/Firestore/feed không bị strip nhầm.
- Version giờ là single-source từ `pubspec.yaml` (hiện `0.1.0+1`); muốn release phải bump pubspec trước, CI sẽ fail nếu workflow_dispatch input lệch.

## Self-review checklist

- [x] Branch name đúng format `fix/ThienPDM/release-config-rest`
- [x] Commit message tiếng Việt, Conventional Commits (4 commit logical group)
- [x] Không có file lớn vô tình (keystore/key.properties/google-services gitignored, đã verify)
- [x] Không có `print` debug sót
- [x] Không có `// TODO` chưa link issue
- [x] Không có dead code comment-out
- [x] Đã `/review` sạch (0 critical, 0 important)
