### PR TITLE
feat(auth): xác minh email + polish notification permission & FCM cache

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
          WorkManager tự handle reschedule khi có permission này (PERM-001). -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- Android 13+ runtime notification permission cho FCM push. Plugin
-         request runtime nhưng phải declare ở manifest (PERM-001). -->
+         request runtime nhưng phải declare ở manifest (PERM-001 / NOTIF-UX-PERM-001). -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application

--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -5,9 +5,11 @@ import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/application/email_verification_gate.dart';
 import 'package:meep/features/auth/application/login_controller.dart';
 import 'package:meep/features/auth/application/sign_up_controller.dart';
 import 'package:meep/features/auth/presentation/intro_page.dart';
+import 'package:meep/features/auth/presentation/verify_email_page.dart';
 import 'package:meep/features/auth/presentation/login/login_email_page.dart';
 import 'package:meep/features/auth/presentation/login/login_password_page.dart';
 import 'package:meep/features/auth/presentation/login/reset_password_page.dart';
@@ -42,6 +44,10 @@ import 'package:meep/features/streak/presentation/streak_screen.dart';
 
 part 'app_router.g.dart';
 
+/// Root navigator key — cho phép show dialog/overlay từ ngoài cây widget của
+/// route (vd rationale dialog quyền thông báo trong [MeepApp] khi FCM init).
+final rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'rootNav');
+
 /// Pure redirect logic — testable không cần GoRouter.
 ///
 /// 5-state machine:
@@ -51,7 +57,12 @@ part 'app_router.g.dart';
 ///     (đang ở /signup/name hoặc /signup/username → giữ nguyên)
 ///   uid != null, profileExists = false, !needsProfile  → /intro (orphaned)
 ///     (đang trong /signup/* → giữ nguyên cho email signup)
+///   uid != null, profileExists = true, requiresEmailVerification → /verify-email
 ///   uid != null, profileExists = true                  → /home
+///
+/// Email-verification hard gate: email/password user chưa verify (profile đã
+/// tồn tại) bị giữ ở /verify-email cho tới khi verify xong. Google user
+/// (email pre-verified) không bị gate.
 ///
 /// Special case: /login/reset-password và /__/auth/* luôn được phép truy cập
 /// bất kể auth state — user có thể có bất kỳ session nào khi reset mật khẩu.
