### PR TITLE
fix(users): tách public profile và siết friend rules

### DIFF
--- a/apps/mobile/lib/dev/widget_catalog_page.dart
+++ b/apps/mobile/lib/dev/widget_catalog_page.dart
@@ -6,7 +6,7 @@ import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_spacing.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/application/friend_state.dart';
 import 'package:meep/features/friend/data/friend_repository.dart';
@@ -21,26 +21,24 @@ import 'package:meep/shared/widgets/app_text_input.dart';
 
 /// Mock FriendRepository for dev catalog
 class _MockFriendRepository implements FriendRepository {
-  final List<UserProfile> _mockFriends = List.generate(
+  final List<PublicProfile> _mockFriends = List.generate(
     12,
-    (i) => UserProfile(
+    (i) => PublicProfile(
       uid: 'mock-uid-$i',
-      email: 'user$i@meep.dev',
       displayName: 'User $i',
       username: 'user$i',
       avatarUrl: null,
-      createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     ),
   );
 
   @override
-  Stream<List<UserProfile>> watchFriends(String uid) {
+  Stream<List<PublicProfile>> watchFriends(String uid) {
     return Stream.value(_mockFriends);
   }
 
   @override
-  Future<UserProfile?> searchUser(String username) async {
+  Future<PublicProfile?> searchUser(String username) async {
     return _mockFriends
         .where((f) => f.username.toLowerCase() == username.toLowerCase())
         .firstOrNull;
@@ -296,52 +294,40 @@ class _MockFriendController extends FriendController {
   FriendState build(String uid) {
     return FriendState(
       friends: [
-        UserProfile(
+        PublicProfile(
           uid: 'friend1',
-          email: 'alice@test.com',
           displayName: 'Alice Nguyen',
           username: 'alice',
-          createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
-        UserProfile(
+        PublicProfile(
           uid: 'friend2',
-          email: 'bob@test.com',
           displayName: 'Bob Tran',
           username: 'bob',
-          createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
-        UserProfile(
+        PublicProfile(
           uid: 'friend3',
-          email: 'charlie@test.com',
           displayName: 'Charlie Le',
           username: 'charlie',
-          createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
-        UserProfile(
+        PublicProfile(
           uid: 'friend4',
-          email: 'david@test.com',
           displayName: 'David Pham',
           username: 'david',
-          createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
-        UserProfile(
+        PublicProfile(
           uid: 'friend5',
-          email: 'eva@test.com',
           displayName: 'Eva Hoang',
           username: 'eva',
-          createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
-        UserProfile(
+        PublicProfile(
           uid: 'friend6',
-          email: 'frank@test.com',
           displayName: 'Frank Vo',
           username: 'frank',
-          createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
       ],

--- a/apps/mobile/lib/features/auth/data/firebase_user_repository.dart
+++ b/apps/mobile/lib/features/auth/data/firebase_user_repository.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/auth/data/user_repository.dart';
 
@@ -35,6 +36,13 @@ class FirebaseUserRepository implements UserRepository {
   }
 
   @override
+  Future<PublicProfile?> getPublicProfile(String uid) async {
+    final snap = await _firestore.doc('users/$uid/public/profile').get();
+    if (!snap.exists) return null;
+    return PublicProfile.fromFirestore(snap);
+  }
+
+  @override
   Future<bool> isUsernameAvailable(String username) async {
     final snap =
         await _firestore.doc('usernames/${username.toLowerCase()}').get();
@@ -47,6 +55,14 @@ class FirebaseUserRepository implements UserRepository {
     return _firestore.doc('users/$uid').snapshots().map((snap) {
       if (!snap.exists) return null;
       return UserProfile.fromJson(snap.data()!);
+    });
+  }
+
+  @override
+  Stream<PublicProfile?> watchPublicProfile(String uid) {
+    return _firestore.doc('users/$uid/public/profile').snapshots().map((snap) {
+      if (!snap.exists) return null;
+      return PublicProfile.fromFirestore(snap);
     });
   }
 }

--- a/apps/mobile/lib/features/auth/data/public_profile.dart
+++ b/apps/mobile/lib/features/auth/data/public_profile.dart
@@ -1,0 +1,38 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'package:meep/features/auth/data/user_profile.dart';
+
+part 'public_profile.freezed.dart';
+part 'public_profile.g.dart';
+
+/// Minimal profile safe for public friend discovery.
+@freezed
+class PublicProfile with _$PublicProfile {
+  const factory PublicProfile({
+    required String uid,
+    required String displayName,
+    required String username,
+    String? avatarUrl,
+    String? bio,
+    @Default(true) bool isSearchable,
+    @TimestampConverter() required DateTime updatedAt,
+  }) = _PublicProfile;
+
+  factory PublicProfile.fromJson(Map<String, dynamic> json) =>
+      _$PublicProfileFromJson(json);
+
+  factory PublicProfile.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> snap,
+  ) {
+    final data = snap.data();
+    if (data == null) {
+      throw StateError('Public profile ${snap.reference.path} is missing data');
+    }
+
+    return PublicProfile.fromJson({
+      ...data,
+      'uid': data['uid'] ?? snap.reference.parent.parent?.id,
+    });
+  }
+}

--- a/apps/mobile/lib/features/auth/data/user_repository.dart
+++ b/apps/mobile/lib/features/auth/data/user_repository.dart
@@ -1,10 +1,15 @@
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 
 abstract class UserRepository {
   Future<void> createProfile(UserProfile profile);
   Future<UserProfile?> getProfile(String uid);
+  Future<PublicProfile?> getPublicProfile(String uid);
   Future<bool> isUsernameAvailable(String username);
 
   /// Real-time stream of a user's profile. Emits null when doc doesn't exist.
   Stream<UserProfile?> watchProfile(String uid);
+
+  /// Real-time stream of public profile fields safe for stranger lookup.
+  Stream<PublicProfile?> watchPublicProfile(String uid);
 }

--- a/apps/mobile/lib/features/chat/application/chat_providers.dart
+++ b/apps/mobile/lib/features/chat/application/chat_providers.dart
@@ -2,7 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:meep/features/auth/application/auth_providers.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/chat/application/chat_controller.dart';
 import 'package:meep/features/chat/data/conversation.dart';
 import 'package:meep/features/chat/data/message.dart';
@@ -74,15 +74,15 @@ Map<String, int> unreadCounts(Ref ref) {
   return result;
 }
 
-/// Resolve a single [UserProfile] by [uid] for display in chat tiles,
+/// Resolve a single [PublicProfile] by [uid] for display in chat tiles,
 /// headers, and member lists.
 ///
-/// Uses [UserRepository.getProfile] (auth module). Riverpod auto-deduplicates
+/// Uses [UserRepository.getPublicProfile] (auth module). Riverpod auto-deduplicates
 /// when multiple widgets watch the same uid — only one Firestore read per uid.
 @riverpod
-Future<UserProfile?> chatUserProfile(Ref ref, String uid) async {
+Future<PublicProfile?> chatUserProfile(Ref ref, String uid) async {
   if (uid.isEmpty) return null;
-  return ref.watch(userRepositoryProvider).getProfile(uid);
+  return ref.watch(userRepositoryProvider).getPublicProfile(uid);
 }
 
 /// Live Space document for a group conversation header / tile.

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -8,6 +8,7 @@ import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_proportions.dart';
 import 'package:meep/core/theme/hex_color.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/feed/application/post_controller.dart';
 import 'package:meep/shared/models/post.dart';

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_widgets.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_widgets.dart
@@ -95,7 +95,7 @@ class _AudienceRow extends ConsumerWidget {
 
     final currentUid = ref.watch(currentUidProvider).valueOrNull ?? '';
     final friends = currentUid.isEmpty
-        ? const <UserProfile>[]
+        ? const <PublicProfile>[]
         : ref.watch(
             friendControllerProvider(currentUid).select((s) => s.friends),
           );
@@ -352,7 +352,7 @@ class _FriendAudienceTile extends StatelessWidget {
     required this.onTap,
   });
 
-  final UserProfile friend;
+  final PublicProfile friend;
   final bool isSelected;
   final double avatarSize;
   final double labelSize;

--- a/apps/mobile/lib/features/feed/presentation/feed_section_header_widgets.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section_header_widgets.dart
@@ -95,10 +95,10 @@ class _AuthorAvatar extends ConsumerWidget {
   }
 }
 
-/// Fetches a user's current avatar URL from their Firestore profile.
+/// Fetches a user's current avatar URL from their public Firestore profile.
 final _authorAvatarUrlProvider =
     FutureProvider.family<String?, String>((ref, uid) async {
-  final profile = await ref.read(userRepositoryProvider).getProfile(uid);
+  final profile = await ref.read(userRepositoryProvider).getPublicProfile(uid);
   return profile?.avatarUrl;
 });
 

--- a/apps/mobile/lib/features/friend/application/friend_controller.dart
+++ b/apps/mobile/lib/features/friend/application/friend_controller.dart
@@ -5,7 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:meep/core/utils/pair_id.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/application/friend_state.dart';
 import 'package:meep/features/friend/data/friend_repository.dart';
 import 'package:meep/features/friend/data/friend_request.dart';
@@ -29,7 +29,7 @@ FriendRequestRepository friendRequestRepository(Ref ref) =>
 @riverpod
 class FriendController extends _$FriendController {
   Timer? _searchDebounce;
-  StreamSubscription<List<UserProfile>>? _friendsSub;
+  StreamSubscription<List<PublicProfile>>? _friendsSub;
   StreamSubscription<List<FriendRequest>>? _requestsSub;
   StreamSubscription<List<FriendRequest>>? _sentSub;
 

--- a/apps/mobile/lib/features/friend/application/friend_state.dart
+++ b/apps/mobile/lib/features/friend/application/friend_state.dart
@@ -1,6 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/data/friend_request.dart';
 
 part 'friend_state.freezed.dart';
@@ -8,10 +8,10 @@ part 'friend_state.freezed.dart';
 @freezed
 class FriendState with _$FriendState {
   const factory FriendState({
-    @Default([]) List<UserProfile> friends,
+    @Default([]) List<PublicProfile> friends,
     @Default([]) List<FriendRequest> pendingRequests,
     @Default([]) List<FriendRequest> sentRequests,
-    UserProfile? searchResult,
+    PublicProfile? searchResult,
     @Default('') String searchQuery,
     @Default(false) bool isLoading,
     String? errorMessage,

--- a/apps/mobile/lib/features/friend/data/firebase_friend_repository.dart
+++ b/apps/mobile/lib/features/friend/data/firebase_friend_repository.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'package:meep/core/error/app_error.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/data/friend_repository.dart';
 import 'package:meep/features/friend/data/friendship.dart';
 
@@ -9,17 +9,19 @@ class FirebaseFriendRepository implements FriendRepository {
   FirebaseFriendRepository(this._firestore);
 
   final FirebaseFirestore _firestore;
+  static const int _whereInLimit = 10;
 
   @override
-  Future<UserProfile?> searchUser(String username) async {
+  Future<PublicProfile?> searchUser(String username) async {
     final query = username.toLowerCase().trim();
     if (query.isEmpty) return null;
 
     final QuerySnapshot<Map<String, dynamic>> snapshot;
     try {
       snapshot = await _firestore
-          .collection('users')
+          .collectionGroup('public')
           .where('username', isEqualTo: query)
+          .where('isSearchable', isEqualTo: true)
           .limit(1)
           .get();
     } on FirebaseException catch (e) {
@@ -28,20 +30,19 @@ class FirebaseFriendRepository implements FriendRepository {
 
     if (snapshot.docs.isEmpty) return null;
 
-    return UserProfile.fromJson(snapshot.docs.first.data());
+    return PublicProfile.fromFirestore(snapshot.docs.first);
   }
 
   @override
-  Stream<List<UserProfile>> watchFriends(String uid) {
+  Stream<List<PublicProfile>> watchFriends(String uid) {
     return _firestore
         .collection('friendships')
         .where('members', arrayContains: uid)
         .snapshots()
         .asyncMap((snapshot) async {
       try {
-        if (snapshot.docs.isEmpty) return <UserProfile>[];
+        if (snapshot.docs.isEmpty) return <PublicProfile>[];
 
-        // Extract friend UIDs
         final friendUids = <String>[];
         for (final doc in snapshot.docs) {
           final friendship = Friendship.fromJson(doc.data());
@@ -50,18 +51,9 @@ class FirebaseFriendRepository implements FriendRepository {
           friendUids.add(friendUid);
         }
 
-        // Batch fetch user profiles
-        if (friendUids.isEmpty) return <UserProfile>[];
+        if (friendUids.isEmpty) return <PublicProfile>[];
 
-        final userDocs = await Future.wait(
-          friendUids
-              .map((fuid) => _firestore.collection('users').doc(fuid).get()),
-        );
-
-        return userDocs
-            .where((doc) => doc.exists)
-            .map((doc) => UserProfile.fromJson(doc.data()!))
-            .toList();
+        return _fetchPublicProfiles(friendUids);
       } on FirebaseException catch (e) {
         throw _mapFirestoreError(e, 'tải danh sách bạn bè');
       }
@@ -71,6 +63,33 @@ class FirebaseFriendRepository implements FriendRepository {
       }
       Error.throwWithStackTrace(e, s);
     });
+  }
+
+  Future<List<PublicProfile>> _fetchPublicProfiles(
+    List<String> friendUids,
+  ) async {
+    final profilesByUid = <String, PublicProfile>{};
+
+    for (var i = 0; i < friendUids.length; i += _whereInLimit) {
+      final end = (i + _whereInLimit > friendUids.length)
+          ? friendUids.length
+          : i + _whereInLimit;
+      final chunk = friendUids.sublist(i, end);
+      final snapshot = await _firestore
+          .collectionGroup('public')
+          .where('uid', whereIn: chunk)
+          .get();
+
+      for (final doc in snapshot.docs) {
+        final profile = PublicProfile.fromFirestore(doc);
+        profilesByUid[profile.uid] = profile;
+      }
+    }
+
+    return friendUids
+        .map((friendUid) => profilesByUid[friendUid])
+        .whereType<PublicProfile>()
+        .toList();
   }
 
   @override

--- a/apps/mobile/lib/features/friend/data/friend_repository.dart
+++ b/apps/mobile/lib/features/friend/data/friend_repository.dart
@@ -1,12 +1,12 @@
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 
 abstract class FriendRepository {
   /// Search user by exact username match (case-insensitive).
   /// Returns the user if found, null otherwise.
-  Future<UserProfile?> searchUser(String username);
+  Future<PublicProfile?> searchUser(String username);
 
   /// Stream of current user's accepted friends.
-  Stream<List<UserProfile>> watchFriends(String uid);
+  Stream<List<PublicProfile>> watchFriends(String uid);
 
   /// Returns UIDs of all friends — used for feed filtering.
   Future<List<String>> getFriendUids(String uid);

--- a/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
+++ b/apps/mobile/lib/features/friend/presentation/friend_sheet.dart
@@ -9,7 +9,7 @@ import 'package:meep/core/config/app_config.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/application/friend_state.dart';
 import 'package:meep/features/friend/data/friend_request.dart';
@@ -19,10 +19,10 @@ import 'package:meep/shared/widgets/app_confirm_dialog.dart';
 
 /// Fetches the sender's profile for a pending friend request row.
 /// [FriendRequest] only carries [FriendRequest.senderId]; the UI needs the
-/// display name + avatar, so we look it up via the existing UserRepository.
+/// display name + avatar, so we look up the public profile only.
 final _senderProfileProvider =
-    FutureProvider.family<UserProfile?, String>((ref, senderId) {
-  return ref.read(userRepositoryProvider).getProfile(senderId);
+    FutureProvider.family<PublicProfile?, String>((ref, senderId) {
+  return ref.read(userRepositoryProvider).getPublicProfile(senderId);
 });
 
 /// Friend management bottom sheet.
@@ -436,7 +436,7 @@ class _FriendSheetState extends ConsumerState<FriendSheet> {
   }
 
   Widget _buildSearchResultItem({
-    required UserProfile user,
+    required PublicProfile user,
     required String currentUid,
     required bool isSelf,
     required bool isFriend,
@@ -485,7 +485,7 @@ class _FriendSheetState extends ConsumerState<FriendSheet> {
   }
 
   Widget _buildSearchActionButton({
-    required UserProfile user,
+    required PublicProfile user,
     required String currentUid,
     required bool isSelf,
     required bool isFriend,
@@ -584,7 +584,7 @@ class _FriendSheetState extends ConsumerState<FriendSheet> {
     );
   }
 
-  Widget _buildFriendItem(UserProfile friend, String currentUid) {
+  Widget _buildFriendItem(PublicProfile friend, String currentUid) {
     return SizedBox(
       height: 50,
       child: Row(
@@ -637,7 +637,10 @@ class _FriendSheetState extends ConsumerState<FriendSheet> {
   /// Confirm + remove an accepted friend. Shows the shared destructive dialog;
   /// the actual delete + friendCount/feed cleanup runs in the controller and
   /// the onFriendshipDeleted Cloud Function.
-  Future<void> _confirmUnfriend(UserProfile friend, String currentUid) async {
+  Future<void> _confirmUnfriend(
+    PublicProfile friend,
+    String currentUid,
+  ) async {
     final confirmed = await showAppConfirmDialog(
       context,
       title: 'Xóa ${friend.displayName} khỏi Meep của bạn?',

--- a/apps/mobile/lib/features/settings/application/blocked_users_provider.dart
+++ b/apps/mobile/lib/features/settings/application/blocked_users_provider.dart
@@ -8,7 +8,7 @@ import 'package:meep/features/settings/application/settings_controller.dart';
 part 'blocked_users_provider.g.dart';
 
 /// Stream danh sách `BlockedUserView` cho BlockedAccountsPage.
-/// Join `BlockRepository.watchBlockedUsers` với `UserRepository.getProfile`
+/// Join `BlockRepository.watchBlockedUsers` với `UserRepository.getPublicProfile`
 /// để có username + avatar (Block chỉ chứa UIDs).
 ///
 /// N+1 reads chấp nhận được vì blocked list thường < 10. Nếu list lớn lên,
@@ -24,7 +24,7 @@ Stream<List<BlockedUserView>> blockedUsers(Ref ref) {
   return blockRepo.watchBlockedUsers(uid).asyncMap((blocks) async {
     if (blocks.isEmpty) return <BlockedUserView>[];
     final profiles = await Future.wait(
-      blocks.map((b) => userRepo.getProfile(b.blockedUid)),
+      blocks.map((b) => userRepo.getPublicProfile(b.blockedUid)),
     );
     return [
       for (var i = 0; i < blocks.length; i++)

--- a/apps/mobile/lib/features/space/presentation/space_management_sheet.dart
+++ b/apps/mobile/lib/features/space/presentation/space_management_sheet.dart
@@ -22,7 +22,7 @@ Future<({Map<String, String> names, Map<String, String?> avatars})>
     _loadMemberProfiles(WidgetRef ref, List<SpaceMember> members) async {
   final userRepo = ref.read(userRepositoryProvider);
   final profiles = await Future.wait(
-    members.map((m) => userRepo.getProfile(m.uid)),
+    members.map((m) => userRepo.getPublicProfile(m.uid)),
   );
   final names = <String, String>{};
   final avatars = <String, String?>{};

--- a/apps/mobile/lib/features/space/presentation/widgets/friend_select_step.dart
+++ b/apps/mobile/lib/features/space/presentation/widgets/friend_select_step.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/shared/widgets/app_avatar.dart';
 import 'package:meep/shared/widgets/app_primary_button.dart';
@@ -35,14 +35,14 @@ class _FriendSelectStepState extends ConsumerState<FriendSelectStep> {
   // emit AsyncLoading lúc mount. `.valueOrNull` ở initState sẽ trả null
   // dù user đã signin → empty stream. Đợi `build` chạy lại khi stream
   // emit value lần đầu rồi mới cache.
-  Stream<List<UserProfile>>? _friendsStream;
+  Stream<List<PublicProfile>>? _friendsStream;
   String? _cachedUid;
 
-  Stream<List<UserProfile>> _ensureStream(String? uid) {
+  Stream<List<PublicProfile>> _ensureStream(String? uid) {
     if (uid == _cachedUid && _friendsStream != null) return _friendsStream!;
     _cachedUid = uid;
     if (uid == null) {
-      _friendsStream = Stream.value(const <UserProfile>[]);
+      _friendsStream = Stream.value(const <PublicProfile>[]);
     } else {
       _friendsStream = ref.read(friendRepositoryProvider).watchFriends(uid);
     }
@@ -55,7 +55,7 @@ class _FriendSelectStepState extends ConsumerState<FriendSelectStep> {
     super.dispose();
   }
 
-  List<UserProfile> _filterFriends(List<UserProfile> friends) {
+  List<PublicProfile> _filterFriends(List<PublicProfile> friends) {
     if (_searchQuery.isEmpty) return friends;
     final query = _searchQuery.toLowerCase();
     return friends
@@ -170,7 +170,7 @@ class _FriendSelectStepState extends ConsumerState<FriendSelectStep> {
           const SizedBox(height: 20),
           // Friend list
           Expanded(
-            child: StreamBuilder<List<UserProfile>>(
+            child: StreamBuilder<List<PublicProfile>>(
               stream: friendsStream,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
@@ -255,7 +255,7 @@ class _FriendListItem extends StatelessWidget {
     required this.onTap,
   });
 
-  final UserProfile friend;
+  final PublicProfile friend;
   final bool isSelected;
   final bool canSelect;
   final VoidCallback onTap;

--- a/apps/mobile/test/features/auth/data/firebase_user_repository_test.dart
+++ b/apps/mobile/test/features/auth/data/firebase_user_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meep/features/auth/data/firebase_user_repository.dart';
@@ -70,6 +71,32 @@ void main() {
     });
   });
 
+  group('getPublicProfile', () {
+    test('trả null khi public profile chưa tồn tại', () async {
+      final result = await repo.getPublicProfile('nonexistent');
+      expect(result, isNull);
+    });
+
+    test('trả PublicProfile đúng khi tồn tại', () async {
+      await fakeFirestore.doc('users/${alice.uid}/public/profile').set({
+        'uid': alice.uid,
+        'displayName': alice.displayName,
+        'username': alice.username,
+        'avatarUrl': null,
+        'bio': null,
+        'isSearchable': true,
+        'updatedAt': Timestamp.fromDate(DateTime(2026, 1, 1)),
+      });
+
+      final result = await repo.getPublicProfile(alice.uid);
+
+      expect(result, isNotNull);
+      expect(result!.uid, alice.uid);
+      expect(result.displayName, alice.displayName);
+      expect(result.username, alice.username);
+    });
+  });
+
   group('isUsernameAvailable', () {
     test('trả true khi username chưa có', () async {
       final available = await repo.isUsernameAvailable('newuser');
@@ -99,6 +126,30 @@ void main() {
       await repo.createProfile(alice);
       final profile = await repo.watchProfile(alice.uid).first;
       expect(profile?.uid, alice.uid);
+    });
+  });
+
+  group('watchPublicProfile', () {
+    test('emits null khi public profile không tồn tại', () async {
+      final profile = await repo.watchPublicProfile('nonexistent').first;
+      expect(profile, isNull);
+    });
+
+    test('emits public profile sau khi tạo', () async {
+      await fakeFirestore.doc('users/${alice.uid}/public/profile').set({
+        'uid': alice.uid,
+        'displayName': alice.displayName,
+        'username': alice.username,
+        'avatarUrl': null,
+        'bio': null,
+        'isSearchable': true,
+        'updatedAt': Timestamp.fromDate(DateTime(2026, 1, 1)),
+      });
+
+      final profile = await repo.watchPublicProfile(alice.uid).first;
+
+      expect(profile?.uid, alice.uid);
+      expect(profile?.displayName, alice.displayName);
     });
   });
 }

--- a/apps/mobile/test/features/chat/presentation/inbox_screen_test.dart
+++ b/apps/mobile/test/features/chat/presentation/inbox_screen_test.dart
@@ -42,9 +42,9 @@ void main() {
             c.toJson(),
           );
     }
-    // Also seed user profiles so chatUserProfileProvider can resolve them.
+    // Also seed public profiles so chatUserProfileProvider can resolve them.
     for (final entry in ChatSeed.usersByUid.entries) {
-      await firestore.collection('users').doc(entry.key).set(
+      await firestore.doc('users/${entry.key}/public/profile').set(
             entry.value.toJson(),
           );
     }

--- a/apps/mobile/test/features/chat/presentation/space_members_sheet_test.dart
+++ b/apps/mobile/test/features/chat/presentation/space_members_sheet_test.dart
@@ -32,9 +32,9 @@ class _FakeSpaceRepository implements SpaceRepository {
 void main() {
   Future<FakeFirebaseFirestore> seededFirestore() async {
     final firestore = FakeFirebaseFirestore();
-    // Seed user profiles so chatUserProfileProvider resolves names + avatars.
+    // Seed public profiles so chatUserProfileProvider resolves names + avatars.
     for (final entry in ChatSeed.usersByUid.entries) {
-      await firestore.collection('users').doc(entry.key).set(
+      await firestore.doc('users/${entry.key}/public/profile').set(
             entry.value.toJson(),
           );
     }

--- a/apps/mobile/test/features/feed/presentation/feed_filter_dropdown_test.dart
+++ b/apps/mobile/test/features/feed/presentation/feed_filter_dropdown_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/feed/presentation/feed_filter_dropdown.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
@@ -22,6 +23,19 @@ UserProfile _profile({
       username: displayName.toLowerCase(),
       avatarUrl: avatarUrl,
       createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+    );
+
+PublicProfile _publicProfile({
+  String uid = 'friend',
+  String displayName = 'Han',
+  String? avatarUrl,
+}) =>
+    PublicProfile(
+      uid: uid,
+      displayName: displayName,
+      username: displayName.toLowerCase(),
+      avatarUrl: avatarUrl,
       updatedAt: DateTime(2026),
     );
 
@@ -47,7 +61,7 @@ Future<void> _pump(
   required String selectedLabel,
   required void Function(String?, String) onFilterSelected,
   required void Function(Space) onSpaceFilterSelected,
-  List<UserProfile> friends = const [],
+  List<PublicProfile> friends = const [],
   List<Space> spaces = const [],
   UserProfile? currentProfile,
 }) async {
@@ -123,7 +137,7 @@ void main() {
         onFilterSelected: (_, __) {},
         onSpaceFilterSelected: (_) {},
         currentProfile: _profile(),
-        friends: [_profile(uid: 'f1', displayName: 'Han')],
+        friends: [_publicProfile(uid: 'f1', displayName: 'Han')],
       );
       expect(find.text('Han'), findsOneWidget);
     });

--- a/apps/mobile/test/features/friend/firebase_friend_repository_test.dart
+++ b/apps/mobile/test/features/friend/firebase_friend_repository_test.dart
@@ -3,7 +3,7 @@ import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:meep/core/utils/pair_id.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/data/firebase_friend_repository.dart';
 
 void main() {
@@ -18,14 +18,12 @@ void main() {
   group('searchUser', () {
     test('returns user when exact username match (case-insensitive)', () async {
       // Arrange
-      await firestore.collection('users').doc('uid1').set({
-        'uid': 'uid1',
-        'email': 'thien@meep.app',
-        'displayName': 'Thien PDM',
-        'username': 'thienpdm',
-        'createdAt': Timestamp.now(),
-        'updatedAt': Timestamp.now(),
-      });
+      await _seedPublicProfile(
+        firestore,
+        uid: 'uid1',
+        displayName: 'Thien PDM',
+        username: 'thienpdm',
+      );
 
       // Act
       final result = await repository.searchUser('ThienPDM');
@@ -54,14 +52,12 @@ void main() {
 
     test('trims whitespace before search', () async {
       // Arrange
-      await firestore.collection('users').doc('uid1').set({
-        'uid': 'uid1',
-        'email': 'thien@meep.app',
-        'displayName': 'Thien PDM',
-        'username': 'thienpdm',
-        'createdAt': Timestamp.now(),
-        'updatedAt': Timestamp.now(),
-      });
+      await _seedPublicProfile(
+        firestore,
+        uid: 'uid1',
+        displayName: 'Thien PDM',
+        username: 'thienpdm',
+      );
 
       // Act
       final result = await repository.searchUser('  ThienPDM  ');
@@ -163,14 +159,12 @@ void main() {
         'createdAt': Timestamp.now(),
       });
 
-      await firestore.collection('users').doc('friend1').set({
-        'uid': 'friend1',
-        'email': 'friend@meep.app',
-        'displayName': 'Friend One',
-        'username': 'friend1',
-        'createdAt': Timestamp.now(),
-        'updatedAt': Timestamp.now(),
-      });
+      await _seedPublicProfile(
+        firestore,
+        uid: 'friend1',
+        displayName: 'Friend One',
+        username: 'friend1',
+      );
 
       // Act
       final stream = repository.watchFriends(uid);
@@ -179,7 +173,7 @@ void main() {
       await expectLater(
         stream,
         emits(
-          predicate<List<UserProfile>>((list) {
+          predicate<List<PublicProfile>>((list) {
             return list.length == 1 && list.first.uid == 'friend1';
           }),
         ),
@@ -193,5 +187,22 @@ void main() {
       // Assert
       await expectLater(stream, emits(isEmpty));
     });
+  });
+}
+
+Future<void> _seedPublicProfile(
+  FakeFirebaseFirestore firestore, {
+  required String uid,
+  required String displayName,
+  required String username,
+}) {
+  return firestore.doc('users/$uid/public/profile').set({
+    'uid': uid,
+    'displayName': displayName,
+    'username': username,
+    'avatarUrl': null,
+    'bio': null,
+    'isSearchable': true,
+    'updatedAt': Timestamp.now(),
   });
 }

--- a/apps/mobile/test/features/friend/friend_controller_test.dart
+++ b/apps/mobile/test/features/friend/friend_controller_test.dart
@@ -6,7 +6,7 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:meep/core/utils/pair_id.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/friend_repository.dart';
 import 'package:meep/features/friend/data/friend_request.dart';
@@ -27,7 +27,7 @@ void main() {
 
     // Setup default streams
     when(() => friendRepo.watchFriends(any())).thenAnswer(
-      (_) => Stream.value(<UserProfile>[]),
+      (_) => Stream.value(<PublicProfile>[]),
     );
     when(() => requestRepo.watchPendingRequests(any())).thenAnswer(
       (_) => Stream.value(<FriendRequest>[]),
@@ -41,14 +41,7 @@ void main() {
     test('searchUser debounces 500ms - only calls repo once', () async {
       // Arrange
       when(() => friendRepo.searchUser(any())).thenAnswer(
-        (_) async => UserProfile(
-          uid: 'user1',
-          email: 'test@meep.app',
-          displayName: 'Test User',
-          username: 'testuser',
-          createdAt: DateTime.now(),
-          updatedAt: DateTime.now(),
-        ),
+        (_) async => _publicProfile(uid: 'user1', name: 'Test User'),
       );
 
       final container = ProviderContainer(
@@ -267,14 +260,7 @@ void main() {
     test(
         'unfriend deletes friendship by pairId and drops friend optimistically',
         () async {
-      final friend = UserProfile(
-        uid: 'friendX',
-        email: 'friendx@meep.app',
-        displayName: 'Friend X',
-        username: 'friendx',
-        createdAt: DateTime.now(),
-        updatedAt: DateTime.now(),
-      );
+      final friend = _publicProfile(uid: 'friendX', name: 'Friend X');
       when(() => friendRepo.watchFriends(any())).thenAnswer(
         (_) => Stream.value([friend]),
       );
@@ -321,14 +307,7 @@ void main() {
 
     test('unfriend reverts the friend list when the repository throws',
         () async {
-      final friend = UserProfile(
-        uid: 'friendX',
-        email: 'friendx@meep.app',
-        displayName: 'Friend X',
-        username: 'friendx',
-        createdAt: DateTime.now(),
-        updatedAt: DateTime.now(),
-      );
+      final friend = _publicProfile(uid: 'friendX', name: 'Friend X');
       when(() => friendRepo.watchFriends(any())).thenAnswer(
         (_) => Stream.value([friend]),
       );
@@ -362,4 +341,13 @@ void main() {
       container.dispose();
     });
   });
+}
+
+PublicProfile _publicProfile({required String uid, required String name}) {
+  return PublicProfile(
+    uid: uid,
+    displayName: name,
+    username: uid.toLowerCase(),
+    updatedAt: DateTime.now(),
+  );
 }

--- a/apps/mobile/test/features/friend/friend_sheet_test.dart
+++ b/apps/mobile/test/features/friend/friend_sheet_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/application/friend_state.dart';
 import 'package:meep/features/friend/data/friend_request.dart';
@@ -89,12 +89,10 @@ void main() {
 
     testWidgets('shows friend list when has friends', (tester) async {
       final friends = [
-        UserProfile(
+        PublicProfile(
           uid: 'friend1',
-          email: 'friend1@test.com',
           displayName: 'Friend One',
           username: 'friend1',
-          createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
       ];
@@ -173,7 +171,7 @@ void main() {
     });
 
     testWidgets('search shows "Thêm" for a non-friend result', (tester) async {
-      final stranger = _userProfile(uid: 'stranger', name: 'Stranger');
+      final stranger = _publicProfile(uid: 'stranger', name: 'Stranger');
 
       await _pumpSearch(tester, searchResult: stranger);
 
@@ -184,7 +182,7 @@ void main() {
 
     testWidgets('search shows "Đã gửi" when request already sent',
         (tester) async {
-      final target = _userProfile(uid: 'target', name: 'Target');
+      final target = _publicProfile(uid: 'target', name: 'Target');
       final sent = [
         FriendRequest(
           requestId: 'req-sent',
@@ -204,7 +202,7 @@ void main() {
 
     testWidgets('search shows "Bạn bè" when result is already a friend',
         (tester) async {
-      final friend = _userProfile(uid: 'friend1', name: 'Friend One');
+      final friend = _publicProfile(uid: 'friend1', name: 'Friend One');
 
       await _pumpSearch(
         tester,
@@ -218,7 +216,7 @@ void main() {
 
     testWidgets('tap X on a friend then confirm calls unfriend',
         (tester) async {
-      final friend = _userProfile(uid: 'friend1', name: 'Friend One');
+      final friend = _publicProfile(uid: 'friend1', name: 'Friend One');
       final fake = FakeFriendController(friends: [friend]);
 
       await tester.pumpWidget(
@@ -249,7 +247,7 @@ void main() {
 
     testWidgets('tap X on a friend then Lưu does not call unfriend',
         (tester) async {
-      final friend = _userProfile(uid: 'friend1', name: 'Friend One');
+      final friend = _publicProfile(uid: 'friend1', name: 'Friend One');
       final fake = FakeFriendController(friends: [friend]);
 
       await tester.pumpWidget(
@@ -276,13 +274,11 @@ void main() {
   });
 }
 
-UserProfile _userProfile({required String uid, required String name}) {
-  return UserProfile(
+PublicProfile _publicProfile({required String uid, required String name}) {
+  return PublicProfile(
     uid: uid,
-    email: '$uid@test.com',
     displayName: name,
     username: uid,
-    createdAt: DateTime.now(),
     updatedAt: DateTime.now(),
   );
 }
@@ -291,8 +287,8 @@ UserProfile _userProfile({required String uid, required String name}) {
 /// surfaces [searchResult] in the search view.
 Future<void> _pumpSearch(
   WidgetTester tester, {
-  required UserProfile searchResult,
-  List<UserProfile> friends = const [],
+  required PublicProfile searchResult,
+  List<PublicProfile> friends = const [],
   List<FriendRequest> sentRequests = const [],
 }) async {
   await tester.pumpWidget(
@@ -324,19 +320,19 @@ Future<void> _pumpSearch(
 // Fake controller for testing
 class FakeFriendController extends FriendController {
   FakeFriendController({
-    List<UserProfile>? friends,
+    List<PublicProfile>? friends,
     List<FriendRequest>? pendingRequests,
     List<FriendRequest>? sentRequests,
-    UserProfile? searchResult,
+    PublicProfile? searchResult,
   })  : _friends = friends ?? [],
         _pendingRequests = pendingRequests ?? [],
         _sentRequests = sentRequests ?? [],
         _searchResult = searchResult;
 
-  final List<UserProfile> _friends;
+  final List<PublicProfile> _friends;
   final List<FriendRequest> _pendingRequests;
   final List<FriendRequest> _sentRequests;
-  final UserProfile? _searchResult;
+  final PublicProfile? _searchResult;
 
   /// Captures unfriend(friendUid) calls so widget tests can assert the
   /// X-button + confirm-dialog flow reaches the controller.

--- a/apps/mobile/test/features/space/friend_select_step_test.dart
+++ b/apps/mobile/test/features/space/friend_select_step_test.dart
@@ -2,23 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/friend_repository.dart';
 import 'package:meep/features/space/presentation/space_create_sheet.dart';
 
 class FakeFriendRepository implements FriendRepository {
-  final List<UserProfile> _friends;
+  final List<PublicProfile> _friends;
 
   FakeFriendRepository(this._friends);
 
   @override
-  Stream<List<UserProfile>> watchFriends(String uid) {
+  Stream<List<PublicProfile>> watchFriends(String uid) {
     return Stream.value(_friends);
   }
 
   @override
-  Future<UserProfile?> searchUser(String username) async {
+  Future<PublicProfile?> searchUser(String username) async {
     return _friends
         .where((f) => f.username.toLowerCase() == username.toLowerCase())
         .firstOrNull;
@@ -35,17 +35,15 @@ class FakeFriendRepository implements FriendRepository {
 
 void main() {
   group('FriendSelectStep', () {
-    late List<UserProfile> mockFriends;
+    late List<PublicProfile> mockFriends;
 
     setUp(() {
       mockFriends = List.generate(
         12,
-        (i) => UserProfile(
+        (i) => PublicProfile(
           uid: 'uid-$i',
-          email: 'user$i@test.com',
           displayName: 'User $i',
           username: 'user$i',
-          createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
       );

--- a/apps/mobile/test/features/space/space_create_sheet_test.dart
+++ b/apps/mobile/test/features/space/space_create_sheet_test.dart
@@ -1,21 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/data/friend_repository.dart';
 import 'package:meep/features/space/presentation/space_create_sheet.dart';
 
 class _FakeFriendRepository implements FriendRepository {
-  final List<UserProfile> _friends;
+  final List<PublicProfile> _friends;
 
   _FakeFriendRepository(this._friends);
 
   @override
-  Stream<List<UserProfile>> watchFriends(String uid) => Stream.value(_friends);
+  Stream<List<PublicProfile>> watchFriends(String uid) =>
+      Stream.value(_friends);
 
   @override
-  Future<UserProfile?> searchUser(String username) async =>
+  Future<PublicProfile?> searchUser(String username) async =>
       _friends.where((f) => f.username == username).firstOrNull;
 
   @override
@@ -30,12 +31,10 @@ void main() {
   group('SpaceCreateSheet scaffold', () {
     final mockFriends = List.generate(
       3,
-      (i) => UserProfile(
+      (i) => PublicProfile(
         uid: 'uid-$i',
-        email: 'user$i@test.com',
         displayName: 'User $i',
         username: 'user$i',
-        createdAt: DateTime.now(),
         updatedAt: DateTime.now(),
       ),
     );

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -53,6 +53,14 @@
       ]
     },
     {
+      "collectionGroup": "public",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "isSearchable", "order": "ASCENDING" },
+        { "fieldPath": "username", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "spaces",
       "queryScope": "COLLECTION",
       "fields": [
@@ -86,5 +94,13 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "public",
+      "fieldPath": "uid",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    }
+  ]
 }

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -57,23 +57,108 @@ service cloud.firestore {
           .data.participantIds.hasAny([request.auth.uid]);
     }
 
-    // ===== /users/{uid} =====
-    match /users/{uid} {
-      allow read: if isAuthed();
-      allow create: if isOwner(uid)
-        && request.resource.data.keys().hasAll(['uid', 'email', 'displayName', 'username', 'createdAt'])
+    function isNullableString(data, field, max) {
+      return !(field in data) ||
+        data[field] == null ||
+        (data[field] is string && data[field].size() <= max);
+    }
+
+    function isValidGender(data) {
+      return !('gender' in data) ||
+        data.gender == null ||
+        data.gender in ['male', 'female', 'other'];
+    }
+
+    function isZeroCounter(data, field) {
+      return !(field in data) ||
+        (data[field] is number && data[field] == 0);
+    }
+
+    function isValidUserCreate(uid) {
+      return request.resource.data.keys().hasAll(
+          ['uid', 'email', 'displayName', 'username', 'createdAt'])
+        && request.resource.data.keys().hasOnly([
+          'uid', 'email', 'displayName', 'username', 'avatarUrl', 'bio',
+          'dateOfBirth', 'phoneNumber', 'gender', 'postCount', 'friendCount',
+          'spaceCount', 'isSearchable', 'createdAt', 'updatedAt',
+        ])
+        && request.resource.data.uid == uid
+        && request.resource.data.email is string
+        && request.resource.data.email.size() <= 254
+        && request.resource.data.displayName is string
+        && request.resource.data.displayName.size() >= 1
+        && request.resource.data.displayName.size() <= 50
         && request.resource.data.username is string
         && request.resource.data.username.size() >= 3
         && request.resource.data.username.size() <= 20
-        && request.resource.data.username.matches('^[a-z0-9_]+$');
-      allow update: if isOwner(uid)
-        && !request.resource.data.diff(resource.data).affectedKeys()
-            .hasAny(['uid', 'createdAt', 'email', 'username',
-                     'postCount', 'friendCount', 'spaceCount']);
+        && request.resource.data.username.matches('^[a-z0-9_]+$')
+        && request.resource.data.createdAt is timestamp
+        && (!('updatedAt' in request.resource.data) ||
+            request.resource.data.updatedAt is timestamp)
+        && isNullableString(request.resource.data, 'avatarUrl', 500)
+        && isNullableString(request.resource.data, 'bio', 300)
+        && isNullableString(request.resource.data, 'dateOfBirth', 20)
+        && isNullableString(request.resource.data, 'phoneNumber', 30)
+        && isValidGender(request.resource.data)
+        && (!('isSearchable' in request.resource.data) ||
+            request.resource.data.isSearchable is bool)
+        && isZeroCounter(request.resource.data, 'postCount')
+        && isZeroCounter(request.resource.data, 'friendCount')
+        && isZeroCounter(request.resource.data, 'spaceCount');
+    }
+
+    function changedUserKeys() {
+      return request.resource.data.diff(resource.data).affectedKeys();
+    }
+
+    function isValidUserUpdate() {
+      return changedUserKeys().hasOnly([
+          'displayName', 'avatarUrl', 'bio', 'dateOfBirth', 'phoneNumber',
+          'gender', 'isSearchable', 'updatedAt',
+        ])
+        && (!changedUserKeys().hasAny(['displayName']) ||
+          (request.resource.data.displayName is string
+            && request.resource.data.displayName.size() >= 1
+            && request.resource.data.displayName.size() <= 50))
+        && (!changedUserKeys().hasAny(['avatarUrl']) ||
+            isNullableString(request.resource.data, 'avatarUrl', 500))
+        && (!changedUserKeys().hasAny(['bio']) ||
+            isNullableString(request.resource.data, 'bio', 300))
+        && (!changedUserKeys().hasAny(['dateOfBirth']) ||
+            isNullableString(request.resource.data, 'dateOfBirth', 20))
+        && (!changedUserKeys().hasAny(['phoneNumber']) ||
+            isNullableString(request.resource.data, 'phoneNumber', 30))
+        && (!changedUserKeys().hasAny(['gender']) ||
+            isValidGender(request.resource.data))
+        && (!changedUserKeys().hasAny(['isSearchable']) ||
+            request.resource.data.isSearchable is bool)
+        && (!changedUserKeys().hasAny(['updatedAt']) ||
+            request.resource.data.updatedAt is timestamp);
+    }
+
+    function isValidFriendshipResource(pid) {
+      return resource.data.members is list
+        && resource.data.members.size() == 2
+        && resource.data.members[0] is string
+        && resource.data.members[1] is string
+        && pid == pairId(resource.data.members[0], resource.data.members[1]);
+    }
+
+    // ===== /users/{uid} =====
+    match /users/{uid} {
+      allow get: if isOwner(uid) || isFriend(uid);
+      allow list: if false;
+      allow create: if isOwner(uid) && isValidUserCreate(uid);
+      allow update: if isOwner(uid) && isValidUserUpdate();
       allow delete: if false; // use deleteAccount CF
 
       match /private/{docId} {
         allow read, write: if isOwner(uid);
+      }
+
+      match /public/{docId} {
+        allow read: if isAuthed();
+        allow write: if false; // onUserProfileChanged + migratePublicProfiles
       }
 
       match /notifications/{notifId} {
@@ -96,6 +181,13 @@ service cloud.firestore {
       match /fcmTokens/{tokenId} {
         allow read, write: if isOwner(uid);
       }
+    }
+
+    // Collection-group rule for public profile reads.
+    // Required for client queries using collectionGroup('public').
+    match /{path=**}/public/{docId} {
+      allow read: if isAuthed();
+      allow write: if false; // onUserProfileChanged + migratePublicProfiles
     }
 
     // ===== /usernames/{username} =====
@@ -212,10 +304,14 @@ service cloud.firestore {
 
     // ===== /friendships/{pairId} =====
     match /friendships/{pid} {
-      allow read: if isAuthed() &&
+      allow get: if isAuthed() &&
+        isValidFriendshipResource(pid) &&
+        request.auth.uid in resource.data.members;
+      allow list: if isAuthed() &&
         request.auth.uid in resource.data.members;
       allow create, update: if false; // CF acceptFriendRequest only
       allow delete: if isAuthed() &&
+        isValidFriendshipResource(pid) &&
         request.auth.uid in resource.data.members;
     }
 

--- a/firebase/functions/src/firestore.rules.test.ts
+++ b/firebase/functions/src/firestore.rules.test.ts
@@ -51,6 +51,10 @@ function unauthed() {
   return testEnv.unauthenticatedContext();
 }
 
+function pairId(a: string, b: string): string {
+  return a < b ? `${a}_${b}` : `${b}_${a}`;
+}
+
 // ===== /users/{uid} =====
 
 describe('/users/{uid}', () => {
@@ -62,13 +66,27 @@ describe('/users/{uid}', () => {
     await assertSucceeds(authed(alice).firestore().doc(`users/${alice}`).get());
   });
 
-  test('other authed user can read', async () => {
+  test('friend can read full user doc', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    const pid = pairId(alice, bob);
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}`).set({ displayName: 'Alice' });
+      await ctx.firestore().doc(`friendships/${pid}`).set({
+        members: [alice, bob],
+        createdAt: new Date(),
+      });
+    });
+    await assertSucceeds(authed(bob).firestore().doc(`users/${alice}`).get());
+  });
+
+  test('stranger cannot read full user doc', async () => {
     const alice = uid('alice');
     const bob = uid('bob');
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await ctx.firestore().doc(`users/${alice}`).set({ displayName: 'Alice' });
     });
-    await assertSucceeds(authed(bob).firestore().doc(`users/${alice}`).get());
+    await assertFails(authed(bob).firestore().doc(`users/${alice}`).get());
   });
 
   test('unauthenticated cannot read', async () => {
@@ -112,6 +130,123 @@ describe('/users/{uid}', () => {
     const alice = uid('alice');
     await assertFails(
       authed(alice).firestore().doc(`users/${alice}/feed/post1`).set({ postId: 'post1' }),
+    );
+  });
+
+  test('/users/{uid}/public/profile — authed stranger can read', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}/public/profile`).set({
+        uid: alice,
+        displayName: 'Alice',
+        username: 'alice',
+        avatarUrl: null,
+        bio: null,
+        isSearchable: true,
+        updatedAt: new Date(),
+      });
+    });
+    await assertSucceeds(
+      authed(bob).firestore().doc(`users/${alice}/public/profile`).get(),
+    );
+  });
+
+  test('/users/{uid}/public/profile — unauthenticated cannot read', async () => {
+    const alice = uid('alice');
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}/public/profile`).set({
+        uid: alice,
+        displayName: 'Alice',
+        username: 'alice',
+        isSearchable: true,
+        updatedAt: new Date(),
+      });
+    });
+    await assertFails(
+      unauthed().firestore().doc(`users/${alice}/public/profile`).get(),
+    );
+  });
+
+  test('/users/{uid}/public/profile — client cannot write', async () => {
+    const alice = uid('alice');
+    await assertFails(
+      authed(alice).firestore().doc(`users/${alice}/public/profile`).set({
+        uid: alice,
+        displayName: 'Alice',
+        username: 'alice',
+        isSearchable: true,
+        updatedAt: new Date(),
+      }),
+    );
+  });
+});
+
+// ===== collectionGroup('public') =====
+
+describe("collectionGroup('public')", () => {
+  const alice = uid('alice');
+  const bob = uid('bob');
+
+  async function seedPublicProfiles() {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}/public/profile`).set({
+        uid: alice,
+        displayName: 'Alice',
+        username: 'alice',
+        avatarUrl: null,
+        bio: null,
+        isSearchable: true,
+        updatedAt: new Date(),
+      });
+      await ctx.firestore().doc(`users/${bob}/public/profile`).set({
+        uid: bob,
+        displayName: 'Bob',
+        username: 'bob',
+        avatarUrl: null,
+        bio: null,
+        isSearchable: true,
+        updatedAt: new Date(),
+      });
+    });
+  }
+
+  test('authed username + isSearchable query succeeds', async () => {
+    await seedPublicProfiles();
+    const snap = await assertSucceeds(
+      authed(alice)
+        .firestore()
+        .collectionGroup('public')
+        .where('username', '==', 'alice')
+        .where('isSearchable', '==', true)
+        .get(),
+    );
+    expect(snap.docs.map((doc) => doc.data().uid)).toEqual([alice]);
+  });
+
+  test('authed uid in query succeeds', async () => {
+    await seedPublicProfiles();
+    const snap = await assertSucceeds(
+      authed(alice)
+        .firestore()
+        .collectionGroup('public')
+        .where('uid', 'in', [alice, bob])
+        .get(),
+    );
+    expect(snap.docs.map((doc) => doc.data().uid).sort()).toEqual(
+      [alice, bob].sort(),
+    );
+  });
+
+  test('unauthenticated collection group query fails', async () => {
+    await seedPublicProfiles();
+    await assertFails(
+      unauthed()
+        .firestore()
+        .collectionGroup('public')
+        .where('username', '==', 'alice')
+        .where('isSearchable', '==', true)
+        .get(),
     );
   });
 });
@@ -307,6 +442,42 @@ describe('/users/{uid} — field validation', () => {
     });
     await assertFails(
       authed(alice).firestore().doc(`users/${alice}`).update({ spaceCount: 999 }),
+    );
+  });
+
+  test('owner cannot set displayName > 50 chars', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}`).set(validProfile);
+    });
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`users/${alice}`)
+        .update({ displayName: 'A'.repeat(51) }),
+    );
+  });
+
+  test('owner cannot set avatarUrl > 500 chars', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}`).set(validProfile);
+    });
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`users/${alice}`)
+        .update({ avatarUrl: 'a'.repeat(501) }),
+    );
+  });
+
+  test('owner cannot set bio > 300 chars', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`users/${alice}`).set(validProfile);
+    });
+    await assertFails(
+      authed(alice)
+        .firestore()
+        .doc(`users/${alice}`)
+        .update({ bio: 'b'.repeat(301) }),
     );
   });
 
@@ -1257,6 +1428,18 @@ describe('/friendships/{pid}', () => {
   test('non-member cannot read', async () => {
     await seedFriendship();
     await assertFails(authed(stranger).firestore().doc(`friendships/${PID}`).get());
+  });
+
+  test('member cannot read friendship with mismatched pairId', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc('friendships/not-the-pair-id').set({
+        members: [alice, bob],
+        createdAt: new Date(),
+      });
+    });
+    await assertFails(
+      authed(alice).firestore().doc('friendships/not-the-pair-id').get(),
+    );
   });
 
   test('client cannot create (server-side only)', async () => {

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -11,6 +11,12 @@ export { onPostDeleted } from "./feed/onPostDeleted.js";
 export { blockUser } from "./settings/blockUser.js";
 export { deleteAccount } from "./settings/deleteAccount.js";
 
+// User module
+export {
+  migratePublicProfiles,
+  onUserProfileChanged,
+} from "./user/publicProfile.js";
+
 initializeApp();
 
 setGlobalOptions({

--- a/firebase/functions/src/settings/deleteAccount.ts
+++ b/firebase/functions/src/settings/deleteAccount.ts
@@ -130,7 +130,8 @@ async function softDeleteConversations(uid: string): Promise<number> {
  * Thứ tự BẮT BUỘC (acceptance T7 #119):
  *   1. Storage prefixes: posts/{uid}/, avatars/{uid}/, diary/{uid}/
  *   2. Firestore subcollections của /users/{uid}: feed, notifications,
- *      fcmTokens, private (xóa trước parent doc — Firestore không cascade)
+ *      fcmTokens, private, public (xóa trước parent doc — Firestore không
+ *      cascade)
  *   3. Cross-collection queries:
  *      a. diary where authorUid == uid
  *      b. posts where authorId == uid (triggers onPostDeleted cho mỗi post
@@ -224,6 +225,7 @@ export const deleteAccount = onCall(
         'users/fcmTokens',
       ),
       deleteCollectionInBatches(userRef.collection('private'), 'users/private'),
+      deleteCollectionInBatches(userRef.collection('public'), 'users/public'),
       deleteCollectionInBatches(
         userRef.collection('space_count_events'),
         'users/space_count_events',

--- a/firebase/functions/src/user/publicProfile.ts
+++ b/firebase/functions/src/user/publicProfile.ts
@@ -1,0 +1,181 @@
+import { FieldPath, FieldValue, getFirestore } from 'firebase-admin/firestore';
+import { logger } from 'firebase-functions/v2';
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { z } from 'zod';
+
+export const publicProfileSourceSchema = z
+  .object({
+    displayName: z.string().min(1).max(50),
+    username: z
+      .string()
+      .min(3)
+      .max(20)
+      .regex(/^[a-z0-9_]+$/),
+    avatarUrl: z.string().max(500).nullable().optional(),
+    bio: z.string().max(300).nullable().optional(),
+    isSearchable: z.boolean().optional(),
+  })
+  .passthrough();
+
+export const migratePublicProfilesSchema = z.object({}).strict();
+
+type PublicProfileSource = z.infer<typeof publicProfileSourceSchema>;
+
+export interface PublicProfileWrite {
+  uid: string;
+  displayName: string;
+  username: string;
+  avatarUrl: string | null;
+  bio: string | null;
+  isSearchable: boolean;
+  updatedAt: unknown;
+}
+
+export function buildPublicProfileData(
+  uid: string,
+  data: PublicProfileSource,
+  updatedAt: unknown = FieldValue.serverTimestamp(),
+): PublicProfileWrite {
+  return {
+    uid,
+    displayName: data.displayName,
+    username: data.username,
+    avatarUrl: data.avatarUrl ?? null,
+    bio: data.bio ?? null,
+    isSearchable: data.isSearchable ?? true,
+    updatedAt,
+  };
+}
+
+function publicProfileRef(uid: string) {
+  return getFirestore().doc(`users/${uid}/public/profile`);
+}
+
+async function writePublicProfile(
+  uid: string,
+  data: Record<string, unknown>,
+): Promise<boolean> {
+  const parsed = publicProfileSourceSchema.safeParse(data);
+  if (!parsed.success) {
+    logger.warn(
+      {
+        uid,
+        fields: parsed.error.issues.map((issue) => issue.path.join('.')),
+      },
+      'publicProfile: user doc has invalid public fields',
+    );
+    return false;
+  }
+
+  await publicProfileRef(uid).set(buildPublicProfileData(uid, parsed.data), {
+    merge: false,
+  });
+  return true;
+}
+
+export const onUserProfileChanged = onDocumentWritten(
+  {
+    document: 'users/{uid}',
+    region: 'asia-southeast1',
+    memory: '256MiB',
+    timeoutSeconds: 60,
+  },
+  async (event) => {
+    const uid = event.params.uid;
+    const after = event.data?.after;
+
+    if (!after?.exists) {
+      await publicProfileRef(uid).delete();
+      logger.info({ uid }, 'publicProfile: deleted');
+      return;
+    }
+
+    const data = after.data();
+    if (!data) {
+      logger.warn({ uid }, 'publicProfile: user doc missing data');
+      return;
+    }
+    await writePublicProfile(uid, data);
+  },
+);
+
+export const migratePublicProfiles = onCall(
+  {
+    region: 'asia-southeast1',
+    memory: '512MiB',
+    timeoutSeconds: 540,
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Login required');
+    }
+    if (request.auth.token.admin !== true) {
+      throw new HttpsError('permission-denied', 'Admin only');
+    }
+
+    const parsed = migratePublicProfilesSchema.safeParse(request.data);
+    if (!parsed.success) {
+      throw new HttpsError('invalid-argument', parsed.error.message);
+    }
+
+    const db = getFirestore();
+    let migrated = 0;
+    let skipped = 0;
+    let lastDoc: FirebaseFirestore.QueryDocumentSnapshot | undefined;
+
+    while (true) {
+      let query: FirebaseFirestore.Query = db
+        .collection('users')
+        .orderBy(FieldPath.documentId())
+        .limit(400);
+
+      if (lastDoc) {
+        query = query.startAfter(lastDoc);
+      }
+
+      const snap = await query.get();
+      if (snap.empty) break;
+
+      const batch = db.batch();
+      let writes = 0;
+
+      for (const doc of snap.docs) {
+        const parsedDoc = publicProfileSourceSchema.safeParse(doc.data());
+        if (!parsedDoc.success) {
+          skipped += 1;
+          logger.warn(
+            {
+              uid: doc.id,
+              fields: parsedDoc.error.issues.map((issue) =>
+                issue.path.join('.'),
+              ),
+            },
+            'publicProfile: skipped invalid user doc during migration',
+          );
+          continue;
+        }
+
+        batch.set(
+          doc.ref.collection('public').doc('profile'),
+          buildPublicProfileData(doc.id, parsedDoc.data),
+          { merge: false },
+        );
+        writes += 1;
+      }
+
+      if (writes > 0) {
+        await batch.commit();
+      }
+      migrated += writes;
+
+      if (snap.size < 400) break;
+      const nextLastDoc = snap.docs.at(-1);
+      if (!nextLastDoc) break;
+      lastDoc = nextLastDoc;
+    }
+
+    logger.info({ migrated, skipped }, 'publicProfile: migration complete');
+    return { success: true, migrated, skipped };
+  },
+);

--- a/firebase/functions/src/user/publicProfile.ts
+++ b/firebase/functions/src/user/publicProfile.ts
@@ -85,14 +85,14 @@ export const onUserProfileChanged = onDocumentWritten(
     const uid = event.params.uid;
     const after = event.data?.after;
 
-    if (!after?.exists) {
+    if (after?.exists !== true) {
       await publicProfileRef(uid).delete();
       logger.info({ uid }, 'publicProfile: deleted');
       return;
     }
 
     const data = after.data();
-    if (!data) {
+    if (data == null) {
       logger.warn({ uid }, 'publicProfile: user doc missing data');
       return;
     }
@@ -130,7 +130,7 @@ export const migratePublicProfiles = onCall(
         .orderBy(FieldPath.documentId())
         .limit(400);
 
-      if (lastDoc) {
+      if (lastDoc !== undefined) {
         query = query.startAfter(lastDoc);
       }
 

--- a/firebase/functions/test/rules/friend.rules.test.ts
+++ b/firebase/functions/test/rules/friend.rules.test.ts
@@ -138,6 +138,23 @@ describe('/friendships/{pairId}', () => {
     await assertFails(authed(charlie).firestore().doc(`friendships/${pid}`).get());
   });
 
+  test('member cannot read friendship with mismatched pairId', async () => {
+    const alice = uid('alice');
+    const bob = uid('bob');
+    const badPid = 'friendship-random-id';
+
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().doc(`friendships/${badPid}`).set({
+        uid1: alice,
+        uid2: bob,
+        members: [alice, bob],
+        createdAt: new Date(),
+      });
+    });
+
+    await assertFails(authed(alice).firestore().doc(`friendships/${badPid}`).get());
+  });
+
   test('unauthenticated cannot read friendship', async () => {
     const alice = uid('alice');
     const bob = uid('bob');

--- a/firebase/functions/test/user/publicProfile.test.ts
+++ b/firebase/functions/test/user/publicProfile.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildPublicProfileData,
+  migratePublicProfilesSchema,
+  publicProfileSourceSchema,
+} from '../../src/user/publicProfile.js';
+
+describe('public profile projection', () => {
+  it('copies only public fields', () => {
+    const source = publicProfileSourceSchema.parse({
+      email: 'alice@example.com',
+      displayName: 'Alice',
+      username: 'alice',
+      avatarUrl: 'https://cdn.example.com/a.jpg',
+      bio: 'Meep user',
+      friendCount: 10,
+      postCount: 20,
+    });
+
+    const publicProfile = buildPublicProfileData('uid-alice', source, 'now');
+
+    expect(publicProfile).toEqual({
+      uid: 'uid-alice',
+      displayName: 'Alice',
+      username: 'alice',
+      avatarUrl: 'https://cdn.example.com/a.jpg',
+      bio: 'Meep user',
+      isSearchable: true,
+      updatedAt: 'now',
+    });
+    expect(publicProfile).not.toHaveProperty('email');
+    expect(publicProfile).not.toHaveProperty('friendCount');
+    expect(publicProfile).not.toHaveProperty('postCount');
+  });
+
+  it('keeps isSearchable=false for privacy opt-out', () => {
+    const source = publicProfileSourceSchema.parse({
+      displayName: 'Alice',
+      username: 'alice',
+      isSearchable: false,
+    });
+
+    const publicProfile = buildPublicProfileData('uid-alice', source, 'now');
+
+    expect(publicProfile.isSearchable).toBe(false);
+  });
+
+  it('rejects public fields over length caps', () => {
+    expect(
+      publicProfileSourceSchema.safeParse({
+        displayName: 'A'.repeat(51),
+        username: 'alice',
+      }).success,
+    ).toBe(false);
+    expect(
+      publicProfileSourceSchema.safeParse({
+        displayName: 'Alice',
+        username: 'alice',
+        avatarUrl: 'a'.repeat(501),
+      }).success,
+    ).toBe(false);
+    expect(
+      publicProfileSourceSchema.safeParse({
+        displayName: 'Alice',
+        username: 'alice',
+        bio: 'b'.repeat(301),
+      }).success,
+    ).toBe(false);
+  });
+
+  it('migration callable input is strict', () => {
+    expect(migratePublicProfilesSchema.safeParse({}).success).toBe(true);
+    expect(
+      migratePublicProfilesSchema.safeParse({ dryRun: true }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## SPEC

Tách public profile khỏi full `/users/{uid}` để đóng privacy boundary USER-SEC-001, đồng thời chuyển friend/search display-only reads sang `/users/{uid}/public/profile` và collection group `public`.

## Rollout bắt buộc

1. Deploy CF `onUserProfileChanged` + `migratePublicProfiles`.
2. Chạy admin backfill `migratePublicProfiles`.
3. Deploy client đọc `/users/{uid}/public/profile`.
4. Deploy/tighten Firestore rules sau khi public profiles đã populate.

## DIFF

- Thêm `PublicProfile` model + `UserRepository.getPublicProfile/watchPublicProfile`.
- Thêm CF trigger denormalize public fields và callable admin-only migration/backfill.
- Chuyển `searchUser`, `watchFriends`, chat/space/settings/feed display-only profile reads sang public profile path.
- Thêm collection-group rules `match /{path=**}/public/{docId}` cho `collectionGroup('public')`.
- Tighten `/users/{uid}` full doc read: owner/friend only; stranger chỉ đọc public profile.
- Thêm length caps cho user profile fields, pairId guard cho friendships, và index coverage cho `public` queries.

## VERIFY

- `flutter analyze` PASS
- `flutter test` local SKIPPED/blocked: Windows local Flutter `frontend_server` compile hang, không vào test case
- GitHub CI Flutter job là gate bắt buộc trước Ready/Merge
- `firebase/functions: npm run build` PASS
- `firebase/functions: npm test` PASS
- `firebase emulators:exec --project demo-meep-test --only firestore,storage "npm run test:rules"` PASS
- `git diff --check` PASS

## Merge Gate

Draft PR. Không mark Ready cho tới khi CI pass toàn bộ.