### PR TITLE
fix(rules): siết Firestore/Storage rules + Functions auth/input/idempotency

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -156,5 +156,4 @@ jobs:
           firebase emulators:exec \
             --only firestore,storage \
             --project demo-meep-test \
-            "cd functions && npm run test:rules" \
-          || echo "::warning::Rules tests skipped (chưa có script test:rules — sẽ enable khi có rules tests đầu tiên)"
+            "cd functions && npm run test:rules"

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- WidgetSyncWorker (T3) reaches Firestore/Storage over network -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Reschedule WidgetSyncWorker periodic work sau khi device reboot —
+         WorkManager tự handle reschedule khi có permission này (PERM-001). -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- Android 13+ runtime notification permission cho FCM push. Plugin
+         request runtime nhưng phải declare ở manifest (PERM-001). -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:label="Meep"

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -144,8 +144,19 @@ service cloud.firestore {
            request.resource.data.caption.size() <= 200)
         );
 
+      // Update chỉ cho phép sửa caption (+ updatedAt). authorId/createdAt/
+      // imageUrl/audienceType/memberIds/... IMMUTABLE post-creation — chặn
+      // author đổi nội dung ảnh hoặc inflate doc size. Caption re-check cap
+      // 200 vì create rule cap không tự áp cho update (POST-SEC-001).
       allow update: if isOwner(resource.data.authorId)
-        && request.resource.data.authorId == resource.data.authorId;
+        && request.resource.data.authorId == resource.data.authorId
+        && request.resource.data.diff(resource.data).affectedKeys()
+             .hasOnly(['caption', 'updatedAt'])
+        && (
+          !request.resource.data.diff(resource.data).affectedKeys().hasAny(['caption']) ||
+          (request.resource.data.caption is string &&
+           request.resource.data.caption.size() <= 200)
+        );
 
       allow delete: if isOwner(resource.data.authorId);
 
@@ -159,10 +170,39 @@ service cloud.firestore {
         allow create: if isAuthed()
           && request.auth.uid == reactorUid
           && request.auth.uid == request.resource.data.reactorUid
-          && request.resource.data.emoji.size() > 0;
+          && (
+            request.auth.uid ==
+              get(/databases/$(database)/documents/posts/$(postId)).data.authorId ||
+            exists(/databases/$(database)/documents/users/$(request.auth.uid)/feed/$(postId))
+          )
+          && request.resource.data.emoji is string
+          && request.resource.data.emoji.size() > 0
+          && request.resource.data.emoji.size() <= 32
+          && (!('reactorName' in request.resource.data) ||
+              (request.resource.data.reactorName is string &&
+               request.resource.data.reactorName.size() <= 50))
+          && (!('reactorAvatarUrl' in request.resource.data) ||
+              (request.resource.data.reactorAvatarUrl is string &&
+               request.resource.data.reactorAvatarUrl.size() <= 500));
+        // Create gate: reactor phải đọc được post (author hoặc có feed
+        // fan-out doc) — mirror reactions READ rule trên, chặn stranger ghi
+        // reaction lên post không thấy. emoji cap 32 (ZWJ family) mirror
+        // /spaces iconEmoji; reactorName cap 50 mirror /messages
+        // senderDisplayName — chống impersonation trong reaction list UI
+        // (REACTION-SEC-001).
         allow update: if isAuthed() && request.auth.uid == reactorUid
           && request.resource.data.diff(resource.data).affectedKeys()
-            .hasOnly(['emoji', 'createdAt', 'reactorName', 'reactorAvatarUrl']);
+            .hasOnly(['emoji', 'createdAt', 'reactorName', 'reactorAvatarUrl'])
+          && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['emoji']) ||
+              (request.resource.data.emoji is string &&
+               request.resource.data.emoji.size() > 0 &&
+               request.resource.data.emoji.size() <= 32))
+          && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['reactorName']) ||
+              (request.resource.data.reactorName is string &&
+               request.resource.data.reactorName.size() <= 50))
+          && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['reactorAvatarUrl']) ||
+              (request.resource.data.reactorAvatarUrl is string &&
+               request.resource.data.reactorAvatarUrl.size() <= 500));
         // reactorName + reactorAvatarUrl whitelist vì denormalize từ
         // UserProfile — user đổi profile rồi react lại sẽ refresh các field
         // này. reactorUid IMMUTABLE (không trong whitelist).
@@ -285,12 +325,40 @@ service cloud.firestore {
             || request.auth.uid in resource.data.participantIds);
       allow list: if isAuthed()
         && request.auth.uid in resource.data.participantIds;
+      // Create gate qua friend graph / space membership — chat chỉ giữa
+      // friends hoặc trong space chung (Meep "intimate friends" semantic).
+      //   - direct: conversationId PHẢI == sorted pairId của 2 participantIds
+      //     (chặn forge id khớp friendship khác để DM người lạ) + friendship
+      //     doc tồn tại (id == pairId ⟹ friendship đúng giữa 2 participant đó).
+      //   - space: conversationId == spaceId, caller là member, mọi
+      //     participant ⊆ memberIds (chặn kéo người ngoài space vào chat).
+      // Space conversation thường do CF tạo (Admin SDK bypass rule); nhánh
+      // này chỉ là defense cho client idempotent retry (CHAT-SEC-001).
       allow create: if isAuthed()
-        && request.resource.data.participantIds.hasAll([request.auth.uid]);
+        && request.auth.uid in request.resource.data.participantIds
+        && (
+          (request.resource.data.type == 'direct'
+            && request.resource.data.participantIds.size() == 2
+            && (conversationId ==
+                  request.resource.data.participantIds[0] + '_' + request.resource.data.participantIds[1]
+                || conversationId ==
+                  request.resource.data.participantIds[1] + '_' + request.resource.data.participantIds[0])
+            && exists(/databases/$(database)/documents/friendships/$(conversationId)))
+          ||
+          (request.resource.data.type == 'space'
+            && isMember(conversationId)
+            && request.resource.data.participantIds.hasOnly(
+                 get(/databases/$(database)/documents/spaces/$(conversationId)).data.memberIds))
+        );
       // Whitelist update fields: lastMessage/lastMessageAt/lastSenderId set
       // bởi sendMessage; lastReadAt bởi markAsRead.
       // (quotedPostId moved to per-MESSAGE — FB story reply pattern, không
       // phải per-conversation nữa.)
+      // Value validation (CHAT-SEC-002): chống tamper inbox preview —
+      // lastSenderId phải == caller (không giả mạo sender), lastMessage cap
+      // 500, lastMessageAt timestamp, lastReadAt map. markAsRead dùng
+      // dot-notation `lastReadAt.{uid}` → affectedKeys = ['lastReadAt'],
+      // request.resource.data.lastReadAt là map đã merge → `is map` pass.
       allow update: if isAuthed()
         && request.auth.uid in resource.data.participantIds
         && request.resource.data.diff(resource.data).affectedKeys()