@@ -60,6 +71,7 @@ String? authRedirect({
   required String? uid,
   required bool? profileExists,
   required bool needsProfile,
+  required bool requiresEmailVerification,
   required String location,
 }) {
   if (isLoading) return null;
@@ -103,6 +115,16 @@ String? authRedirect({
 
   // uid != null, profile exists — không redirect user khỏi reset page
   if (location == '/login/reset-password') return null;
+
+  // Email-verification hard gate — sau profileExists==true, trước /home.
+  // Email/password user chưa verify bị giữ ở /verify-email.
+  if (requiresEmailVerification) {
+    if (location == '/verify-email') return null;
+    return '/verify-email';
+  }
+  // Đã verify (hoặc Google) → không để kẹt trên /verify-email.
+  if (location == '/verify-email') return '/home';
+
   return onAuthRoute ? '/home' : null;
 }
 
@@ -167,6 +189,8 @@ class _RouterNotifier extends ChangeNotifier {
       loginControllerProvider.select((s) => s.needsProfile),
       (_, __) => notifyListeners(),
     );
+    // Email-verify gate: redirect re-eval khi verify status đổi (poll/reload).
+    ref.listen(emailVerificationGateProvider, (_, __) => notifyListeners());
     // No-op listen — chỉ để keepAlive, không trigger redirect re-eval.
     ref.listen(signUpControllerProvider, (_, __) {});
   }
@@ -200,6 +224,7 @@ GoRouter appRouter(Ref ref) {
 
   final router = GoRouter(
     initialLocation: initialLocation,
+    navigatorKey: rootNavigatorKey,
     refreshListenable: notifier,
     onException: (context, state, router) {
       final uri = state.uri;
@@ -227,6 +252,7 @@ GoRouter appRouter(Ref ref) {
       final uidState = ref.read(currentUidProvider);
       final profileState = ref.read(currentUserProfileProvider);
       final needsProfile = ref.read(loginControllerProvider).needsProfile;
+      final requiresEmailVerification = ref.read(emailVerificationGateProvider);
       final uid = uidState.valueOrNull;
       final isLoading =
           uidState.isLoading || (uid != null && profileState.isLoading);
@@ -249,6 +275,7 @@ GoRouter appRouter(Ref ref) {
         uid: uid,
         profileExists: profileExists,
         needsProfile: needsProfile,
+        requiresEmailVerification: requiresEmailVerification,
         location: state.matchedLocation,
       );
     },
@@ -277,6 +304,10 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/signup/username',
         builder: (_, __) => const SignUpUsernamePage(),
+      ),
+      GoRoute(
+        path: '/verify-email',
+        builder: (_, __) => const VerifyEmailPage(),
       ),
       GoRoute(
         path: '/login/email',

--- a/apps/mobile/lib/features/auth/application/email_verification_gate.dart
+++ b/apps/mobile/lib/features/auth/application/email_verification_gate.dart
@@ -1,0 +1,40 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/auth/application/auth_providers.dart';
+
+part 'email_verification_gate.g.dart';
+
+/// True khi user hiện tại CẦN xác minh email trước khi vào app: đăng nhập bằng
+/// email/password (provider `password`) VÀ chưa verify. Google/social provider
+/// luôn false (email pre-verified). Signed-out → false.
+///
+/// Seed đồng bộ trong [build] từ [authRepositoryProvider]; vì `revalidateSession`
+/// đã `user.reload()` trước `runApp`, giá trị cold-start đã fresh. [refresh]
+/// reload lại từ server (poll / nút "Tôi đã xác minh") rồi re-eval — khi verify
+/// xong state đổi true→false → router rời `/verify-email` về `/home`.
+@riverpod
+class EmailVerificationGate extends _$EmailVerificationGate {
+  @override
+  bool build() {
+    // Rebuild khi uid đổi (login / logout / cold-start).
+    ref.watch(currentUidProvider);
+    return _computeRequiresVerification();
+  }
+
+  bool _computeRequiresVerification() {
+    final repo = ref.read(authRepositoryProvider);
+    if (repo.currentUid == null) return false;
+    // Chỉ gate email/password — Google email đã pre-verified.
+    if (repo.currentProviderId != 'password') return false;
+    return !repo.isEmailVerified;
+  }
+
+  /// Reload user từ server rồi re-đọc `emailVerified`. Gọi từ poll Timer + nút
+  /// "Tôi đã xác minh" trên `/verify-email`. State đổi → `_RouterNotifier` được
+  /// notify → GoRouter re-eval redirect.
+  Future<void> refresh() async {
+    await ref.read(authRepositoryProvider).reloadUser();
+    final next = _computeRequiresVerification();
+    if (next != state) state = next;
+  }
+}

--- a/apps/mobile/lib/features/auth/application/sign_up_controller.dart
+++ b/apps/mobile/lib/features/auth/application/sign_up_controller.dart
@@ -186,6 +186,16 @@ class SignUpController extends _$SignUpController {
           updatedAt: DateTime.now(),
         ),
       );
+
+      // Email/password signup: gửi email xác minh ngay. Swallow lỗi gửi —
+      // tài khoản đã tạo hợp lệ, user resend được từ /verify-email; không
+      // rollback chỉ vì gửi mail fail (vd too-many-requests).
+      if (!state.isGoogleSignIn) {
+        try {
+          await authRepo.sendEmailVerification();
+        } catch (_) {/* resend available on /verify-email */}
+      }
+
       state = state.copyWith(isLoading: false);
     } catch (e) {
       // Rollback: nếu Firebase Auth user đã tạo nhưng Firestore batch fail →

--- a/apps/mobile/lib/features/auth/data/auth_repository.dart
+++ b/apps/mobile/lib/features/auth/data/auth_repository.dart
@@ -69,6 +69,32 @@ abstract class AuthRepository {
   /// Gọi 1 lần khi app khởi động trước `runApp`.
   Future<void> revalidateSession();
 
+  /// True nếu email user hiện tại đã xác minh.
+  ///
+  /// Đọc giá trị CACHED trên `User` — KHÔNG tự cập nhật khi user click link
+  /// xác minh trong inbox (external). Caller phải gọi [reloadUser] trước để
+  /// lấy giá trị mới nhất từ server. Google/social providers luôn trả true
+  /// (email pre-verified). Trả false nếu chưa đăng nhập.
+  bool get isEmailVerified;
+
+  /// Force-reload user state từ server để refresh [isEmailVerified] sau khi
+  /// user click link xác minh trong inbox.
+  ///
+  /// No-op nếu chưa đăng nhập. Network/timeout → swallow (offline-friendly,
+  /// giống [revalidateSession]); session-permanently-invalid codes → [signOut].
+  /// Caller re-đọc [isEmailVerified] sau khi method này trả về.
+  Future<void> reloadUser();
+
+  /// Gửi email xác minh tới địa chỉ của user hiện tại.
+  ///
+  /// Gọi sau signup email/password và khi user bấm "Gửi lại" trên màn xác minh.
+  ///
+  /// Throws:
+  /// - [UnauthenticatedError] khi chưa đăng nhập
+  /// - [UnauthenticatedError] code 'too-many-requests' khi gửi quá nhiều
+  /// - [NetworkError] khi mất mạng
+  Future<void> sendEmailVerification();
+
   /// Delete the current user's Firebase Auth account.
   /// Used for rollback when Firestore batch write fails after createUser.
   Future<void> deleteCurrentUser();

--- a/apps/mobile/lib/features/auth/data/firebase_auth_repository.dart
+++ b/apps/mobile/lib/features/auth/data/firebase_auth_repository.dart
@@ -181,6 +181,42 @@ class FirebaseAuthRepository implements AuthRepository {
   }
 
   @override
+  bool get isEmailVerified => _auth.currentUser?.emailVerified ?? false;
+
+  @override
+  Future<void> reloadUser() async {
+    final user = _auth.currentUser;
+    if (user == null) return;
+    try {
+      await user.reload().timeout(const Duration(seconds: 5));
+    } on FirebaseAuthException catch (e) {
+      if (_isSessionPermanentlyInvalid(e.code)) {
+        await signOut();
+      }
+      // else: transient → giữ session, poll sẽ retry.
+    } on TimeoutException {
+      // Mạng chậm → giữ session.
+    } catch (_) {
+      // Unknown — conservative, không signOut.
+    }
+  }
+
+  @override
+  Future<void> sendEmailVerification() async {
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw const UnauthenticatedError(
+        message: 'Bạn cần đăng nhập để xác minh email',
+      );
+    }
+    try {
+      await user.sendEmailVerification();
+    } on FirebaseAuthException catch (e) {
+      throw _mapSendVerificationError(e);
+    }
+  }
+
+  @override
   Future<void> deleteCurrentUser() async {
     final user = _auth.currentUser;
     if (user == null) return;
@@ -317,6 +353,16 @@ class FirebaseAuthRepository implements AuthRepository {
       };
 
   AppError _mapGenericError(FirebaseAuthException e) => switch (e.code) {
+        'network-request-failed' =>
+          const NetworkError(message: 'Không có kết nối mạng'),
+        _ => UnexpectedError(message: e.message ?? e.code, cause: e),
+      };
+
+  AppError _mapSendVerificationError(FirebaseAuthException e) =>
+      switch (e.code) {
+        'too-many-requests' => const UnauthenticatedError(
+            message: 'Quá nhiều lần gửi. Vui lòng thử lại sau',
+          ),
         'network-request-failed' =>
           const NetworkError(message: 'Không có kết nối mạng'),
         _ => UnexpectedError(message: e.message ?? e.code, cause: e),

--- a/apps/mobile/lib/features/auth/presentation/signup/signup_username_page.dart
+++ b/apps/mobile/lib/features/auth/presentation/signup/signup_username_page.dart
@@ -83,12 +83,15 @@ class _SignUpUsernamePageState extends ConsumerState<SignUpUsernamePage> {
       if (!ref.read(signUpControllerProvider).isUsernameAvailable) return;
     }
 
+    final isGoogle = ref.read(signUpControllerProvider).isGoogleSignIn;
     await ref.read(signUpControllerProvider.notifier).createAccount();
     if (!mounted) return;
     if (ref.read(signUpControllerProvider).errorMessage == null) {
       // Delay 800ms để user thấy "Hoàn tất" trước khi redirect
       await Future<void>.delayed(const Duration(milliseconds: 800));
-      if (mounted) context.go('/home');
+      // Email/password signup chưa verify → màn xác minh; Google đã verified
+      // → thẳng /home. Router redirect cũng backstop, đây chỉ tránh flash.
+      if (mounted) context.go(isGoogle ? '/home' : '/verify-email');
     }
   }
 

--- a/apps/mobile/lib/features/auth/presentation/verify_email_page.dart
+++ b/apps/mobile/lib/features/auth/presentation/verify_email_page.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/application/email_verification_gate.dart';
+import 'package:meep/shared/widgets/app_primary_button.dart';
+
+/// Màn xác minh email (AUTH-SEC-002 hard gate). Email/password user chưa verify
+/// bị router giữ ở đây. Firebase không có realtime listener cho `emailVerified`
+/// → poll `reloadUser()` mỗi 4s + nút "Tôi đã xác minh". Khi verify xong,
+/// `emailVerificationGateProvider` đổi false → `_RouterNotifier` notify →
+/// router rời màn về /home.
+class VerifyEmailPage extends ConsumerStatefulWidget {
+  const VerifyEmailPage({super.key});
+
+  @override
+  ConsumerState<VerifyEmailPage> createState() => _VerifyEmailPageState();
+}
+
+class _VerifyEmailPageState extends ConsumerState<VerifyEmailPage> {
+  static const _pollInterval = Duration(seconds: 4);
+  static const _resendCooldown = 60;
+
+  Timer? _pollTimer;
+  Timer? _cooldownTimer;
+  int _cooldownSeconds = 0;
+  bool _isChecking = false;
+  String? _resendError;
+
+  @override
+  void initState() {
+    super.initState();
+    _pollTimer = Timer.periodic(_pollInterval, (_) => _poll());
+    // Check ngay 1 lần — case user verify trên web ngay trước khi mở màn này.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _poll());
+  }
+
+  @override
+  void dispose() {
+    _pollTimer?.cancel();
+    _cooldownTimer?.cancel();
+    // KHÔNG đụng ref trong dispose — router teardown có thể đã dispose element.
+    super.dispose();
+  }
+
+  /// Reload + re-check. Nếu đã verify, gate flip → router tự điều hướng /home.
+  Future<void> _poll() async {
+    if (_isChecking) return;
+    setState(() => _isChecking = true);
+    await ref.read(emailVerificationGateProvider.notifier).refresh();
+    if (!mounted) return;
+    setState(() => _isChecking = false);
+  }
+
+  Future<void> _onResend() async {
+    setState(() => _resendError = null);
+    try {
+      await ref.read(authRepositoryProvider).sendEmailVerification();
+      if (!mounted) return;
+      _startCooldown();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _resendError = AppError.fromUnknown(e).message);
+    }
+  }
+
+  void _startCooldown() {
+    _cooldownTimer?.cancel();
+    setState(() => _cooldownSeconds = _resendCooldown);
+    _cooldownTimer = Timer.periodic(const Duration(seconds: 1), (t) {
+      if (!mounted) {
+        t.cancel();
+        return;
+      }
+      setState(() => _cooldownSeconds--);
+      if (_cooldownSeconds <= 0) t.cancel();
+    });
+  }
+
+  Future<void> _onSignOut() async {
+    // uid → null → router redirect /intro. Gate recompute → false.
+    await ref.read(authRepositoryProvider).signOut();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final email = ref.read(authRepositoryProvider).currentEmail ?? '';
+    final canResend = _cooldownSeconds <= 0;
+
+    return Scaffold(
+      backgroundColor: AppColors.bw900,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 27),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Spacer(),
+              Text(
+                'Xác minh email của bạn',
+                style: AppTextStyles.xlBold.copyWith(color: AppColors.bw100),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                email.isEmpty
+                    ? 'Chúng tôi đã gửi email xác minh. Mở email và bấm vào '
+                        'liên kết để tiếp tục.'
+                    : 'Chúng tôi đã gửi email xác minh tới $email. Mở email '
+                        'và bấm vào liên kết để tiếp tục.',
+                style:
+                    AppTextStyles.smSemiBold.copyWith(color: AppColors.bw500),
+                textAlign: TextAlign.center,
+              ),
+              if (_resendError != null) ...[
+                const SizedBox(height: 12),
+                Text(
+                  _resendError!,
+                  style: AppTextStyles.smSemiBold
+                      .copyWith(color: AppColors.error400),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+              const SizedBox(height: 24),
+              GestureDetector(
+                onTap: canResend ? _onResend : null,
+                child: Text(
+                  canResend
+                      ? 'Chưa nhận được email? Gửi lại'
+                      : 'Gửi lại sau ${_cooldownSeconds}s.',
+                  style: AppTextStyles.smSemiBold.copyWith(
+                    color: canResend ? AppColors.bw100 : AppColors.bw500,
+                    decoration: canResend ? TextDecoration.underline : null,
+                    decorationColor: AppColors.bw100,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              const Spacer(),
+              AppPrimaryButton(
+                label: 'Tôi đã xác minh',
+                isLoading: _isChecking,
+                onPressed: _isChecking ? null : _poll,
+              ),
+              const SizedBox(height: 12),
+              TextButton(
+                onPressed: _onSignOut,
+                child: Text(
+                  'Đổi tài khoản',
+                  style:
+                      AppTextStyles.smSemiBold.copyWith(color: AppColors.bw500),
+                ),
+              ),
+              const SizedBox(height: 21),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/notification/application/notification_controller.dart
+++ b/apps/mobile/lib/features/notification/application/notification_controller.dart
@@ -4,6 +4,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:meep/features/auth/application/auth_providers.dart';
@@ -55,27 +56,65 @@ class NotificationController extends _$NotificationController {
     return NotificationState(bannerSuppressed: suppressed);
   }
 
-  /// Idempotent — re-entry on uid stream re-emit (vd refresh token flip
-  /// AsyncLoading→AsyncData) must NOT chain extra `onMessage` listeners,
-  /// else `_handleForeground` fires N times per push.
+  /// Kiểm tra quyền thông báo (Android 13+ POST_NOTIFICATIONS) khi user login.
+  ///
+  /// Nếu đã granted → wire FCM ngay. Nếu chưa → KHÔNG tự request ở đây; chỉ set
+  /// [NotificationState.permissionStatus] để UI (MeepApp) hiển thị rationale
+  /// dialog (denied/chưa hỏi) hoặc fallback banner (permanentlyDenied). User
+  /// bấm "Cho phép" → [requestPermission]. Android < 13 luôn granted.
   Future<void> initFcm() async {
+    if (_fcmInitialized) return;
+
+    final status = await Permission.notification.status;
+    if (status.isGranted) {
+      await _setupFcm();
+      state = state.copyWith(
+        permissionStatus: NotificationPermissionStatus.granted,
+      );
+      return;
+    }
+    state = state.copyWith(permissionStatus: _mapStatus(status));
+  }
+
+  /// Request POST_NOTIFICATIONS qua hệ thống — gọi từ rationale dialog khi user
+  /// bấm "Cho phép". Granted → wire FCM; denied/permanent → set state cho UI.
+  Future<void> requestPermission() async {
+    final result = await Permission.notification.request();
+    if (result.isGranted) {
+      await _setupFcm();
+      state = state.copyWith(
+        permissionStatus: NotificationPermissionStatus.granted,
+      );
+      return;
+    }
+    state = state.copyWith(permissionStatus: _mapStatus(result));
+  }
+
+  /// Mở màn Cài đặt ứng dụng để user bật thông báo thủ công khi
+  /// permanentlyDenied (hệ thống không cho hỏi lại trong app).
+  Future<bool> openNotificationSettings() => openAppSettings();
+
+  static NotificationPermissionStatus _mapStatus(PermissionStatus s) {
+    if (s.isGranted || s.isLimited || s.isProvisional) {
+      return NotificationPermissionStatus.granted;
+    }
+    if (s.isPermanentlyDenied || s.isRestricted) {
+      return NotificationPermissionStatus.permanentlyDenied;
+    }
+    return NotificationPermissionStatus.denied;
+  }
+
+  /// Wire FCM: local notifications + token save + onTokenRefresh + cold-start
+  /// deep link + foreground/opened listeners.
+  ///
+  /// Idempotent qua [_fcmInitialized] — re-entry on uid stream re-emit (vd
+  /// refresh token flip AsyncLoading→AsyncData) must NOT chain extra
+  /// `onMessage` listeners, else `_handleForeground` fires N times per push.
+  Future<void> _setupFcm() async {
     if (_fcmInitialized) return;
     _fcmInitialized = true;
 
     final messaging = FirebaseMessaging.instance;
-
-    final settings = await messaging.requestPermission(
-      alert: true,
-      badge: true,
-      sound: true,
-    );
-
-    if (settings.authorizationStatus == AuthorizationStatus.denied) {
-      state = state.copyWith(fcmPermissionDenied: true);
-      // Reset so retry after user grants in Settings re-runs the full flow.
-      _fcmInitialized = false;
-      return;
-    }
 
     await _initLocalNotifications();
 
@@ -273,7 +312,7 @@ class NotificationController extends _$NotificationController {
     state = state.copyWith(
       currentBanner: null,
       lastOpenedApp: null,
-      fcmPermissionDenied: false,
+      permissionStatus: NotificationPermissionStatus.unknown,
     );
   }
 }

--- a/apps/mobile/lib/features/notification/application/notification_state.dart
+++ b/apps/mobile/lib/features/notification/application/notification_state.dart
@@ -2,6 +2,20 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'notification_state.freezed.dart';
 
+/// Trạng thái quyền thông báo (Android 13+ POST_NOTIFICATIONS).
+///
+/// - [unknown]: chưa kiểm tra / chưa hỏi.
+/// - [granted]: đã cấp → FCM hoạt động.
+/// - [denied]: từ chối nhưng còn hỏi lại được → show rationale dialog.
+/// - [permanentlyDenied]: từ chối vĩnh viễn (chọn "Don't allow") → chỉ bật
+///   được trong Cài đặt hệ thống → show fallback banner + "Mở Cài đặt".
+enum NotificationPermissionStatus {
+  unknown,
+  granted,
+  denied,
+  permanentlyDenied
+}
+
 @freezed
 class BannerPayload with _$BannerPayload {
   const factory BannerPayload({
@@ -30,7 +44,8 @@ class OpenedAppPayload with _$OpenedAppPayload {
 @freezed
 class NotificationState with _$NotificationState {
   const factory NotificationState({
-    @Default(false) bool fcmPermissionDenied,
+    @Default(NotificationPermissionStatus.unknown)
+    NotificationPermissionStatus permissionStatus,
     @Default(false) bool bannerSuppressed,
     BannerPayload? currentBanner,
     OpenedAppPayload? lastOpenedApp,

--- a/apps/mobile/lib/features/notification/data/firebase_notification_repository.dart
+++ b/apps/mobile/lib/features/notification/data/firebase_notification_repository.dart
@@ -4,13 +4,18 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:crypto/crypto.dart';
 
 import 'package:meep/features/notification/data/app_notification.dart';
+import 'package:meep/features/notification/data/notification_preferences.dart';
 import 'package:meep/features/notification/data/notification_repository.dart';
 
 class FirebaseNotificationRepository implements NotificationRepository {
-  FirebaseNotificationRepository({required FirebaseFirestore firestore})
-      : _firestore = firestore;
+  FirebaseNotificationRepository({
+    required FirebaseFirestore firestore,
+    required NotificationPreferences prefs,
+  })  : _firestore = firestore,
+        _prefs = prefs;
 
   final FirebaseFirestore _firestore;
+  final NotificationPreferences _prefs;
 
   CollectionReference<Map<String, dynamic>> _fcmTokensRef(String uid) =>
       _firestore.collection('users').doc(uid).collection('fcmTokens');
@@ -26,6 +31,11 @@ class FirebaseNotificationRepository implements NotificationRepository {
   /// and one fewer write).
   @override
   Future<void> saveFcmToken(String uid, String token) async {
+    // NOTIF-PERF-001: skip get + batch write Firestore nếu token cho uid này
+    // không đổi so với lần ghi gần nhất (local cache). FCM token ổn định giữa
+    // các lần login cùng device → tránh 1 read + 1 batch write mỗi initFcm.
+    if (_prefs.cachedFcmToken(uid) == token) return;
+
     final tokenId = sha256.convert(utf8.encode(token)).toString();
     final existing = await _fcmTokensRef(uid).get();
     final batch = _firestore.batch();
@@ -39,11 +49,15 @@ class FirebaseNotificationRepository implements NotificationRepository {
       'updatedAt': FieldValue.serverTimestamp(),
     });
     await batch.commit();
+    await _prefs.setCachedFcmToken(uid, token);
   }
 
   /// Logout cleanup — remove every fcmTokens doc for this uid.
   @override
   Future<void> deleteFcmToken(String uid) async {
+    // Clear cache trước để lần login kế tiếp (cùng device, có thể khác user)
+    // luôn ghi lại token vào Firestore thay vì skip nhầm theo cache cũ.
+    await _prefs.clearCachedFcmToken(uid);
     final snap = await _fcmTokensRef(uid).get();
     if (snap.docs.isEmpty) return;
     final batch = _firestore.batch();

--- a/apps/mobile/lib/features/notification/data/notification_preferences.dart
+++ b/apps/mobile/lib/features/notification/data/notification_preferences.dart
@@ -6,9 +6,22 @@ class NotificationPreferences {
   final SharedPreferences _prefs;
 
   static const _bannerSuppressedKey = 'notification_banner_suppressed';
+  static const _fcmTokenKeyPrefix = 'fcm_token_saved_';
 
   bool get isBannerSuppressed => _prefs.getBool(_bannerSuppressedKey) ?? false;
 
   Future<void> setBannerSuppressed(bool value) =>
       _prefs.setBool(_bannerSuppressedKey, value);
+
+  /// Token FCM đã ghi Firestore thành công cho [uid] (null nếu chưa ghi).
+  /// Keyed theo uid để user B login cùng device không bị skip ghi khi token
+  /// trùng token của user A (NOTIF-PERF-001).
+  String? cachedFcmToken(String uid) =>
+      _prefs.getString('$_fcmTokenKeyPrefix$uid');
+
+  Future<void> setCachedFcmToken(String uid, String token) =>
+      _prefs.setString('$_fcmTokenKeyPrefix$uid', token);
+
+  Future<void> clearCachedFcmToken(String uid) =>
+      _prefs.remove('$_fcmTokenKeyPrefix$uid');
 }

--- a/apps/mobile/lib/features/notification/presentation/widgets/notification_permission_dialog.dart
+++ b/apps/mobile/lib/features/notification/presentation/widgets/notification_permission_dialog.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/shared/widgets/app_primary_button.dart';
+
+/// Rationale dialog (NOTIF-UX-PERM-001) — giải thích lợi ích TRƯỚC khi request
+/// POST_NOTIFICATIONS (Android 13+). Show lần đầu khi quyền chưa được cấp và
+/// còn hỏi lại được. Trả `true` nếu user bấm "Cho phép".
+class NotificationPermissionDialog extends StatelessWidget {
+  const NotificationPermissionDialog({super.key});
+
+  /// Show modal; returns true nếu user đồng ý cho phép.
+  static Future<bool> show(BuildContext context) async {
+    final result = await showDialog<bool>(
+      context: context,
+      barrierColor: const Color(0x73000000),
+      builder: (_) => const NotificationPermissionDialog(),
+    );
+    return result ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.bw800,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Bật thông báo',
+              style: AppTextStyles.lgBold.copyWith(color: AppColors.bw100),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Cho phép Meep gửi thông báo để không bỏ lỡ ảnh và tim từ '
+              'bạn bè.',
+              style: AppTextStyles.smSemiBold.copyWith(color: AppColors.bw500),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            AppPrimaryButton(
+              label: 'Cho phép',
+              showTrailingIcon: false,
+              onPressed: () => Navigator.of(context).pop(true),
+            ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: Text(
+                'Để sau',
+                style:
+                    AppTextStyles.smSemiBold.copyWith(color: AppColors.bw500),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Fallback banner (NOTIF-UX-PERM-001) — hiện khi quyền thông báo bị từ chối
+/// vĩnh viễn (permanentlyDenied). Hệ thống không cho hỏi lại trong app nên chỉ
+/// còn cách mở Cài đặt. Hiển thị qua Overlay (giống NotificationBanner).
+class NotificationPermissionBanner extends StatelessWidget {
+  const NotificationPermissionBanner({
+    super.key,
+    required this.onOpenSettings,
+    required this.onDismiss,
+  });
+
+  /// Mở Cài đặt ứng dụng (NotificationController.openNotificationSettings).
+  final VoidCallback onOpenSettings;
+
+  /// Đóng banner cho phiên hiện tại.
+  final VoidCallback onDismiss;
+
+  static const _width = 364.0;
+
+  @override
+  Widget build(BuildContext context) {
+    // Material wrapper — banner thường render trong Overlay (không có Material
+    // ancestor) nên TextButton/IconButton cần lớp này.
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        width: _width,
+        padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+        decoration: BoxDecoration(
+          color: AppColors.bw800,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Thông báo đang tắt',
+                    style: AppTextStyles.smSemiBold
+                        .copyWith(color: AppColors.bw100),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Bật trong Cài đặt để nhận ảnh từ bạn bè.',
+                    style: AppTextStyles.xsSemiBold
+                        .copyWith(color: AppColors.bw500),
+                  ),
+                ],
+              ),
+            ),
+            TextButton(
+              onPressed: onOpenSettings,
+              child: Text(
+                'Mở Cài đặt',
+                style: AppTextStyles.smSemiBold
+                    .copyWith(color: AppColors.turquoise300),
+              ),
+            ),
+            IconButton(
+              onPressed: onDismiss,
+              icon: const Icon(Icons.close, size: 18, color: AppColors.bw500),
+              tooltip: 'Đóng',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -40,6 +40,7 @@ import 'package:meep/features/notification/application/notification_state.dart';
 import 'package:meep/features/notification/data/firebase_notification_repository.dart';
 import 'package:meep/features/notification/data/notification_preferences.dart';
 import 'package:meep/features/notification/presentation/widgets/notification_banner.dart';
+import 'package:meep/features/notification/presentation/widgets/notification_permission_dialog.dart';
 import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/features/space/data/firebase_space_repository.dart';
 import 'package:meep/features/streak/application/streak_controller.dart';
@@ -82,6 +83,7 @@ void main() async {
   };
 
   final prefs = await SharedPreferences.getInstance();
+  final notifPrefs = NotificationPreferences(prefs: prefs);
 
   final authRepo = FirebaseAuthRepository(
     auth: FirebaseAuth.instance,
@@ -139,11 +141,12 @@ void main() async {
           FirebaseReactionRepository(FirebaseFirestore.instance),
         ),
         notificationRepositoryProvider.overrideWithValue(
-          FirebaseNotificationRepository(firestore: FirebaseFirestore.instance),
+          FirebaseNotificationRepository(
+            firestore: FirebaseFirestore.instance,
+            prefs: notifPrefs,
+          ),
         ),
-        notificationPreferencesProvider.overrideWithValue(
-          NotificationPreferences(prefs: prefs),
-        ),
+        notificationPreferencesProvider.overrideWithValue(notifPrefs),
         diaryRepositoryProvider.overrideWithValue(
           FirebaseDiaryRepository.firebase(
             firestore: FirebaseFirestore.instance,
@@ -174,6 +177,8 @@ class MeepApp extends ConsumerStatefulWidget {
 
 class _MeepAppState extends ConsumerState<MeepApp> with WidgetsBindingObserver {
   OverlayEntry? _bannerOverlay;
+  OverlayEntry? _permissionOverlay;
+  bool _rationaleAsked = false;
 
   @override
   void initState() {
@@ -184,6 +189,7 @@ class _MeepAppState extends ConsumerState<MeepApp> with WidgetsBindingObserver {
   @override
   void dispose() {
     _bannerOverlay?.remove();
+    _permissionOverlay?.remove();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -193,6 +199,60 @@ class _MeepAppState extends ConsumerState<MeepApp> with WidgetsBindingObserver {
     if (state == AppLifecycleState.resumed) {
       ref.read(widgetDataServiceProvider).recordLastViewedAt();
     }
+  }
+
+  /// NOTIF-UX-PERM-001 — phản ứng theo trạng thái quyền thông báo:
+  /// - denied (lần đầu) → rationale dialog; user đồng ý → request quyền.
+  /// - permanentlyDenied → fallback banner + "Mở Cài đặt".
+  /// - granted → gỡ banner nếu đang hiện.
+  void _handlePermissionStatus(NotificationPermissionStatus status) {
+    switch (status) {
+      case NotificationPermissionStatus.denied:
+        if (_rationaleAsked) return;
+        _rationaleAsked = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) async {
+          final ctx = rootNavigatorKey.currentContext;
+          if (ctx == null) return;
+          final allow = await NotificationPermissionDialog.show(ctx);
+          if (!mounted || !allow) return;
+          await ref
+              .read(notificationControllerProvider.notifier)
+              .requestPermission();
+        });
+      case NotificationPermissionStatus.permanentlyDenied:
+        _showPermissionBanner();
+      case NotificationPermissionStatus.granted:
+      case NotificationPermissionStatus.unknown:
+        _removePermissionBanner();
+    }
+  }
+
+  void _showPermissionBanner() {
+    _removePermissionBanner();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final overlay = Overlay.maybeOf(context, rootOverlay: true);
+      if (overlay == null) return;
+      final entry = OverlayEntry(
+        builder: (_) => Positioned(
+          top: MediaQuery.of(context).padding.top + 10,
+          left: (MediaQuery.of(context).size.width - 364) / 2,
+          child: NotificationPermissionBanner(
+            onOpenSettings: () => ref
+                .read(notificationControllerProvider.notifier)
+                .openNotificationSettings(),
+            onDismiss: _removePermissionBanner,
+          ),
+        ),
+      );
+      overlay.insert(entry);
+      _permissionOverlay = entry;
+    });
+  }
+
+  void _removePermissionBanner() {
+    _permissionOverlay?.remove();
+    _permissionOverlay = null;
   }
 
   @override
@@ -226,6 +286,12 @@ class _MeepAppState extends ConsumerState<MeepApp> with WidgetsBindingObserver {
         ref.read(notificationControllerProvider.notifier).initFcm();
       }
     });
+
+    // ── Notification: react to permission status (NOTIF-UX-PERM-001) ────
+    ref.listen(
+      notificationControllerProvider.select((s) => s.permissionStatus),
+      (_, status) => _handlePermissionStatus(status),
+    );
 
     // ── Notification: foreground banner overlay ─────────────────────────
     // The first `ref.listen` fire can happen before `MaterialApp.router`

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -1187,10 +1187,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1335,6 +1335,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.4.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.9"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -1720,10 +1768,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   flutter_svg: ^2.0.10+1
   image_picker: ^1.1.2
   intl: ^0.19.0
+  permission_handler: ^11.3.1
   share_plus: ^10.0.3
   shared_preferences: ^2.3.3
 

--- a/apps/mobile/test/core/router/app_router_test.dart
+++ b/apps/mobile/test/core/router/app_router_test.dart
@@ -11,6 +11,7 @@ void main() {
           uid: null,
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/home',
         ),
         isNull,
@@ -21,6 +22,7 @@ void main() {
           uid: 'u1',
           profileExists: true,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/intro',
         ),
         isNull,
@@ -35,6 +37,7 @@ void main() {
           uid: null,
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/intro',
         ),
         isNull,
@@ -48,6 +51,7 @@ void main() {
           uid: null,
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/login/email',
         ),
         isNull,
@@ -61,6 +65,7 @@ void main() {
           uid: null,
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/signup/email',
         ),
         isNull,
@@ -74,6 +79,7 @@ void main() {
           uid: null,
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/home',
         ),
         '/intro',
@@ -87,6 +93,7 @@ void main() {
           uid: null,
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/profile',
         ),
         '/intro',
@@ -101,6 +108,7 @@ void main() {
           uid: 'u1',
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/home',
         ),
         isNull,
@@ -111,6 +119,7 @@ void main() {
           uid: 'u1',
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/intro',
         ),
         isNull,
@@ -125,6 +134,7 @@ void main() {
           uid: 'u1',
           profileExists: false,
           needsProfile: true,
+          requiresEmailVerification: false,
           location: '/signup/name',
         ),
         isNull,
@@ -139,6 +149,7 @@ void main() {
           uid: 'u1',
           profileExists: false,
           needsProfile: true,
+          requiresEmailVerification: false,
           location: '/signup/username',
         ),
         isNull,
@@ -152,6 +163,7 @@ void main() {
           uid: 'u1',
           profileExists: false,
           needsProfile: true,
+          requiresEmailVerification: false,
           location: '/home',
         ),
         '/signup/name',
@@ -165,6 +177,7 @@ void main() {
           uid: 'u1',
           profileExists: false,
           needsProfile: true,
+          requiresEmailVerification: false,
           location: '/signup/email',
         ),
         '/signup/name',
@@ -179,6 +192,7 @@ void main() {
           uid: 'u1',
           profileExists: false,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/intro',
         ),
         '/intro',
@@ -192,6 +206,7 @@ void main() {
           uid: 'u1',
           profileExists: false,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/home',
         ),
         '/intro',
@@ -207,6 +222,7 @@ void main() {
           uid: 'u1',
           profileExists: false,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/signup/email',
         ),
         isNull,
@@ -221,6 +237,7 @@ void main() {
           uid: 'u1',
           profileExists: true,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/home',
         ),
         isNull,
@@ -234,6 +251,7 @@ void main() {
           uid: 'u1',
           profileExists: true,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/profile',
         ),
         isNull,
@@ -247,6 +265,7 @@ void main() {
           uid: 'u1',
           profileExists: true,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/intro',
         ),
         '/home',
@@ -260,6 +279,7 @@ void main() {
           uid: 'u1',
           profileExists: true,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/signup/email',
         ),
         '/home',
@@ -273,6 +293,7 @@ void main() {
           uid: 'u1',
           profileExists: true,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/login/email',
         ),
         '/home',
@@ -286,6 +307,7 @@ void main() {
           uid: 'u1',
           profileExists: true,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/dev/widgets',
         ),
         '/home',
@@ -300,6 +322,7 @@ void main() {
           uid: null,
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/inbox',
         ),
         isNull,
@@ -313,6 +336,7 @@ void main() {
           uid: 'u1',
           profileExists: true,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/chat/conv-1',
         ),
         isNull,
@@ -326,9 +350,196 @@ void main() {
           uid: null,
           profileExists: null,
           needsProfile: false,
+          requiresEmailVerification: false,
           location: '/group-chat/conv-1',
         ),
         isNull,
+      );
+    });
+  });
+
+  group('authRedirect — email verification hard gate (AUTH-SEC-002)', () {
+    test('unverified + profile + /home → /verify-email', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/home',
+        ),
+        '/verify-email',
+      );
+    });
+
+    test('unverified + /intro → /verify-email', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/intro',
+        ),
+        '/verify-email',
+      );
+    });
+
+    test('unverified + already on /verify-email → null (stay)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/verify-email',
+        ),
+        isNull,
+      );
+    });
+
+    test('unverified + deep link /profile → /verify-email (gate catches all)',
+        () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/profile',
+        ),
+        '/verify-email',
+      );
+    });
+
+    test('verified + on /verify-email → /home (evict)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: false,
+          location: '/verify-email',
+        ),
+        '/home',
+      );
+    });
+
+    test('verified + /home → null (stay, no gate)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: false,
+          location: '/home',
+        ),
+        isNull,
+      );
+    });
+
+    test('unverified BUT reset-password deep link → null (bypass gate)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/login/reset-password',
+        ),
+        isNull,
+      );
+    });
+
+    test('unverified BUT /__/auth/action → null (bypass gate)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/__/auth/action',
+        ),
+        isNull,
+      );
+    });
+
+    test('unverified BUT /chat dev bypass → null', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/chat/c1',
+        ),
+        isNull,
+      );
+    });
+
+    test('unverified + profile==null (orphan) → /intro (gate not reached)', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: false,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/home',
+        ),
+        '/intro',
+      );
+    });
+
+    test('unverified + profileExists==null → null (wait, gate not reached)',
+        () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: 'u1',
+          profileExists: null,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/home',
+        ),
+        isNull,
+      );
+    });
+
+    test('isLoading wins over gate', () {
+      expect(
+        authRedirect(
+          isLoading: true,
+          uid: 'u1',
+          profileExists: true,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/home',
+        ),
+        isNull,
+      );
+    });
+
+    test('uid null + gate true (impossible but safe) → /intro', () {
+      expect(
+        authRedirect(
+          isLoading: false,
+          uid: null,
+          profileExists: null,
+          needsProfile: false,
+          requiresEmailVerification: true,
+          location: '/home',
+        ),
+        '/intro',
       );
     });
   });

