### PR TITLE
ci(staging): tạo google-services tạm cho build APK

### DIFF
--- a/.github/workflows/develop-staging.yml
+++ b/.github/workflows/develop-staging.yml
@@ -8,6 +8,7 @@ name: Deploy to Staging
 # CHƯA KÍCH HOẠT: cần anh fill GitHub Secrets:
 #   - FIREBASE_PROJECT_STAGING (vd "meep-dev-abc123")
 #   - FIREBASE_SERVICE_ACCOUNT_STAGING (JSON key)
+#   - GOOGLE_SERVICES_JSON_STAGING_BASE64 (base64 của apps/mobile/android/app/google-services.json)
 # Sau khi fill secrets, comment-out dòng `if: false` ở job `deploy-functions` để kích hoạt.
 
 on:
@@ -52,6 +53,18 @@ jobs:
 
       - name: Code generation
         run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Prepare Android Firebase config
+        run: |
+          if [ -n "${{ secrets.GOOGLE_SERVICES_JSON_STAGING_BASE64 }}" ]; then
+            echo "${{ secrets.GOOGLE_SERVICES_JSON_STAGING_BASE64 }}" | base64 -d > android/app/google-services.json
+          else
+            echo "::warning::GOOGLE_SERVICES_JSON_STAGING_BASE64 chưa được cấu hình; dùng dummy google-services.json chỉ để CI build APK."
+            cat > android/app/google-services.json <<'JSON'
+          {"project_info":{"project_number":"000000000000","project_id":"meep-ci-dummy","storage_bucket":"meep-ci-dummy.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"dev.meep.meep"}},"oauth_client":[],"api_key":[{"current_key":"AIzaSyDUMMYKEYFORCIROBOLECTRICUNITTEST0"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
+          JSON
+          fi
+          test -s android/app/google-services.json
 
       - name: Build APK
         run: flutter build apk --debug


### PR DESCRIPTION
## Mô tả

PR này sửa workflow `Deploy to Staging` đang fail sau merge PR #308 vì CI không có `apps/mobile/android/app/google-services.json`. Workflow sẽ tạo file tạm thời từ secret `GOOGLE_SERVICES_JSON_STAGING_BASE64`; nếu secret chưa được cấu hình thì dùng dummy config chỉ để Gradle build APK không fail vì thiếu file.

## Refs

- Follow-up sau merge #308
- Run fail: https://github.com/manhthien2005/Meep/actions/runs/27150032638

## Thay đổi chính

- `.github/workflows/develop-staging.yml`: thêm bước `Prepare Android Firebase config` trước `flutter build apk --debug`.

## Loại thay đổi

- [x] chore — Maintenance, deps, config

## Test

- [x] Đã chạy `git diff --check` PASS
- [x] Pre-commit hook PASS khi commit
- [ ] Đã chạy `flutter test` PASS
- [ ] Đã chạy `flutter analyze` clean (0 warning)
- [ ] Đã chạy `dart format --set-exit-if-changed .` PASS

### Cách test thủ công

1. Merge PR này vào `develop`.
2. Mở workflow `Deploy to Staging` của merge commit.
3. Kiểm tra job `Build Android APK (debug)` không còn fail ở task `:app:processDebugGoogleServices`.

## Screenshot / video

Không có UI thay đổi.

## Lưu ý cho reviewer

Nếu muốn APK staging dùng Firebase native config thật cho Android native/home-screen widget, cần thêm secret `GOOGLE_SERVICES_JSON_STAGING_BASE64`. Fallback dummy chỉ nhằm giữ CI build gate xanh khi secret chưa có.

## Self-review checklist

- [x] Branch name đúng format `<type>/<DevName>/<desc>`
- [x] Commit message tiếng Việt, theo Conventional Commits
- [x] Không có file lớn vô tình (`.env`, keystore, service account)
- [x] Không có `console.log` / `print` debug còn sót
- [x] Không có `// TODO` chưa link issue
- [x] Không có code comment-out dead code
- [x] Đã review chính diff của mình một lần trước khi mở PR