### PR TITLE
fix(security): activate Firebase App Check chặn abuse traffic

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
@@ -62,6 +63,16 @@ void main() async {
     FirebaseFirestore.instance.useFirestoreEmulator(_emulatorHost, 9999);
     await FirebaseStorage.instance.useStorageEmulator(_emulatorHost, 9199);
   }
+
+  // App Check chặn automated abuse traffic tới Firestore/Storage/Functions.
+  // Phải activate sau Firebase.initializeApp và TRƯỚC mọi Firebase service call
+  // để token đính kèm ngay request đầu tiên. Debug build dùng AndroidProvider.debug
+  // — Logcat in token cần allowlist qua Firebase Console > App Check > Debug tokens.
+  // Release build dùng Play Integrity attestation từ Google Play (SEC-APPCHECK-001).
+  await FirebaseAppCheck.instance.activate(
+    androidProvider:
+        kDebugMode ? AndroidProvider.debug : AndroidProvider.playIntegrity,
+  );
 
   // Crashlytics: bật collection chỉ ở production build (tắt debug + emulator để
   // dashboard không nhiễu). Bắt cả Flutter framework error lẫn Dart-zone error.

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -497,6 +497,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.10+16"
+  firebase_app_check:
+    dependency: "direct main"
+    description:
+      name: firebase_app_check
+      sha256: c4124632094a4062d7a1ff0a9f9c657ff54bece5d8393af4626cb191351a2aac
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2+10"
+  firebase_app_check_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_app_check_platform_interface
+      sha256: "4ca80bcc6c5c55289514d85e7c8ba8bc354342d23ab807b01c3f82e2fc7158e4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1+10"
+  firebase_app_check_web:
+    dependency: transitive
+    description:
+      name: firebase_app_check_web
+      sha256: b3150a78fe18c27525af05b149724ee33bd8592a5959e484fdfa5c98e25edb5f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0+14"
   firebase_auth:
     dependency: "direct main"
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   logger: ^2.4.0
 
   cupertino_icons: ^1.0.8
+  firebase_app_check: ^0.3.2+10
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Mục đích

Closes SEC-APPCHECK-001 (audit #294 P0). PR-1 của Phase 2 polish (bị miss khỏi 3 PR Wave 1 đầu, redo trên develop mới sau khi config/rules/auth merged).

## Thay đổi

- `apps/mobile/lib/main.dart`: gọi `FirebaseAppCheck.instance.activate(...)` sau `Firebase.initializeApp` + emulator block, TRƯỚC mọi Firebase service call
  - Debug build: `AndroidProvider.debug`
  - Release build: `AndroidProvider.playIntegrity`
- `apps/mobile/pubspec.yaml`: add `firebase_app_check`

## Test

- [x] `flutter analyze --no-pub`: No issues found (sau build_runner codegen)
- [x] `flutter test --no-pub`: 790 test PASS (no regression)
- [ ] Manual emulator: CHƯA — cần chạy trên device để confirm debug token in Logcat + sign-in flow vẫn work

## Followup (KHÔNG trong PR này)

Sau khi merge + deploy mobile build có App Check:
1. Copy debug token từ Logcat → Firebase Console > App Check > Debug tokens
2. Enable enforce trên Firebase Console (Firestore + Storage + Functions) — staging trước
3. Verify production traffic không bị block trước khi enforce prod

Reference: docs/audits/05_security_firebase_audit.md APPCHECK-001.

## Self-review

- [x] Branch name format `fix/ThienPDM/firebase-app-check-redo`
- [x] Commit message tiếng Việt, Conventional Commits
- [x] Không file lớn vô tình (generated .g.dart gitignored)
- [x] Surgical change — chỉ 36 dòng, không touch logic khác