--- a/apps/mobile/test/features/auth/application/email_verification_gate_test.dart
+++ b/apps/mobile/test/features/auth/application/email_verification_gate_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/application/email_verification_gate.dart';
+import 'package:meep/features/auth/data/auth_repository.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late MockAuthRepository repo;
+
+  setUp(() {
+    repo = MockAuthRepository();
+    // currentUidProvider watch repo.watchUid(); keep it simple/stable.
+    when(() => repo.watchUid()).thenAnswer((_) => const Stream.empty());
+    when(() => repo.reloadUser()).thenAnswer((_) async {});
+  });
+
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer(
+      overrides: [authRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('EmailVerificationGate', () {
+    test('signed out → false', () {
+      when(() => repo.currentUid).thenReturn(null);
+      when(() => repo.currentProviderId).thenReturn(null);
+      when(() => repo.isEmailVerified).thenReturn(false);
+
+      final c = makeContainer();
+      expect(c.read(emailVerificationGateProvider), isFalse);
+    });
+
+    test('password user + chưa verify → true (gate)', () {
+      when(() => repo.currentUid).thenReturn('u1');
+      when(() => repo.currentProviderId).thenReturn('password');
+      when(() => repo.isEmailVerified).thenReturn(false);
+
+      final c = makeContainer();
+      expect(c.read(emailVerificationGateProvider), isTrue);
+    });
+
+    test('password user + đã verify → false', () {
+      when(() => repo.currentUid).thenReturn('u1');
+      when(() => repo.currentProviderId).thenReturn('password');
+      when(() => repo.isEmailVerified).thenReturn(true);
+
+      final c = makeContainer();
+      expect(c.read(emailVerificationGateProvider), isFalse);
+    });
+
+    test('Google user chưa verify → false (provider exempt)', () {
+      // Contrived: Google email luôn verified, nhưng vẫn assert short-circuit.
+      when(() => repo.currentUid).thenReturn('u1');
+      when(() => repo.currentProviderId).thenReturn('google.com');
+      when(() => repo.isEmailVerified).thenReturn(false);
+
+      final c = makeContainer();
+      expect(c.read(emailVerificationGateProvider), isFalse);
+    });
+
+    test('refresh() reload rồi flip true→false khi đã verify', () async {
+      when(() => repo.currentUid).thenReturn('u1');
+      when(() => repo.currentProviderId).thenReturn('password');
+      // Trước reload: chưa verify.
+      var verified = false;
+      when(() => repo.isEmailVerified).thenAnswer((_) => verified);
+      // reload mô phỏng user click link → verified.
+      when(() => repo.reloadUser()).thenAnswer((_) async {
+        verified = true;
+      });
+
+      final c = makeContainer();
+      expect(c.read(emailVerificationGateProvider), isTrue);
+
+      await c.read(emailVerificationGateProvider.notifier).refresh();
+
+      expect(c.read(emailVerificationGateProvider), isFalse);
+      verify(() => repo.reloadUser()).called(1);
+    });
+  });
+}

--- a/apps/mobile/test/features/auth/application/sign_up_controller_test.dart
+++ b/apps/mobile/test/features/auth/application/sign_up_controller_test.dart
@@ -6,9 +6,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/auth/application/sign_up_controller.dart';
 import 'package:meep/features/auth/application/sign_up_state.dart';
+import 'package:meep/features/auth/data/auth_repository.dart';
 import 'package:meep/features/auth/data/firebase_auth_repository.dart';
 import 'package:meep/features/auth/data/firebase_user_repository.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/user_repository.dart';
 import 'package:mock_exceptions/mock_exceptions.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+class _MockUserRepository extends Mock implements UserRepository {}
+
+class _FakeUserProfile extends Fake implements UserProfile {}
 
 ProviderContainer makeContainer({
   MockFirebaseAuth? auth,
@@ -244,6 +254,96 @@ void main() {
         container.read(signUpControllerProvider).errorMessage,
         isNotNull,
       );
+    });
+  });
+
+  group('SignUpController — email verification (AUTH-SEC-002)', () {
+    late _MockAuthRepository authRepo;
+    late _MockUserRepository userRepo;
+
+    setUpAll(() => registerFallbackValue(_FakeUserProfile()));
+
+    setUp(() {
+      authRepo = _MockAuthRepository();
+      userRepo = _MockUserRepository();
+      when(() => authRepo.currentUid).thenReturn('uid-new');
+      when(() => authRepo.currentEmail).thenReturn('new@example.com');
+      when(
+        () => authRepo.signUpWithEmail(
+          email: any(named: 'email'),
+          password: any(named: 'password'),
+        ),
+      ).thenAnswer((_) async {});
+      when(() => authRepo.signInWithGoogle()).thenAnswer((_) async {});
+      when(() => authRepo.sendEmailVerification()).thenAnswer((_) async {});
+      when(() => userRepo.createProfile(any())).thenAnswer((_) async {});
+    });
+
+    ProviderContainer mockContainer() {
+      final c = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(authRepo),
+          userRepositoryProvider.overrideWithValue(userRepo),
+        ],
+      );
+      addTearDown(c.dispose);
+      return c;
+    }
+
+    test('email signup → sendEmailVerification được gọi', () async {
+      final c = mockContainer();
+      final ctrl = c.read(signUpControllerProvider.notifier);
+      ctrl.setEmail('new@example.com');
+      ctrl.setPassword('pass1234');
+      ctrl.setDisplayName('New User');
+      ctrl.state = c.read(signUpControllerProvider).copyWith(
+            username: 'newuser',
+            isUsernameAvailable: true,
+          );
+
+      await ctrl.createAccount();
+
+      expect(c.read(signUpControllerProvider).errorMessage, isNull);
+      verify(() => authRepo.sendEmailVerification()).called(1);
+    });
+
+    test('Google signup → KHÔNG gọi sendEmailVerification', () async {
+      final c = mockContainer();
+      final ctrl = c.read(signUpControllerProvider.notifier);
+      ctrl.prefillFromGoogle('Google User');
+      ctrl.setDisplayName('Google User');
+      ctrl.state = c.read(signUpControllerProvider).copyWith(
+            username: 'googleuser',
+            isUsernameAvailable: true,
+          );
+
+      await ctrl.createAccount();
+
+      expect(c.read(signUpControllerProvider).errorMessage, isNull);
+      verifyNever(() => authRepo.sendEmailVerification());
+    });
+
+    test('sendEmailVerification fail → KHÔNG rollback, account vẫn tạo',
+        () async {
+      when(() => authRepo.sendEmailVerification())
+          .thenThrow(Exception('too-many-requests'));
+      final c = mockContainer();
+      final ctrl = c.read(signUpControllerProvider.notifier);
+      ctrl.setEmail('new@example.com');
+      ctrl.setPassword('pass1234');
+      ctrl.setDisplayName('New User');
+      ctrl.state = c.read(signUpControllerProvider).copyWith(
+            username: 'newuser',
+            isUsernameAvailable: true,
+          );
+
+      await ctrl.createAccount();
+
+      // Profile created, no fatal error, no Auth-user rollback.
+      verify(() => userRepo.createProfile(any())).called(1);
+      expect(c.read(signUpControllerProvider).errorMessage, isNull);
+      expect(c.read(signUpControllerProvider).isLoading, isFalse);
+      verifyNever(() => authRepo.deleteCurrentUser());
     });
   });
 }