@@ -299,7 +367,16 @@ service cloud.firestore {
                'lastMessageAt',
                'lastSenderId',
                'lastReadAt',
-             ]);
+             ])
+        && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['lastMessage'])
+            || (request.resource.data.lastMessage is string
+                && request.resource.data.lastMessage.size() <= 500))
+        && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['lastSenderId'])
+            || request.resource.data.lastSenderId == request.auth.uid)
+        && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['lastMessageAt'])
+            || request.resource.data.lastMessageAt is timestamp)
+        && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['lastReadAt'])
+            || request.resource.data.lastReadAt is map);
       allow delete: if false;
 
       // Messages subcollection vẫn dùng isParticipant() — query luôn scoped
@@ -335,10 +412,17 @@ service cloud.firestore {
         && request.resource.data.privacy in ['private', 'public']
         && request.resource.data.content.size() <= 20
         && request.resource.data.moodCaption.size() <= 50;
+      // Update mirror create validation: privacy enum + type guard trước
+      // .size() (content là list, moodCaption là string per DiaryEntry model)
+      // — chống set privacy='invalid' hoặc shape sai gây crash list render
+      // (DIARY-SEC-001).
       allow update: if isAuthed()
         && resource.data.authorUid == request.auth.uid
         && request.resource.data.authorUid == resource.data.authorUid
+        && request.resource.data.privacy in ['private', 'public']
+        && request.resource.data.content is list
         && request.resource.data.content.size() <= 20
+        && request.resource.data.moodCaption is string
         && request.resource.data.moodCaption.size() <= 50;
       allow delete: if isAuthed()
         && resource.data.authorUid == request.auth.uid;

--- a/firebase/functions/src/firestore.rules.test.ts
+++ b/firebase/functions/src/firestore.rules.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@firebase/rules-unit-testing';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
 // ===== Setup =====
 
@@ -834,6 +834,7 @@ describe('/conversations/{conversationId}', () => {
   });
 
   test('participant cannot send message when conversation is blocked', async () => {
+    await seedConversation();
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await ctx.firestore().doc(`conversations/${CONV_ID}`).update({
         status: 'blocked',
@@ -894,6 +895,387 @@ describe('/conversations/{conversationId}', () => {
         .doc(`conversations/${CONV_ID}/messages/msg-del`)
         .delete(),
     );
+  });
+});
+
+// ===== /posts — update field whitelist + caption cap (POST-SEC-001) =====
+
+describe('/posts/{postId} — update', () => {
+  const alice = uid('alice');
+  const bob = uid('bob');
+  const POST_ID = 'post-upd';
+
+  async function seedPost() {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`posts/${POST_ID}`).set({
+        authorId: alice,
+        authorName: 'Alice',
+        imageUrl: 'https://example.com/photo.jpg',
+        audienceType: 'all',
+        caption: 'ok',
+        createdAt: new Date(),
+      });
+    });
+  }
+
+  test('author can edit caption (within cap)', async () => {
+    await seedPost();
+    await assertSucceeds(
+      authed(alice).firestore().doc(`posts/${POST_ID}`).update({ caption: 'updated' }),
+    );
+  });
+
+  test('author cannot set caption > 200 chars', async () => {
+    await seedPost();
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`posts/${POST_ID}`)
+        .update({ caption: 'a'.repeat(201) }),
+    );
+  });
+
+  test('author cannot mutate imageUrl (not in whitelist)', async () => {
+    await seedPost();
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`posts/${POST_ID}`)
+        .update({ imageUrl: 'https://evil.com/x.jpg' }),
+    );
+  });
+
+  test('author cannot mutate authorId', async () => {
+    await seedPost();
+    await assertFails(
+      authed(alice).firestore().doc(`posts/${POST_ID}`).update({ authorId: bob }),
+    );
+  });
+
+  test('non-author cannot update', async () => {
+    await seedPost();
+    await assertFails(
+      authed(bob).firestore().doc(`posts/${POST_ID}`).update({ caption: 'hijack' }),
+    );
+  });
+});
+
+// ===== /posts/{postId}/reactions — field validation (REACTION-SEC-001) =====
+
+describe('/posts/{postId}/reactions/{reactorUid}', () => {
+  const alice = uid('alice');
+  const bob = uid('bob');
+  const POST_ID = 'post-react';
+
+  async function seedPostAndFeed() {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`posts/${POST_ID}`).set({
+        authorId: alice,
+        authorName: 'Alice',
+        imageUrl: 'https://example.com/photo.jpg',
+        audienceType: 'all',
+        createdAt: new Date(),
+      });
+      // bob nhận post qua feed fan-out → được react.
+      await ctx.firestore().doc(`users/${bob}/feed/${POST_ID}`).set({ postId: POST_ID });
+    });
+  }
+
+  test('reactor can create valid reaction', async () => {
+    await seedPostAndFeed();
+    await assertSucceeds(
+      authed(bob).firestore().doc(`posts/${POST_ID}/reactions/${bob}`).set({
+        reactorUid: bob,
+        reactorName: 'Bob',
+        emoji: '❤️',
+        createdAt: new Date(),
+      }),
+    );
+  });
+
+  test('reactorName > 50 chars rejected on create', async () => {
+    await seedPostAndFeed();
+    await assertFails(
+      authed(bob).firestore().doc(`posts/${POST_ID}/reactions/${bob}`).set({
+        reactorUid: bob,
+        reactorName: 'B'.repeat(51),
+        emoji: '❤️',
+        createdAt: new Date(),
+      }),
+    );
+  });
+
+  test('emoji > 32 chars rejected on create', async () => {
+    await seedPostAndFeed();
+    await assertFails(
+      authed(bob).firestore().doc(`posts/${POST_ID}/reactions/${bob}`).set({
+        reactorUid: bob,
+        reactorName: 'Bob',
+        emoji: '😀'.repeat(20),
+        createdAt: new Date(),
+      }),
+    );
+  });
+
+  test('reactor cannot tamper reactorName > 50 on update', async () => {
+    await seedPostAndFeed();
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`posts/${POST_ID}/reactions/${bob}`).set({
+        reactorUid: bob,
+        reactorName: 'Bob',
+        emoji: '❤️',
+        createdAt: new Date(),
+      });
+    });
+    await assertFails(
+      authed(bob)
+        .firestore()
+        .doc(`posts/${POST_ID}/reactions/${bob}`)
+        .update({ reactorName: 'X'.repeat(51) }),
+    );
+  });
+});
+
+// ===== /conversations — create gate + update tamper (CHAT-SEC-001/002) =====
+
+describe('/conversations — create friend/space gate', () => {
+  const alice = uid('alice');
+  const bob = uid('bob');
+  const stranger = uid('stranger');
+
+  test('friend can create direct conversation', async () => {
+    const convId = [alice, bob].sort().join('_');
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`friendships/${convId}`).set({
+        members: [alice, bob],
+        createdAt: new Date(),
+      });
+    });
+    await assertSucceeds(
+      authed(alice).firestore().doc(`conversations/${convId}`).set({
+        conversationId: convId,
+        type: 'direct',
+        participantIds: [alice, bob],
+        status: 'active',
+        lastMessage: '',
+        lastMessageAt: new Date(),
+        lastSenderId: '',
+        createdAt: new Date(),
+      }),
+    );
+  });
+
+  test('stranger (no friendship) cannot create direct conversation', async () => {
+    const convId = [alice, stranger].sort().join('_');
+    await assertFails(
+      authed(alice).firestore().doc(`conversations/${convId}`).set({
+        conversationId: convId,
+        type: 'direct',
+        participantIds: [alice, stranger],
+        status: 'active',
+        lastMessage: '',
+        lastMessageAt: new Date(),
+        lastSenderId: '',
+        createdAt: new Date(),
+      }),
+    );
+  });
+
+  test('cannot forge conversationId to a friend pairId while DM-ing a non-friend', async () => {
+    // alice friend bob (friendships/alice_bob exists). alice tries to create
+    // doc at id=alice_bob but with participantIds=[alice, stranger] → must DENY
+    // (conversationId không khớp pairId của participantIds).
+    const bobPair = [alice, bob].sort().join('_');
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`friendships/${bobPair}`).set({
+        members: [alice, bob],
+        createdAt: new Date(),
+      });
+    });
+    await assertFails(
+      authed(alice).firestore().doc(`conversations/${bobPair}`).set({
+        conversationId: bobPair,
+        type: 'direct',
+        participantIds: [alice, stranger],
+        status: 'active',
+        lastMessage: '',
+        lastMessageAt: new Date(),
+        lastSenderId: '',
+        createdAt: new Date(),
+      }),
+    );
+  });
+
+  test('space member can create space conversation', async () => {
+    const SPACE_ID = 'space-conv-1';
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`spaces/${SPACE_ID}`).set({
+        creatorId: alice,
+        memberIds: [alice, bob],
+        name: 'Space',
+        createdAt: new Date(),
+      });
+    });
+    await assertSucceeds(
+      authed(alice).firestore().doc(`conversations/${SPACE_ID}`).set({
+        conversationId: SPACE_ID,
+        type: 'space',
+        participantIds: [alice, bob],
+        status: 'active',
+        lastMessage: '',
+        lastMessageAt: new Date(),
+        lastSenderId: '',
+        createdAt: new Date(),
+      }),
+    );
+  });
+});
+
+describe('/conversations — update tamper guards', () => {
+  const alice = uid('alice');
+  const bob = uid('bob');
+  const CONV_ID = [alice, bob].sort().join('_');
+
+  async function seedConversation() {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`conversations/${CONV_ID}`).set({
+        conversationId: CONV_ID,
+        type: 'direct',
+        participantIds: [alice, bob],
+        status: 'active',
+        lastMessage: '',
+        lastMessageAt: new Date(),
+        lastSenderId: '',
+        createdAt: new Date(),
+      });
+    });
+  }
+
+  test('participant can update with valid lastMessage + own lastSenderId', async () => {
+    await seedConversation();
+    await assertSucceeds(
+      authed(alice).firestore().doc(`conversations/${CONV_ID}`).update({
+        lastMessage: 'Hi',
+        lastMessageAt: new Date(),
+        lastSenderId: alice,
+      }),
+    );
+  });
+
+  test('cannot forge lastSenderId to another user', async () => {
+    await seedConversation();
+    await assertFails(
+      authed(alice).firestore().doc(`conversations/${CONV_ID}`).update({
+        lastMessage: 'fake from bob',
+        lastSenderId: bob,
+      }),
+    );
+  });
+
+  test('cannot set lastMessage > 500 chars', async () => {
+    await seedConversation();
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`conversations/${CONV_ID}`)
+        .update({ lastMessage: 'a'.repeat(501), lastSenderId: alice }),
+    );
+  });
+
+  test('markAsRead dot-notation lastReadAt still allowed', async () => {
+    await seedConversation();
+    await assertSucceeds(
+      authed(alice)
+        .firestore()
+        .doc(`conversations/${CONV_ID}`)
+        .update({ [`lastReadAt.${alice}`]: new Date() }),
+    );
+  });
+});
+
+// ===== /diary — update privacy enum + type guard (DIARY-SEC-001) =====
+
+describe('/diary/{entryId} — update validation', () => {
+  const alice = uid('alice');
+  const ENTRY_ID = 'entry-upd';
+
+  async function seedEntry() {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`diary/${ENTRY_ID}`).set({
+        authorUid: alice,
+        privacy: 'private',
+        moodTemplate: 'happy',
+        coverImageUrl: 'https://example.com/cover.jpg',
+        moodCaption: 'Title',
+        content: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    });
+  }
+
+  test('owner can update with valid privacy', async () => {
+    await seedEntry();
+    await assertSucceeds(
+      authed(alice).firestore().doc(`diary/${ENTRY_ID}`).update({
+        moodCaption: 'New title',
+        updatedAt: new Date(),
+      }),
+    );
+  });
+
+  test('invalid privacy enum rejected on update', async () => {
+    await seedEntry();
+    await assertFails(
+      authed(alice).firestore().doc(`diary/${ENTRY_ID}`).update({ privacy: 'leaked' }),
+    );
+  });
+});
+
+// ===== /friendships/{pid} (TESTING-SEC-001 coverage) =====
+
+describe('/friendships/{pid}', () => {
+  const alice = uid('alice');
+  const bob = uid('bob');
+  const stranger = uid('stranger');
+  const PID = [alice, bob].sort().join('_');
+
+  async function seedFriendship() {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`friendships/${PID}`).set({
+        members: [alice, bob],
+        createdAt: new Date(),
+      });
+    });
+  }
+
+  test('member can read', async () => {
+    await seedFriendship();
+    await assertSucceeds(authed(alice).firestore().doc(`friendships/${PID}`).get());
+  });
+
+  test('non-member cannot read', async () => {
+    await seedFriendship();
+    await assertFails(authed(stranger).firestore().doc(`friendships/${PID}`).get());
+  });
+
+  test('client cannot create (server-side only)', async () => {
+    await assertFails(
+      authed(alice).firestore().doc(`friendships/${PID}`).set({
+        members: [alice, bob],
+        createdAt: new Date(),
+      }),
+    );
+  });
+
+  test('member can delete (unfriend)', async () => {
+    await seedFriendship();
+    await assertSucceeds(authed(alice).firestore().doc(`friendships/${PID}`).delete());
+  });
+
+  test('non-member cannot delete', async () => {
+    await seedFriendship();
+    await assertFails(authed(stranger).firestore().doc(`friendships/${PID}`).delete());
   });
 });
 

--- a/firebase/functions/src/friend/acceptFriendRequest.ts
+++ b/firebase/functions/src/friend/acceptFriendRequest.ts
@@ -2,9 +2,11 @@ import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { z } from 'zod';
 
-const acceptFriendRequestSchema = z.object({
-  requestId: z.string().min(1),
-});
+const acceptFriendRequestSchema = z
+  .object({
+    requestId: z.string().min(1),
+  })
+  .strict();
 
 /**
  * Accept a pending friend request and create the friendship doc.

--- a/firebase/functions/src/index.test.ts
+++ b/firebase/functions/src/index.test.ts
@@ -3,9 +3,12 @@ import { z } from 'zod';
 
 // Re-declare the schema here for testing (intentional duplication —
 // keeps the test stable even if index.ts later splits the schema out).
-const sendFriendRequestSchema = z.object({
-  toUid: z.string().min(1).max(128),
-});
+// .strict() mirror FUNC-SEC-001 — reject excess properties.
+const sendFriendRequestSchema = z
+  .object({
+    toUid: z.string().min(1).max(128),
+  })
+  .strict();
 
 describe('sendFriendRequestSchema', () => {
   test('accepts a valid uid', () => {
@@ -25,6 +28,14 @@ describe('sendFriendRequestSchema', () => {
 
   test('rejects a non-string uid', () => {
     const result = sendFriendRequestSchema.safeParse({ toUid: 12345 });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects excess properties (.strict — FUNC-SEC-001)', () => {
+    const result = sendFriendRequestSchema.safeParse({
+      toUid: 'user-abc',
+      evil: 'payload',
+    });
     expect(result.success).toBe(false);
   });
 });

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -21,9 +21,11 @@ setGlobalOptions({
 
 // ===== Schemas =====
 
-const sendFriendRequestSchema = z.object({
-  toUid: z.string().min(1).max(128),
-});
+const sendFriendRequestSchema = z
+  .object({
+    toUid: z.string().min(1).max(128),
+  })
+  .strict();
 
 // ===== Callable functions =====
 

--- a/firebase/functions/src/settings/blockUser.ts
+++ b/firebase/functions/src/settings/blockUser.ts
@@ -8,9 +8,11 @@ import { z } from 'zod';
  * Server source of truth: client (`FirebaseBlockRepository.blockUser`) chỉ
  * gửi `targetUid` — server tự derive `blockerUid` từ `request.auth.uid`.
  */