--- a/apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart
+++ b/apps/mobile/test/features/auth/data/firebase_auth_repository_test.dart
@@ -402,4 +402,112 @@ void main() {
       );
     });
   });
+
+  group('isEmailVerified', () {
+    test('false khi chưa đăng nhập', () {
+      expect(repo.isEmailVerified, isFalse);
+    });
+
+    test('true khi user đã verify', () {
+      final auth = MockFirebaseAuth(
+        mockUser: MockUser(uid: 'u1', isEmailVerified: true),
+        signedIn: true,
+      );
+      expect(FirebaseAuthRepository(auth: auth).isEmailVerified, isTrue);
+    });
+
+    test('false khi user chưa verify', () {
+      final auth = MockFirebaseAuth(
+        mockUser: MockUser(uid: 'u1', isEmailVerified: false),
+        signedIn: true,
+      );
+      expect(FirebaseAuthRepository(auth: auth).isEmailVerified, isFalse);
+    });
+  });
+
+  group('sendEmailVerification', () {
+    test('UnauthenticatedError khi chưa đăng nhập', () async {
+      await expectLater(
+        repo.sendEmailVerification(),
+        throwsA(isA<UnauthenticatedError>()),
+      );
+    });
+
+    test('completes khi user signed in', () async {
+      final auth = MockFirebaseAuth(
+        mockUser: MockUser(uid: 'u1', email: 'a@b.com'),
+        signedIn: true,
+      );
+      await expectLater(
+        FirebaseAuthRepository(auth: auth).sendEmailVerification(),
+        completes,
+      );
+    });
+
+    test('UnauthenticatedError "too-many-requests" map tiếng Việt', () async {
+      final user = MockUser(uid: 'u-spam', email: 'a@b.com');
+      final auth = MockFirebaseAuth(mockUser: user, signedIn: true);
+      whenCalling(Invocation.method(#sendEmailVerification, null))
+          .on(user)
+          .thenThrow(FirebaseAuthException(code: 'too-many-requests'));
+      Object? caught;
+      try {
+        await FirebaseAuthRepository(auth: auth).sendEmailVerification();
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<UnauthenticatedError>());
+      expect((caught! as UnauthenticatedError).message, contains('Quá nhiều'));
+    });
+
+    test('NetworkError khi mất mạng', () async {
+      final user = MockUser(uid: 'u-net', email: 'a@b.com');
+      final auth = MockFirebaseAuth(mockUser: user, signedIn: true);
+      whenCalling(Invocation.method(#sendEmailVerification, null))
+          .on(user)
+          .thenThrow(FirebaseAuthException(code: 'network-request-failed'));
+      await expectLater(
+        FirebaseAuthRepository(auth: auth).sendEmailVerification(),
+        throwsA(isA<NetworkError>()),
+      );
+    });
+  });
+
+  group('reloadUser', () {
+    test('no-op khi chưa đăng nhập', () async {
+      await expectLater(repo.reloadUser(), completes);
+    });
+
+    test('reload thành công → giữ session', () async {
+      final auth = MockFirebaseAuth(
+        mockUser: MockUser(uid: 'u1'),
+        signedIn: true,
+      );
+      final r = FirebaseAuthRepository(auth: auth);
+      await r.reloadUser();
+      expect(r.currentUid, 'u1');
+    });
+
+    test('reload throws user-not-found → signOut', () async {
+      final user = MockUser(uid: 'u-deleted');
+      final auth = MockFirebaseAuth(mockUser: user, signedIn: true);
+      whenCalling(Invocation.method(#reload, null))
+          .on(user)
+          .thenThrow(FirebaseAuthException(code: 'user-not-found'));
+      final r = FirebaseAuthRepository(auth: auth);
+      await r.reloadUser();
+      expect(r.currentUid, isNull);
+    });
+
+    test('reload throws network-request-failed → giữ session', () async {
+      final user = MockUser(uid: 'u-offline');
+      final auth = MockFirebaseAuth(mockUser: user, signedIn: true);
+      whenCalling(Invocation.method(#reload, null))
+          .on(user)
+          .thenThrow(FirebaseAuthException(code: 'network-request-failed'));
+      final r = FirebaseAuthRepository(auth: auth);
+      await r.reloadUser();
+      expect(r.currentUid, 'u-offline');
+    });
+  });
 }

--- a/apps/mobile/test/features/auth/presentation/verify_email_page_test.dart
+++ b/apps/mobile/test/features/auth/presentation/verify_email_page_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/auth_repository.dart';
+import 'package:meep/features/auth/presentation/verify_email_page.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late _MockAuthRepository repo;
+
+  setUp(() {
+    repo = _MockAuthRepository();
+    when(() => repo.watchUid()).thenAnswer((_) => const Stream.empty());
+    when(() => repo.currentUid).thenReturn('u1');
+    when(() => repo.currentProviderId).thenReturn('password');
+    when(() => repo.currentEmail).thenReturn('alice@example.com');
+    when(() => repo.isEmailVerified).thenReturn(false);
+    when(() => repo.reloadUser()).thenAnswer((_) async {});
+    when(() => repo.sendEmailVerification()).thenAnswer((_) async {});
+  });
+
+  Widget wrap() => ProviderScope(
+        overrides: [authRepositoryProvider.overrideWithValue(repo)],
+        child: const MaterialApp(home: VerifyEmailPage()),
+      );
+
+  testWidgets('renders email + verify + resend affordances', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump(); // settle initState post-frame poll
+
+    expect(find.textContaining('alice@example.com'), findsOneWidget);
+    expect(find.text('Tôi đã xác minh'), findsOneWidget);
+    expect(find.text('Chưa nhận được email? Gửi lại'), findsOneWidget);
+    expect(find.text('Đổi tài khoản'), findsOneWidget);
+  });
+
+  testWidgets('tap "Tôi đã xác minh" → reloadUser called', (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await tester.tap(find.text('Tôi đã xác minh'));
+    await tester.pump();
+
+    verify(() => repo.reloadUser()).called(greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('tap "Gửi lại" → sendEmailVerification + cooldown',
+      (tester) async {
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await tester.tap(find.text('Chưa nhận được email? Gửi lại'));
+    await tester.pump();
+
+    verify(() => repo.sendEmailVerification()).called(1);
+    // Cooldown kicks in → resend text switches to countdown.
+    expect(find.textContaining('Gửi lại sau'), findsOneWidget);
+  });
+
+  testWidgets('resend lỗi → hiện message tiếng Việt', (tester) async {
+    when(() => repo.sendEmailVerification())
+        .thenThrow(const NetworkError(message: 'Không có kết nối mạng'));
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await tester.tap(find.text('Chưa nhận được email? Gửi lại'));
+    await tester.pump();
+
+    expect(find.text('Không có kết nối mạng'), findsOneWidget);
+  });
+
+  testWidgets('tap "Đổi tài khoản" → signOut', (tester) async {
+    when(() => repo.signOut()).thenAnswer((_) async {});
+    await tester.pumpWidget(wrap());
+    await tester.pump();
+
+    await tester.tap(find.text('Đổi tài khoản'));
+    await tester.pump();
+
+    verify(() => repo.signOut()).called(1);
+  });
+}

--- a/apps/mobile/test/features/notification/application/notification_controller_test.dart
+++ b/apps/mobile/test/features/notification/application/notification_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meep/features/notification/application/notification_controller.dart';
+import 'package:meep/features/notification/application/notification_state.dart';
 import 'package:meep/features/notification/data/notification_preferences.dart';
 import 'package:meep/features/notification/data/notification_repository.dart';
 
@@ -41,7 +42,7 @@ void main() {
     test('bannerSuppressed = false by default (no pref set)', () {
       final state = container.read(notificationControllerProvider);
       expect(state.bannerSuppressed, isFalse);
-      expect(state.fcmPermissionDenied, isFalse);
+      expect(state.permissionStatus, NotificationPermissionStatus.unknown);
       expect(state.currentBanner, isNull);
     });
 
@@ -341,12 +342,12 @@ void main() {
     // return at `if (_fcmInitialized) return;` skips token save for user B
     // and they get no push until cold restart.
 
-    test('clears currentBanner + lastOpenedApp + fcmPermissionDenied',
+    test('clears currentBanner + lastOpenedApp + resets permissionStatus',
         () async {
       final controller =
           container.read(notificationControllerProvider.notifier);
 
-      // Seed state with a banner + opened-app + denied flag.
+      // Seed state with a banner + opened-app.
       controller.handleForeground(
         const RemoteMessage(
           messageId: 'fg-1',
@@ -371,7 +372,7 @@ void main() {
       final state = container.read(notificationControllerProvider);
       expect(state.currentBanner, isNull);
       expect(state.lastOpenedApp, isNull);
-      expect(state.fcmPermissionDenied, isFalse);
+      expect(state.permissionStatus, NotificationPermissionStatus.unknown);
     });
 
     test('is idempotent — calling twice is safe', () async {

--- a/apps/mobile/test/features/notification/data/firebase_notification_repository_test.dart
+++ b/apps/mobile/test/features/notification/data/firebase_notification_repository_test.dart
@@ -4,20 +4,28 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:crypto/crypto.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meep/features/notification/data/app_notification.dart';
 import 'package:meep/features/notification/data/firebase_notification_repository.dart';
+import 'package:meep/features/notification/data/notification_preferences.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late FakeFirebaseFirestore db;
+  late NotificationPreferences prefs;
   late FirebaseNotificationRepository repo;
 
   const uid = 'uid-alice';
   const otherUid = 'uid-bob';
 
-  setUp(() {
+  setUp(() async {
     db = FakeFirebaseFirestore();
-    repo = FirebaseNotificationRepository(firestore: db);
+    SharedPreferences.setMockInitialValues({});
+    prefs =
+        NotificationPreferences(prefs: await SharedPreferences.getInstance());
+    repo = FirebaseNotificationRepository(firestore: db, prefs: prefs);
   });
 
   CollectionReference<Map<String, dynamic>> fcmTokensRef(String forUid) =>
@@ -87,6 +95,46 @@ void main() {
       expect(all.docs.first.id, tokenIdOf(token));
     });
 
+    test('NOTIF-PERF-001: skips Firestore write when cached token unchanged',
+        () async {
+      // First save writes + caches the token.
+      await repo.saveFcmToken(uid, token);
+      expect(prefs.cachedFcmToken(uid), token);
+
+      // Delete the doc out-of-band; a cached-skip save must NOT recreate it.
+      await fcmTokensRef(uid).doc(tokenIdOf(token)).delete();
+      await repo.saveFcmToken(uid, token);
+
+      final snap = await fcmTokensRef(uid).get();
+      expect(
+        snap.docs,
+        isEmpty,
+        reason: 'cached token unchanged → no get + no batch write',
+      );
+    });
+
+    test('NOTIF-PERF-001: writes again when token changes', () async {
+      await repo.saveFcmToken(uid, token);
+      const newToken = 'fcm-token-rotated-xyz';
+      await repo.saveFcmToken(uid, newToken);
+
+      final all = await fcmTokensRef(uid).get();
+      expect(all.docs.length, 1);
+      expect(all.docs.first.id, tokenIdOf(newToken));
+      expect(prefs.cachedFcmToken(uid), newToken);
+    });
+
+    test('NOTIF-PERF-001: per-uid cache — user B not skipped by user A token',
+        () async {
+      await repo.saveFcmToken(uid, token);
+      // Same token, different uid (user B on same device) → must still write.
+      await repo.saveFcmToken(otherUid, token);
+
+      final bSnap = await fcmTokensRef(otherUid).get();
+      expect(bSnap.docs.length, 1);
+      expect(bSnap.docs.first.id, tokenIdOf(token));
+    });
+
     test('does not touch other users fcmTokens', () async {
       await fcmTokensRef(otherUid).doc('other-token-id').set({
         'token': 'other-token',
@@ -128,6 +176,21 @@ void main() {
 
     test('no-op when uid has no tokens — does not throw', () async {
       await expectLater(repo.deleteFcmToken(uid), completes);
+    });
+
+    test('NOTIF-PERF-001: clears token cache so next save re-writes', () async {
+      const token = 'fcm-token-abc123';
+      await repo.saveFcmToken(uid, token);
+      expect(prefs.cachedFcmToken(uid), token);
+
+      await repo.deleteFcmToken(uid);
+      expect(prefs.cachedFcmToken(uid), isNull);
+
+      // Same token after delete must write again (cache cleared).
+      await repo.saveFcmToken(uid, token);
+      final snap = await fcmTokensRef(uid).get();
+      expect(snap.docs.length, 1);
+      expect(snap.docs.first.id, tokenIdOf(token));
     });
 
     test('does not touch other users fcmTokens', () async {


### PR DESCRIPTION
## Mô tả

Polish auth flow + notification module (Phase 2). Enforce xác minh email cho signup email/password (hard gate, chặn vào /home tới khi verified), thêm UX xin quyền thông báo Android 13+ (rationale dialog + fallback banner mở Cài đặt), và cache FCM token để giảm Firestore read/write mỗi lần login.

## Refs

- Closes #  <!-- chưa có issue tracking, leader gán nếu cần -->
- Audit: `docs/audits/05_security_firebase_audit.md` (AUTH-SEC-002), `03_ux_flutter_audit.md` (NOTIF-UX-PERM-001), `04_performance_audit.md` (NOTIF-PERF-001)

## Thay đổi chính

**AUTH-SEC-002 — hard gate xác minh email**
- `auth/data/auth_repository.dart` + `firebase_auth_repository.dart`: thêm `isEmailVerified`, `reloadUser()`, `sendEmailVerification()` — Firebase I/O qua repo, map AppError tiếng Việt tại boundary
- `auth/application/email_verification_gate.dart` (mới): `NotifierProvider<bool>` gate router, Google exempt (chỉ gate provider `password`)
- `core/router/app_router.dart`: `authRedirect` thêm param `requiresEmailVerification` + nhánh `/verify-email` (sau `profileExists==true`), giữ bypass reset-password + dev chat
- `auth/presentation/verify_email_page.dart` (mới): poll 4s + resend cooldown 60s + nút "Tôi đã xác minh" + "Đổi tài khoản"
- `auth/application/sign_up_controller.dart`: gửi verification sau createProfile (email branch, swallow lỗi gửi)

**NOTIF-UX-PERM-001 — UX xin quyền thông báo**
- `notification/.../notification_permission_dialog.dart` (mới): rationale dialog + fallback banner
- `notification/application/notification_controller.dart`: tách permission flow khỏi `_setupFcm`, phân biệt `denied` vs `permanentlyDenied`
- `pubspec.yaml`: +`permission_handler ^11.3.1`; `AndroidManifest.xml`: +`POST_NOTIFICATIONS`

**NOTIF-PERF-001 — cache FCM token**
- `notification/data/firebase_notification_repository.dart` + `notification_preferences.dart`: cache token keyed-by-uid, skip get+batch-write Firestore nếu token không đổi

## Loại thay đổi

- [x] feat — Tính năng mới
- [x] perf — Cải thiện performance (NOTIF-PERF-001)

## Test

- [x] Đã chạy `flutter test` PASS (auth/notification/router: 207; settings: 48; verify_email: 5)
- [x] Đã chạy `flutter analyze` clean (0 issues)
- [x] Đã chạy `dart format` PASS
- [ ] (Functions) — không đụng
- [ ] (Firestore rules) — không đụng (gate ở client; rule server-side `email_verified` claim để PR riêng theo audit)
- [ ] Đã test thủ công trên Android — **CHƯA**, cần chạy trên device

### Cách test thủ công

1. Signup bằng email/password → app chuyển `/verify-email`, KHÔNG vào được `/home`. Mở email bấm link xác minh → quay lại app bấm "Tôi đã xác minh" (hoặc chờ poll 4s) → vào `/home`.
2. Signup bằng Google → vào thẳng `/home` (không qua verify).
3. Deny quyền thông báo → rationale dialog. Deny lần 2 (permanent) → banner "Thông báo đang tắt" + nút "Mở Cài đặt".

## Lưu ý cho reviewer

- **Verify-link không deep-link lại app**: `sendEmailVerification()` gọi không kèm `ActionCodeSettings` (khác `sendPasswordResetEmail`). User bấm link → mở web page Firebase mặc định; app biết verified qua **poll/nút thủ công**, không qua link landing. Đây là lựa chọn surgical (tránh thêm AppConfig URL + assetlinks). Nếu muốn link reopen app → cần PR riêng.
- **Gate ở client (navigation layer)**: hard gate enforce ở `authRedirect`, KHÔNG ở Firestore rule. Defense server-side (`email_verified` token claim trong `/users` create rule) thuộc audit nhưng để PR riêng như đã thống nhất.
- **Permission flow gọi native** (`permission_handler`) nên không unit-test phần request; logic state-mapping + UI đã có test, phần request đánh dấu manual.

## Self-review checklist

- [x] Branch name đúng format `fix/ThienPDM/auth-notification-polish`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không có file lớn vô tình (.env, keystore, service account) — `.claude/settings.json` đã loại khỏi commit
- [x] Không có `print` debug còn sót
- [x] Không có `// TODO` chưa link issue
- [x] Không có dead code comment-out
- [x] Đã `/review` chính diff một lần (NEEDS-FIX chỉ ở branch hygiene, code READY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)