-const blockUserSchema = z.object({
-  targetUid: z.string().min(1).max(128),
-});
+const blockUserSchema = z
+  .object({
+    targetUid: z.string().min(1).max(128),
+  })
+  .strict();
 
 /**
  * Block a user atomically.

--- a/firebase/functions/src/settings/deleteAccount.test.ts
+++ b/firebase/functions/src/settings/deleteAccount.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from 'vitest';
+import {
+  isReauthWithinWindow,
+  REAUTH_WINDOW_SECONDS,
+} from './deleteAccount.js';
+
+describe('isReauthWithinWindow (AUTH-SEC-001)', () => {
+  const now = 1_000_000;
+
+  test('fresh token (auth_time = now) is within window', () => {
+    expect(isReauthWithinWindow(now, now)).toBe(true);
+  });
+
+  test('token at exactly the window boundary is allowed', () => {
+    expect(isReauthWithinWindow(now - REAUTH_WINDOW_SECONDS, now)).toBe(true);
+  });
+
+  test('token 1 second past the window is rejected', () => {
+    expect(isReauthWithinWindow(now - REAUTH_WINDOW_SECONDS - 1, now)).toBe(false);
+  });
+
+  test('stale token (1 hour old) is rejected', () => {
+    expect(isReauthWithinWindow(now - 3600, now)).toBe(false);
+  });
+
+  test('clock skew (auth_time in the future) is treated as fresh', () => {
+    expect(isReauthWithinWindow(now + 30, now)).toBe(true);
+  });
+});

--- a/firebase/functions/src/settings/deleteAccount.ts
+++ b/firebase/functions/src/settings/deleteAccount.ts
@@ -15,6 +15,32 @@ import { z } from 'zod';
 const deleteAccountSchema = z.unknown();
 
 /**
+ * Reauth window cho destructive ops — 5 phút (giây).
+ *
+ * Firebase Auth SDK enforce recent-login cho `user.delete()` NATIVE, nhưng
+ * KHÔNG áp dụng cho callable CF. id_token sống ~1h → gọi CF trực tiếp với
+ * token cũ vẫn cascade-delete được dù client UI đã prompt reauth (bypass).
+ * Server-side check `auth_time` đóng gap đó (AUTH-SEC-001).
+ */
+export const REAUTH_WINDOW_SECONDS = 5 * 60;
+
+/**
+ * True khi token được cấp/refresh trong [windowSec] gần đây.
+ *
+ * Pure để unit test không cần emulator — handler truyền Date.now()/1000.
+ * `authTimeSec` = claim `auth_time` (epoch seconds, thời điểm user thực sự
+ * nhập credential gần nhất). Clamp âm: clock skew (authTime > now) vẫn coi là
+ * fresh.
+ */
+export function isReauthWithinWindow(
+  authTimeSec: number,
+  nowSec: number,
+  windowSec: number = REAUTH_WINDOW_SECONDS,
+): boolean {
+  return nowSec - authTimeSec <= windowSec;
+}
+
+/**
  * Firestore batch limit: 500 writes/batch (admin SDK). Dùng 499 để chừa 1 slot
  * an toàn cho race case (mặc dù trong cascade này không có race nhưng giữ
  * consistent với pattern onSpaceDeleted).
@@ -132,9 +158,10 @@ async function softDeleteConversations(uid: string): Promise<number> {
  * login retry. Order Auth LAST đảm bảo Storage/Firestore cleanup không bị
  * mất quyền truy cập (Auth gone = không re-auth được).
  *
- * Pre-condition: client (DeleteAccountDialog) phải reauthenticate trước
- * khi gọi CF này (Firebase Auth requires-recent-login policy). CF chỉ check
- * `request.auth` exists, không enforce recent-login (Firebase SDK enforce).
+ * Pre-condition: client (DeleteAccountDialog) phải reauthenticate trước khi
+ * gọi CF này. CF enforce lại server-side qua `auth_time` claim
+ * (isReauthWithinWindow) — chặn bypass khi gọi callable trực tiếp với
+ * id_token cũ (AUTH-SEC-001).
  */
 export const deleteAccount = onCall(
   {
@@ -147,6 +174,21 @@ export const deleteAccount = onCall(
   async (request) => {
     if (!request.auth) {
       throw new HttpsError('unauthenticated', 'Login required');
+    }
+
+    // Reauth window: token phải fresh (≤ 5 phút từ last credential entry).
+    // Client DeleteAccountDialog reauth trước khi gọi — server enforce lại để
+    // chặn bypass khi gọi CF trực tiếp với id_token cũ (AUTH-SEC-001).
+    const authTime = request.auth.token.auth_time;
+    const nowSec = Math.floor(Date.now() / 1000);
+    if (
+      typeof authTime !== 'number' ||
+      !isReauthWithinWindow(authTime, nowSec)
+    ) {
+      throw new HttpsError(
+        'failed-precondition',
+        'Vui lòng đăng nhập lại trước khi xoá tài khoản',
+      );
     }
 
     const parsed = deleteAccountSchema.safeParse(request.data);
@@ -182,6 +224,10 @@ export const deleteAccount = onCall(
         'users/fcmTokens',
       ),
       deleteCollectionInBatches(userRef.collection('private'), 'users/private'),
+      deleteCollectionInBatches(
+        userRef.collection('space_count_events'),
+        'users/space_count_events',
+      ),
     ]);
 
     // Step 3a-3c: Cross-collection queries có Firestore trigger downstream

--- a/firebase/functions/src/space/createSpace.ts
+++ b/firebase/functions/src/space/createSpace.ts
@@ -9,19 +9,21 @@ import { z } from 'zod';
  * truyền name/iconEmoji/colorHex/friendUids. Server validate lại đầy đủ —
  * KHÔNG tin client.
  */
-const createSpaceSchema = z.object({
-  name: z.string().trim().min(1).max(30),
-  // ZWJ emoji sequences (👨‍👩‍👧‍👦) có JS length 11 vì code units + ZWJ joiners.
-  // Cap 32 đủ rộng cho mọi single emoji + flag + ZWJ family, vẫn chặn abuse.
-  iconEmoji: z.string().min(1).max(32),
-  // 7-char hex `#RRGGBB`. Reject malformed để Camera UI parser luôn an toàn.
-  colorHex: z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'colorHex must be #RRGGBB'),
-  // friendUids: invited friends; creator auto-added → tổng ≤ 10 (max 9 friends).
-  // min(2) = Space cần ≥ 3 thành viên (creator + 2 friends) — match client
-  // guard (SpaceController.createSpace) + UI button "Tiếp tục" disabled khi
-  // < 2 friend chọn.
-  friendUids: z.array(z.string().min(1).max(128)).min(2).max(9),
-});
+const createSpaceSchema = z
+  .object({
+    name: z.string().trim().min(1).max(30),
+    // ZWJ emoji sequences (👨‍👩‍👧‍👦) có JS length 11 vì code units + ZWJ joiners.
+    // Cap 32 đủ rộng cho mọi single emoji + flag + ZWJ family, vẫn chặn abuse.
+    iconEmoji: z.string().min(1).max(32),
+    // 7-char hex `#RRGGBB`. Reject malformed để Camera UI parser luôn an toàn.
+    colorHex: z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'colorHex must be #RRGGBB'),
+    // friendUids: invited friends; creator auto-added → tổng ≤ 10 (max 9 friends).
+    // min(2) = Space cần ≥ 3 thành viên (creator + 2 friends) — match client
+    // guard (SpaceController.createSpace) + UI button "Tiếp tục" disabled khi
+    // < 2 friend chọn.
+    friendUids: z.array(z.string().min(1).max(128)).min(2).max(9),
+  })
+  .strict();
 
 /**
  * Create a Space + group conversation in 1 atomic batch.

--- a/firebase/functions/src/space/kickMember.ts
+++ b/firebase/functions/src/space/kickMember.ts
@@ -2,10 +2,12 @@ import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { z } from 'zod';
 
-const kickMemberSchema = z.object({
-  spaceId: z.string().min(1),
-  targetUid: z.string().min(1),
-});
+const kickMemberSchema = z
+  .object({
+    spaceId: z.string().min(1),
+    targetUid: z.string().min(1),
+  })
+  .strict();
 
 /**
  * Creator kick một member khỏi Space.

--- a/firebase/functions/src/space/leaveSpace.ts
+++ b/firebase/functions/src/space/leaveSpace.ts
@@ -2,9 +2,11 @@ import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { z } from 'zod';
 
-const leaveSpaceSchema = z.object({
-  spaceId: z.string().min(1),
-});
+const leaveSpaceSchema = z
+  .object({
+    spaceId: z.string().min(1),
+  })
+  .strict();
 
 /**
  * Member rời Space (không phải creator).

--- a/firebase/functions/src/space/onSpaceMember.test.ts
+++ b/firebase/functions/src/space/onSpaceMember.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from 'vitest';
+import { shouldCountJoin } from './onSpaceMemberAdded.js';
+import { shouldCountLeave } from './onSpaceMemberRemoved.js';
+
+// FUNC-SEC-002 — marker-based idempotency. Transaction reads marker existence
+// then decides whether to apply the spaceCount delta.
+
+describe('shouldCountJoin', () => {
+  test('first event (no marker) → count the join', () => {
+    expect(shouldCountJoin(false)).toBe(true);
+  });
+
+  test('re-fire (marker exists) → skip increment', () => {
+    expect(shouldCountJoin(true)).toBe(false);
+  });
+});
+
+describe('shouldCountLeave', () => {
+  test('first delete (marker exists) → count the leave', () => {
+    expect(shouldCountLeave(true)).toBe(true);
+  });
+
+  test('re-fire (marker already gone) → skip decrement', () => {
+    expect(shouldCountLeave(false)).toBe(false);
+  });
+});
+
+describe('join/leave pairing keeps spaceCount balanced', () => {
+  test('a single join followed by a single leave nets zero', () => {
+    // join: marker absent → +1, marker set
+    expect(shouldCountJoin(false)).toBe(true);
+    // duplicate join: marker present → skip
+    expect(shouldCountJoin(true)).toBe(false);
+    // leave: marker present → -1, marker deleted
+    expect(shouldCountLeave(true)).toBe(true);
+    // duplicate leave: marker absent → skip
+    expect(shouldCountLeave(false)).toBe(false);
+  });
+});

--- a/firebase/functions/src/space/onSpaceMemberAdded.ts
+++ b/firebase/functions/src/space/onSpaceMemberAdded.ts
@@ -3,18 +3,25 @@ import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { logger } from 'firebase-functions/v2';
 
 /**
+ * Idempotency guard: chỉ increment khi marker CHƯA tồn tại (event đầu tiên).
+ * Pure để unit test không cần emulator.
+ */
+export function shouldCountJoin(markerExists: boolean): boolean {
+  return !markerExists;
+}
+
+/**
  * Trigger khi /space_members/{spaceId}/members/{uid} doc CREATE.
  *
  * Increment /users/{uid}.spaceCount cho member mới. KHÔNG touch
  * /spaces/{spaceId}.memberCount vì CF (`createSpace`, future addMember)
  * đã update trong batch — tránh double-count.
  *
- * Idempotent: dùng `set(merge)` với `FieldValue.increment(1)`. Firestore
- * trigger v2 mặc định at-least-once → cùng event re-fire sẽ
- * double-increment. Trade-off accepted cho MVP (spaceCount user-visible
- * minor, hiếm khi re-fire). Future: dùng deterministic doc id
- * /users/{uid}/space_count_events/{spaceId} + transaction để strict
- * idempotent.
+ * Idempotent (FUNC-SEC-002): Firestore trigger v2 at-least-once → cùng event
+ * có thể re-fire. Marker doc /users/{uid}/space_count_events/{spaceId}
+ * (deterministic ID) trong transaction đảm bảo increment đúng 1 lần: re-fire
+ * thấy marker đã tồn tại → skip. onSpaceMemberRemoved xóa marker khi member
+ * rời → cặp Added/Removed cân nhau. Marker dọn trong deleteAccount cascade.
  */
 export const onSpaceMemberAdded = onDocumentCreated(
   {
@@ -23,14 +30,21 @@ export const onSpaceMemberAdded = onDocumentCreated(
   },
   async (event) => {
     const { spaceId, uid } = event.params;
+    const db = getFirestore();
+    const userRef = db.doc(`users/${uid}`);
+    const markerRef = db.doc(`users/${uid}/space_count_events/${spaceId}`);
 
     try {
-      await getFirestore()
-        .doc(`users/${uid}`)
-        .set(
+      await db.runTransaction(async (tx) => {
+        const marker = await tx.get(markerRef);
+        if (!shouldCountJoin(marker.exists)) return;
+        tx.set(
+          userRef,
           { spaceCount: FieldValue.increment(1) },
           { merge: true },
         );
+        tx.set(markerRef, { joinedAt: FieldValue.serverTimestamp() });
+      });
       logger.info(`spaceCount++ for ${uid} (joined ${spaceId})`);
     } catch (e) {
       logger.error(`onSpaceMemberAdded failed for ${uid}/${spaceId}`, e);

--- a/firebase/functions/src/space/onSpaceMemberRemoved.ts
+++ b/firebase/functions/src/space/onSpaceMemberRemoved.ts
@@ -3,13 +3,24 @@ import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { logger } from 'firebase-functions/v2';
 
 /**
+ * Idempotency guard: chỉ decrement khi marker CÒN tồn tại (chưa xử lý leave).
+ * Pure để unit test không cần emulator. Mirror shouldCountJoin nghịch đảo.
+ */
+export function shouldCountLeave(markerExists: boolean): boolean {
+  return markerExists;
+}
+
+/**
  * Trigger khi /space_members/{spaceId}/members/{uid} doc DELETE
  * (leaveSpace, kickMember, onSpaceDeleted cleanup).
  *
  * Decrement /users/{uid}.spaceCount. Mirror onSpaceMemberAdded — KHÔNG
  * touch /spaces/{spaceId}.memberCount vì CF đã update trong batch.
  *
- * Idempotent caveat: same as Added — at-least-once delivery. MVP accepted.
+ * Idempotent (FUNC-SEC-002): transaction xóa marker
+ * /users/{uid}/space_count_events/{spaceId} + decrement đúng 1 lần. Re-fire
+ * thấy marker đã mất → skip. Cặp với onSpaceMemberAdded (set marker) nên
+ * spaceCount luôn khớp số space thực tế.
  */
 export const onSpaceMemberRemoved = onDocumentDeleted(
   {
@@ -18,14 +29,21 @@ export const onSpaceMemberRemoved = onDocumentDeleted(
   },
   async (event) => {
     const { spaceId, uid } = event.params;
+    const db = getFirestore();
+    const userRef = db.doc(`users/${uid}`);
+    const markerRef = db.doc(`users/${uid}/space_count_events/${spaceId}`);
 
     try {
-      await getFirestore()
-        .doc(`users/${uid}`)
-        .set(
+      await db.runTransaction(async (tx) => {
+        const marker = await tx.get(markerRef);
+        if (!shouldCountLeave(marker.exists)) return;
+        tx.set(
+          userRef,
           { spaceCount: FieldValue.increment(-1) },
           { merge: true },
         );
+        tx.delete(markerRef);
+      });
       logger.info(`spaceCount-- for ${uid} (left ${spaceId})`);
     } catch (e) {
       logger.error(`onSpaceMemberRemoved failed for ${uid}/${spaceId}`, e);

--- a/firebase/functions/src/space/transferOwnership.ts
+++ b/firebase/functions/src/space/transferOwnership.ts
@@ -2,10 +2,12 @@ import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { z } from 'zod';
 
-const transferOwnershipSchema = z.object({
-  spaceId: z.string().min(1),
-  newCreatorUid: z.string().min(1),
-});
+const transferOwnershipSchema = z
+  .object({
+    spaceId: z.string().min(1),
+    newCreatorUid: z.string().min(1),
+  })
+  .strict();
 
 /**
  * Creator chuyển quyền sở hữu Space cho member khác. Bước bắt buộc trước

--- a/firebase/functions/src/space/updateSpace.ts
+++ b/firebase/functions/src/space/updateSpace.ts
@@ -24,6 +24,7 @@ const updateSpaceSchema = z
       .regex(/^#[0-9A-Fa-f]{6}$/, 'colorHex must be #RRGGBB')
       .optional(),
   })
+  .strict()
   .refine(
     (d) =>
       d.name !== undefined ||

--- a/firebase/functions/src/storage.rules.test.ts
+++ b/firebase/functions/src/storage.rules.test.ts
@@ -20,14 +20,25 @@ import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
 let testEnv: RulesTestEnvironment;
 
 const RULES_PATH = resolve(__dirname, '../../storage.rules');
+const FIRESTORE_RULES_PATH = resolve(__dirname, '../../firestore.rules');
 
 beforeAll(async () => {
   testEnv = await initializeTestEnvironment({
-    projectId: 'meep-storage-test',
+    // Project ID khớp emulator launch (--project demo-meep-test) +
+    // singleProjectMode để cross-service firestore.get/exists từ storage rule
+    // route đúng database (STORAGE-001/002 mirror friend boundary).
+    projectId: 'demo-meep-test',
     storage: {
       rules: readFileSync(RULES_PATH, 'utf8'),
       host: '127.0.0.1',
       port: 9199,
+    },
+    // Storage rules đọc cross-service /posts + /diary + /friendships để mirror
+    // friend boundary (STORAGE-001/002) → cần firestore emulator chạy cùng.
+    firestore: {
+      rules: readFileSync(FIRESTORE_RULES_PATH, 'utf8'),
+      host: '127.0.0.1',
+      port: 9999,
     },
   });
 });
@@ -38,6 +49,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await testEnv.clearStorage();
+  await testEnv.clearFirestore();
 });
 
 // ===== Helpers =====
@@ -50,6 +62,17 @@ function authed(userId: string) {
 
 function unauthed() {
   return testEnv.unauthenticatedContext();
+}
+
+/** Seed friendship doc (sorted pairId) để Storage rule isFriend() pass. */
+async function seedFriendship(a: string, b: string) {
+  const pid = [a, b].sort().join('_');
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await ctx.firestore().doc(`friendships/${pid}`).set({
+      members: [a, b],
+      createdAt: new Date(),
+    });
+  });
 }
 
 /**
@@ -271,19 +294,68 @@ describe('Storage /diary/{uid}/', () => {
       await assertSucceeds(ref.getDownloadURL());
     });
 
-    test('other authed user can read (Firestore rule controls visibility)', async () => {
-      // Storage rule cho phép mọi authed user read; Firestore rule
-      // `/diary/{id}` mới enforce friend + privacy. URL đã được lưu
-      // trong doc nên client KHÔNG list được prefix.
+    test('friend can read PUBLIC diary image (STORAGE-002)', async () => {
       const alice = uid('alice');
       const bob = uid('bob');
       await authed(alice)
         .storage()
         .ref(`diary/${alice}/entry-1/cover.jpg`)
         .put(fakeImage(1024));
+      await testEnv.withSecurityRulesDisabled(async (ctx) => {
+        await ctx.firestore().doc('diary/entry-1').set({
+          authorUid: alice,
+          privacy: 'public',
+        });
+      });
+      await seedFriendship(alice, bob);
 
       await assertSucceeds(
         authed(bob)
+          .storage()
+          .ref(`diary/${alice}/entry-1/cover.jpg`)
+          .getDownloadURL(),
+      );
+    });
+
+    test('friend CANNOT read PRIVATE diary image (STORAGE-002)', async () => {
+      const alice = uid('alice');
+      const bob = uid('bob');
+      await authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`)
+        .put(fakeImage(1024));
+      await testEnv.withSecurityRulesDisabled(async (ctx) => {
+        await ctx.firestore().doc('diary/entry-1').set({
+          authorUid: alice,
+          privacy: 'private',
+        });
+      });
+      await seedFriendship(alice, bob);
+
+      await assertFails(
+        authed(bob)
+          .storage()
+          .ref(`diary/${alice}/entry-1/cover.jpg`)
+          .getDownloadURL(),
+      );
+    });
+
+    test('stranger (non-friend) cannot read public diary image', async () => {
+      const alice = uid('alice');
+      const stranger = uid('stranger');
+      await authed(alice)
+        .storage()
+        .ref(`diary/${alice}/entry-1/cover.jpg`)
+        .put(fakeImage(1024));
+      await testEnv.withSecurityRulesDisabled(async (ctx) => {
+        await ctx.firestore().doc('diary/entry-1').set({
+          authorUid: alice,
+          privacy: 'public',
+        });
+      });
+
+      await assertFails(
+        authed(stranger)
           .storage()
           .ref(`diary/${alice}/entry-1/cover.jpg`)
           .getDownloadURL(),
@@ -304,6 +376,75 @@ describe('Storage /diary/{uid}/', () => {
           .getDownloadURL(),
       );
     });
+  });
+});
+
+// ===== /posts/{uid}/{postId}/ — friend boundary (STORAGE-001) =====
+
+describe('Storage /posts/{uid}/', () => {
+  const alice = uid('alice');
+  const bob = uid('bob');
+  const stranger = uid('stranger');
+  const POST_ID = 'post-1';
+
+  async function seedPostImage(opts: { memberIds?: string[] } = {}) {
+    await authed(alice)
+      .storage()
+      .ref(`posts/${alice}/${POST_ID}/photo.jpg`)
+      .put(fakeImage(1024));
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`posts/${POST_ID}`).set({
+        authorId: alice,
+        createdAt: new Date(),
+        ...(opts.memberIds ? { memberIds: opts.memberIds } : {}),
+      });
+    });
+  }
+
+  function readImage(reader: string) {
+    return authed(reader)
+      .storage()
+      .ref(`posts/${alice}/${POST_ID}/photo.jpg`)
+      .getDownloadURL();
+  }
+
+  test('owner can read own post image', async () => {
+    await seedPostImage();
+    await assertSucceeds(readImage(alice));
+  });
+
+  test('friend can read post image', async () => {
+    await seedPostImage();
+    await seedFriendship(alice, bob);
+    await assertSucceeds(readImage(bob));
+  });
+
+  test('user with feed fan-out doc can read', async () => {
+    await seedPostImage();
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${bob}/feed/${POST_ID}`).set({ postId: POST_ID });
+    });
+    await assertSucceeds(readImage(bob));
+  });
+
+  test('space member (not friend) can read space post image', async () => {
+    await seedPostImage({ memberIds: [alice, bob] });
+    await assertSucceeds(readImage(bob));
+  });
+
+  test('stranger (no friend, no space, no feed) cannot read', async () => {
+    await seedPostImage();
+    await assertFails(readImage(stranger));
+  });
+
+  test('unauthenticated cannot read', async () => {
+    await seedPostImage();
+    await assertFails(
+      unauthed()
+        .storage()
+        .ref(`posts/${alice}/${POST_ID}/photo.jpg`)
+        .getDownloadURL(),
+    );
   });
 });
 

--- a/firebase/functions/test/rules/chat.rules.test.ts
+++ b/firebase/functions/test/rules/chat.rules.test.ts
@@ -328,10 +328,17 @@ describe('/conversations/{conversationId}', () => {
 
   // --- Write: conversations -------------------------------------------------
 
-  test('authenticated user can create conversation with self as participant',
-      () async {
-    const newConvId = [alice, uid('charlie')].sort().join('_');
-    // Must create with rules ENABLED to verify `allow create` works.
+  test('friend can create direct conversation (CHAT-SEC-001)',
+      async () => {
+    const charlie = uid('charlie');
+    const newConvId = [alice, charlie].sort().join('_');
+    // Friendship doc gate create — seed trước (id == sorted pairId).
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`friendships/${newConvId}`).set({
+        members: [alice, charlie],
+        createdAt: new Date(),
+      });
+    });
     await assertSucceeds(
       authed(alice)
         .firestore()
@@ -339,7 +346,28 @@ describe('/conversations/{conversationId}', () => {
         .set({
           conversationId: newConvId,
           type: 'direct',
-          participantIds: [alice, uid('charlie')],
+          participantIds: [alice, charlie],
+          status: 'active',
+          lastMessage: '',
+          lastMessageAt: new Date(),
+          lastSenderId: '',
+          createdAt: new Date(),
+        }),
+    );
+  });
+
+  test('non-friend cannot create direct conversation (CHAT-SEC-001)',
+      async () => {
+    const newConvId = [alice, stranger].sort().join('_');
+    // No friendship doc → create denied (chống stranger spam DM).
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`conversations/${newConvId}`)
+        .set({
+          conversationId: newConvId,
+          type: 'direct',
+          participantIds: [alice, stranger],
           status: 'active',
           lastMessage: '',
           lastMessageAt: new Date(),

--- a/firebase/functions/vitest.rules.config.ts
+++ b/firebase/functions/vitest.rules.config.ts
@@ -7,5 +7,12 @@ export default defineConfig({
     include: ['src/**/*.rules.test.ts', 'test/**/*.rules.test.ts'],
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    // Rules tests pin tới 1 emulator instance (firestore port 9999 + storage
+    // 9199). fileParallelism:false → chạy TUẦN TỰ từng file (tránh nhiều
+    // worker tranh cùng emulator + clearFirestore race). pool:forks (KHÔNG
+    // singleFork) → mỗi file 1 child process riêng, RAM giải phóng sau mỗi
+    // file → tránh OOM tích luỹ khi load @firebase/rules-unit-testing nhiều lần.
+    pool: 'forks',
+    fileParallelism: false,
   },
 });

--- a/firebase/storage.rules
+++ b/firebase/storage.rules
@@ -3,10 +3,57 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
 
+    // ===== Helpers — mirror friend boundary của firestore.rules =====
+    // Storage path posts/{uid}/{postId}/... và diary/{uid}/{entryId}/... chứa
+    // doc ID nên đọc cross-service được /posts + /diary doc để mirror CHÍNH
+    // XÁC Firestore read rule (STORAGE-001/002). KHÔNG còn `if authed` lax.
+
+    /// Sorted pair ID — same as Dart pairIdOf() + firestore.rules pairId().
+    function pairId(a, b) {
+      return a < b ? a + '_' + b : b + '_' + a;
+    }
+
+    /// True khi caller là friend của [other] (friendship doc tồn tại).
+    function isFriend(other) {
+      return request.auth != null && firestore.exists(
+        /databases/(default)/documents/friendships/$(pairId(request.auth.uid, other))
+      );
+    }
+
+    /// True khi caller có feed fan-out doc cho [postId] (friend của author
+    /// nhận post qua CF onPostCreated). exists() — rẻ, không cần đọc post doc.
+    function hasFeedDoc(postId) {
+      return request.auth != null && firestore.exists(
+        /databases/(default)/documents/users/$(request.auth.uid)/feed/$(postId)
+      );
+    }
+
+    /// True khi caller là member của Space chứa [postId]. Đọc memberIds
+    /// denormalized trên post doc — mirror disjunct (3) của /posts read rule.
+    /// Space post KHÔNG fan-out tới friend feed nên phải check memberIds trực
+    /// tiếp. Pattern `'memberIds' in data && ...hasAny` y hệt firestore.rules
+    /// (post thường không có memberIds → branch đầu false → an toàn).
+    function postData(postId) {
+      return firestore.get(/databases/(default)/documents/posts/$(postId)).data;
+    }
+    function isSpaceMemberOfPost(postId) {
+      return request.auth != null
+        && firestore.exists(/databases/(default)/documents/posts/$(postId))
+        && 'memberIds' in postData(postId)
+        && postData(postId).memberIds.hasAny([request.auth.uid]);
+    }
+
     // User's own posts — uploaded by the owner only.
-    match /posts/{uid}/{allPaths=**} {
-      // Anyone authenticated can read (Firestore rule controls visibility).
-      allow read: if request.auth != null;
+    // Read mirror /posts: owner OR friend(author) OR space-member OR feed-doc.
+    // Stranger hoàn toàn (không friend + không chung space) bị chặn dù có URL
+    // (STORAGE-001). `uid` trong path = authorId của post.
+    match /posts/{uid}/{postId}/{fileName=**} {
+      allow read: if request.auth != null && (
+        request.auth.uid == uid ||
+        isFriend(uid) ||
+        hasFeedDoc(postId) ||
+        isSpaceMemberOfPost(postId)
+      );
 
       allow write: if request.auth != null
         && request.auth.uid == uid
@@ -15,6 +62,8 @@ service firebase.storage {
     }
 
     // Avatars — owner-only write, anyone authenticated reads.
+    // Avatar là minimal-profile asset (hiển thị cho stranger lookup, friend
+    // list) — giữ authed-read OK, không phải friend boundary.
     // Size cap 5MB khớp Profile spec §Security (docs/specs/2026-05-22-profile.md)
     // và client-side check trong FirebaseProfileRepository._maxAvatarBytes.
     match /avatars/{uid}/{filename} {
@@ -25,9 +74,20 @@ service firebase.storage {
         && request.resource.contentType.matches('image/.*');
     }
 
-    // Diary images — owner-only write, anyone authenticated reads.
-    match /diary/{uid}/{allPaths=**} {
-      allow read: if request.auth != null;
+    // Diary images — owner-only write.
+    // Read mirror /diary: owner OR (privacy=='public' AND friend(author)).
+    // Private diary image chặn mọi non-owner dù lộ URL (STORAGE-002).
+    // `uid` trong path = authorUid của entry.
+    match /diary/{uid}/{entryId}/{fileName=**} {
+      allow read: if request.auth != null && (
+        request.auth.uid == uid ||
+        (
+          firestore.exists(/databases/(default)/documents/diary/$(entryId))
+          && firestore.get(/databases/(default)/documents/diary/$(entryId))
+               .data.privacy == 'public'
+          && isFriend(uid)
+        )
+      );
       allow write: if request.auth != null
         && request.auth.uid == uid
         && request.resource.size < 10 * 1024 * 1024  // 10MB


### PR DESCRIPTION
## Mô tả

Đóng **15 issue P1-P3** từ audit `docs/audits/05_security_firebase_audit.md` trong 1 PR security hardening (chỉ rules + storage + functions). Defer USER-SEC-001/002 + FRIEND-SEC-001/002 + USERNAME-SEC-001/002 sang PR migration riêng (đụng client auth flow + cần CF mới).

## Refs

- Refs #303 (Phase 2 polish)
- Audit: `docs/audits/05_security_firebase_audit.md`

## Thay đổi chính

**Firestore rules** (`firebase/firestore.rules`):
- `POST-SEC-001`: /posts update whitelist `[caption, updatedAt]` + cap caption 200, các field khác immutable
- `CHAT-SEC-001`: /conversations create gate friend/space **+ ràng buộc `conversationId == pairId(participantIds)`** chống forge id để DM người lạ (phát hiện trong self-review)
- `CHAT-SEC-002`: /conversations update value validation (`lastSenderId == caller`, lastMessage ≤ 500, lastReadAt map — tương thích dot-notation markAsRead)
- `REACTION-SEC-001`: type+size guard reactorName/reactorAvatarUrl + emoji cap 32, **+ create gate** theo quyền đọc post (đóng gap stranger ghi reaction)
- `DIARY-SEC-001`: /diary update privacy enum + type guard content(list)/moodCaption(string)

**Storage rules** (`firebase/storage.rules`):
- `STORAGE-001/002`: mirror **chính xác** friend boundary qua cross-service `firestore.get/exists` (capture postId/entryId từ path). /posts = owner∨friend∨space-member∨feed-doc; /diary = owner∨(public∧friend). Người lạ hoàn toàn bị chặn, space-member + friend xem ảnh hợp lệ (không broken-image).

**Functions** (`firebase/functions/src/`):
- `AUTH-SEC-001`: `deleteAccount` enforce `auth_time` reauth window 5 phút (helper pure `isReauthWithinWindow`)
- `FUNC-SEC-001`: `.strict()` cho 8 zod schema callable (reject excess properties)
- `FUNC-SEC-002`: marker doc `space_count_events/{spaceId}` + transaction → spaceCount idempotent 2 chiều

**Khác**:
- `PERM-001`: AndroidManifest thêm `RECEIVE_BOOT_COMPLETED` + `POST_NOTIFICATIONS`
- `CI-SEC-001`: bỏ fallback `|| echo warning` trong job firestore-rules
- `TESTING-SEC-001`: thêm rules tests cho posts update / conversations / reactions / diary / friendships + storage /posts cross-service

## Loại thay đổi

- [x] fix — Sửa bug / security hardening

## Test

- [x] (Functions) `npm test` PASS — **132/132**
- [x] (Functions) `npm run lint` + `npm run typecheck` clean
- [x] (Firestore + Storage rules) Rules tests PASS — **285/285** qua emulator (firestore+storage)

### Cách test thủ công

1. `cd firebase && firebase emulators:exec --only firestore,storage --project demo-meep-test "cd functions && npm run test:rules"` → 285 pass
2. `cd firebase/functions && npm test && npm run lint` → 132 pass, lint clean

## Lưu ý cho reviewer

1. **🔴 tìm trong self-review**: CHAT-SEC-001 ban đầu vẫn lọt spam DM non-friend (forge `conversationId` khớp friendship khác). Đã fix bằng ràng buộc `conversationId == pairId(participantIds)` + test `cannot forge conversationId...`.
2. **2 việc ngoài 17-issue gốc, đều trace được**: (a) reaction create-gate — test team `create by stranger → DENY` đã kỳ vọng từ #250 nhưng rule chưa làm; (b) sửa transform-fail có sẵn trong `test/rules/chat.rules.test.ts` (Dart syntax `() async {`) + update self-create test theo CHAT-SEC-001.
3. **Finding quan trọng**: rules tests **chưa từng chạy thật trong CI** từ #250 — fallback `|| echo warning` che + chat.rules transform-fail làm sập cả suite. CI-SEC-001 bỏ fallback mới enforce thật. `vitest.rules.config.ts` đổi sang per-file fork tuần tự để tránh OOM + race port emulator.
4. **Cross-service storage test** cần projectId khớp emulator launch (`demo-meep-test`) trong singleProjectMode.

## Self-review checklist

- [x] Branch name đúng format
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không file lớn vô tình (.env/keystore/service account)
- [x] Không console.log/print debug sót, không dead code
- [x] Đã `/review` 6-axis trước khi mở PR (tìm + fix 1 🔴 + 1 🟡)

🤖 Generated with [Claude Code](https://claude.com/claude-code)