### PR TITLE
feat(friend): CF searchUserByUsername + tests/quality phase 2

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,6 +19,7 @@ jobs:
   validate-branch-name:
     name: Branch name format
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check branch name matches <type>/<DevName>/<desc>
         run: |
@@ -36,6 +37,7 @@ jobs:
   validate-commits:
     name: Commit message format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,6 +64,7 @@ jobs:
   flutter:
     name: Flutter (mobile app)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: apps/mobile
@@ -118,6 +121,7 @@ jobs:
   functions:
     name: Cloud Functions (TypeScript)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: firebase/functions
@@ -153,6 +157,7 @@ jobs:
   firestore-rules:
     name: Firestore security rules tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: firebase/functions

--- a/apps/mobile/integration_test/_helpers.dart
+++ b/apps/mobile/integration_test/_helpers.dart
@@ -1,0 +1,683 @@
+import 'dart:async';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meep/core/error/app_error.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/auth_repository.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/user_repository.dart';
+import 'package:meep/features/feed/application/feed_controller.dart';
+import 'package:meep/features/feed/application/post_controller.dart';
+import 'package:meep/features/feed/data/post_repository.dart';
+import 'package:meep/features/feed/data/storage_repository.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/friend/data/friend_repository.dart';
+import 'package:meep/features/friend/data/friend_request.dart';
+import 'package:meep/features/friend/data/friend_request_repository.dart';
+import 'package:meep/features/reaction/application/reaction_controller.dart';
+import 'package:meep/features/reaction/data/reaction.dart';
+import 'package:meep/features/reaction/data/reaction_repository.dart';
+import 'package:meep/features/widget/application/widget_data_service.dart';
+import 'package:meep/shared/models/post.dart';
+
+class MeepIntegrationHarness {
+  MeepIntegrationHarness._({
+    required this.container,
+    required this.auth,
+    required this.users,
+    required this.posts,
+    required this.friends,
+    required this.friendRequests,
+    required this.reactions,
+  });
+
+  final ProviderContainer container;
+  final InMemoryAuthRepository auth;
+  final InMemoryUserRepository users;
+  final InMemoryPostRepository posts;
+  final InMemoryFriendRepository friends;
+  final InMemoryFriendRequestRepository friendRequests;
+  final InMemoryReactionRepository reactions;
+
+  static Future<MeepIntegrationHarness> create({
+    UserProfile? signedInProfile,
+    Iterable<PublicProfile> publicProfiles = const [],
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    final auth = InMemoryAuthRepository();
+    final users = InMemoryUserRepository();
+    final posts = InMemoryPostRepository();
+    final friends = InMemoryFriendRepository(users);
+    final friendRequests = InMemoryFriendRequestRepository();
+    final reactions = InMemoryReactionRepository();
+
+    for (final profile in publicProfiles) {
+      users.seedPublicProfile(profile);
+    }
+    if (signedInProfile != null) {
+      users.seedProfile(signedInProfile);
+      auth.seedSignedIn(
+        uid: signedInProfile.uid,
+        email: signedInProfile.email,
+        displayName: signedInProfile.displayName,
+      );
+    }
+
+    final container = ProviderContainer(
+      overrides: [
+        authRepositoryProvider.overrideWithValue(auth),
+        userRepositoryProvider.overrideWithValue(users),
+        postRepositoryProvider.overrideWithValue(posts),
+        storageRepositoryProvider.overrideWithValue(
+          const InMemoryStorageRepository(),
+        ),
+        postImageCompressorProvider.overrideWithValue(
+          (_) async => const [0xFF, 0xD8, 0xFF],
+        ),
+        friendRepositoryProvider.overrideWithValue(friends),
+        friendRequestRepositoryProvider.overrideWithValue(friendRequests),
+        reactionRepositoryProvider.overrideWithValue(reactions),
+        widgetDataServiceProvider.overrideWithValue(
+          WidgetDataService(prefs: prefs),
+        ),
+      ],
+    );
+
+    return MeepIntegrationHarness._(
+      container: container,
+      auth: auth,
+      users: users,
+      posts: posts,
+      friends: friends,
+      friendRequests: friendRequests,
+      reactions: reactions,
+    );
+  }
+
+  Future<void> dispose() async {
+    container.dispose();
+    await auth.dispose();
+    await users.dispose();
+    await posts.dispose();
+    await friendRequests.dispose();
+    await reactions.dispose();
+  }
+}
+
+class InMemoryAuthRepository implements AuthRepository {
+  final _uidController = StreamController<String?>.broadcast();
+  final _accounts = <String, _Account>{};
+
+  _Account? _current;
+  int verificationEmailCount = 0;
+
+  @override
+  String? get currentUid => _current?.uid;
+
+  @override
+  String? get currentEmail => _current?.email;
+
+  @override
+  String? get currentDisplayName => _current?.displayName;
+
+  @override
+  bool get isEmailVerified => _current?.emailVerified ?? false;
+
+  @override
+  String? get currentProviderId => _current == null ? null : 'password';
+
+  void seedSignedIn({
+    required String uid,
+    required String email,
+    required String displayName,
+    String password = 'pass1234',
+  }) {
+    final account = _Account(
+      uid: uid,
+      email: email,
+      password: password,
+      displayName: displayName,
+      emailVerified: true,
+    );
+    _accounts[email] = account;
+    _current = account;
+  }
+
+  @override
+  Stream<String?> watchUid() async* {
+    yield _current?.uid;
+    yield* _uidController.stream;
+  }
+
+  @override
+  Future<void> signUpWithEmail({
+    required String email,
+    required String password,
+  }) async {
+    if (_accounts.containsKey(email)) {
+      throw const ValidationError(message: 'Email already exists');
+    }
+    final uid =
+        'uid-${email.split('@').first.replaceAll(RegExp(r'[^a-z0-9]'), '')}';
+    final account = _Account(
+      uid: uid,
+      email: email,
+      password: password,
+      displayName: '',
+      emailVerified: false,
+    );
+    _accounts[email] = account;
+    _current = account;
+    _uidController.add(uid);
+  }
+
+  @override
+  Future<void> signInWithEmail({
+    required String email,
+    required String password,
+  }) async {
+    final account = _accounts[email];
+    if (account == null || account.password != password) {
+      throw const UnauthenticatedError(message: 'Sai email hoặc mật khẩu');
+    }
+    _current = account;
+    _uidController.add(account.uid);
+  }
+
+  @override
+  Future<void> signOut() async {
+    _current = null;
+    _uidController.add(null);
+  }
+
+  @override
+  Future<bool> isEmailAvailable(String email) async =>
+      !_accounts.containsKey(email);
+
+  @override
+  Future<void> sendEmailVerification() async {
+    if (_current == null) throw const UnauthenticatedError();
+    verificationEmailCount++;
+  }
+
+  @override
+  Future<void> deleteCurrentUser() async {
+    final current = _current;
+    if (current == null) return;
+    _accounts.remove(current.email);
+    await signOut();
+  }
+
+  @override
+  Future<void> reloadUser() async {}
+
+  @override
+  Future<void> revalidateSession() async {}
+
+  @override
+  Future<void> signInWithGoogle() async {
+    throw const OperationCancelledError();
+  }
+
+  @override
+  Future<void> sendPasswordResetEmail({required String email}) async {}
+
+  @override
+  Future<String> verifyPasswordResetCode({required String oobCode}) async =>
+      currentEmail ?? 'test@example.com';
+
+  @override
+  Future<void> confirmPasswordReset({
+    required String oobCode,
+    required String newPassword,
+  }) async {}
+
+  @override
+  Future<void> reauthenticateWithCredential(AuthCredential credential) async {}
+
+  @override
+  Future<void> reauthenticateWithPassword(String password) async {}
+
+  @override
+  Future<void> reauthenticateWithGoogle() async {}
+
+  @override
+  Future<void> updateEmail(String newEmail) async {}
+
+  @override
+  Future<void> deleteAccountCascade() async {
+    await deleteCurrentUser();
+  }
+
+  Future<void> dispose() => _uidController.close();
+}
+
+class _Account {
+  _Account({
+    required this.uid,
+    required this.email,
+    required this.password,
+    required this.displayName,
+    required this.emailVerified,
+  });
+
+  final String uid;
+  final String email;
+  final String password;
+  final String displayName;
+  final bool emailVerified;
+}
+
+class InMemoryUserRepository implements UserRepository {
+  final _profiles = <String, UserProfile>{};
+  final _publicProfiles = <String, PublicProfile>{};
+  final _profileControllers = <String, StreamController<UserProfile?>>{};
+  final _publicControllers = <String, StreamController<PublicProfile?>>{};
+
+  void seedProfile(UserProfile profile) {
+    _profiles[profile.uid] = profile;
+    seedPublicProfile(
+      PublicProfile(
+        uid: profile.uid,
+        displayName: profile.displayName,
+        username: profile.username,
+        avatarUrl: profile.avatarUrl,
+        updatedAt: profile.updatedAt,
+      ),
+    );
+  }
+
+  void seedPublicProfile(PublicProfile profile) {
+    _publicProfiles[profile.uid] = profile;
+  }
+
+  @override
+  Future<void> createProfile(UserProfile profile) async {
+    _profiles[profile.uid] = profile;
+    final publicProfile = PublicProfile(
+      uid: profile.uid,
+      displayName: profile.displayName,
+      username: profile.username,
+      avatarUrl: profile.avatarUrl,
+      updatedAt: profile.updatedAt,
+    );
+    _publicProfiles[profile.uid] = publicProfile;
+    _profileController(profile.uid).add(profile);
+    _publicController(profile.uid).add(publicProfile);
+  }
+
+  @override
+  Future<UserProfile?> getProfile(String uid) async => _profiles[uid];
+
+  @override
+  Future<PublicProfile?> getPublicProfile(String uid) async =>
+      _publicProfiles[uid];
+
+  @override
+  Future<bool> isUsernameAvailable(String username) async =>
+      !_publicProfiles.values.any((p) => p.username == username);
+
+  @override
+  Stream<UserProfile?> watchProfile(String uid) async* {
+    yield _profiles[uid];
+    yield* _profileController(uid).stream;
+  }
+
+  @override
+  Stream<PublicProfile?> watchPublicProfile(String uid) async* {
+    yield _publicProfiles[uid];
+    yield* _publicController(uid).stream;
+  }
+
+  StreamController<UserProfile?> _profileController(String uid) =>
+      _profilesControllerFor(uid, _profileControllers);
+
+  StreamController<PublicProfile?> _publicController(String uid) =>
+      _profilesControllerFor(uid, _publicControllers);
+
+  StreamController<T?> _profilesControllerFor<T>(
+    String uid,
+    Map<String, StreamController<T?>> controllers,
+  ) =>
+      controllers.putIfAbsent(uid, () => StreamController<T?>.broadcast());
+
+  Future<void> dispose() async {
+    for (final controller in _profileControllers.values) {
+      await controller.close();
+    }
+    for (final controller in _publicControllers.values) {
+      await controller.close();
+    }
+  }
+}
+
+class InMemoryPostRepository implements PostRepository {
+  final _feedController = StreamController<List<Post>>.broadcast();
+  final _posts = <Post>[];
+  int _nextPost = 1;
+
+  List<Post> get createdPosts => List.unmodifiable(_posts);
+
+  void seedPost(Post post) {
+    _posts.add(post);
+    _emit();
+  }
+
+  @override
+  String newPostId() => 'post-${_nextPost++}';
+
+  @override
+  Future<Post> createPost(Post post) async {
+    _posts.add(post);
+    _emit();
+    return post;
+  }
+
+  @override
+  Stream<List<Post>> watchFeed(String uid, {String? spaceId}) async* {
+    yield _visiblePosts(uid, spaceId: spaceId);
+    yield* _feedController.stream.map(
+      (_) => _visiblePosts(uid, spaceId: spaceId),
+    );
+  }
+
+  @override
+  Future<void> deletePost(String postId) async {
+    _posts.removeWhere((post) => post.postId == postId);
+    _emit();
+  }
+
+  @override
+  Future<List<Post>> getPostsByAuthor(String authorId) async =>
+      _posts.where((post) => post.authorId == authorId).toList();
+
+  @override
+  Future<Post?> getPost(String postId) async {
+    for (final post in _posts) {
+      if (post.postId == postId) return post;
+    }
+    return null;
+  }
+
+  List<Post> _visiblePosts(String uid, {String? spaceId}) {
+    final filtered = spaceId == null
+        ? _posts
+        : _posts.where((post) => post.spaceIds.contains(spaceId));
+    final result = filtered.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return result;
+  }
+
+  void _emit() => _feedController.add(List.unmodifiable(_posts));
+
+  Future<void> dispose() => _feedController.close();
+}
+
+class InMemoryStorageRepository implements StorageRepository {
+  const InMemoryStorageRepository();
+
+  @override
+  Future<String> uploadImage({
+    required String uid,
+    required String postId,
+    required List<int> bytes,
+    required String mimeType,
+    String fileName = 'photo.jpg',
+  }) async =>
+      'memory://posts/$uid/$postId/$fileName';
+
+  @override
+  Future<void> deleteImage(String storagePath) async {}
+}
+
+class InMemoryFriendRepository implements FriendRepository {
+  InMemoryFriendRepository(this._users);
+
+  final InMemoryUserRepository _users;
+  final _friendsByUid = <String, List<PublicProfile>>{};
+
+  void seedFriend(String uid, PublicProfile friend) {
+    _friendsByUid.update(
+      uid,
+      (friends) => [...friends, friend],
+      ifAbsent: () => [friend],
+    );
+  }
+
+  @override
+  Future<PublicProfile?> searchUser(String username) async {
+    final lower = username.toLowerCase();
+    for (final profile in _users._publicProfiles.values) {
+      if (profile.username == lower) return profile;
+    }
+    return null;
+  }
+
+  @override
+  Stream<List<PublicProfile>> watchFriends(String uid) =>
+      Stream.value(List.unmodifiable(_friendsByUid[uid] ?? const []));
+
+  @override
+  Future<List<String>> getFriendUids(String uid) async =>
+      (_friendsByUid[uid] ?? const []).map((profile) => profile.uid).toList();
+
+  @override
+  Future<void> unfriend(String pairId) async {}
+}
+
+class InMemoryFriendRequestRepository implements FriendRequestRepository {
+  final _requests = <FriendRequest>[];
+  final _changes = StreamController<void>.broadcast();
+
+  List<FriendRequest> sentFrom(String uid) =>
+      _requests.where((request) => request.senderId == uid).toList();
+
+  @override
+  Stream<List<FriendRequest>> watchPendingRequests(String receiverUid) async* {
+    yield _pendingFor(receiverUid);
+    yield* _changes.stream.map((_) => _pendingFor(receiverUid));
+  }
+
+  @override
+  Stream<List<FriendRequest>> watchSentRequests(String senderUid) async* {
+    yield _sentFor(senderUid);
+    yield* _changes.stream.map((_) => _sentFor(senderUid));
+  }
+
+  @override
+  Future<void> sendFriendRequest({
+    required String senderUid,
+    required String receiverUid,
+  }) async {
+    if (senderUid == receiverUid) {
+      throw const ValidationError(message: 'Không thể tự kết bạn');
+    }
+    final exists = _requests.any(
+      (request) =>
+          request.senderId == senderUid &&
+          request.receiverId == receiverUid &&
+          request.status == FriendRequestStatus.pending,
+    );
+    if (exists) return;
+
+    final now = DateTime.now();
+    _requests.add(
+      FriendRequest(
+        requestId: 'req-$senderUid-$receiverUid',
+        senderId: senderUid,
+        receiverId: receiverUid,
+        status: FriendRequestStatus.pending,
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+    _changes.add(null);
+  }
+
+  @override
+  Future<void> acceptFriendRequest(String requestId) async {
+    _replaceStatus(requestId, FriendRequestStatus.accepted);
+  }
+
+  @override
+  Future<void> cancelFriendRequest(String requestId) async {
+    _replaceStatus(requestId, FriendRequestStatus.cancelled);
+  }
+
+  @override
+  Future<void> declineFriendRequest(String requestId) async {
+    _replaceStatus(requestId, FriendRequestStatus.declined);
+  }
+
+  List<FriendRequest> _pendingFor(String receiverUid) => _requests
+      .where(
+        (request) =>
+            request.receiverId == receiverUid &&
+            request.status == FriendRequestStatus.pending,
+      )
+      .toList();
+
+  List<FriendRequest> _sentFor(String senderUid) => _requests
+      .where(
+        (request) =>
+            request.senderId == senderUid &&
+            request.status == FriendRequestStatus.pending,
+      )
+      .toList();
+
+  void _replaceStatus(String requestId, FriendRequestStatus status) {
+    final index =
+        _requests.indexWhere((request) => request.requestId == requestId);
+    if (index == -1) return;
+    _requests[index] = _requests[index].copyWith(
+      status: status,
+      updatedAt: DateTime.now(),
+    );
+    _changes.add(null);
+  }
+
+  Future<void> dispose() => _changes.close();
+}
+
+class InMemoryReactionRepository implements ReactionRepository {
+  final _reactions = <String, List<Reaction>>{};
+  final _controllers = <String, StreamController<List<Reaction>>>{};
+
+  List<Reaction> forPost(String postId) =>
+      List.unmodifiable(_reactions[postId] ?? const []);
+
+  @override
+  Stream<List<Reaction>> watchReactions(String postId) async* {
+    yield forPost(postId);
+    yield* _controller(postId).stream;
+  }
+
+  @override
+  Future<Reaction?> getMyReaction({
+    required String postId,
+    required String uid,
+  }) async {
+    for (final reaction in _reactions[postId] ?? const <Reaction>[]) {
+      if (reaction.reactorUid == uid) return reaction;
+    }
+    return null;
+  }
+
+  @override
+  Future<void> upsertReaction({
+    required String postId,
+    required String reactorUid,
+    required String reactorName,
+    String? reactorAvatarUrl,
+    required String emoji,
+  }) async {
+    final current = [...(_reactions[postId] ?? const <Reaction>[])];
+    final next = Reaction(
+      reactorUid: reactorUid,
+      reactorName: reactorName,
+      reactorAvatarUrl: reactorAvatarUrl,
+      emoji: emoji,
+      createdAt: DateTime.now(),
+    );
+    final index = current.indexWhere((r) => r.reactorUid == reactorUid);
+    if (index == -1) {
+      current.add(next);
+    } else {
+      current[index] = next;
+    }
+    _reactions[postId] = current;
+    _controller(postId).add(forPost(postId));
+  }
+
+  @override
+  Future<void> deleteReaction({
+    required String postId,
+    required String reactorUid,
+  }) async {
+    _reactions[postId] = [
+      for (final reaction in _reactions[postId] ?? const <Reaction>[])
+        if (reaction.reactorUid != reactorUid) reaction,
+    ];
+    _controller(postId).add(forPost(postId));
+  }
+
+  StreamController<List<Reaction>> _controller(String postId) =>
+      _controllers.putIfAbsent(
+        postId,
+        () => StreamController<List<Reaction>>.broadcast(),
+      );
+
+  Future<void> dispose() async {
+    for (final controller in _controllers.values) {
+      await controller.close();
+    }
+  }
+}
+
+UserProfile testUserProfile({
+  String uid = 'uid-me',
+  String email = 'me@example.com',
+  String displayName = 'Meep Tester',
+  String username = 'meep',
+}) =>
+    UserProfile(
+      uid: uid,
+      email: email,
+      displayName: displayName,
+      username: username,
+      createdAt: DateTime(2026, 6, 1),
+      updatedAt: DateTime(2026, 6, 1),
+    );
+
+PublicProfile testPublicProfile({
+  required String uid,
+  required String displayName,
+  required String username,
+}) =>
+    PublicProfile(
+      uid: uid,
+      displayName: displayName,
+      username: username,
+      updatedAt: DateTime(2026, 6, 1),
+    );
+
+Post testPost({
+  required String postId,
+  required String authorId,
+  String authorName = 'Friend',
+  String? imageUrl,
+}) =>
+    Post(
+      postId: postId,
+      authorId: authorId,
+      authorName: authorName,
+      imageUrl: imageUrl ?? 'https://example.com/$postId.jpg',
+      audienceType: AudienceType.all,
+      createdAt: DateTime(2026, 6, 1),
+    );

--- a/apps/mobile/integration_test/auth_flow_test.dart
+++ b/apps/mobile/integration_test/auth_flow_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/application/login_controller.dart';
+import 'package:meep/features/auth/application/sign_up_controller.dart';
+
+import '_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('auth flow signs up, creates public profile, then logs in',
+      (tester) async {
+    final harness = await MeepIntegrationHarness.create();
+    addTearDown(harness.dispose);
+
+    final signUp = harness.container.read(signUpControllerProvider.notifier);
+
+    final emailAvailable =
+        await signUp.checkEmailAvailable('alice@example.com');
+    expect(emailAvailable, isTrue);
+    signUp
+      ..setPassword('pass1234')
+      ..setDisplayName('Alice Nguyen');
+    await signUp.checkUsername('alice');
+    await signUp.createAccount();
+
+    final profile = await harness.users.getProfile('uid-alice');
+    expect(profile, isNotNull);
+    expect(profile!.displayName, 'Alice Nguyen');
+    expect(profile.username, 'alice');
+    expect(harness.auth.currentUid, 'uid-alice');
+    expect(harness.auth.verificationEmailCount, 1);
+
+    final publicProfile = await harness.users.getPublicProfile('uid-alice');
+    expect(publicProfile, isNotNull);
+    expect(publicProfile!.displayName, 'Alice Nguyen');
+
+    final watchedProfile =
+        await harness.container.read(currentUserProfileProvider.future);
+    expect(watchedProfile?.uid, 'uid-alice');
+
+    await harness.auth.signOut();
+    final login = harness.container.read(loginControllerProvider.notifier)
+      ..setEmail('alice@example.com')
+      ..setPassword('pass1234');
+    await login.signIn();
+
+    final loginState = harness.container.read(loginControllerProvider);
+    expect(loginState.isSuccess, isTrue);
+    expect(loginState.errorMessage, isNull);
+    expect(harness.auth.currentUid, 'uid-alice');
+  });
+}

--- a/apps/mobile/integration_test/feed_reaction_test.dart
+++ b/apps/mobile/integration_test/feed_reaction_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:meep/features/feed/application/feed_controller.dart';
+import 'package:meep/features/reaction/application/reaction_controller.dart';
+
+import '_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('feed emits friend post and reaction toggles optimistically',
+      (tester) async {
+    final harness = await MeepIntegrationHarness.create(
+      signedInProfile: testUserProfile(),
+    );
+    addTearDown(harness.dispose);
+
+    harness.posts.seedPost(
+      testPost(
+        postId: 'post-friend',
+        authorId: 'uid-friend',
+        authorName: 'Bob Tran',
+      ),
+    );
+
+    final feedState = await harness.container.read(
+      feedControllerProvider(filter: FeedFilter.all).future,
+    );
+    expect(feedState.posts.map((post) => post.postId), ['post-friend']);
+
+    final reactionController = harness.container.read(
+      reactionControllerProvider('post-friend').notifier,
+    );
+    await reactionController.toggleReact(
+      uid: 'uid-me',
+      displayName: 'Meep Tester',
+      emoji: '❤️',
+    );
+
+    expect(harness.reactions.forPost('post-friend'), hasLength(1));
+    expect(harness.reactions.forPost('post-friend').single.emoji, '❤️');
+    expect(
+      harness.container.read(reactionControllerProvider('post-friend')).myEmoji,
+      '❤️',
+    );
+
+    await reactionController.toggleReact(
+      uid: 'uid-me',
+      displayName: 'Meep Tester',
+      emoji: '❤️',
+    );
+    expect(harness.reactions.forPost('post-friend'), isEmpty);
+  });
+}

--- a/apps/mobile/integration_test/friend_request_test.dart
+++ b/apps/mobile/integration_test/friend_request_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:meep/features/friend/application/friend_controller.dart';
+
+import '_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('friend request search sends one idempotent pending request',
+      (tester) async {
+    final bob = testPublicProfile(
+      uid: 'uid-bob',
+      displayName: 'Bob Tran',
+      username: 'bob',
+    );
+    final harness = await MeepIntegrationHarness.create(
+      signedInProfile: testUserProfile(),
+      publicProfiles: [bob],
+    );
+    addTearDown(harness.dispose);
+
+    final controller =
+        harness.container.read(friendControllerProvider('uid-me').notifier);
+    await tester.pump();
+
+    await controller.searchUser('bob');
+    await tester.pump(const Duration(milliseconds: 600));
+
+    final searched =
+        harness.container.read(friendControllerProvider('uid-me')).searchResult;
+    expect(searched?.uid, 'uid-bob');
+
+    await controller.sendFriendRequest('uid-bob');
+    await tester.pump();
+    await controller.sendFriendRequest('uid-bob');
+    await tester.pump();
+
+    expect(harness.friendRequests.sentFrom('uid-me'), hasLength(1));
+    expect(
+      harness.container
+          .read(friendControllerProvider('uid-me'))
+          .sentRequests
+          .map((request) => request.receiverId),
+      ['uid-bob'],
+    );
+  });
+}

--- a/apps/mobile/integration_test/post_creation_test.dart
+++ b/apps/mobile/integration_test/post_creation_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/feed/application/post_controller.dart';
+import 'package:meep/shared/models/post.dart';
+
+import '_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('post creation uploads bytes and writes a feed post',
+      (tester) async {
+    final harness = await MeepIntegrationHarness.create(
+      signedInProfile: testUserProfile(),
+    );
+    addTearDown(harness.dispose);
+
+    await harness.container.read(currentUidProvider.future);
+    await harness.container.read(currentUserProfileProvider.future);
+
+    final controller = harness.container.read(postControllerProvider.notifier)
+      ..setPendingImage('memory/photo.jpg')
+      ..setCaption('Hello Meep')
+      ..setAudience(AudienceType.select, const ['uid-friend']);
+
+    final submitted = await controller.submit();
+
+    expect(submitted, isTrue);
+    expect(harness.posts.createdPosts, hasLength(1));
+
+    final post = harness.posts.createdPosts.single;
+    expect(post.postId, 'post-1');
+    expect(post.authorId, 'uid-me');
+    expect(post.authorName, 'Meep Tester');
+    expect(post.caption, 'Hello Meep');
+    expect(post.audienceType, AudienceType.select);
+    expect(post.audienceUids, ['uid-friend']);
+    expect(post.imageUrl, 'memory://posts/uid-me/post-1/photo.jpg');
+    expect(
+      harness.container.read(postControllerProvider).pendingImagePath,
+      isNull,
+    );
+  });
+}

--- a/apps/mobile/lib/core/router/app_router.dart
+++ b/apps/mobile/lib/core/router/app_router.dart
@@ -364,10 +364,17 @@ GoRouter appRouter(Ref ref) {
       ),
       GoRoute(
         path: '/diary/:entryId',
-        builder: (_, state) => DiaryCanvasScreen(
-          mode: DiaryCanvasMode.read,
-          entryId: state.pathParameters['entryId'],
-        ),
+        builder: (_, state) {
+          final extra = state.extra;
+          final ownerActionsEnabled = extra is Map<String, dynamic>
+              ? extra['ownerActionsEnabled'] as bool? ?? true
+              : true;
+          return DiaryCanvasScreen(
+            mode: DiaryCanvasMode.read,
+            entryId: state.pathParameters['entryId'],
+            ownerActionsEnabled: ownerActionsEnabled,
+          );
+        },
       ),
       GoRoute(
         path: '/invite/:uid',

--- a/apps/mobile/lib/features/auth/data/firebase_user_repository.dart
+++ b/apps/mobile/lib/features/auth/data/firebase_user_repository.dart
@@ -37,9 +37,14 @@ class FirebaseUserRepository implements UserRepository {
 
   @override
   Future<PublicProfile?> getPublicProfile(String uid) async {
-    final snap = await _firestore.doc('users/$uid/public/profile').get();
-    if (!snap.exists) return null;
-    return PublicProfile.fromFirestore(snap);
+    final publicSnap = await _firestore.doc('users/$uid/public/profile').get();
+    if (publicSnap.exists) return PublicProfile.fromFirestore(publicSnap);
+
+    final userSnap = await _getUserDocForPublicFallback(uid);
+    if (userSnap == null) return null;
+    final data = userSnap.data();
+    if (!userSnap.exists || data == null) return null;
+    return _publicProfileFromUserData(uid, data);
   }
 
   @override
@@ -60,9 +65,41 @@ class FirebaseUserRepository implements UserRepository {
 
   @override
   Stream<PublicProfile?> watchPublicProfile(String uid) {
-    return _firestore.doc('users/$uid/public/profile').snapshots().map((snap) {
-      if (!snap.exists) return null;
-      return PublicProfile.fromFirestore(snap);
+    return _firestore.doc('users/$uid/public/profile').snapshots().asyncMap(
+      (snap) async {
+        if (snap.exists) return PublicProfile.fromFirestore(snap);
+
+        final userSnap = await _getUserDocForPublicFallback(uid);
+        if (userSnap == null) return null;
+        final data = userSnap.data();
+        if (!userSnap.exists || data == null) return null;
+        return _publicProfileFromUserData(uid, data);
+      },
+    );
+  }
+
+  Future<DocumentSnapshot<Map<String, dynamic>>?> _getUserDocForPublicFallback(
+    String uid,
+  ) async {
+    try {
+      return _firestore.doc('users/$uid').get();
+    } on FirebaseException catch (e) {
+      if (e.code == 'permission-denied') return null;
+      rethrow;
+    }
+  }
+
+  PublicProfile? _publicProfileFromUserData(
+    String uid,
+    Map<String, dynamic> data,
+  ) {
+    final updatedAt = data['updatedAt'] ?? data['createdAt'];
+    if (updatedAt == null) return null;
+
+    return PublicProfile.fromJson({
+      ...data,
+      'uid': data['uid'] ?? uid,
+      'updatedAt': updatedAt,
     });
   }
 }

--- a/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_canvas_screen.dart
@@ -52,6 +52,7 @@ class DiaryCanvasScreen extends ConsumerStatefulWidget {
     this.initialContent,
     this.initialImageUrl,
     this.entryDate,
+    this.ownerActionsEnabled = true,
   });
 
   final DiaryCanvasMode mode;
@@ -71,6 +72,10 @@ class DiaryCanvasScreen extends ConsumerStatefulWidget {
   /// Ngày của entry — hiển thị ở topbar center. Khi null (create mode) →
   /// dùng `DateTime.now()` tự động.
   final DateTime? entryDate;
+
+  /// Read mode dùng chung cho own diary và diary public của bạn bè.
+  /// Khi false, ẩn menu edit/delete/share của owner.
+  final bool ownerActionsEnabled;
 
   @override
   ConsumerState<DiaryCanvasScreen> createState() => _DiaryCanvasScreenState();
@@ -266,6 +271,8 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
   /// Create mode: cover = '' (mood asset là visual, không upload).
   /// Inline images — upload tuần tự nếu user đã pick.
   Future<void> _handleSave() async {
+    if (ref.read(diaryControllerProvider).isSaving) return;
+
     final mood = _loadedMood ?? widget.moodTemplate;
     if (mood == null) {
       unawaited(Navigator.of(context).maybePop());
@@ -280,7 +287,8 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
       return;
     }
 
-    final uid = ref.read(currentUidProvider).valueOrNull;
+    final uid = await ref.read(currentUidProvider.future);
+    if (!mounted) return;
     if (uid == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Bạn cần đăng nhập để lưu nhật ký')),
@@ -380,7 +388,10 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
     if (widget.mode == DiaryCanvasMode.create) {
       unawaited(_clearDraft());
     }
-    unawaited(Navigator.of(context).maybePop());
+    setState(() => _allowPop = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(Navigator.of(context).maybePop());
+    });
   }
 
   /// Build content blocks: text block + ImageBlock cho mỗi inline ảnh.
@@ -479,6 +490,8 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
 
   /// Mở Menu nhật ký (read mode topbar ellipsis) — Chỉnh sửa / Xóa / Chia sẻ.
   Future<void> _openMenu() async {
+    if (!widget.ownerActionsEnabled) return;
+
     final action = await DiaryMenuSheet.show(context);
     if (action == null || !mounted) return;
 
@@ -526,6 +539,10 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final isSaving = ref.watch(
+      diaryControllerProvider.select((s) => s.isSaving),
+    );
+
     // Read/edit mode: listen currentEntry → sync controllers + local state
     // khi loadEntry hoàn thành (initState fire postFrame).
     if (widget.mode != DiaryCanvasMode.create) {
@@ -556,22 +573,32 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
       },
       child: Scaffold(
         backgroundColor: _canvasBg,
-        body: SafeArea(
-          child: Column(
-            children: [
-              _buildTopbar(),
-              // Box border đen + dots — hug content vertically, width fixed
-              // theo margin ngoài. Scroll cả màn khi content vượt screen height.
-              Expanded(
-                child: SingleChildScrollView(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                  child: _buildCanvasBox(),
-                ),
+        body: Stack(
+          children: [
+            SafeArea(
+              child: Column(
+                children: [
+                  _buildTopbar(),
+                  // Box border đen + dots — hug content vertically, width fixed
+                  // theo margin ngoài. Scroll cả màn khi content vượt screen height.
+                  Expanded(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 12,
+                      ),
+                      child: _buildCanvasBox(),
+                    ),
+                  ),
+                  if (!_isReadOnly) _buildToolbar(),
+                ],
               ),
-              if (!_isReadOnly) _buildToolbar(),
-            ],
-          ),
+            ),
+            if (isSaving)
+              const Positioned.fill(
+                child: _SavingOverlay(),
+              ),
+          ],
         ),
       ),
     );
@@ -643,11 +670,13 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
             Align(
               alignment: Alignment.centerRight,
               child: _isReadOnly
-                  ? _SvgIconBtn(
-                      asset: 'assets/icons/ic_diary_ellipsis.svg',
-                      semanticLabel: 'Tùy chọn',
-                      onTap: _openMenu,
-                    )
+                  ? widget.ownerActionsEnabled
+                      ? _SvgIconBtn(
+                          asset: 'assets/icons/ic_diary_ellipsis.svg',
+                          semanticLabel: 'Tùy chọn',
+                          onTap: _openMenu,
+                        )
+                      : const SizedBox(width: 44, height: 44)
                   : Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
@@ -890,4 +919,29 @@ class _DiaryCanvasScreenState extends ConsumerState<DiaryCanvasScreen> {
     color: AppColors.bw900,
     height: 24 / 16,
   );
+}
+
+class _SavingOverlay extends StatelessWidget {
+  const _SavingOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return AbsorbPointer(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: AppColors.bw900.withValues(alpha: 0.18),
+        ),
+        child: const Center(
+          child: SizedBox(
+            width: 36,
+            height: 36,
+            child: CircularProgressIndicator(
+              color: AppColors.turquoise500,
+              strokeWidth: 3,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
+++ b/apps/mobile/lib/features/diary/presentation/diary_list_screen.dart
@@ -99,7 +99,9 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
             child: Align(
               alignment: Alignment.bottomCenter,
               child: Padding(
-                padding: const EdgeInsets.only(bottom: 12),
+                padding: EdgeInsets.only(
+                  bottom: MediaQuery.of(context).size.height * 0.045,
+                ),
                 child: AppTaskbar(
                   activeTab: TaskbarTab.diary,
                   onTabSelected: (tab) {
@@ -155,7 +157,9 @@ class _DiaryListScreenState extends ConsumerState<DiaryListScreen> {
 
                 // FAB — toggle [+] ↔ [x]
                 Positioned(
-                  bottom: 90,
+                  bottom: AppTaskbar.height +
+                      MediaQuery.of(context).size.height * 0.045 +
+                      20,
                   left: 0,
                   right: 0,
                   child: Center(child: _buildFab()),

--- a/apps/mobile/lib/features/feed/application/app_camera_controller.dart
+++ b/apps/mobile/lib/features/feed/application/app_camera_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
@@ -142,8 +143,9 @@ class AppCameraController extends _$AppCameraController {
       state = state.copyWith(isCapturing: true);
       try {
         final file = await _cameraCtrl!.takePicture();
-        debugPrint(
-          '[CameraCapture] takePicture done → ${file.path} | front=${state.isFrontCamera}',
+        _log(
+          'takePicture done',
+          {'path': file.path, 'front': state.isFrontCamera},
         );
         if (state.isFrontCamera) {
           await flipImageHorizontallyInPlace(file.path);
@@ -151,8 +153,8 @@ class AppCameraController extends _$AppCameraController {
           await fixOrientationInPlace(file.path);
         }
         return file.path;
-      } catch (e) {
-        debugPrint('capture error: $e');
+      } catch (e, st) {
+        _log('capture error', e, st);
         return null;
       } finally {
         state = state.copyWith(isCapturing: false);
@@ -191,8 +193,8 @@ class AppCameraController extends _$AppCameraController {
       }
 
       return path;
-    } catch (e) {
-      debugPrint('dual capture error: $e');
+    } catch (e, st) {
+      _log('dual capture error', e, st);
       return null;
     } finally {
       state = state.copyWith(isCapturing: false);
@@ -316,6 +318,16 @@ class AppCameraController extends _$AppCameraController {
   void resumePreview() => _cameraCtrl?.resumePreview();
 
   CameraController? get cameraController => _cameraCtrl;
+
+  void _log(String message, [Object? error, StackTrace? stackTrace]) {
+    if (!kDebugMode) return;
+    developer.log(
+      message,
+      name: 'camera',
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
 
   Future<void> _disposeController() async {
     await _cameraCtrl?.dispose();

--- a/apps/mobile/lib/features/feed/application/post_controller.dart
+++ b/apps/mobile/lib/features/feed/application/post_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
@@ -16,6 +18,32 @@ part 'post_controller.g.dart';
 
 @Riverpod(keepAlive: false)
 CaptionService captionService(Ref ref) => CaptionServiceImpl();
+
+typedef PostImageCompressor = Future<List<int>?> Function(String path);
+
+@Riverpod(keepAlive: false)
+PostImageCompressor postImageCompressor(Ref ref) {
+  return (path) async {
+    final result = await FlutterImageCompress.compressWithFile(
+      path,
+      minWidth: PostController._maxWidthPx,
+      minHeight: PostController._maxWidthPx,
+      quality: PostController._compressQuality,
+      format: CompressFormat.jpeg,
+    );
+    if (result == null) return null;
+    if (result.length > PostController._maxSizeBytes) {
+      return FlutterImageCompress.compressWithFile(
+        path,
+        minWidth: PostController._maxWidthPx,
+        minHeight: PostController._maxWidthPx,
+        quality: 60,
+        format: CompressFormat.jpeg,
+      );
+    }
+    return result;
+  };
+}
 
 @riverpod
 class PostController extends _$PostController {
@@ -61,7 +89,11 @@ class PostController extends _$PostController {
   }
 
   void setAudience(AudienceType type, List<String> uids) {
-    state = state.copyWith(audienceType: type, selectedUids: uids);
+    final currentUid = ref.read(currentUidProvider).valueOrNull;
+    final selectedUids = type == AudienceType.all
+        ? const <String>[]
+        : _sanitizeAudienceUids(uids, currentUid: currentUid);
+    state = state.copyWith(audienceType: type, selectedUids: selectedUids);
   }
 
   /// Toggle 1 Space trong `selectedSpaceIds`. KHÔNG ảnh hưởng `selectedUids`
@@ -93,8 +125,16 @@ class PostController extends _$PostController {
       return false;
     }
 
+    final selectedAudienceUids = state.audienceType == AudienceType.all
+        ? const <String>[]
+        : _sanitizeAudienceUids(state.selectedUids, currentUid: uid);
     if (state.audienceType == AudienceType.select &&
-        state.selectedUids.isEmpty &&
+        !listEquals(state.selectedUids, selectedAudienceUids)) {
+      state = state.copyWith(selectedUids: selectedAudienceUids);
+    }
+
+    if (state.audienceType == AudienceType.select &&
+        selectedAudienceUids.isEmpty &&
         state.selectedSpaceIds.isEmpty) {
       state = state.copyWith(
         errorMessage: 'Chọn ít nhất 1 người nhận hoặc 1 Space',
@@ -217,7 +257,7 @@ class PostController extends _$PostController {
         captionType: state.captionType,
         audienceType: state.audienceType,
         audienceUids:
-            state.audienceType == AudienceType.all ? [] : state.selectedUids,
+            state.audienceType == AudienceType.all ? [] : selectedAudienceUids,
         spaceIds: selectedSpaceIds,
         memberIds: memberIdsUnion,
         createdAt: DateTime.now(),
@@ -270,8 +310,12 @@ class PostController extends _$PostController {
         : detail is FirebaseException
             ? ' [${detail.runtimeType} code=${detail.code} msg=${detail.message}]'
             : ' [${detail.runtimeType}] $detail';
-    debugPrint('[PostController.submit] $message$detailStr');
-    if (st != null) debugPrint(st.toString());
+    developer.log(
+      '$message$detailStr',
+      name: 'post.submit',
+      error: detail,
+      stackTrace: st,
+    );
   }
 
   Future<void> deletePost(String postId) async {
@@ -281,27 +325,23 @@ class PostController extends _$PostController {
 
   Future<List<int>?> _compress(String path) async {
     try {
-      final result = await FlutterImageCompress.compressWithFile(
-        path,
-        minWidth: _maxWidthPx,
-        minHeight: _maxWidthPx,
-        quality: _compressQuality,
-        format: CompressFormat.jpeg,
-      );
-      if (result == null) return null;
-      if (result.length > _maxSizeBytes) {
-        // Re-compress at lower quality
-        return FlutterImageCompress.compressWithFile(
-          path,
-          minWidth: _maxWidthPx,
-          minHeight: _maxWidthPx,
-          quality: 60,
-          format: CompressFormat.jpeg,
-        );
-      }
-      return result;
+      return await ref.read(postImageCompressorProvider)(path);
     } catch (_) {
       return null;
     }
+  }
+
+  List<String> _sanitizeAudienceUids(
+    List<String> uids, {
+    required String? currentUid,
+  }) {
+    final seen = <String>{};
+    final sanitized = <String>[];
+    for (final uid in uids) {
+      final trimmed = uid.trim();
+      if (trimmed.isEmpty || trimmed == currentUid) continue;
+      if (seen.add(trimmed)) sanitized.add(trimmed);
+    }
+    return sanitized;
   }
 }

--- a/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
+++ b/apps/mobile/lib/features/feed/data/firebase_post_repository.dart
@@ -22,9 +22,16 @@ class FirebasePostRepository implements PostRepository {
 
   @override
   Future<Post> createPost(Post post) async {
-    if (post.audienceType == AudienceType.select && post.audienceUids.isEmpty) {
+    final audienceUids = post.audienceType == AudienceType.all
+        ? const <String>[]
+        : _sanitizeAudienceUids(
+            post.audienceUids,
+            authorId: post.authorId,
+          );
+    if (post.audienceType == AudienceType.select && audienceUids.isEmpty) {
       throw ArgumentError('select audience requires at least one uid');
     }
+    final sanitizedPost = post.copyWith(audienceUids: audienceUids);
 
     final ref = _db.collection(_posts).doc(post.postId);
     // Strip null fields BEFORE writing: Firestore rule `/posts/{postId}` requires
@@ -32,12 +39,12 @@ class FirebasePostRepository implements PostRepository {
     // explicit `caption: null` (or other null fields) in the payload trips a
     // permission-denied. Removing the keys makes the rule's `!('caption' in data)`
     // branch satisfy instead.
-    final data = post.toJson()
+    final data = sanitizedPost.toJson()
       ..removeWhere((_, value) => value == null)
       ..['createdAt'] = FieldValue
           .serverTimestamp(); // spec: serverTimestamp, not device clock
     await ref.set(data);
-    return post;
+    return sanitizedPost;
   }
 
   @override
@@ -213,5 +220,19 @@ class FirebasePostRepository implements PostRepository {
     final doc = await _db.collection(_posts).doc(postId).get();
     if (!doc.exists) return null;
     return Post.fromJson({...doc.data()!, 'postId': doc.id});
+  }
+
+  List<String> _sanitizeAudienceUids(
+    List<String> uids, {
+    required String authorId,
+  }) {
+    final seen = <String>{};
+    final sanitized = <String>[];
+    for (final uid in uids) {
+      final trimmed = uid.trim();
+      if (trimmed.isEmpty || trimmed == authorId) continue;
+      if (seen.add(trimmed)) sanitized.add(trimmed);
+    }
+    return sanitized;
   }
 }

--- a/apps/mobile/lib/features/feed/presentation/camera_section.dart
+++ b/apps/mobile/lib/features/feed/presentation/camera_section.dart
@@ -134,10 +134,9 @@ class _CameraSectionState extends ConsumerState<CameraSection> {
 
     return Column(
       children: [
-        // Spacer above the photo, balanced by the spacer below the dots, so
-        // the (photo + dots) cluster sits vertically centered in the space
-        // between the top bar and the action bar.
-        const Spacer(),
+        // Topbar is overlaid on Home, so the viewfinder needs extra breathing
+        // room above while the lower controls stay clear of the taskbar.
+        const Spacer(flex: 2),
         _ViewfinderArea(
           camState: camState,
           borderColor: null,

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_screen.dart
@@ -9,7 +9,6 @@ import 'package:meep/core/theme/app_proportions.dart';
 import 'package:meep/core/theme/hex_color.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/auth/data/public_profile.dart';
-import 'package:meep/features/auth/data/user_profile.dart';
 import 'package:meep/features/feed/application/post_controller.dart';
 import 'package:meep/shared/models/post.dart';
 import 'package:meep/features/feed/presentation/capture_action_bar.dart';

--- a/apps/mobile/lib/features/feed/presentation/capture_preview_widgets.dart
+++ b/apps/mobile/lib/features/feed/presentation/capture_preview_widgets.dart
@@ -57,21 +57,13 @@ class _AudienceRow extends ConsumerWidget {
 
   static const double _tileGap = 12.0;
 
-  void _onAllTap(String currentUid) {
-    if (audienceType == AudienceType.all) {
-      // Đang "Tất cả" → bỏ, tự chọn "Bạn" (bản thân)
-      onAudienceChanged(AudienceType.select, [currentUid]);
-    } else {
-      // Chọn "Tất cả" → unselect hết friend đã pick lẻ
-      onAudienceChanged(AudienceType.all, const []);
-    }
+  void _onAllTap() {
+    if (audienceType == AudienceType.all) return;
+    // Chọn "Tất cả" → unselect hết friend đã pick lẻ
+    onAudienceChanged(AudienceType.all, const []);
   }
 
-  void _onSelfTap(String currentUid) {
-    onAudienceChanged(AudienceType.select, [currentUid]);
-  }
-
-  void _onFriendTap(String currentUid, String friendUid) {
+  void _onFriendTap(String friendUid) {
     if (audienceType == AudienceType.all) {
       // Từ "Tất cả" → chọn riêng friend này
       onAudienceChanged(AudienceType.select, [friendUid]);
@@ -104,9 +96,8 @@ class _AudienceRow extends ConsumerWidget {
         : ref.watch(
             spaceControllerProvider(currentUid).select((s) => s.spaces),
           );
-    final profile = ref.watch(currentUserProfileProvider).valueOrNull;
 
-    // Build ordered tile list: Spaces → Tất cả → Bạn → Friends
+    // Build ordered tile list: Spaces → Tất cả → Friends
     final tileWidgets = <Widget>[];
     for (final space in spaces) {
       tileWidgets.add(
@@ -126,25 +117,10 @@ class _AudienceRow extends ConsumerWidget {
         isSelected: isAll,
         avatarSize: avatarSize,
         labelSize: labelSize,
-        onTap: () => _onAllTap(currentUid),
+        onTap: _onAllTap,
       ),
     );
     tileWidgets.add(const SizedBox(width: _tileGap));
-    // Bạn tile (author/self)
-    if (profile != null) {
-      tileWidgets.add(
-        _SelfAudienceTile(
-          profile: profile,
-          isSelected: audienceType == AudienceType.select &&
-              selectedUids.length == 1 &&
-              selectedUids.first == currentUid,
-          avatarSize: avatarSize,
-          labelSize: labelSize,
-          onTap: () => _onSelfTap(currentUid),
-        ),
-      );
-      tileWidgets.add(const SizedBox(width: _tileGap));
-    }
     // Friends
     for (final friend in friends) {
       tileWidgets.add(
@@ -153,7 +129,7 @@ class _AudienceRow extends ConsumerWidget {
           isSelected: selectedUids.contains(friend.uid),
           avatarSize: avatarSize,
           labelSize: labelSize,
-          onTap: () => _onFriendTap(currentUid, friend.uid),
+          onTap: () => _onFriendTap(friend.uid),
         ),
       );
       tileWidgets.add(const SizedBox(width: _tileGap));
@@ -268,72 +244,6 @@ class _AllAudienceTile extends StatelessWidget {
               fontWeight: FontWeight.w800,
               fontFamily: 'Nunito',
               height: 1.1,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// "Bạn" tile — author/self. Selected khi audienceType=select và chỉ có
-/// mỗi currentUid trong selectedUids.
-class _SelfAudienceTile extends StatelessWidget {
-  const _SelfAudienceTile({
-    required this.profile,
-    required this.isSelected,
-    required this.avatarSize,
-    required this.labelSize,
-    required this.onTap,
-  });
-
-  final UserProfile profile;
-  final bool isSelected;
-  final double avatarSize;
-  final double labelSize;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final accent = isSelected ? AppColors.turquoise500 : AppColors.bw100;
-    return GestureDetector(
-      onTap: onTap,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: avatarSize,
-            height: avatarSize,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              border: Border.all(
-                color: isSelected ? AppColors.turquoise500 : AppColors.bw600,
-                width: 1.5,
-              ),
-            ),
-            child: AppAvatar(
-              imageUrl: profile.avatarUrl,
-              size: avatarSize,
-              fallbackText: profile.displayName.isNotEmpty
-                  ? profile.displayName[0].toUpperCase()
-                  : null,
-            ),
-          ),
-          const SizedBox(height: 4),
-          SizedBox(
-            width: avatarSize + 8,
-            child: Text(
-              'Bạn',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: accent,
-                fontSize: labelSize,
-                fontWeight: FontWeight.w900,
-                fontFamily: 'Nunito',
-                height: 1.1,
-              ),
             ),
           ),
         ],

--- a/apps/mobile/lib/features/feed/presentation/feed_section_header_widgets.dart
+++ b/apps/mobile/lib/features/feed/presentation/feed_section_header_widgets.dart
@@ -4,7 +4,7 @@ part of 'feed_section.dart';
 /// the avatar + `<name> d thg M`; own variant shows just `Bạn d thg M` (no
 /// avatar — the user already sees themselves on every screen, so it would
 /// just be visual noise).
-class PostHeaderRow extends StatelessWidget {
+class PostHeaderRow extends ConsumerWidget {
   const PostHeaderRow({
     super.key,
     required this.post,
@@ -19,8 +19,22 @@ class PostHeaderRow extends StatelessWidget {
   static String _formatDate(DateTime dt) => '${dt.day} thg ${dt.month}';
 
   @override
-  Widget build(BuildContext context) {
-    final nameText = isOwn ? 'Bạn' : post.authorName;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final postAvatarUrl = post.authorAvatarUrl;
+    final needsAuthorLookup = !isOwn &&
+        ((postAvatarUrl == null || postAvatarUrl.isEmpty) ||
+            post.authorName.trim().isEmpty);
+    final authorProfile = needsAuthorLookup
+        ? ref.watch(_authorProfileProvider(post.authorId)).valueOrNull
+        : null;
+    final authorName = post.authorName.trim().isNotEmpty
+        ? post.authorName.trim()
+        : authorProfile?.displayName.trim() ?? '';
+    final nameText = isOwn
+        ? 'Bạn'
+        : authorName.isNotEmpty
+            ? authorName
+            : 'Người dùng';
     final dateText = ' ${_formatDate(post.createdAt)}';
     final label = Text.rich(
       TextSpan(
@@ -48,7 +62,10 @@ class PostHeaderRow extends StatelessWidget {
       return Center(child: label);
     }
     final avatar = _AuthorAvatar(
-      post: post,
+      avatarUrl: postAvatarUrl != null && postAvatarUrl.isNotEmpty
+          ? postAvatarUrl
+          : authorProfile?.avatarUrl,
+      fallbackText: avatarFallbackFromName(authorName) ?? '?',
       onTap: onAvatarTap,
     );
     return Row(
@@ -63,29 +80,25 @@ class PostHeaderRow extends StatelessWidget {
   }
 }
 
-/// Resolves the author's avatar: uses [Post.authorAvatarUrl] when available,
-/// otherwise falls back to the author's current Firestore profile avatar.
-class _AuthorAvatar extends ConsumerWidget {
-  const _AuthorAvatar({required this.post, this.onTap});
+/// Author avatar for friend posts. Caller resolves denormalized post data plus
+/// public-profile fallback before passing values here.
+class _AuthorAvatar extends StatelessWidget {
+  const _AuthorAvatar({
+    required this.avatarUrl,
+    required this.fallbackText,
+    this.onTap,
+  });
 
-  final Post post;
+  final String? avatarUrl;
+  final String fallbackText;
   final VoidCallback? onTap;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // Ưu tiên authorAvatarUrl từ post (đã có sẵn từ lúc tạo post).
-    // Nếu null (post cũ, email signup), lookup từ profile author hiện tại.
-    String? avatarUrl = post.authorAvatarUrl;
-    if (avatarUrl == null || avatarUrl.isEmpty) {
-      avatarUrl =
-          ref.watch(_authorAvatarUrlProvider(post.authorId)).valueOrNull;
-    }
-
+  Widget build(BuildContext context) {
     final child = AppAvatar(
       imageUrl: avatarUrl,
       size: 28,
-      fallbackText:
-          post.authorName.isNotEmpty ? post.authorName[0].toUpperCase() : null,
+      fallbackText: fallbackText,
     );
 
     if (onTap != null) {
@@ -95,11 +108,10 @@ class _AuthorAvatar extends ConsumerWidget {
   }
 }
 
-/// Fetches a user's current avatar URL from their public Firestore profile.
-final _authorAvatarUrlProvider =
-    FutureProvider.family<String?, String>((ref, uid) async {
-  final profile = await ref.read(userRepositoryProvider).getPublicProfile(uid);
-  return profile?.avatarUrl;
+/// Fetches a user's current public profile for old posts missing denormalized
+/// author fields.
+final _authorProfileProvider = FutureProvider.family((ref, String uid) async {
+  return ref.read(userRepositoryProvider).getPublicProfile(uid);
 });
 
 /// Activity pill — own posts only. Two states:

--- a/apps/mobile/lib/features/feed/presentation/grid_photo_tile.dart
+++ b/apps/mobile/lib/features/feed/presentation/grid_photo_tile.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_proportions.dart';
 import 'package:meep/shared/models/post.dart';
+import 'package:meep/shared/widgets/dual_post_image.dart';
 
 /// Single tile in feed grid view (`580:2883`). 1:1 aspect, light corner radius.
 /// Tap → caller opens detail sheet.
@@ -32,15 +33,24 @@ class GridPhotoTile extends StatelessWidget {
         aspectRatio: 1,
         child: ClipRRect(
           borderRadius: BorderRadius.circular(cornerRadius),
-          child: CachedNetworkImage(
-            imageUrl: post.coverImageUrl,
-            fit: BoxFit.cover,
-            memCacheWidth: cacheW,
-            memCacheHeight: cacheW,
-            placeholder: (_, __) => const ColoredBox(color: AppColors.bw800),
-            errorWidget: (_, __, ___) =>
-                const ColoredBox(color: AppColors.bw800),
-          ),
+          child: post.isDualCamera
+              ? DualPostImage(
+                  backImageUrl: post.backImageUrl ?? '',
+                  frontImageUrl: post.frontImageUrl ?? '',
+                  enableSwapOnTap: false,
+                  memCacheWidth: cacheW,
+                  memCacheHeight: cacheW,
+                )
+              : CachedNetworkImage(
+                  imageUrl: post.coverImageUrl,
+                  fit: BoxFit.cover,
+                  memCacheWidth: cacheW,
+                  memCacheHeight: cacheW,
+                  placeholder: (_, __) =>
+                      const ColoredBox(color: AppColors.bw800),
+                  errorWidget: (_, __, ___) =>
+                      const ColoredBox(color: AppColors.bw800),
+                ),
         ),
       ),
     );

--- a/apps/mobile/lib/features/feed/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen.dart
@@ -269,29 +269,43 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       // TextField. Sheet đã tự lift bằng MediaQuery.viewInsets — Scaffold
       // không cần can thiệp.
       resizeToAvoidBottomInset: false,
-      body: SafeArea(
-        child: Column(
-          children: [
-            _HomeTopBar(
-              isFeedMode: _currentPage >= 1,
-              selectedLabel: filterSelection.label,
-              onFilterSelected: _onFilterSelected,
-              onSpaceFilterSelected: _onSpaceFilterSelected,
-              spaceId: widget.spaceId,
+      body: Stack(
+        children: [
+          Positioned.fill(
+            child: feedAsync.when(
+              loading: () => _buildPageView(null, isLoading: true),
+              error: (e, st) => _buildPageView(null, isError: true),
+              data: (state) {
+                _posts = state.posts;
+                return _buildPageView(state.posts);
+              },
             ),
-            Expanded(
-              child: feedAsync.when(
-                loading: () => _buildPageView(null, isLoading: true),
-                error: (e, st) => _buildPageView(null, isError: true),
-                data: (state) {
-                  _posts = state.posts;
-                  return _buildPageView(state.posts);
-                },
+          ),
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: SafeArea(
+              bottom: false,
+              child: _HomeTopBar(
+                isFeedMode: _currentPage >= 1,
+                selectedLabel: filterSelection.label,
+                onFilterSelected: _onFilterSelected,
+                onSpaceFilterSelected: _onSpaceFilterSelected,
+                spaceId: widget.spaceId,
               ),
             ),
-            _buildTaskbar(totalUnread, _ringColor),
-          ],
-        ),
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: SafeArea(
+              top: false,
+              child: _buildTaskbar(totalUnread, _ringColor),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/features/feed/presentation/home_screen_widgets.dart
+++ b/apps/mobile/lib/features/feed/presentation/home_screen_widgets.dart
@@ -1,5 +1,11 @@
 part of 'home_screen.dart';
 
+const Key _homePageViewKey = ValueKey('homePageView');
+const Key _homeTopBarKey = ValueKey('homeTopBar');
+const Key _homeTaskbarKey = ValueKey('homeTaskbar');
+
+const double _topbarPillAlpha = 0.4;
+
 extension _HomeScreenStateWidgets on _HomeScreenState {
   /// Derive màu ring cho AppTaskbar từ Space đầu tiên trong post hiện tại.
   /// Multi-Space post pick first (visual hint dùng 1 màu).
@@ -17,6 +23,7 @@ extension _HomeScreenStateWidgets on _HomeScreenState {
   Widget _buildTaskbar(int chatBadgeCount, Color? ringColor) {
     if (_currentPage >= 1) {
       return Padding(
+        key: _homeTaskbarKey,
         padding: EdgeInsets.fromLTRB(
           16,
           12,
@@ -35,6 +42,7 @@ extension _HomeScreenStateWidgets on _HomeScreenState {
       );
     }
     return Padding(
+      key: _homeTaskbarKey,
       padding: EdgeInsets.only(
         bottom: MediaQuery.of(context).size.height * 0.045,
       ),
@@ -56,21 +64,25 @@ extension _HomeScreenStateWidgets on _HomeScreenState {
     final postCount = (isLoading || isError || posts == null || posts.isEmpty)
         ? 1
         : posts.length;
+    final bottomChromePadding =
+        AppTaskbar.height + MediaQuery.of(context).size.height * 0.045 + 8;
 
     return PageView.builder(
+      key: _homePageViewKey,
       controller: _pageController,
       scrollDirection: Axis.vertical,
       onPageChanged: _onPageChanged,
       itemCount: 1 + postCount,
       itemBuilder: (context, index) {
-        if (index == 0) return CameraSection(onGoToFeed: _goToFeed);
-        if (isLoading) {
-          return const Center(
+        Widget page;
+        if (index == 0) {
+          page = CameraSection(onGoToFeed: _goToFeed);
+        } else if (isLoading) {
+          page = const Center(
             child: CircularProgressIndicator(color: AppColors.turquoise500),
           );
-        }
-        if (isError) {
-          return FeedErrorView(
+        } else if (isError) {
+          page = FeedErrorView(
             onRetry: () {
               final sel = ref.read(feedFilterControllerProvider);
               ref.invalidate(
@@ -82,13 +94,18 @@ extension _HomeScreenStateWidgets on _HomeScreenState {
               );
             },
           );
-        }
-        if (posts == null || posts.isEmpty) {
-          return _EmptyFeedPage(
+        } else if (posts == null || posts.isEmpty) {
+          page = _EmptyFeedPage(
             onCapture: () => _pageController.jumpToPage(0),
           );
+        } else {
+          page = _PostPage(post: posts[index - 1]);
         }
-        return _PostPage(post: posts[index - 1]);
+
+        return Padding(
+          padding: EdgeInsets.only(bottom: bottomChromePadding),
+          child: page,
+        );
       },
     );
   }
@@ -165,6 +182,7 @@ class _HomeTopBar extends ConsumerWidget {
           );
 
     return Padding(
+      key: _homeTopBarKey,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
         children: [
@@ -214,7 +232,7 @@ class _HomeTopBar extends ConsumerWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
         decoration: BoxDecoration(
-          color: AppColors.bw700.withValues(alpha: 0.08),
+          color: AppColors.bw700.withValues(alpha: _topbarPillAlpha),
           borderRadius: BorderRadius.circular(40),
         ),
         child: Row(
@@ -249,7 +267,7 @@ class _HomeTopBar extends ConsumerWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
         decoration: BoxDecoration(
-          color: AppColors.bw700.withValues(alpha: 0.08),
+          color: AppColors.bw700.withValues(alpha: _topbarPillAlpha),
           borderRadius: BorderRadius.circular(40),
         ),
         child: Row(

--- a/apps/mobile/lib/features/friend/data/firebase_friend_repository.dart
+++ b/apps/mobile/lib/features/friend/data/firebase_friend_repository.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 
 import 'package:meep/core/error/app_error.dart';
 import 'package:meep/features/auth/data/public_profile.dart';
@@ -6,9 +7,13 @@ import 'package:meep/features/friend/data/friend_repository.dart';
 import 'package:meep/features/friend/data/friendship.dart';
 
 class FirebaseFriendRepository implements FriendRepository {
-  FirebaseFriendRepository(this._firestore);
+  FirebaseFriendRepository(
+    this._firestore, {
+    FirebaseFunctions? functions,
+  }) : _functions = functions;
 
   final FirebaseFirestore _firestore;
+  final FirebaseFunctions? _functions;
   static const int _whereInLimit = 10;
 
   @override
@@ -16,6 +21,49 @@ class FirebaseFriendRepository implements FriendRepository {
     final query = username.toLowerCase().trim();
     if (query.isEmpty) return null;
 
+    final functions = _functions;
+    if (functions != null) {
+      try {
+        final result = await _searchUserByCallable(functions, query);
+        if (result != null) return result;
+      } on FirebaseFunctionsException catch (e) {
+        if (e.code != 'not-found' && e.code != 'unimplemented') {
+          throw _mapFunctionsError(e, 'tìm bạn bè');
+        }
+      }
+    }
+
+    final publicResult = await _searchUserByPublicProfile(query);
+    if (publicResult != null) return publicResult;
+
+    return _searchUserByUserDoc(query);
+  }
+
+  Future<PublicProfile?> _searchUserByCallable(
+    FirebaseFunctions functions,
+    String query,
+  ) async {
+    final callable = functions.httpsCallable('searchUserByUsername');
+    final result = await callable.call<Map<String, dynamic>>({
+      'username': query,
+    });
+    final profileData = result.data['profile'];
+    if (profileData == null) return null;
+
+    final profile = Map<String, dynamic>.from(profileData as Map);
+    final updatedAtMillis = (profile['updatedAtMillis'] as num).toInt();
+    return PublicProfile(
+      uid: profile['uid'] as String,
+      displayName: profile['displayName'] as String,
+      username: profile['username'] as String,
+      avatarUrl: profile['avatarUrl'] as String?,
+      bio: profile['bio'] as String?,
+      isSearchable: profile['isSearchable'] as bool? ?? true,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(updatedAtMillis),
+    );
+  }
+
+  Future<PublicProfile?> _searchUserByPublicProfile(String query) async {
     final QuerySnapshot<Map<String, dynamic>> snapshot;
     try {
       snapshot = await _firestore
@@ -31,6 +79,28 @@ class FirebaseFriendRepository implements FriendRepository {
     if (snapshot.docs.isEmpty) return null;
 
     return PublicProfile.fromFirestore(snapshot.docs.first);
+  }
+
+  Future<PublicProfile?> _searchUserByUserDoc(String query) async {
+    final QuerySnapshot<Map<String, dynamic>> snapshot;
+    try {
+      snapshot = await _firestore
+          .collection('users')
+          .where('username', isEqualTo: query)
+          .limit(1)
+          .get();
+    } on FirebaseException catch (e) {
+      throw _mapFirestoreError(e, 'tìm bạn bè');
+    }
+
+    if (snapshot.docs.isEmpty) return null;
+
+    final profile = _publicProfileFromUserData(
+      snapshot.docs.first.id,
+      snapshot.docs.first.data(),
+    );
+    if (profile?.isSearchable == false) return null;
+    return profile;
   }
 
   @override
@@ -84,12 +154,56 @@ class FirebaseFriendRepository implements FriendRepository {
         final profile = PublicProfile.fromFirestore(doc);
         profilesByUid[profile.uid] = profile;
       }
+
+      final missingUids = chunk
+          .where((friendUid) => !profilesByUid.containsKey(friendUid))
+          .toList();
+      if (missingUids.isEmpty) continue;
+
+      final userDocs = await Future.wait(
+        missingUids.map(_getUserDocForPublicFallback),
+      );
+
+      for (final doc in userDocs) {
+        if (doc == null) continue;
+        final data = doc.data();
+        if (!doc.exists || data == null) continue;
+        final profile = _publicProfileFromUserData(doc.id, data);
+        if (profile != null) {
+          profilesByUid[profile.uid] = profile;
+        }
+      }
     }
 
     return friendUids
         .map((friendUid) => profilesByUid[friendUid])
         .whereType<PublicProfile>()
         .toList();
+  }
+
+  Future<DocumentSnapshot<Map<String, dynamic>>?> _getUserDocForPublicFallback(
+    String uid,
+  ) async {
+    try {
+      return _firestore.collection('users').doc(uid).get();
+    } on FirebaseException catch (e) {
+      if (e.code == 'permission-denied') return null;
+      rethrow;
+    }
+  }
+
+  PublicProfile? _publicProfileFromUserData(
+    String uid,
+    Map<String, dynamic> data,
+  ) {
+    final updatedAt = data['updatedAt'] ?? data['createdAt'];
+    if (updatedAt == null) return null;
+
+    return PublicProfile.fromJson({
+      ...data,
+      'uid': data['uid'] ?? uid,
+      'updatedAt': updatedAt,
+    });
   }
 
   @override
@@ -140,6 +254,42 @@ class FirebaseFriendRepository implements FriendRepository {
           cause: e,
         ),
       'failed-precondition' => ValidationError(
+          message: serverMessage ?? 'Không thể $action: dữ liệu không hợp lệ',
+          code: e.code,
+          cause: e,
+        ),
+      _ => UnexpectedError(
+          message: serverMessage ?? 'Không thể $action. Thử lại sau.',
+          code: e.code,
+          cause: e,
+        ),
+    };
+  }
+
+  AppError _mapFunctionsError(FirebaseFunctionsException e, String action) {
+    final serverMessage = e.message;
+    return switch (e.code) {
+      'permission-denied' => ForbiddenError.message(
+          message: serverMessage ?? 'Bạn không có quyền $action',
+          code: e.code,
+          cause: e,
+        ),
+      'unauthenticated' => UnauthenticatedError(
+          message: serverMessage ?? 'Bạn cần đăng nhập để $action',
+          code: e.code,
+          cause: e,
+        ),
+      'not-found' => NotFoundError.message(
+          message: serverMessage ?? 'Không tìm thấy dữ liệu bạn bè',
+          code: e.code,
+          cause: e,
+        ),
+      'unavailable' || 'deadline-exceeded' || 'cancelled' => NetworkError(
+          message: serverMessage ?? 'Mất kết nối khi $action. Thử lại sau.',
+          code: e.code,
+          cause: e,
+        ),
+      'invalid-argument' || 'failed-precondition' => ValidationError(
           message: serverMessage ?? 'Không thể $action: dữ liệu không hợp lệ',
           code: e.code,
           cause: e,

--- a/apps/mobile/lib/features/profile/application/profile_diary_entries_provider.dart
+++ b/apps/mobile/lib/features/profile/application/profile_diary_entries_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/diary_entry.dart';
+
+part 'profile_diary_entries_provider.g.dart';
+
+/// Public diary entries shown on Profile Diary tab, newest first.
+@riverpod
+Future<List<DiaryEntry>> profileDiaryEntries(Ref ref, String uid) async {
+  if (uid.isEmpty) return const [];
+
+  final entries = await ref.read(diaryRepositoryProvider).getPublicEntries(uid);
+  final sorted = [...entries]
+    ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+  return sorted;
+}

--- a/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/friend_profile_screen.dart
@@ -239,7 +239,10 @@ class _FriendProfileBody extends ConsumerWidget {
             Expanded(
               child: activeTab == 0
                   ? _FriendPhotosTab(friendUid: friendUid)
-                  : const DiaryTabContent(),
+                  : DiaryTabContent(
+                      uid: friendUid,
+                      ownerActionsEnabled: false,
+                    ),
             ),
           ],
         ),
@@ -306,6 +309,7 @@ class _FriendPhotosTab extends ConsumerWidget {
             final urls = posts.map((p) => p.coverImageUrl).toList();
             return PhotoGrid(
               photos: urls,
+              posts: posts,
               onTap: (index) {
                 final post = posts[index];
                 context.push(

--- a/apps/mobile/lib/features/profile/presentation/profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/profile_screen.dart
@@ -6,6 +6,8 @@ import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/chat/application/chat_providers.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/friend/presentation/friend_sheet.dart';
 import 'package:meep/features/profile/application/profile_controller.dart';
 import 'package:meep/features/profile/application/profile_posts_provider.dart';
 import 'package:meep/features/profile/presentation/widgets/diary_tab_content.dart';
@@ -36,11 +38,20 @@ class ProfileScreen extends ConsumerStatefulWidget {
 class _ProfileScreenState extends ConsumerState<ProfileScreen> {
   int _activeTab = 0;
 
+  void _openFriendSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      barrierColor: const Color(0x73000000),
+      builder: (_) => const FriendSheet(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final effectiveUid = widget.uid.isEmpty
-        ? ref.watch(currentUidProvider).valueOrNull ?? ''
-        : widget.uid;
+    final currentUid = ref.watch(currentUidProvider).valueOrNull;
+    final effectiveUid = widget.uid.isEmpty ? currentUid ?? '' : widget.uid;
     final state = ref.watch(profileControllerProvider(effectiveUid));
     final unreadCounts = ref.watch(unreadCountsProvider);
     final totalUnread =
@@ -74,6 +85,14 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
       );
     }
 
+    final friendCount = currentUid != null && effectiveUid == currentUid
+        ? ref.watch(
+            friendControllerProvider(currentUid).select(
+              (s) => s.friends.length,
+            ),
+          )
+        : profile.friendCount;
+
     return Scaffold(
       backgroundColor: _cBg,
       body: SafeArea(
@@ -98,10 +117,14 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                           Expanded(
                             child: _StatsRow(
                               postCount: profile.postCount,
-                              friendCount: profile.friendCount,
+                              friendCount: friendCount,
                               spaceCount: profile.spaceCount,
                               onFriendTap: () {
-                                // TODO(P/T3/HanDHG): open FriendSheet
+                                if (currentUid == null ||
+                                    effectiveUid != currentUid) {
+                                  return;
+                                }
+                                _openFriendSheet(context);
                               },
                             ),
                           ),
@@ -138,7 +161,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                               label: 'Chia sẻ trang cá nhân',
                               onTap: () => ShareProfileSheet.show(
                                 context,
-                                uid: widget.uid,
+                                uid: effectiveUid,
                                 username: profile.username,
                               ),
                             ),
@@ -156,8 +179,8 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                 const SizedBox(height: 10),
                 Expanded(
                   child: _activeTab == 0
-                      ? _PhotosTab(uid: widget.uid)
-                      : const DiaryTabContent(),
+                      ? _PhotosTab(uid: effectiveUid)
+                      : DiaryTabContent(uid: effectiveUid),
                 ),
               ],
             ),
@@ -234,6 +257,7 @@ class _PhotosTab extends ConsumerWidget {
                 posts.map((p) => p.coverImageUrl).toList(growable: false);
             return PhotoGrid(
               photos: photos,
+              posts: posts,
               onTap: (index) {
                 final post = posts[index];
                 context.push(

--- a/apps/mobile/lib/features/profile/presentation/profile_screen.dart
+++ b/apps/mobile/lib/features/profile/presentation/profile_screen.dart
@@ -93,6 +93,14 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
           )
         : profile.friendCount;
 
+    // "Khoảnh khắc" lấy từ số post thật (grid bên dưới), không phải counter
+    // `profile.postCount` vốn drift được (CF miss/race — xem _StatItem note).
+    // Chỉ áp cho profile của chính mình; fallback counter khi posts đang load.
+    final momentCount = currentUid != null && effectiveUid == currentUid
+        ? ref.watch(profilePostsProvider(effectiveUid)).valueOrNull?.length ??
+            profile.postCount
+        : profile.postCount;
+
     return Scaffold(
       backgroundColor: _cBg,
       body: SafeArea(
@@ -116,7 +124,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                           const SizedBox(width: 25),
                           Expanded(
                             child: _StatsRow(
-                              postCount: profile.postCount,
+                              postCount: momentCount,
                               friendCount: friendCount,
                               spaceCount: profile.spaceCount,
                               onFriendTap: () {

--- a/apps/mobile/lib/features/profile/presentation/widgets/diary_tab_content.dart
+++ b/apps/mobile/lib/features/profile/presentation/widgets/diary_tab_content.dart
@@ -1,21 +1,101 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
+import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/presentation/widgets/diary_mood_card.dart';
+import 'package:meep/features/profile/application/profile_diary_entries_provider.dart';
 
 /// Diary tab trong ProfileScreen.
 ///
-/// M2 (issue #114): empty state — chưa wire `DiaryRepository.getPublicEntries`
-/// vì Diary module T1 (`FirebaseDiaryRepository`) chưa done. Tab vẫn tappable
-/// (không grayed out) theo spec.
-///
-/// M3: TODO khi Diary T1 merged — wire `DiaryRepository.getPublicEntries(uid)`
-/// → `DiaryMoodCard` grid, tap card → `DiaryCanvasScreen(mode: read)`.
-class DiaryTabContent extends StatelessWidget {
-  const DiaryTabContent({super.key, this.itemCount});
+/// Hiển thị các public diary entries của profile owner. Own profile vẫn chỉ
+/// hiện public entries ở tab này; danh sách đầy đủ nằm ở Diary module.
+class DiaryTabContent extends ConsumerWidget {
+  const DiaryTabContent({
+    super.key,
+    required this.uid,
+    this.ownerActionsEnabled = true,
+    this.itemCount,
+  });
 
-  /// Reserved cho M3 wire — giới hạn số entry hiển thị. Hiện không dùng (M2
-  /// empty state).
+  final String uid;
+  final bool ownerActionsEnabled;
   final int? itemCount;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ref.watch(profileDiaryEntriesProvider(uid)).when(
+          loading: () => const Center(
+            child: CircularProgressIndicator(color: AppColors.bw100),
+          ),
+          error: (e, _) => Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                'Không tải được nhật ký. Thử lại sau.',
+                style: AppTextStyles.smRegular.copyWith(color: AppColors.bw500),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+          data: (entries) {
+            final visibleEntries = itemCount == null
+                ? entries
+                : entries.take(itemCount!).toList(growable: false);
+            if (visibleEntries.isEmpty) return const _EmptyDiaryState();
+            return _DiaryGrid(
+              entries: visibleEntries,
+              ownerActionsEnabled: ownerActionsEnabled,
+            );
+          },
+        );
+  }
+}
+
+class _DiaryGrid extends StatelessWidget {
+  const _DiaryGrid({
+    required this.entries,
+    required this.ownerActionsEnabled,
+  });
+
+  final List<DiaryEntry> entries;
+  final bool ownerActionsEnabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      padding: const EdgeInsets.fromLTRB(39, 0, 39, 120),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        mainAxisSpacing: 32,
+        crossAxisSpacing: 32,
+        childAspectRatio: 150.5 / 186,
+      ),
+      itemCount: entries.length,
+      itemBuilder: (context, index) {
+        final entry = entries[index];
+        return DiaryMoodCard(
+          title: entry.moodCaption,
+          date: _formatShortDate(entry.createdAt),
+          mood: entry.moodTemplate,
+          onTap: () => context.push(
+            '/diary/${entry.entryId}',
+            extra: <String, Object>{
+              'ownerActionsEnabled': ownerActionsEnabled,
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  static String _formatShortDate(DateTime date) =>
+      '${date.day} tháng ${date.month}';
+}
+
+class _EmptyDiaryState extends StatelessWidget {
+  const _EmptyDiaryState();
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/features/profile/presentation/widgets/photo_grid.dart
+++ b/apps/mobile/lib/features/profile/presentation/widgets/photo_grid.dart
@@ -1,14 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
+import 'package:meep/shared/models/post.dart';
+import 'package:meep/shared/widgets/dual_post_image.dart';
 
 class PhotoGrid extends StatelessWidget {
   const PhotoGrid({
     super.key,
     required this.photos,
+    this.posts,
     required this.onTap,
-  });
+  }) : assert(posts == null || posts.length == photos.length);
 
   final List<String> photos;
+  final List<Post>? posts;
   final ValueChanged<int> onTap;
 
   @override
@@ -31,6 +36,7 @@ class PhotoGrid extends StatelessWidget {
       itemCount: photos.length,
       itemBuilder: (context, index) => _PhotoItem(
         url: photos[index],
+        post: posts?[index],
         onTap: () => onTap(index),
       ),
     );
@@ -38,13 +44,22 @@ class PhotoGrid extends StatelessWidget {
 }
 
 class _PhotoItem extends StatelessWidget {
-  const _PhotoItem({required this.url, required this.onTap});
+  const _PhotoItem({
+    required this.url,
+    required this.onTap,
+    this.post,
+  });
 
   final String url;
   final VoidCallback onTap;
+  final Post? post;
 
   @override
   Widget build(BuildContext context) {
+    final cacheW = (MediaQuery.sizeOf(context).width /
+            AppProportions.gridColumns *
+            MediaQuery.devicePixelRatioOf(context))
+        .round();
     return Semantics(
       button: true,
       label: 'Xem ảnh',
@@ -52,13 +67,23 @@ class _PhotoItem extends StatelessWidget {
         onTap: onTap,
         child: ClipRRect(
           borderRadius: BorderRadius.circular(20),
-          child: Image.network(
-            url,
-            fit: BoxFit.cover,
-            errorBuilder: (_, __, ___) => Container(color: AppColors.bw700),
-            loadingBuilder: (_, child, progress) =>
-                progress == null ? child : Container(color: AppColors.bw800),
-          ),
+          child: post?.isDualCamera == true
+              ? DualPostImage(
+                  backImageUrl: post?.backImageUrl ?? '',
+                  frontImageUrl: post?.frontImageUrl ?? '',
+                  enableSwapOnTap: false,
+                  memCacheWidth: cacheW,
+                  memCacheHeight: cacheW,
+                )
+              : Image.network(
+                  url,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, __, ___) =>
+                      Container(color: AppColors.bw700),
+                  loadingBuilder: (_, child, progress) => progress == null
+                      ? child
+                      : Container(color: AppColors.bw800),
+                ),
         ),
       ),
     );

--- a/apps/mobile/lib/features/settings/presentation/widget_confirm_sheet.dart
+++ b/apps/mobile/lib/features/settings/presentation/widget_confirm_sheet.dart
@@ -7,6 +7,7 @@ import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_spacing.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/widget/application/widget_data_service.dart';
 import 'package:meep/shared/widgets/app_bottom_sheet.dart';
 
@@ -15,8 +16,14 @@ class WidgetConfirmSheet extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final friendCount =
-        ref.watch(currentUserProfileProvider).valueOrNull?.friendCount ?? 0;
+    final currentUid = ref.watch(currentUidProvider).valueOrNull;
+    final friendCount = currentUid == null
+        ? 0
+        : ref.watch(
+            friendControllerProvider(currentUid).select(
+              (s) => s.friends.length,
+            ),
+          );
     return AppBottomSheet(
       child: SingleChildScrollView(
         child: Padding(

--- a/apps/mobile/lib/features/settings/presentation/widgets/settings_quick_actions.dart
+++ b/apps/mobile/lib/features/settings/presentation/widgets/settings_quick_actions.dart
@@ -5,19 +5,28 @@ import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_spacing.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
 import 'package:meep/features/friend/presentation/friend_sheet.dart';
 import 'package:meep/features/settings/presentation/share_profile_sheet.dart';
 
 /// Hàng 2 nút nhanh trong SettingsSheet: [Bạn bè] mở FriendSheet,
 /// [Chia sẻ] mở ShareProfileSheet. Đọc [currentUserProfileProvider] cho
-/// friendCount + username real-time.
+/// username real-time; friend count lấy từ friend graph để tránh profile
+/// counter drift.
 class SettingsQuickActions extends ConsumerWidget {
   const SettingsQuickActions({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final currentUid = ref.watch(currentUidProvider).valueOrNull;
     final profile = ref.watch(currentUserProfileProvider).valueOrNull;
-    final friendCount = profile?.friendCount ?? 0;
+    final friendCount = currentUid == null
+        ? 0
+        : ref.watch(
+            friendControllerProvider(currentUid).select(
+              (s) => s.friends.length,
+            ),
+          );
     final username = profile?.username ?? '';
 
     return Row(

--- a/apps/mobile/lib/features/streak/presentation/streak_screen.dart
+++ b/apps/mobile/lib/features/streak/presentation/streak_screen.dart
@@ -48,18 +48,21 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
     final totalUnread =
         unreadCounts.values.fold<int>(0, (sum, val) => sum + val);
 
-    final hasNoPosts = state.allPostDates.isEmpty;
     final nowLocal = ref.watch(nowProvider)();
     final viewingMonth =
         state.viewingMonth ?? DateTime(nowLocal.year, nowLocal.month);
+    final isCalendarLoading = state.isLoading || state.viewingMonth == null;
+    final showEmpty = !isCalendarLoading &&
+        state.allPostDates.isEmpty &&
+        state.monthPosts.isEmpty;
 
     return Scaffold(
-      backgroundColor: const Color(0xFF0D0804),
+      backgroundColor: AppColors.bw900,
       body: SafeArea(
         child: Stack(
           children: [
             SingleChildScrollView(
-              physics: const NeverScrollableScrollPhysics(),
+              physics: const ClampingScrollPhysics(),
               child: ConstrainedBox(
                 constraints: BoxConstraints(
                   minHeight: MediaQuery.of(context).size.height -
@@ -69,18 +72,23 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
                   children: [
                     const _Topbar(),
                     if (state.errorMessage != null)
-                      _ErrorBanner(message: state.errorMessage!),
-                    if (hasNoPosts) ...[
-                      const SizedBox(height: 36),
+                      _ErrorBanner(
+                        message: state.errorMessage!,
+                        onRetry: () =>
+                            ref.read(streakControllerProvider.notifier).init(),
+                      ),
+                    if (showEmpty) ...[
+                      const SizedBox(height: 24),
                       const EmptyStateOverlay(),
                     ] else
-                      const SizedBox(height: 90),
+                      const SizedBox(height: 72),
                     Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 41),
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
                       child: StreakCalendar(
                         viewingMonth: viewingMonth,
                         monthPosts: state.monthPosts,
                         today: nowLocal,
+                        isLoading: isCalendarLoading,
                         onTapDay: (index) => _openPhotoDetail(context, index),
                         onTapToday: () => context.go('/home'),
                         onSwipePrev: () => ref
@@ -91,18 +99,17 @@ class _StreakScreenState extends ConsumerState<StreakScreen> {
                             .swipeNext(),
                       ),
                     ),
-                    if (hasNoPosts) ...[
-                      const SizedBox(height: 16),
+                    if (showEmpty) ...[
+                      const SizedBox(height: 12),
                       const StreakArrowDown(),
-                      const SizedBox(height: 16),
+                      const SizedBox(height: 12),
                     ] else
-                      const SizedBox(height: 28),
+                      const SizedBox(height: 24),
                     StreakStatsPill(
                       totalMoments: totalMoments,
                       currentStreak: state.currentStreak,
                     ),
-                    // Spacer cuối để Taskbar floating không đè lên pill
-                    const SizedBox(height: 100),
+                    const SizedBox(height: 132),
                   ],
                 ),
               ),
@@ -189,8 +196,7 @@ class _Topbar extends StatelessWidget {
               child: Text(
                 'Kỷ niệm',
                 textAlign: TextAlign.center,
-                style: AppTextStyles.baseBold
-                    .copyWith(color: const Color(0xFFFFFFFF)),
+                style: AppTextStyles.baseBold.copyWith(color: AppColors.bw100),
               ),
             ),
             const AppTopAvatar(),
@@ -204,20 +210,38 @@ class _Topbar extends StatelessWidget {
 // ─── Error banner ─────────────────────────────────────────────────────────────
 
 class _ErrorBanner extends StatelessWidget {
-  const _ErrorBanner({required this.message});
+  const _ErrorBanner({
+    required this.message,
+    required this.onRetry,
+  });
 
   final String message;
+  final VoidCallback onRetry;
 
   @override
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
-      color: AppColors.error700.withValues(alpha: 0.9),
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      child: Text(
-        message,
-        textAlign: TextAlign.center,
-        style: AppTextStyles.smSemiBold.copyWith(color: AppColors.bw100),
+      color: AppColors.error800.withValues(alpha: 0.92),
+      padding: const EdgeInsets.fromLTRB(16, 10, 12, 10),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              message,
+              style: AppTextStyles.smSemiBold.copyWith(color: AppColors.bw100),
+            ),
+          ),
+          TextButton(
+            onPressed: onRetry,
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.bw100,
+              minimumSize: const Size(64, 40),
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+            ),
+            child: const Text('Thử lại'),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/features/streak/presentation/widgets/calendar_day_cell.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/calendar_day_cell.dart
@@ -21,6 +21,9 @@ class CalendarDayCell extends StatelessWidget {
     required this.isToday,
     this.imageUrl,
     this.onTap,
+    this.isLoading = false,
+    this.width = 37,
+    this.height = 35,
   });
 
   /// Day thuộc tháng đang xem (false = padding day từ tháng khác).
@@ -32,26 +35,36 @@ class CalendarDayCell extends StatelessWidget {
   /// URL ảnh thumbnail nếu day có post; null = no post.
   final String? imageUrl;
 
+  /// Render placeholder thay vì trạng thái thật trong lúc tải tháng.
+  final bool isLoading;
+
+  final double width;
+  final double height;
+
   /// Tap handler:
   /// - Day có post → mở PhotoDetailScreen.
   /// - Today no-post → điều hướng về `/home` (camera).
   /// - Day khác no-post → null (cell không tappable).
   final VoidCallback? onTap;
 
-  static const _dotColor = Color(0x6E585754);
-  static const _todayStroke = Color(0xFF656565);
-
   @override
   Widget build(BuildContext context) {
     if (!isInMonth) {
-      return const SizedBox(width: 37, height: 35);
+      return SizedBox(width: width, height: height);
     }
 
     final hasPost = imageUrl != null && imageUrl!.isNotEmpty;
     final showTodayCta = isToday && !hasPost;
     Widget content;
 
-    if (hasPost) {
+    if (isLoading) {
+      content = DecoratedBox(
+        decoration: BoxDecoration(
+          color: AppColors.bw700.withValues(alpha: 0.48),
+          borderRadius: BorderRadius.circular(7),
+        ),
+      );
+    } else if (hasPost) {
       content = ClipRRect(
         borderRadius: BorderRadius.circular(7),
         child: CachedNetworkImage(
@@ -66,11 +79,12 @@ class CalendarDayCell extends StatelessWidget {
     } else if (showTodayCta) {
       content = DecoratedBox(
         decoration: BoxDecoration(
-          color: AppColors.turquoise600,
+          color: AppColors.bw800.withValues(alpha: 0.86),
           borderRadius: BorderRadius.circular(7),
+          border: Border.all(color: AppColors.turquoise500, width: 1.2),
         ),
         child: const Center(
-          child: Icon(Icons.add, size: 18, color: AppColors.bw100),
+          child: Icon(Icons.add, size: 18, color: AppColors.turquoise400),
         ),
       );
     } else {
@@ -79,7 +93,7 @@ class CalendarDayCell extends StatelessWidget {
           width: 11,
           height: 11,
           decoration: BoxDecoration(
-            color: _dotColor,
+            color: AppColors.bw700.withValues(alpha: 0.72),
             borderRadius: BorderRadius.circular(7),
           ),
         ),
@@ -88,11 +102,11 @@ class CalendarDayCell extends StatelessWidget {
 
     // Stroke chỉ vẽ khi today có post — để phân biệt ngày hôm nay trong dãy
     // thumbnail. Today CTA đã có màu turquoise nổi bật, không cần stroke.
-    final showStroke = isToday && hasPost;
+    final showStroke = isToday && hasPost && !isLoading;
 
     final cell = SizedBox(
-      width: 37,
-      height: 35,
+      width: width,
+      height: height,
       child: Stack(
         children: [
           Positioned.fill(child: content),
@@ -100,7 +114,7 @@ class CalendarDayCell extends StatelessWidget {
             Positioned.fill(
               child: DecoratedBox(
                 decoration: BoxDecoration(
-                  border: Border.all(color: _todayStroke, width: 1),
+                  border: Border.all(color: AppColors.turquoise500, width: 1),
                   borderRadius: BorderRadius.circular(7),
                 ),
               ),
@@ -109,7 +123,7 @@ class CalendarDayCell extends StatelessWidget {
       ),
     );
 
-    if (onTap == null) return cell;
+    if (isLoading || onTap == null) return cell;
     final label = showTodayCta ? 'Chụp khoảnh khắc hôm nay' : 'Xem ảnh ngày';
     return Semantics(
       button: true,

--- a/apps/mobile/lib/features/streak/presentation/widgets/empty_state_overlay.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/empty_state_overlay.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+
 /// Empty state cho StreakScreen (chưa post lần nào).
 ///
 /// Match Figma `269:1985`:
@@ -15,17 +18,10 @@ import 'package:flutter_svg/flutter_svg.dart';
 class EmptyStateOverlay extends StatelessWidget {
   const EmptyStateOverlay({super.key});
 
-  static const _muted = Color(0x7AFFFFFF);
-  static const _labelStyle = TextStyle(
-    fontFamily: 'Nunito',
-    fontSize: 14,
-    fontWeight: FontWeight.w700,
-    height: 18 / 14,
-    color: _muted,
-  );
-
   @override
   Widget build(BuildContext context) {
+    final muted = AppColors.bw100.withValues(alpha: 0.64);
+
     return IgnorePointer(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24),
@@ -33,19 +29,16 @@ class EmptyStateOverlay extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const SizedBox(height: 16),
-            const Text(
+            Text(
               'Gửi khoảnh khắc đầu tiên của bạn tại Meep !',
               textAlign: TextAlign.center,
-              style: _labelStyle,
+              style: AppTextStyles.smSemiBold.copyWith(color: muted),
             ),
-            const SizedBox(height: 12),
-            // Arrow lên: subtitle → Taskbar send icon (icon nhỏ ở dưới)
-            // Render send icon + curved arrow chỉ về phía Taskbar.
+            const SizedBox(height: 10),
             Center(
               child: SizedBox(
-                width: 80,
-                height: 85,
+                width: 72,
+                height: 66,
                 child: Stack(
                   alignment: Alignment.center,
                   children: [
@@ -53,16 +46,16 @@ class EmptyStateOverlay extends StatelessWidget {
                       top: 0,
                       child: SvgPicture.asset(
                         'assets/icons/ic_send.svg',
-                        width: 24,
-                        height: 24,
-                        colorFilter: const ColorFilter.mode(
-                          _muted,
+                        width: 22,
+                        height: 22,
+                        colorFilter: ColorFilter.mode(
+                          muted,
                           BlendMode.srcIn,
                         ),
                       ),
                     ),
                     CustomPaint(
-                      size: const Size(40, 85),
+                      size: const Size(36, 66),
                       painter: _CurvedArrowPainter(direction: _Direction.down),
                     ),
                   ],
@@ -85,7 +78,7 @@ class StreakArrowDown extends StatelessWidget {
   Widget build(BuildContext context) {
     return IgnorePointer(
       child: CustomPaint(
-        size: const Size(30, 65),
+        size: const Size(24, 46),
         painter: _CurvedArrowPainter(direction: _Direction.up),
       ),
     );
@@ -99,12 +92,10 @@ class _CurvedArrowPainter extends CustomPainter {
 
   final _Direction direction;
 
-  static const _stroke = Color(0x7AFFFFFF);
-
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
-      ..color = _stroke
+      ..color = AppColors.bw100.withValues(alpha: 0.5)
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.5
       ..strokeCap = StrokeCap.round;

--- a/apps/mobile/lib/features/streak/presentation/widgets/streak_calendar.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/streak_calendar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/shared/models/post.dart';
 import 'package:meep/features/streak/presentation/widgets/calendar_day_cell.dart';
 
@@ -11,14 +13,15 @@ import 'package:meep/features/streak/presentation/widgets/calendar_day_cell.dart
 /// - Tuần bắt đầu CN (col 0 = Sunday) — match Figma layout
 ///
 /// Swipe horizontal:
-/// - Right→Left (drag end velocity > 0) = swipePrev → tháng cũ hơn
-/// - Left→Right = swipeNext → tháng mới hơn (controller cap tại tháng hiện tại)
+/// - Kéo phải→trái = swipePrev → tháng cũ hơn
+/// - Kéo trái→phải = swipeNext → tháng mới hơn (controller cap tháng hiện tại)
 class StreakCalendar extends StatelessWidget {
   const StreakCalendar({
     super.key,
     required this.viewingMonth,
     required this.monthPosts,
     required this.today,
+    this.isLoading = false,
     this.onTapDay,
     this.onTapToday,
     this.onSwipePrev,
@@ -35,6 +38,9 @@ class StreakCalendar extends StatelessWidget {
   /// Ngày hôm nay (local timezone) — dùng để highlight ô today.
   final DateTime today;
 
+  /// Render skeleton cells trong lúc controller đang tải dữ liệu.
+  final bool isLoading;
+
   /// Tap handler khi user tap ô có post. Receives index trong [monthPosts]
   /// (sort theo createdAt ASC). Null = no-op.
   final ValueChanged<int>? onTapDay;
@@ -47,10 +53,6 @@ class StreakCalendar extends StatelessWidget {
   final VoidCallback? onSwipePrev;
   final VoidCallback? onSwipeNext;
 
-  static const _bgFill = Color(0x6E585754);
-  static const _headerFill = Color(0x6E838383);
-  static const _columnGap = 8.0;
-  static const _rowGap = 4.0;
   static const _columns = 7;
   static const _rows = 6;
 
@@ -82,41 +84,67 @@ class StreakCalendar extends StatelessWidget {
       onHorizontalDragEnd: (details) {
         final v = details.primaryVelocity ?? 0;
         if (v < -200) {
-          // swipe right→left = next month (controller cap)
-          onSwipeNext?.call();
-        } else if (v > 200) {
-          // swipe left→right = prev month
+          // Kéo phải→trái = tháng cũ hơn.
           onSwipePrev?.call();
+        } else if (v > 200) {
+          // Kéo trái→phải = tháng mới hơn.
+          onSwipeNext?.call();
         }
       },
       child: Container(
         decoration: BoxDecoration(
-          color: _bgFill,
+          color: AppColors.bw800.withValues(alpha: 0.74),
           borderRadius: BorderRadius.circular(22),
+          border: Border.all(
+            color: AppColors.bw700.withValues(alpha: 0.46),
+          ),
         ),
-        padding: const EdgeInsets.only(bottom: 10),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _MonthHeader(
-              month: viewingMonth,
-              fill: _headerFill,
-            ),
-            const SizedBox(height: 10),
-            _Grid(
-              leadingEmpty: leadingEmpty,
-              daysInMonth: daysInMonth,
-              todayDay: todayInMonth ? today.day : null,
-              dayToPostIndex: dayToPostIndex,
-              postsForDay: (day) {
-                final i = dayToPostIndex[day];
-                if (i == null) return null;
-                return monthPosts[i].coverImageUrl;
-              },
-              onTapDay: onTapDay,
-              onTapToday: onTapToday,
-            ),
-          ],
+        clipBehavior: Clip.antiAlias,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final maxWidth = constraints.maxWidth;
+            final horizontalPadding = maxWidth < 330 ? 10.0 : 14.0;
+            final columnGap = maxWidth < 330 ? 4.0 : 6.0;
+            const rowGap = 6.0;
+            final gridWidth = maxWidth - horizontalPadding * 2;
+            final cellWidth =
+                (gridWidth - columnGap * (_columns - 1)) / _columns;
+            final cellHeight = (cellWidth * 0.92).clamp(30.0, 42.0);
+
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _MonthHeader(month: viewingMonth),
+                const SizedBox(height: 12),
+                Padding(
+                  padding: EdgeInsets.fromLTRB(
+                    horizontalPadding,
+                    0,
+                    horizontalPadding,
+                    12,
+                  ),
+                  child: _Grid(
+                    leadingEmpty: leadingEmpty,
+                    daysInMonth: daysInMonth,
+                    todayDay: todayInMonth ? today.day : null,
+                    dayToPostIndex: dayToPostIndex,
+                    postsForDay: (day) {
+                      final i = dayToPostIndex[day];
+                      if (i == null) return null;
+                      return monthPosts[i].coverImageUrl;
+                    },
+                    onTapDay: onTapDay,
+                    onTapToday: onTapToday,
+                    isLoading: isLoading,
+                    cellWidth: cellWidth,
+                    cellHeight: cellHeight.toDouble(),
+                    columnGap: columnGap,
+                    rowGap: rowGap,
+                  ),
+                ),
+              ],
+            );
+          },
         ),
       ),
     );
@@ -124,29 +152,22 @@ class StreakCalendar extends StatelessWidget {
 }
 
 class _MonthHeader extends StatelessWidget {
-  const _MonthHeader({required this.month, required this.fill});
+  const _MonthHeader({required this.month});
 
   final DateTime month;
-  final Color fill;
 
   @override
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(
-        color: fill,
+        color: AppColors.bw700.withValues(alpha: 0.82),
         borderRadius: const BorderRadius.vertical(top: Radius.circular(22)),
       ),
       padding: const EdgeInsets.fromLTRB(16, 11, 16, 11),
       child: Text(
         _format(month),
-        style: const TextStyle(
-          fontFamily: 'Inter',
-          fontSize: 14,
-          fontWeight: FontWeight.w600,
-          color: Color(0xFFFFFFFF),
-          height: 17 / 14,
-        ),
+        style: AppTextStyles.smSemiBold.copyWith(color: AppColors.bw100),
       ),
     );
   }
@@ -166,6 +187,11 @@ class _Grid extends StatelessWidget {
     required this.postsForDay,
     required this.onTapDay,
     required this.onTapToday,
+    required this.isLoading,
+    required this.cellWidth,
+    required this.cellHeight,
+    required this.columnGap,
+    required this.rowGap,
   });
 
   final int leadingEmpty;
@@ -175,6 +201,11 @@ class _Grid extends StatelessWidget {
   final String? Function(int day) postsForDay;
   final ValueChanged<int>? onTapDay;
   final VoidCallback? onTapToday;
+  final bool isLoading;
+  final double cellWidth;
+  final double cellHeight;
+  final double columnGap;
+  final double rowGap;
 
   @override
   Widget build(BuildContext context) {
@@ -201,15 +232,18 @@ class _Grid extends StatelessWidget {
             isToday: isTodayCell,
             imageUrl: url,
             onTap: tapHandler,
+            isLoading: isLoading,
+            width: cellWidth,
+            height: cellHeight,
           ),
         );
         if (j < StreakCalendar._columns - 1) {
-          row.add(const SizedBox(width: StreakCalendar._columnGap));
+          row.add(SizedBox(width: columnGap));
         }
       }
       cells.add(Row(mainAxisSize: MainAxisSize.min, children: row));
       if (i < StreakCalendar._rows - 1) {
-        cells.add(const SizedBox(height: StreakCalendar._rowGap));
+        cells.add(SizedBox(height: rowGap));
       }
     }
 

--- a/apps/mobile/lib/features/streak/presentation/widgets/streak_stats_pill.dart
+++ b/apps/mobile/lib/features/streak/presentation/widgets/streak_stats_pill.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_text_styles.dart';
+
 /// Pill stats bottom của StreakScreen — match Figma `269:1992`.
 ///
-/// Layout: " N Meep | Xd chuỗi"
+/// Layout: " N Khoảnh khắc | Xd chuỗi"
 /// - Số (N / Xd): WHITE Nunito Bold 12
-/// - Chữ (Meep / chuỗi): WHITE 48% alpha Nunito Bold 12
+/// - Chữ (Khoảnh khắc / chuỗi): WHITE 48% alpha Nunito Bold 12
 /// - Separator "|": Inter SemiBold 10 WHITE 48% alpha
 /// - Container: bg `#5857546e`, cornerRadius 12, padding 8/11
 class StreakStatsPill extends StatelessWidget {
@@ -17,51 +20,39 @@ class StreakStatsPill extends StatelessWidget {
   final int totalMoments;
   final int currentStreak;
 
-  static const _bgFill = Color(0x6E585754);
-  static const _muted = Color(0x7AFFFFFF); // white 48%
-
-  static const _numberStyle = TextStyle(
-    fontFamily: 'Nunito',
-    fontSize: 12,
-    fontWeight: FontWeight.w700,
-    height: 16 / 12,
-    color: Color(0xFFFFFFFF),
-  );
-
-  static const _labelStyle = TextStyle(
-    fontFamily: 'Nunito',
-    fontSize: 12,
-    fontWeight: FontWeight.w700,
-    height: 16 / 12,
-    color: _muted,
-  );
-
-  static const _sepStyle = TextStyle(
-    fontFamily: 'Inter',
-    fontSize: 10,
-    fontWeight: FontWeight.w600,
-    color: _muted,
-  );
-
   @override
   Widget build(BuildContext context) {
+    final muted = AppColors.bw100.withValues(alpha: 0.58);
+    final numberStyle = AppTextStyles.xsSemiBold.copyWith(
+      color: AppColors.bw100,
+      fontWeight: FontWeight.w700,
+    );
+    final labelStyle = AppTextStyles.xsSemiBold.copyWith(
+      color: muted,
+      fontWeight: FontWeight.w700,
+    );
+    final sepStyle = AppTextStyles.xsSemiBold.copyWith(color: muted);
+
     return Semantics(
-      label: '$totalMoments Meep, chuỗi $currentStreak ngày',
+      label: '$totalMoments khoảnh khắc, chuỗi $currentStreak ngày',
       child: Container(
         decoration: BoxDecoration(
-          color: _bgFill,
+          color: AppColors.bw800.withValues(alpha: 0.78),
           borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: AppColors.bw700.withValues(alpha: 0.5),
+          ),
         ),
-        padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
         child: RichText(
           text: TextSpan(
-            style: _numberStyle,
+            style: numberStyle,
             children: [
               TextSpan(text: ' $totalMoments'),
-              const TextSpan(text: ' Meep ', style: _labelStyle),
-              const TextSpan(text: '|', style: _sepStyle),
+              TextSpan(text: ' Khoảnh khắc ', style: labelStyle),
+              TextSpan(text: '|', style: sepStyle),
               TextSpan(text: ' ${currentStreak}d'),
-              const TextSpan(text: ' chuỗi ', style: _labelStyle),
+              TextSpan(text: ' chuỗi ', style: labelStyle),
             ],
           ),
         ),

--- a/apps/mobile/lib/features/widget/application/widget_data_service.dart
+++ b/apps/mobile/lib/features/widget/application/widget_data_service.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -97,10 +99,10 @@ class WidgetDataService {
       final result = await _channel.invokeMethod<bool>('requestPinAppWidget');
       return result ?? false;
     } on PlatformException catch (e, st) {
-      debugPrint('[WidgetDataService] requestPinAppWidget failed: $e\n$st');
+      _log('requestPinAppWidget failed', e, st);
       return false;
     } on MissingPluginException catch (e, st) {
-      debugPrint('[WidgetDataService] requestPinAppWidget missing: $e\n$st');
+      _log('requestPinAppWidget missing', e, st);
       return false;
     }
   }
@@ -132,10 +134,20 @@ class WidgetDataService {
     try {
       await _channel.invokeMethod(method);
     } on PlatformException catch (e, st) {
-      debugPrint('[WidgetDataService] $method failed: $e\n$st');
+      _log('$method failed', e, st);
     } on MissingPluginException catch (e, st) {
-      debugPrint('[WidgetDataService] $method missing: $e\n$st');
+      _log('$method missing', e, st);
     }
+  }
+
+  void _log(String message, Object error, StackTrace stackTrace) {
+    if (!kDebugMode) return;
+    developer.log(
+      message,
+      name: 'widget',
+      error: error,
+      stackTrace: stackTrace,
+    );
   }
 }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -63,10 +63,13 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 
+  final functions = FirebaseFunctions.instanceFor(region: 'asia-southeast1');
+
   if (_useEmulator) {
     await FirebaseAuth.instance.useAuthEmulator(_emulatorHost, 9099);
     FirebaseFirestore.instance.useFirestoreEmulator(_emulatorHost, 9999);
     await FirebaseStorage.instance.useStorageEmulator(_emulatorHost, 9199);
+    functions.useFunctionsEmulator(_emulatorHost, 5001);
   }
 
   // App Check chặn automated abuse traffic tới Firestore/Storage/Functions.
@@ -101,11 +104,14 @@ void main() async {
   final prefs = await SharedPreferences.getInstance();
   final notifPrefs = NotificationPreferences(prefs: prefs);
   final firestore = FirebaseFirestore.instance;
-  final friendRepo = FirebaseFriendRepository(firestore);
+  final friendRepo = FirebaseFriendRepository(
+    firestore,
+    functions: functions,
+  );
 
   final authRepo = FirebaseAuthRepository(
     auth: FirebaseAuth.instance,
-    functions: FirebaseFunctions.instanceFor(region: 'asia-southeast1'),
+    functions: functions,
     googleSignIn: GoogleSignIn(
       serverClientId: AppConfig.googleServerClientId,
     ),
@@ -132,19 +138,19 @@ void main() async {
         friendRequestRepositoryProvider.overrideWithValue(
           FirebaseFriendRequestRepository(
             FirebaseFirestore.instance,
-            FirebaseFunctions.instanceFor(region: 'asia-southeast1'),
+            functions,
           ),
         ),
         spaceRepositoryProvider.overrideWithValue(
           FirebaseSpaceRepository(
             FirebaseFirestore.instance,
-            FirebaseFunctions.instanceFor(region: 'asia-southeast1'),
+            functions,
           ),
         ),
         blockRepositoryProvider.overrideWithValue(
           FirebaseBlockRepository(
             FirebaseFirestore.instance,
-            FirebaseFunctions.instanceFor(region: 'asia-southeast1'),
+            functions,
           ),
         ),
         conversationRepositoryProvider.overrideWithValue(

--- a/apps/mobile/lib/shared/widgets/app_glass_surface.dart
+++ b/apps/mobile/lib/shared/widgets/app_glass_surface.dart
@@ -16,7 +16,7 @@ class AppGlassSurface extends StatelessWidget {
     required this.child,
     this.height,
     this.borderRadius,
-    this.blurSigma = 5,
+    this.blurSigma = 8,
     this.disableBlur = false,
   });
 
@@ -29,7 +29,7 @@ class AppGlassSurface extends StatelessWidget {
   /// Cường độ blur nền. Tinh chỉnh khi xem trên device.
   final double blurSigma;
 
-  /// Embedded: không blur, chỉ màu đơn 20% opacity (đúng Figma SVG).
+  /// Embedded legacy path: không blur, chỉ màu đơn opacity thấp.
   final bool disableBlur;
 
   @override
@@ -48,18 +48,18 @@ class AppGlassSurface extends StatelessWidget {
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
                   colors: [
-                    AppColors.bw800.withValues(alpha: 0.1),
-                    AppColors.bw800.withValues(alpha: 0),
+                    AppColors.bw800.withValues(alpha: 0.06),
+                    AppColors.bw800.withValues(alpha: 0.015),
                   ],
                 ),
-          color: disableBlur ? AppColors.bw800.withValues(alpha: 0.2) : null,
+          color: disableBlur ? AppColors.bw800.withValues(alpha: 0.08) : null,
           boxShadow: disableBlur
               ? null
               : const [
                   BoxShadow(
-                    color: Color(0x40000000),
-                    offset: Offset(0, 4),
-                    blurRadius: 4,
+                    color: Color(0x26000000),
+                    offset: Offset(0, 3),
+                    blurRadius: 10,
                   ),
                 ],
         ),
@@ -108,7 +108,7 @@ class _GlassBorderPainter extends CustomPainter {
         begin: Alignment.topCenter,
         end: Alignment.bottomCenter,
         colors: [
-          AppColors.glassBorder.withValues(alpha: 0.8),
+          AppColors.glassBorder.withValues(alpha: 0.45),
           const Color(0x00FFFFFF),
         ],
       ).createShader(rect);

--- a/apps/mobile/lib/shared/widgets/app_taskbar.dart
+++ b/apps/mobile/lib/shared/widgets/app_taskbar.dart
@@ -39,6 +39,9 @@ class AppTaskbar extends StatelessWidget {
     this.ringColor,
   });
 
+  /// Fixed visual height used by screens that overlay the taskbar on content.
+  static const double height = _Const.height;
+
   /// Tab đang active. `null` = không tab nào active (ẩn indicator).
   final TaskbarTab? activeTab;
   final ValueChanged<TaskbarTab> onTabSelected;
@@ -201,11 +204,9 @@ class _EmbeddedTaskbar extends StatelessWidget {
             onTap: onGridTap,
           ),
           Expanded(
-            child: Container(
-              decoration: BoxDecoration(
-                color: AppColors.bw800.withValues(alpha: 0.05),
-                borderRadius: BorderRadius.circular(_Const.embeddedRadius),
-              ),
+            child: AppGlassSurface(
+              height: _Const.height,
+              borderRadius: _Const.embeddedRadius,
               child: Stack(
                 alignment: Alignment.center,
                 children: [

--- a/apps/mobile/lib/shared/widgets/app_taskbar_widgets.dart
+++ b/apps/mobile/lib/shared/widgets/app_taskbar_widgets.dart
@@ -158,7 +158,7 @@ class _PillIndicator extends StatelessWidget {
       width: _Const.pillWidth,
       height: _Const.pillHeight,
       decoration: BoxDecoration(
-        color: AppColors.bw500.withValues(alpha: 0.6),
+        color: AppColors.bw500.withValues(alpha: 0.32),
         borderRadius: BorderRadius.circular(_Const.pillRadius),
       ),
     );
@@ -196,9 +196,9 @@ class _RingIndicator extends StatelessWidget {
           Container(
             width: _Const.ringInner,
             height: _Const.ringInner,
-            decoration: const BoxDecoration(
+            decoration: BoxDecoration(
               shape: BoxShape.circle,
-              color: AppColors.bw100,
+              color: AppColors.bw100.withValues(alpha: 0.94),
             ),
           ),
         ],

--- a/apps/mobile/lib/shared/widgets/dual_post_image.dart
+++ b/apps/mobile/lib/shared/widgets/dual_post_image.dart
@@ -1,0 +1,141 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import 'package:meep/core/theme/app_colors.dart';
+import 'package:meep/core/theme/app_proportions.dart';
+
+/// Dual-camera PiP layout: one lens fills the frame, the other is shown as a
+/// small top-right preview. Back camera is primary by default.
+class DualPostImage extends StatefulWidget {
+  const DualPostImage({
+    super.key,
+    required this.backImageUrl,
+    required this.frontImageUrl,
+    this.initialPrimaryIsFront = false,
+    this.enableSwapOnTap = true,
+    this.memCacheWidth,
+    this.memCacheHeight,
+  });
+
+  final String backImageUrl;
+  final String frontImageUrl;
+  final bool initialPrimaryIsFront;
+  final bool enableSwapOnTap;
+  final int? memCacheWidth;
+  final int? memCacheHeight;
+
+  @override
+  State<DualPostImage> createState() => _DualPostImageState();
+}
+
+class _DualPostImageState extends State<DualPostImage> {
+  late bool _primaryIsFront;
+
+  @override
+  void initState() {
+    super.initState();
+    _primaryIsFront = widget.initialPrimaryIsFront;
+  }
+
+  @override
+  void didUpdateWidget(DualPostImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.backImageUrl != widget.backImageUrl ||
+        oldWidget.frontImageUrl != widget.frontImageUrl ||
+        oldWidget.initialPrimaryIsFront != widget.initialPrimaryIsFront) {
+      _primaryIsFront = widget.initialPrimaryIsFront;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final primary =
+        _primaryIsFront ? widget.frontImageUrl : widget.backImageUrl;
+    final secondary =
+        _primaryIsFront ? widget.backImageUrl : widget.frontImageUrl;
+
+    final content = LayoutBuilder(
+      builder: (context, constraints) {
+        final frameSize = constraints.maxWidth;
+        final pipSize = AppProportions.pipSize(frameSize);
+        final pipMargin = AppProportions.pipMargin(frameSize);
+
+        return Stack(
+          children: [
+            Positioned.fill(
+              child: _NetworkImage(
+                url: primary,
+                memCacheWidth: widget.memCacheWidth,
+                memCacheHeight: widget.memCacheHeight,
+              ),
+            ),
+            Positioned(
+              top: pipMargin,
+              right: pipMargin,
+              child: ClipRRect(
+                borderRadius:
+                    BorderRadius.circular(AppProportions.pipCornerRadius),
+                child: SizedBox(
+                  width: pipSize,
+                  height: pipSize,
+                  child: _NetworkImage(
+                    url: secondary,
+                    memCacheWidth: widget.memCacheWidth,
+                    memCacheHeight: widget.memCacheHeight,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (!widget.enableSwapOnTap) return content;
+    return Semantics(
+      button: true,
+      label: 'Đổi ảnh cam trước/sau',
+      child: GestureDetector(
+        onTap: () => setState(() => _primaryIsFront = !_primaryIsFront),
+        child: content,
+      ),
+    );
+  }
+}
+
+class _NetworkImage extends StatelessWidget {
+  const _NetworkImage({
+    required this.url,
+    this.memCacheWidth,
+    this.memCacheHeight,
+  });
+
+  final String url;
+  final int? memCacheWidth;
+  final int? memCacheHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    if (url.trim().isEmpty) {
+      return const ColoredBox(
+        color: AppColors.bw800,
+        child: Center(
+          child: Icon(Icons.broken_image, color: AppColors.bw600),
+        ),
+      );
+    }
+
+    return CachedNetworkImage(
+      imageUrl: url,
+      fit: BoxFit.cover,
+      width: double.infinity,
+      memCacheWidth: memCacheWidth,
+      memCacheHeight: memCacheHeight,
+      placeholder: (_, __) => const ColoredBox(color: AppColors.bw800),
+      errorWidget: (_, __, ___) => const ColoredBox(
+        color: AppColors.bw800,
+        child: Icon(Icons.broken_image, color: AppColors.bw600),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/shared/widgets/photo_detail_screen.dart
+++ b/apps/mobile/lib/shared/widgets/photo_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:meep/core/theme/app_colors.dart';
 import 'package:meep/core/theme/app_text_styles.dart';
 import 'package:meep/shared/models/post.dart';
+import 'package:meep/shared/widgets/dual_post_image.dart';
 import 'package:meep/shared/widgets/share_photo_sheet.dart';
 
 /// Full-screen photo viewer with PageView swipe + thumbnail strip.
@@ -341,12 +342,19 @@ class _PhotoCarousel extends StatelessWidget {
           final post = posts[index];
           final image = ClipRRect(
             borderRadius: BorderRadius.circular(_cornerRadius),
-            child: CachedNetworkImage(
-              imageUrl: post.coverImageUrl,
-              fit: BoxFit.cover,
-              errorWidget: (_, __, ___) => Container(color: AppColors.bw700),
-              placeholder: (_, __) => Container(color: AppColors.bw800),
-            ),
+            child: post.isDualCamera
+                ? DualPostImage(
+                    key: ValueKey('photo-detail-dual-${post.postId}'),
+                    backImageUrl: post.backImageUrl ?? '',
+                    frontImageUrl: post.frontImageUrl ?? '',
+                  )
+                : CachedNetworkImage(
+                    imageUrl: post.coverImageUrl,
+                    fit: BoxFit.cover,
+                    errorWidget: (_, __, ___) =>
+                        Container(color: AppColors.bw700),
+                    placeholder: (_, __) => Container(color: AppColors.bw800),
+                  ),
           );
           return AnimatedContainer(
             duration: const Duration(milliseconds: 200),
@@ -524,7 +532,7 @@ class _ThumbnailStrip extends StatelessWidget {
                     child: ClipRRect(
                       borderRadius:
                           BorderRadius.circular(_thumbRadius - _ringPadding),
-                      child: _thumbImage(posts[index].coverImageUrl),
+                      child: _thumbImage(posts[index]),
                     ),
                   ),
                 ),
@@ -558,9 +566,17 @@ class _ThumbnailStrip extends StatelessWidget {
     }
   }
 
-  Widget _thumbImage(String url) {
+  Widget _thumbImage(Post post) {
+    if (post.isDualCamera) {
+      return DualPostImage(
+        key: ValueKey('photo-detail-thumb-dual-${post.postId}'),
+        backImageUrl: post.backImageUrl ?? '',
+        frontImageUrl: post.frontImageUrl ?? '',
+        enableSwapOnTap: false,
+      );
+    }
     return CachedNetworkImage(
-      imageUrl: url,
+      imageUrl: post.coverImageUrl,
       fit: BoxFit.cover,
       errorWidget: (_, __, ___) => Container(color: AppColors.bw700),
       placeholder: (_, __) => Container(color: AppColors.bw800),

--- a/apps/mobile/lib/shared/widgets/post_card.dart
+++ b/apps/mobile/lib/shared/widgets/post_card.dart
@@ -5,6 +5,7 @@ import 'package:meep/core/theme/app_proportions.dart';
 import 'package:meep/shared/models/post.dart';
 import 'package:meep/shared/widgets/app_note_pill.dart';
 import 'package:meep/shared/widgets/app_photo_frame.dart';
+import 'package:meep/shared/widgets/dual_post_image.dart';
 
 /// Full-width post card showing photo + optional note overlay.
 /// Used by feed (friend + own variants), profile gallery detail, grid detail.
@@ -35,10 +36,6 @@ class PostCard extends StatefulWidget {
 }
 
 class _PostCardState extends State<PostCard> {
-  // Dual mode: which lens occupies the primary (large) slot. Back-first
-  // matches capture order; tap swaps to front.
-  bool _primaryIsFront = false;
-
   @override
   Widget build(BuildContext context) {
     final post = widget.post;
@@ -53,9 +50,6 @@ class _PostCardState extends State<PostCard> {
       children: [
         GestureDetector(
           onLongPress: widget.onLongPress,
-          onTap: post.isDualCamera
-              ? () => setState(() => _primaryIsFront = !_primaryIsFront)
-              : null,
           child: AppPhotoFrame(
             borderColor: widget.borderColor,
             overlay: hasCaption
@@ -70,10 +64,10 @@ class _PostCardState extends State<PostCard> {
                   )
                 : null,
             child: post.isDualCamera
-                ? _DualPostImage(
+                ? DualPostImage(
+                    key: ValueKey('post-card-dual-${post.postId}'),
                     backImageUrl: post.backImageUrl ?? '',
                     frontImageUrl: post.frontImageUrl ?? '',
-                    primaryIsFront: _primaryIsFront,
                   )
                 : CachedNetworkImage(
                     imageUrl: post.coverImageUrl,
@@ -94,78 +88,6 @@ class _PostCardState extends State<PostCard> {
           widget.footer!,
         ],
       ],
-    );
-  }
-}
-
-/// Dual-camera PiP layout for the feed: back camera full-frame as background,
-/// front camera small overlay at top-right. Tap swaps which lens is primary.
-/// Mirrors the capture preview so the feed matches what the author saw.
-class _DualPostImage extends StatelessWidget {
-  const _DualPostImage({
-    required this.backImageUrl,
-    required this.frontImageUrl,
-    required this.primaryIsFront,
-  });
-
-  final String backImageUrl;
-  final String frontImageUrl;
-  final bool primaryIsFront;
-
-  @override
-  Widget build(BuildContext context) {
-    final primary = primaryIsFront ? frontImageUrl : backImageUrl;
-    final secondary = primaryIsFront ? backImageUrl : frontImageUrl;
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final frameSize = constraints.maxWidth;
-        final pipSize = AppProportions.pipSize(frameSize);
-        final pipMargin = AppProportions.pipMargin(frameSize);
-
-        return Stack(
-          children: [
-            // Primary (back camera by default) — full frame
-            Positioned.fill(
-              child: _NetworkImage(url: primary),
-            ),
-            // Secondary (front camera by default) — PiP top-right
-            Positioned(
-              top: pipMargin,
-              right: pipMargin,
-              child: ClipRRect(
-                borderRadius:
-                    BorderRadius.circular(AppProportions.pipCornerRadius),
-                child: SizedBox(
-                  width: pipSize,
-                  height: pipSize,
-                  child: _NetworkImage(url: secondary),
-                ),
-              ),
-            ),
-          ],
-        );
-      },
-    );
-  }
-}
-
-class _NetworkImage extends StatelessWidget {
-  const _NetworkImage({required this.url});
-
-  final String url;
-
-  @override
-  Widget build(BuildContext context) {
-    return CachedNetworkImage(
-      imageUrl: url,
-      fit: BoxFit.cover,
-      width: double.infinity,
-      placeholder: (_, __) => const ColoredBox(color: AppColors.bw800),
-      errorWidget: (_, __, ___) => const ColoredBox(
-        color: AppColors.bw800,
-        child: Icon(Icons.broken_image, color: AppColors.bw600),
-      ),
     );
   }
 }

--- a/apps/mobile/test/features/diary/presentation/diary_canvas_screen_test.dart
+++ b/apps/mobile/test/features/diary/presentation/diary_canvas_screen_test.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/data/diary_repository.dart';
+import 'package:meep/features/diary/data/firebase_diary_repository.dart';
+import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const uid = 'uid-owner';
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Widget host(_FakeDiaryRepository repo) {
+    return ProviderScope(
+      overrides: [
+        currentUidProvider.overrideWith((ref) => Stream.value(uid)),
+        diaryRepositoryProvider.overrideWithValue(repo),
+        diaryStorageClientProvider.overrideWithValue(_FakeStorageClient()),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const DiaryCanvasScreen(
+                          mode: DiaryCanvasMode.create,
+                          moodTemplate: MoodTemplate.happy,
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('OPEN_CANVAS'),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> openCanvas(
+    WidgetTester tester,
+    _FakeDiaryRepository repo,
+  ) async {
+    await tester.pumpWidget(host(repo));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('OPEN_CANVAS'));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> enterContentAndSave(WidgetTester tester) async {
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Viết nhật ký của bạn...'),
+      'Hôm nay trời đẹp',
+    );
+    await tester.pump();
+    await tester.tap(find.bySemanticsLabel('Lưu'), warnIfMissed: false);
+    await tester.pump();
+  }
+
+  testWidgets('saving hiện loading, chặn tap lặp, success quay về list',
+      (tester) async {
+    final repo = _FakeDiaryRepository(blockCreate: true);
+    await openCanvas(tester, repo);
+
+    await enterContentAndSave(tester);
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(repo.createCalls, 1);
+    expect(repo.lastCreated?.privacy, DiaryPrivacy.private);
+
+    await tester.tap(find.bySemanticsLabel('Lưu'), warnIfMissed: false);
+    await tester.pump();
+
+    expect(repo.createCalls, 1);
+
+    repo.completeCreate();
+    await tester.pumpAndSettle();
+
+    expect(find.text('OPEN_CANVAS'), findsOneWidget);
+  });
+
+  testWidgets('chọn Công khai rồi lưu truyền DiaryPrivacy.public',
+      (tester) async {
+    final repo = _FakeDiaryRepository();
+    await openCanvas(tester, repo);
+
+    await tester.tap(find.bySemanticsLabel('Quyền riêng tư'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Công khai'));
+    await tester.tap(find.text('Xong'));
+    await tester.pumpAndSettle();
+
+    await enterContentAndSave(tester);
+    await tester.pumpAndSettle();
+
+    expect(repo.createCalls, 1);
+    expect(repo.lastCreated?.privacy, DiaryPrivacy.public);
+  });
+}
+
+class _FakeDiaryRepository implements DiaryRepository {
+  _FakeDiaryRepository({this.blockCreate = false});
+
+  final bool blockCreate;
+  final _entries = <DiaryEntry>[];
+  Completer<void>? _createCompleter;
+  int createCalls = 0;
+  DiaryEntry? lastCreated;
+
+  @override
+  String reserveEntryId() => 'entry-new';
+
+  @override
+  Future<DiaryEntry> createEntry(DiaryEntry entry) async {
+    createCalls++;
+    lastCreated = entry;
+    if (blockCreate) {
+      _createCompleter ??= Completer<void>();
+      await _createCompleter!.future;
+    }
+    _entries.add(entry);
+    return entry;
+  }
+
+  void completeCreate() {
+    _createCompleter?.complete();
+  }
+
+  @override
+  Stream<List<DiaryEntry>> watchEntries(String authorUid) => Stream.value(
+        _entries.where((e) => e.authorUid == authorUid).toList(),
+      );
+
+  @override
+  Future<DiaryEntry?> getEntry(String entryId) async {
+    for (final entry in _entries) {
+      if (entry.entryId == entryId) return entry;
+    }
+    return null;
+  }
+
+  @override
+  Future<List<DiaryEntry>> getPublicEntries(String authorUid) async => _entries
+      .where(
+        (e) => e.authorUid == authorUid && e.privacy == DiaryPrivacy.public,
+      )
+      .toList();
+
+  @override
+  Future<List<DiaryEntry>> searchEntries({
+    required String authorUid,
+    required String query,
+  }) async =>
+      const [];
+
+  @override
+  Future<void> updateEntry(DiaryEntry entry) async {}
+
+  @override
+  Future<void> updatePrivacy({
+    required String entryId,
+    required DiaryPrivacy privacy,
+  }) async {}
+
+  @override
+  Future<void> deleteEntry(String entryId) async {}
+}
+
+class _FakeStorageClient implements DiaryStorageClient {
+  @override
+  Future<String> upload({
+    required String uid,
+    required String entryId,
+    required String fileName,
+    required Uint8List bytes,
+    required String contentType,
+  }) async =>
+      'https://stub/$uid/$entryId/$fileName';
+
+  @override
+  Future<void> deletePrefix(String prefix) async {}
+}

--- a/apps/mobile/test/features/feed/application/post_controller_test.dart
+++ b/apps/mobile/test/features/feed/application/post_controller_test.dart
@@ -14,6 +14,7 @@ import 'package:meep/shared/models/post.dart';
 /// đúng đường repository, KHÔNG bind Firebase.
 class _FakePostRepo implements PostRepository {
   int newPostIdCalls = 0;
+  Post? createdPost;
 
   @override
   String newPostId() {
@@ -22,7 +23,10 @@ class _FakePostRepo implements PostRepository {
   }
 
   @override
-  Future<Post> createPost(Post post) async => post;
+  Future<Post> createPost(Post post) async {
+    createdPost = post;
+    return post;
+  }
 
   @override
   Stream<List<Post>> watchFeed(String uid, {String? spaceId}) =>
@@ -100,6 +104,52 @@ void main() {
         'Chọn ít nhất 1 người nhận hoặc 1 Space',
       );
       expect(postRepo.newPostIdCalls, 0);
+    });
+
+    test('returns false + error when select audience only contains self',
+        () async {
+      final container = makeContainer();
+      await container.read(currentUidProvider.future);
+
+      final notifier = container.read(postControllerProvider.notifier)
+        ..setPendingImage('/tmp/photo.jpg')
+        ..setAudience(AudienceType.select, const ['uid1']);
+
+      final ok = await notifier.submit();
+
+      expect(ok, isFalse);
+      expect(container.read(postControllerProvider).selectedUids, isEmpty);
+      expect(
+        container.read(postControllerProvider).errorMessage,
+        'Chọn ít nhất 1 người nhận hoặc 1 Space',
+      );
+      expect(postRepo.newPostIdCalls, 0);
+    });
+  });
+
+  group('PostController.setAudience', () {
+    test('dedupes recipients and removes current uid', () async {
+      final container = makeContainer();
+      await container.read(currentUidProvider.future);
+
+      final notifier = container.read(postControllerProvider.notifier)
+        ..setAudience(
+          AudienceType.select,
+          const ['uid1', 'friend-1', 'friend-1', ''],
+        );
+
+      expect(
+        container.read(postControllerProvider).selectedUids,
+        ['friend-1'],
+      );
+      expect(
+        container.read(postControllerProvider).audienceType,
+        AudienceType.select,
+      );
+      expect(postRepo.newPostIdCalls, 0);
+      expect(postRepo.createdPost, isNull);
+      // Keep notifier referenced so provider stays alive until assertions read.
+      expect(notifier, isNotNull);
     });
   });
 

--- a/apps/mobile/test/features/feed/firebase_post_repository_test.dart
+++ b/apps/mobile/test/features/feed/firebase_post_repository_test.dart
@@ -88,6 +88,31 @@ void main() {
       expect(snap.data()!['audienceUids'], ['uid2', 'uid3']);
     });
 
+    test('select audience strips author uid and duplicates', () async {
+      final post = _makePost(
+        authorId: 'uid1',
+        audience: AudienceType.select,
+        uids: ['uid1', 'uid2', 'uid2', ' '],
+      );
+      final created = await repo.createPost(post);
+
+      final snap = await db.collection('posts').doc('p1').get();
+      expect(created.audienceUids, ['uid2']);
+      expect(snap.data()!['audienceUids'], ['uid2']);
+    });
+
+    test('select audience with only author uid throws ArgumentError', () async {
+      final post = _makePost(
+        authorId: 'uid1',
+        audience: AudienceType.select,
+        uids: ['uid1'],
+      );
+      await expectLater(
+        () => repo.createPost(post),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
     test('strips null fields so Firestore rule does not reject the create',
         () async {
       // Single-camera post WITHOUT a caption — used to write

--- a/apps/mobile/test/features/feed/presentation/capture_preview_audience_test.dart
+++ b/apps/mobile/test/features/feed/presentation/capture_preview_audience_test.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
+import 'package:meep/features/feed/presentation/capture_preview_args.dart';
+import 'package:meep/features/feed/presentation/capture_preview_screen.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/friend/application/friend_state.dart';
+import 'package:meep/features/space/application/space_controller.dart';
+
+class _FakeFriendController extends FriendController {
+  _FakeFriendController(this._state);
+
+  final FriendState _state;
+
+  @override
+  FriendState build(String uid) => _state;
+}
+
+class _FakeSpaceController extends SpaceController {
+  _FakeSpaceController(this._state);
+
+  final SpaceState _state;
+
+  @override
+  SpaceState build(String uid) => _state;
+}
+
+PublicProfile _friend() => PublicProfile(
+      uid: 'friend-1',
+      displayName: 'Han',
+      username: 'han',
+      updatedAt: DateTime(2026, 6, 1),
+    );
+
+File _onePixelPng() {
+  final dir = Directory.systemTemp.createTempSync('meep_preview_test_');
+  final file = File('${dir.path}/photo.png');
+  addTearDown(() => dir.deleteSync(recursive: true));
+  file.writeAsBytesSync(
+    base64Decode(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+    ),
+  );
+  return file;
+}
+
+void main() {
+  testWidgets('audience row không render lựa chọn "Bạn"', (tester) async {
+    tester.view.physicalSize = const Size(430, 932);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final image = _onePixelPng();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          currentUidProvider.overrideWith((ref) => Stream.value('me')),
+          friendControllerProvider('me').overrideWith(
+            () => _FakeFriendController(
+              FriendState(friends: [_friend()]),
+            ),
+          ),
+          spaceControllerProvider('me').overrideWith(
+            () => _FakeSpaceController(const SpaceState()),
+          ),
+        ],
+        child: MaterialApp(
+          home: CapturePreviewScreen(
+            args: CapturePreviewArgs.single(imagePath: image.path),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tất cả'), findsOneWidget);
+    expect(find.text('Han'), findsOneWidget);
+    expect(find.text('Bạn'), findsNothing);
+  });
+}

--- a/apps/mobile/test/features/feed/presentation/feed_section_test.dart
+++ b/apps/mobile/test/features/feed/presentation/feed_section_test.dart
@@ -6,6 +6,9 @@ import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/auth/data/user_repository.dart';
 import 'package:meep/features/feed/application/feed_controller.dart';
 import 'package:meep/features/feed/data/post_repository.dart';
 import 'package:meep/features/feed/data/storage_repository.dart';
@@ -31,6 +34,32 @@ class _FakeStorageRepo implements StorageRepository {
 
   @override
   Future<void> deleteImage(String storagePath) async {}
+}
+
+class _FakeUserRepository implements UserRepository {
+  _FakeUserRepository(this.publicProfiles);
+
+  final Map<String, PublicProfile> publicProfiles;
+
+  @override
+  Future<void> createProfile(UserProfile profile) async {}
+
+  @override
+  Future<UserProfile?> getProfile(String uid) async => null;
+
+  @override
+  Future<PublicProfile?> getPublicProfile(String uid) async =>
+      publicProfiles[uid];
+
+  @override
+  Future<bool> isUsernameAvailable(String username) async => true;
+
+  @override
+  Stream<UserProfile?> watchProfile(String uid) => Stream.value(null);
+
+  @override
+  Stream<PublicProfile?> watchPublicProfile(String uid) =>
+      Stream.value(publicProfiles[uid]);
 }
 
 /// Repo điều khiển được watchFeed cho từng case (data/empty/error). newPostId
@@ -59,13 +88,31 @@ class _StubPostRepo implements PostRepository {
   Future<Post?> getPost(String postId) async => null;
 }
 
-Post _post({required String postId, required String authorId}) => Post(
+Post _post({
+  required String postId,
+  required String authorId,
+  String authorName = 'Author',
+}) =>
+    Post(
       postId: postId,
       authorId: authorId,
-      authorName: 'Author',
+      authorName: authorName,
       imageUrl: 'https://example.com/$postId.jpg',
       audienceType: AudienceType.all,
       createdAt: DateTime(2026, 5, 27),
+    );
+
+PublicProfile _publicProfile({
+  required String uid,
+  required String displayName,
+  String? avatarUrl,
+}) =>
+    PublicProfile(
+      uid: uid,
+      displayName: displayName,
+      username: displayName.toLowerCase(),
+      avatarUrl: avatarUrl,
+      updatedAt: DateTime(2026, 5, 27),
     );
 
 void main() {
@@ -83,7 +130,11 @@ void main() {
 
   const myUid = 'uid-me';
 
-  Future<void> pump(WidgetTester tester, Stream<List<Post>> feed) async {
+  Future<void> pump(
+    WidgetTester tester,
+    Stream<List<Post>> feed, {
+    Map<String, PublicProfile> publicProfiles = const {},
+  }) async {
     tester.view.physicalSize = const Size(900, 1600);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -112,6 +163,9 @@ void main() {
         overrides: [
           // LAYER-001: uid qua currentUidProvider — KHÔNG bind FirebaseAuth.
           currentUidProvider.overrideWith((ref) => Stream.value(myUid)),
+          userRepositoryProvider.overrideWithValue(
+            _FakeUserRepository(publicProfiles),
+          ),
           postRepositoryProvider.overrideWithValue(_StubPostRepo(feed)),
           storageRepositoryProvider.overrideWithValue(_FakeStorageRepo()),
           reactionRepositoryProvider.overrideWithValue(reactionRepo),
@@ -142,6 +196,32 @@ void main() {
     await tester.pump();
     expect(find.byType(FriendPostCard), findsOneWidget);
     expect(find.byType(OwnPostCard), findsNothing);
+  });
+
+  testWidgets('friend post thiếu avatar → fallback chữ cái từ authorName',
+      (tester) async {
+    await pump(
+      tester,
+      Stream.value([_post(postId: 'p2', authorId: 'friend-1')]),
+    );
+    await tester.pump();
+    expect(find.text('A'), findsOneWidget);
+  });
+
+  testWidgets('post cũ thiếu authorName → fallback từ public profile',
+      (tester) async {
+    await pump(
+      tester,
+      Stream.value([
+        _post(postId: 'p2', authorId: 'friend-1', authorName: ''),
+      ]),
+      publicProfiles: {
+        'friend-1': _publicProfile(uid: 'friend-1', displayName: 'Bob Tran'),
+      },
+    );
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Bob Tran'), findsOneWidget);
+    expect(find.text('B'), findsOneWidget);
   });
 
   testWidgets('empty feed → "Chưa có ảnh nào"', (tester) async {

--- a/apps/mobile/test/features/feed/presentation/home_screen_chrome_test.dart
+++ b/apps/mobile/test/features/feed/presentation/home_screen_chrome_test.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
+import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/chat/application/chat_controller.dart';
+import 'package:meep/features/chat/data/conversation.dart';
+import 'package:meep/features/chat/data/conversation_repository.dart';
+import 'package:meep/features/chat/data/message.dart';
+import 'package:meep/features/feed/application/app_camera_controller.dart';
+import 'package:meep/features/feed/application/camera_state.dart';
+import 'package:meep/features/feed/application/feed_controller.dart';
+import 'package:meep/features/feed/data/post_repository.dart';
+import 'package:meep/features/feed/data/storage_repository.dart';
+import 'package:meep/features/feed/presentation/home_screen.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/friend/data/friend_repository.dart';
+import 'package:meep/features/friend/data/friend_request.dart';
+import 'package:meep/features/friend/data/friend_request_repository.dart';
+import 'package:meep/features/widget/application/widget_data_service.dart';
+import 'package:meep/shared/models/post.dart';
+import 'package:meep/shared/widgets/app_photo_frame.dart';
+import 'package:meep/shared/widgets/app_taskbar.dart';
+
+class _FakeCameraController extends AppCameraController {
+  @override
+  CameraState build() => const CameraState(
+        error: 'Camera disabled in widget tests',
+      );
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  void resumePreview() {}
+
+  @override
+  void stopPreview() {}
+}
+
+class _FakePostRepository implements PostRepository {
+  @override
+  String newPostId() => 'post-id';
+
+  @override
+  Future<Post> createPost(Post post) async => post;
+
+  @override
+  Future<void> deletePost(String postId) async {}
+
+  @override
+  Future<List<Post>> getPostsByAuthor(String authorId) async => const [];
+
+  @override
+  Future<Post?> getPost(String postId) async => null;
+
+  @override
+  Stream<List<Post>> watchFeed(String uid, {String? spaceId}) {
+    return Stream.value(const []);
+  }
+}
+
+class _FakeStorageRepository implements StorageRepository {
+  @override
+  Future<void> deleteImage(String storagePath) async {}
+
+  @override
+  Future<String> uploadImage({
+    required String uid,
+    required String postId,
+    required List<int> bytes,
+    required String mimeType,
+    String fileName = 'photo.jpg',
+  }) async {
+    return 'https://example.com/photo.jpg';
+  }
+}
+
+class _FakeFriendRepository implements FriendRepository {
+  @override
+  Future<List<String>> getFriendUids(String uid) async => const [];
+
+  @override
+  Future<PublicProfile?> searchUser(String username) async => null;
+
+  @override
+  Future<void> unfriend(String pairId) async {}
+
+  @override
+  Stream<List<PublicProfile>> watchFriends(String uid) {
+    return Stream.value(const []);
+  }
+}
+
+class _FakeFriendRequestRepository implements FriendRequestRepository {
+  @override
+  Future<void> acceptFriendRequest(String requestId) async {}
+
+  @override
+  Future<void> cancelFriendRequest(String requestId) async {}
+
+  @override
+  Future<void> declineFriendRequest(String requestId) async {}
+
+  @override
+  Future<void> sendFriendRequest({
+    required String senderUid,
+    required String receiverUid,
+  }) async {}
+
+  @override
+  Stream<List<FriendRequest>> watchPendingRequests(String receiverUid) {
+    return Stream.value(const []);
+  }
+
+  @override
+  Stream<List<FriendRequest>> watchSentRequests(String senderUid) {
+    return Stream.value(const []);
+  }
+}
+
+class _FakeConversationRepository implements ConversationRepository {
+  @override
+  Future<Conversation> getOrCreateConversation({
+    required String uid,
+    required String otherUid,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> markAsRead({
+    required String conversationId,
+    required String uid,
+  }) async {}
+
+  @override
+  Future<void> sendMessage({
+    required String conversationId,
+    required String senderId,
+    required String text,
+    String? senderDisplayName,
+    String? quotedPostId,
+  }) async {}
+
+  @override
+  Stream<List<Conversation>> watchConversations(String uid) {
+    return Stream.value(const []);
+  }
+
+  @override
+  Stream<List<Message>> watchMessages(String conversationId, {int limit = 50}) {
+    return Stream.value(const []);
+  }
+}
+
+UserProfile _profile() {
+  final now = DateTime.utc(2026, 6, 9);
+  return UserProfile(
+    uid: 'uid-me',
+    email: 'me@example.com',
+    displayName: 'Meep User',
+    username: 'meep',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late WidgetDataService widgetDataService;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    widgetDataService = WidgetDataService(prefs: prefs);
+  });
+
+  Future<void> pumpHome(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(412, 917);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appCameraControllerProvider.overrideWith(_FakeCameraController.new),
+          currentUidProvider.overrideWith((ref) => Stream.value('uid-me')),
+          currentUserProfileProvider
+              .overrideWith((ref) => Stream.value(_profile())),
+          postRepositoryProvider.overrideWithValue(_FakePostRepository()),
+          storageRepositoryProvider.overrideWithValue(_FakeStorageRepository()),
+          friendRepositoryProvider.overrideWithValue(_FakeFriendRepository()),
+          friendRequestRepositoryProvider
+              .overrideWithValue(_FakeFriendRequestRepository()),
+          conversationRepositoryProvider
+              .overrideWithValue(_FakeConversationRepository()),
+          widgetDataServiceProvider.overrideWithValue(widgetDataService),
+        ],
+        child: const MaterialApp(home: HomeScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('topbar and taskbar overlay the full-height PageView',
+      (tester) async {
+    await pumpHome(tester);
+
+    final pageViewRect = tester.getRect(find.byKey(const Key('homePageView')));
+    final topbarRect = tester.getRect(find.byKey(const Key('homeTopBar')));
+    final taskbarRect = tester.getRect(find.byKey(const Key('homeTaskbar')));
+    final frameRect = tester.getRect(find.byType(AppPhotoFrame));
+
+    expect(pageViewRect.top, 0);
+    expect(pageViewRect.bottom, tester.view.physicalSize.height);
+    expect(pageViewRect.top, lessThan(topbarRect.bottom));
+    expect(frameRect.top, greaterThan(topbarRect.bottom + 8));
+    expect(pageViewRect.bottom, greaterThan(taskbarRect.top));
+    expect(
+      taskbarRect.top,
+      greaterThan(tester.view.physicalSize.height * 0.75),
+    );
+    expect(find.byType(AppTaskbar), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/features/profile/application/profile_diary_entries_provider_test.dart
+++ b/apps/mobile/test/features/profile/application/profile_diary_entries_provider_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
+import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/data/diary_repository.dart';
+import 'package:meep/features/profile/application/profile_diary_entries_provider.dart';
+
+void main() {
+  ProviderContainer makeContainer(_FakeDiaryRepository repo) {
+    final c = ProviderContainer(
+      overrides: [diaryRepositoryProvider.overrideWithValue(repo)],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  DiaryEntry entry({
+    required String id,
+    required DateTime createdAt,
+    String authorUid = 'uid-alice',
+  }) =>
+      DiaryEntry(
+        entryId: id,
+        authorUid: authorUid,
+        moodTemplate: MoodTemplate.happy,
+        coverImageUrl: '',
+        moodCaption: id,
+        content: const [DiaryContentBlock.text(value: 'Body')],
+        privacy: DiaryPrivacy.public,
+        createdAt: createdAt,
+        updatedAt: createdAt,
+      );
+
+  test('uid rỗng trả list rỗng và không gọi repository', () async {
+    final repo = _FakeDiaryRepository([]);
+    final c = makeContainer(repo);
+
+    final result = await c.read(profileDiaryEntriesProvider('').future);
+
+    expect(result, isEmpty);
+    expect(repo.requestedUids, isEmpty);
+  });
+
+  test('gọi getPublicEntries(uid) và sort createdAt DESC', () async {
+    final repo = _FakeDiaryRepository([
+      entry(id: 'old', createdAt: DateTime.utc(2026, 5, 1)),
+      entry(id: 'new', createdAt: DateTime.utc(2026, 5, 22)),
+      entry(id: 'mid', createdAt: DateTime.utc(2026, 5, 10)),
+    ]);
+    final c = makeContainer(repo);
+
+    final result =
+        await c.read(profileDiaryEntriesProvider('uid-alice').future);
+
+    expect(repo.requestedUids, ['uid-alice']);
+    expect(result.map((e) => e.entryId).toList(), ['new', 'mid', 'old']);
+  });
+}
+
+class _FakeDiaryRepository implements DiaryRepository {
+  _FakeDiaryRepository(this.entries);
+
+  final List<DiaryEntry> entries;
+  final requestedUids = <String>[];
+
+  @override
+  Future<List<DiaryEntry>> getPublicEntries(String authorUid) async {
+    requestedUids.add(authorUid);
+    return entries.where((e) => e.authorUid == authorUid).toList();
+  }
+
+  @override
+  Stream<List<DiaryEntry>> watchEntries(String authorUid) =>
+      Stream.value(const []);
+
+  @override
+  Future<DiaryEntry?> getEntry(String entryId) async => null;
+
+  @override
+  Future<List<DiaryEntry>> searchEntries({
+    required String authorUid,
+    required String query,
+  }) async =>
+      const [];
+
+  @override
+  String reserveEntryId() => 'reserved-id';
+
+  @override
+  Future<DiaryEntry> createEntry(DiaryEntry entry) async => entry;
+
+  @override
+  Future<void> updateEntry(DiaryEntry entry) async {}
+
+  @override
+  Future<void> updatePrivacy({
+    required String entryId,
+    required DiaryPrivacy privacy,
+  }) async {}
+
+  @override
+  Future<void> deleteEntry(String entryId) async {}
+}

--- a/apps/mobile/test/features/profile/presentation/friend_profile_screen_test.dart
+++ b/apps/mobile/test/features/profile/presentation/friend_profile_screen_test.dart
@@ -8,6 +8,11 @@ import 'package:go_router/go_router.dart';
 import 'package:meep/features/auth/application/auth_providers.dart';
 import 'package:meep/features/auth/data/firebase_auth_repository.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
+import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/data/diary_repository.dart';
+import 'package:meep/features/diary/presentation/diary_canvas_screen.dart';
 import 'package:meep/features/feed/application/feed_controller.dart';
 import 'package:meep/features/feed/data/firebase_post_repository.dart';
 import 'package:meep/features/friend/application/friend_controller.dart';
@@ -34,6 +39,53 @@ class _FakeProfileRepository implements ProfileRepository {
 
   @override
   Future<void> removeAvatar(String uid) async {}
+}
+
+class _FakeDiaryRepository implements DiaryRepository {
+  _FakeDiaryRepository(this.entries);
+
+  final List<DiaryEntry> entries;
+
+  @override
+  Future<List<DiaryEntry>> getPublicEntries(String authorUid) async =>
+      entries.where((e) => e.authorUid == authorUid).toList();
+
+  @override
+  Stream<List<DiaryEntry>> watchEntries(String authorUid) =>
+      Stream.value(entries.where((e) => e.authorUid == authorUid).toList());
+
+  @override
+  Future<DiaryEntry?> getEntry(String entryId) async {
+    for (final entry in entries) {
+      if (entry.entryId == entryId) return entry;
+    }
+    return null;
+  }
+
+  @override
+  Future<List<DiaryEntry>> searchEntries({
+    required String authorUid,
+    required String query,
+  }) async =>
+      const [];
+
+  @override
+  String reserveEntryId() => 'reserved-id';
+
+  @override
+  Future<DiaryEntry> createEntry(DiaryEntry entry) async => entry;
+
+  @override
+  Future<void> updateEntry(DiaryEntry entry) async {}
+
+  @override
+  Future<void> updatePrivacy({
+    required String entryId,
+    required DiaryPrivacy privacy,
+  }) async {}
+
+  @override
+  Future<void> deleteEntry(String entryId) async {}
 }
 
 void main() {
@@ -73,6 +125,7 @@ void main() {
   Widget makeApp({
     UserProfile? profile,
     bool seedFriend = true,
+    _FakeDiaryRepository? diaryRepository,
   }) {
     final mockAuth = MockFirebaseAuth(
       mockUser: MockUser(uid: currentUid),
@@ -99,6 +152,20 @@ void main() {
           builder: (_, __) => const Scaffold(body: Text('DIARY_PLACEHOLDER')),
         ),
         GoRoute(
+          path: '/diary/:entryId',
+          builder: (_, state) {
+            final extra = state.extra;
+            final ownerActionsEnabled = extra is Map<String, dynamic>
+                ? extra['ownerActionsEnabled'] as bool? ?? true
+                : true;
+            return DiaryCanvasScreen(
+              mode: DiaryCanvasMode.read,
+              entryId: state.pathParameters['entryId'],
+              ownerActionsEnabled: ownerActionsEnabled,
+            );
+          },
+        ),
+        GoRoute(
           path: '/home',
           builder: (_, __) => const Scaffold(body: Text('HOME_PLACEHOLDER')),
         ),
@@ -123,10 +190,30 @@ void main() {
             .overrideWithValue(FirebasePostRepository(firestore)),
         friendRepositoryProvider
             .overrideWithValue(FirebaseFriendRepository(firestore)),
+        diaryRepositoryProvider.overrideWithValue(
+          diaryRepository ?? _FakeDiaryRepository(const []),
+        ),
       ],
       child: MaterialApp.router(routerConfig: router),
     );
   }
+
+  DiaryEntry diaryEntry({
+    required String entryId,
+    required String title,
+    required DateTime createdAt,
+  }) =>
+      DiaryEntry(
+        entryId: entryId,
+        authorUid: friendUid,
+        moodTemplate: MoodTemplate.happy,
+        coverImageUrl: '',
+        moodCaption: title,
+        content: const [DiaryContentBlock.text(value: 'Friend public body')],
+        privacy: DiaryPrivacy.public,
+        createdAt: createdAt,
+        updatedAt: createdAt,
+      );
 
   testWidgets('hiện gate khi chưa là bạn bè', (tester) async {
     await tester.pumpWidget(makeApp(profile: bobProfile, seedFriend: false));
@@ -180,5 +267,36 @@ void main() {
     await tester.pumpWidget(makeApp(profile: bobProfile));
     await tester.pumpAndSettle();
     expect(find.text('Chưa có ảnh nào'), findsOneWidget);
+  });
+
+  testWidgets('Diary tab render public diary và mở read-only không owner menu',
+      (tester) async {
+    await seedFriendship();
+    final diaryRepository = _FakeDiaryRepository([
+      diaryEntry(
+        entryId: 'e-friend',
+        title: 'Nhật ký của Bob',
+        createdAt: DateTime.utc(2026, 5, 22),
+      ),
+    ]);
+
+    await tester.pumpWidget(
+      makeApp(
+        profile: bobProfile,
+        diaryRepository: diaryRepository,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.bySemanticsLabel('Tab nhật ký'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Nhật ký của Bob'), findsOneWidget);
+
+    await tester.tap(find.text('Nhật ký của Bob'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Friend public body'), findsOneWidget);
+    expect(find.bySemanticsLabel('Tùy chọn'), findsNothing);
   });
 }

--- a/apps/mobile/test/features/profile/presentation/profile_screen_test.dart
+++ b/apps/mobile/test/features/profile/presentation/profile_screen_test.dart
@@ -3,9 +3,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/diary/application/diary_controller.dart';
+import 'package:meep/features/diary/data/diary_content_block.dart';
+import 'package:meep/features/diary/data/diary_entry.dart';
+import 'package:meep/features/diary/data/diary_repository.dart';
 import 'package:meep/features/feed/application/feed_controller.dart';
 import 'package:meep/features/feed/data/firebase_post_repository.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/friend/application/friend_state.dart';
 import 'package:meep/features/profile/application/profile_controller.dart';
 import 'package:meep/features/profile/data/profile_repository.dart';
 import 'package:meep/features/profile/presentation/profile_screen.dart';
@@ -31,6 +39,65 @@ class _FakeProfileRepository implements ProfileRepository {
   Future<void> removeAvatar(String uid) async {}
 }
 
+class _FakeFriendController extends FriendController {
+  _FakeFriendController(this._state);
+
+  final FriendState _state;
+
+  @override
+  FriendState build(String uid) => _state;
+}
+
+class _FakeDiaryRepository implements DiaryRepository {
+  _FakeDiaryRepository(this.entries);
+
+  final List<DiaryEntry> entries;
+  final requestedPublicUids = <String>[];
+
+  @override
+  Future<List<DiaryEntry>> getPublicEntries(String authorUid) async {
+    requestedPublicUids.add(authorUid);
+    return entries.where((e) => e.authorUid == authorUid).toList();
+  }
+
+  @override
+  Stream<List<DiaryEntry>> watchEntries(String authorUid) =>
+      Stream.value(entries.where((e) => e.authorUid == authorUid).toList());
+
+  @override
+  Future<DiaryEntry?> getEntry(String entryId) async {
+    for (final entry in entries) {
+      if (entry.entryId == entryId) return entry;
+    }
+    return null;
+  }
+
+  @override
+  Future<List<DiaryEntry>> searchEntries({
+    required String authorUid,
+    required String query,
+  }) async =>
+      const [];
+
+  @override
+  String reserveEntryId() => 'reserved-id';
+
+  @override
+  Future<DiaryEntry> createEntry(DiaryEntry entry) async => entry;
+
+  @override
+  Future<void> updateEntry(DiaryEntry entry) async {}
+
+  @override
+  Future<void> updatePrivacy({
+    required String entryId,
+    required DiaryPrivacy privacy,
+  }) async {}
+
+  @override
+  Future<void> deleteEntry(String entryId) async {}
+}
+
 void main() {
   late FakeFirebaseFirestore firestore;
 
@@ -51,13 +118,26 @@ void main() {
     firestore = FakeFirebaseFirestore();
   });
 
-  Widget makeApp({UserProfile? profile}) {
+  PublicProfile publicFriend(String uid) => PublicProfile(
+        uid: uid,
+        displayName: uid,
+        username: uid,
+        updatedAt: DateTime.utc(2026, 1, 1),
+      );
+
+  Widget makeApp({
+    UserProfile? profile,
+    String currentUid = 'uid-alice',
+    List<PublicProfile> friends = const [],
+    String routeUid = 'uid-alice',
+    _FakeDiaryRepository? diaryRepository,
+  }) {
     final router = GoRouter(
       initialLocation: '/profile',
       routes: [
         GoRoute(
           path: '/profile',
-          builder: (_, __) => const ProfileScreen(uid: 'uid-alice'),
+          builder: (_, __) => ProfileScreen(uid: routeUid),
         ),
         GoRoute(
           path: '/profile/edit',
@@ -85,23 +165,54 @@ void main() {
     addTearDown(router.dispose);
     return ProviderScope(
       overrides: [
+        currentUidProvider.overrideWith((ref) => Stream.value(currentUid)),
+        friendControllerProvider(currentUid).overrideWith(
+          () => _FakeFriendController(FriendState(friends: friends)),
+        ),
         profileRepositoryProvider
             .overrideWithValue(_FakeProfileRepository(profile)),
         postRepositoryProvider
             .overrideWithValue(FirebasePostRepository(firestore)),
+        diaryRepositoryProvider.overrideWithValue(
+          diaryRepository ?? _FakeDiaryRepository(const []),
+        ),
       ],
       child: MaterialApp.router(routerConfig: router),
     );
   }
 
-  testWidgets('renders displayName/bio/stats từ ProfileState', (tester) async {
-    await tester.pumpWidget(makeApp(profile: aliceProfile));
+  DiaryEntry diaryEntry({
+    required String entryId,
+    required String title,
+    required DateTime createdAt,
+    String authorUid = 'uid-alice',
+  }) =>
+      DiaryEntry(
+        entryId: entryId,
+        authorUid: authorUid,
+        moodTemplate: MoodTemplate.happy,
+        coverImageUrl: '',
+        moodCaption: title,
+        content: const [DiaryContentBlock.text(value: 'Public body')],
+        privacy: DiaryPrivacy.public,
+        createdAt: createdAt,
+        updatedAt: createdAt,
+      );
+
+  testWidgets('renders displayName/bio/stats từ ProfileState + friend stream',
+      (tester) async {
+    await tester.pumpWidget(
+      makeApp(
+        profile: aliceProfile,
+        friends: [publicFriend('friend-1'), publicFriend('friend-2')],
+      ),
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('alice'), findsOneWidget); // username
     expect(find.text('Hello world'), findsOneWidget); // bio
     expect(find.text('7'), findsOneWidget); // postCount
-    expect(find.text('12'), findsOneWidget); // friendCount
+    expect(find.text('2'), findsOneWidget); // friends.length
     expect(find.text('3'), findsOneWidget); // spaceCount
     expect(find.text('Khoảnh khắc'), findsOneWidget);
     expect(find.text('Bạn bè'), findsOneWidget);
@@ -136,6 +247,56 @@ void main() {
     await tester.pumpWidget(makeApp(profile: aliceProfile));
     await tester.pumpAndSettle();
     expect(find.text('Chưa có ảnh nào'), findsOneWidget);
+  });
+
+  testWidgets('Diary tab dùng effectiveUid và render public diary',
+      (tester) async {
+    final diaryRepository = _FakeDiaryRepository([
+      diaryEntry(
+        entryId: 'e-1',
+        title: 'Một ngày vui',
+        createdAt: DateTime.utc(2026, 5, 22),
+      ),
+    ]);
+
+    await tester.pumpWidget(
+      makeApp(
+        profile: aliceProfile,
+        routeUid: '',
+        diaryRepository: diaryRepository,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.bySemanticsLabel('Tab nhật ký'));
+    await tester.pumpAndSettle();
+
+    expect(diaryRepository.requestedPublicUids, contains('uid-alice'));
+    expect(find.text('Một ngày vui'), findsOneWidget);
+  });
+
+  testWidgets('friendCount drift trên profile doc → hiển thị 0 khi stream rỗng',
+      (tester) async {
+    final driftProfile = aliceProfile.copyWith(friendCount: 1);
+    await tester.pumpWidget(makeApp(profile: driftProfile));
+    await tester.pumpAndSettle();
+
+    expect(find.text('1'), findsNothing);
+    expect(find.text('0'), findsOneWidget);
+  });
+
+  testWidgets('friendCount lấy từ friends stream khi có bạn', (tester) async {
+    final driftProfile = aliceProfile.copyWith(friendCount: 1);
+    await tester.pumpWidget(
+      makeApp(
+        profile: driftProfile,
+        friends: [publicFriend('friend-1'), publicFriend('friend-2')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('1'), findsNothing);
+    expect(find.text('2'), findsOneWidget);
   });
 
   testWidgets('action button "Chỉnh sửa" navigate /profile/edit',

--- a/apps/mobile/test/features/profile/presentation/profile_screen_test.dart
+++ b/apps/mobile/test/features/profile/presentation/profile_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:meep/features/friend/application/friend_state.dart';
 import 'package:meep/features/profile/application/profile_controller.dart';
 import 'package:meep/features/profile/data/profile_repository.dart';
 import 'package:meep/features/profile/presentation/profile_screen.dart';
+import 'package:meep/shared/models/post.dart';
 
 class _FakeProfileRepository implements ProfileRepository {
   _FakeProfileRepository(this.profile);
@@ -125,6 +126,20 @@ void main() {
         updatedAt: DateTime.utc(2026, 1, 1),
       );
 
+  Future<void> seedPosts(int count, {String authorUid = 'uid-alice'}) async {
+    for (var i = 0; i < count; i++) {
+      final post = Post(
+        postId: 'p$i',
+        authorId: authorUid,
+        authorName: 'Alice',
+        imageUrl: 'https://cdn/p$i.jpg',
+        audienceType: AudienceType.all,
+        createdAt: DateTime.utc(2026, 5, 10, 12).add(Duration(minutes: i)),
+      );
+      await firestore.doc('posts/${post.postId}').set(post.toJson());
+    }
+  }
+
   Widget makeApp({
     UserProfile? profile,
     String currentUid = 'uid-alice',
@@ -201,6 +216,7 @@ void main() {
 
   testWidgets('renders displayName/bio/stats từ ProfileState + friend stream',
       (tester) async {
+    await seedPosts(7);
     await tester.pumpWidget(
       makeApp(
         profile: aliceProfile,
@@ -211,7 +227,7 @@ void main() {
 
     expect(find.text('alice'), findsOneWidget); // username
     expect(find.text('Hello world'), findsOneWidget); // bio
-    expect(find.text('7'), findsOneWidget); // postCount
+    expect(find.text('7'), findsOneWidget); // Khoảnh khắc = 7 post thật
     expect(find.text('2'), findsOneWidget); // friends.length
     expect(find.text('3'), findsOneWidget); // spaceCount
     expect(find.text('Khoảnh khắc'), findsOneWidget);
@@ -278,6 +294,7 @@ void main() {
   testWidgets('friendCount drift trên profile doc → hiển thị 0 khi stream rỗng',
       (tester) async {
     final driftProfile = aliceProfile.copyWith(friendCount: 1);
+    await seedPosts(7); // postCount=7 để '0' chỉ còn là friendCount
     await tester.pumpWidget(makeApp(profile: driftProfile));
     await tester.pumpAndSettle();
 
@@ -297,6 +314,23 @@ void main() {
 
     expect(find.text('1'), findsNothing);
     expect(find.text('2'), findsOneWidget);
+  });
+
+  testWidgets('Khoảnh khắc đếm post thật, bỏ qua postCount counter bị drift',
+      (tester) async {
+    // Bug: CF counter postCount=4 (miss 1 event) nhưng user có 5 post thật.
+    // Header phải hiển thị 5 = số post grid load, không phải 4.
+    final driftProfile = aliceProfile.copyWith(postCount: 4);
+    await seedPosts(5);
+    await tester.pumpWidget(makeApp(profile: driftProfile));
+    await tester.pumpAndSettle();
+
+    expect(find.text('5'), findsOneWidget);
+    expect(
+      find.text('4'),
+      findsNothing,
+      reason: 'counter drift 4 không được hiển thị, dùng số post thật',
+    );
   });
 
   testWidgets('action button "Chỉnh sửa" navigate /profile/edit',

--- a/apps/mobile/test/features/settings/settings_sheet_test.dart
+++ b/apps/mobile/test/features/settings/settings_sheet_test.dart
@@ -4,13 +4,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/friend/application/friend_state.dart';
 import 'package:meep/features/settings/presentation/settings_sheet.dart';
 import 'package:meep/features/space/application/space_controller.dart';
 import 'package:meep/features/space/data/space.dart';
 import 'package:meep/features/space/data/space_repository.dart';
 
 class MockSpaceRepository extends Mock implements SpaceRepository {}
+
+class _FakeFriendController extends FriendController {
+  _FakeFriendController(this._state);
+
+  final FriendState _state;
+
+  @override
+  FriendState build(String uid) => _state;
+}
 
 UserProfile _profile({
   String uid = 'user1',
@@ -31,6 +43,13 @@ UserProfile _profile({
   );
 }
 
+PublicProfile _friend(String uid) => PublicProfile(
+      uid: uid,
+      displayName: 'Friend $uid',
+      username: uid,
+      updatedAt: DateTime(2026, 6, 1),
+    );
+
 void main() {
   late MockSpaceRepository spaceRepo;
 
@@ -44,6 +63,7 @@ void main() {
   Widget harness({
     String? currentUid = 'user1',
     List<Space>? spacesStream,
+    List<PublicProfile> friends = const [],
     UserProfile? profile,
     bool useNullProfile = false,
   }) {
@@ -58,6 +78,10 @@ void main() {
         currentUidProvider.overrideWith(
           (ref) => Stream.value(currentUid),
         ),
+        if (currentUid != null)
+          friendControllerProvider(currentUid).overrideWith(
+            () => _FakeFriendController(FriendState(friends: friends)),
+          ),
         currentUserProfileProvider.overrideWith(
           (ref) => Stream<UserProfile?>.value(
             useNullProfile ? null : (profile ?? _profile()),
@@ -83,12 +107,27 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('friendCount hiển thị từ profile thật (7 → "7 người bạn")',
+    testWidgets(
+        'friendCount drift trên profile doc → hiển thị 0 khi stream rỗng',
         (tester) async {
       await tester.pumpWidget(harness(profile: _profile(friendCount: 7)));
       await tester.pump();
 
-      expect(find.text('7 người bạn'), findsOneWidget);
+      expect(find.text('0 người bạn'), findsOneWidget);
+      expect(find.text('7 người bạn'), findsNothing);
+    });
+
+    testWidgets('friendCount lấy từ friends stream khi có bạn', (tester) async {
+      await tester.pumpWidget(
+        harness(
+          profile: _profile(friendCount: 7),
+          friends: [_friend('friend-1'), _friend('friend-2')],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('2 người bạn'), findsOneWidget);
+      expect(find.text('7 người bạn'), findsNothing);
     });
 
     testWidgets(

--- a/apps/mobile/test/features/settings/widget_confirm_sheet_test.dart
+++ b/apps/mobile/test/features/settings/widget_confirm_sheet_test.dart
@@ -5,9 +5,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meep/features/auth/application/auth_providers.dart';
+import 'package:meep/features/auth/data/public_profile.dart';
 import 'package:meep/features/auth/data/user_profile.dart';
+import 'package:meep/features/friend/application/friend_controller.dart';
+import 'package:meep/features/friend/application/friend_state.dart';
 import 'package:meep/features/settings/presentation/widget_confirm_sheet.dart';
 import 'package:meep/features/widget/application/widget_data_service.dart';
+
+class _FakeFriendController extends FriendController {
+  _FakeFriendController(this._state);
+
+  final FriendState _state;
+
+  @override
+  FriendState build(String uid) => _state;
+}
 
 UserProfile _profile({int friendCount = 15}) {
   return UserProfile(
@@ -20,6 +32,13 @@ UserProfile _profile({int friendCount = 15}) {
     updatedAt: DateTime(2026, 1, 1),
   );
 }
+
+PublicProfile _friend(String uid) => PublicProfile(
+      uid: uid,
+      displayName: 'Friend $uid',
+      username: uid,
+      updatedAt: DateTime(2026, 6, 1),
+    );
 
 /// Controls what [WidgetDataService.requestPinAppWidget] returns in tests.
 bool _mockPinSupported = true;
@@ -47,10 +66,20 @@ void main() {
       testWidgetDataService = WidgetDataService(prefs: prefs);
     });
 
-    Widget harness() => ProviderScope(
+    Widget harness({
+      UserProfile? profile,
+      List<PublicProfile> friends = const [],
+    }) =>
+        ProviderScope(
           overrides: [
+            currentUidProvider.overrideWith(
+              (ref) => Stream<String?>.value('user1'),
+            ),
             currentUserProfileProvider.overrideWith(
-              (ref) => Stream<UserProfile?>.value(_profile()),
+              (ref) => Stream<UserProfile?>.value(profile ?? _profile()),
+            ),
+            friendControllerProvider('user1').overrideWith(
+              () => _FakeFriendController(FriendState(friends: friends)),
             ),
             widgetDataServiceProvider.overrideWith(
               (ref) => testWidgetDataService,
@@ -87,6 +116,22 @@ void main() {
       expect(find.text('Thêm vào màn hình chờ?'), findsOneWidget);
       expect(find.text('Thêm'), findsOneWidget);
       expect(find.text('Huỷ'), findsOneWidget);
+    });
+
+    testWidgets(
+        'preview lấy số bạn từ friends stream, không dùng profile drift',
+        (tester) async {
+      await tester.pumpWidget(
+        harness(
+          profile: _profile(friendCount: 15),
+          friends: [_friend('friend-1'), _friend('friend-2')],
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('2 người bạn'), findsOneWidget);
+      expect(find.text('15 người bạn'), findsNothing);
     });
 
     testWidgets(

--- a/apps/mobile/test/features/streak/presentation/streak_screen_test.dart
+++ b/apps/mobile/test/features/streak/presentation/streak_screen_test.dart
@@ -10,19 +10,33 @@ import 'package:meep/shared/models/post.dart';
 import 'package:meep/features/streak/application/streak_controller.dart';
 import 'package:meep/features/streak/data/streak_repository.dart';
 import 'package:meep/features/streak/presentation/streak_screen.dart';
+import 'package:meep/features/streak/presentation/widgets/calendar_day_cell.dart';
 import 'package:meep/features/streak/presentation/widgets/empty_state_overlay.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_calendar.dart';
 import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 
 class FakeStreakRepo implements StreakRepository {
-  FakeStreakRepo({this.allDates = const [], this.monthPostsMap = const {}});
+  FakeStreakRepo({
+    this.allDates = const [],
+    this.monthPostsMap = const {},
+    this.getAllDatesOverride,
+  });
 
   final List<DateTime> allDates;
   final Map<DateTime, List<Post>> monthPostsMap;
+  final FutureOr<List<DateTime>> Function(String uid)? getAllDatesOverride;
+  int getAllDatesCalls = 0;
 
   @override
-  Future<List<DateTime>> getUserAllDates(String uid) async => allDates;
+  Future<List<DateTime>> getUserAllDates(String uid) async {
+    getAllDatesCalls++;
+    final override = getAllDatesOverride;
+    if (override != null) {
+      return await override(uid);
+    }
+    return allDates;
+  }
 
   @override
   Stream<List<Post>> watchUserMonth(String uid, DateTime month) {
@@ -99,6 +113,51 @@ void main() {
       findsOneWidget,
     );
     expect(find.byType(StreakArrowDown), findsOneWidget);
+  });
+
+  testWidgets('loading state không render empty state', (tester) async {
+    final completer = Completer<List<DateTime>>();
+    final repo = FakeStreakRepo(
+      getAllDatesOverride: (_) => completer.future,
+    );
+
+    await tester.pumpWidget(host(repo: repo, profile: fakeProfile()));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+
+    expect(find.byType(EmptyStateOverlay), findsNothing);
+    expect(find.byType(StreakCalendar), findsOneWidget);
+    expect(
+      tester
+          .widgetList<CalendarDayCell>(find.byType(CalendarDayCell))
+          .any((cell) => cell.isLoading),
+      isTrue,
+    );
+
+    completer.complete(const []);
+    await pumpUntilSettled(tester);
+  });
+
+  testWidgets('error banner có nút retry gọi init lại', (tester) async {
+    var attempts = 0;
+    final repo = FakeStreakRepo(
+      getAllDatesOverride: (_) async {
+        attempts++;
+        if (attempts == 1) throw Exception('boom');
+        return const [];
+      },
+    );
+
+    await tester.pumpWidget(host(repo: repo, profile: fakeProfile()));
+    await pumpUntilSettled(tester);
+
+    expect(find.text('Không thể tải Kỷ niệm'), findsOneWidget);
+    expect(find.text('Thử lại'), findsOneWidget);
+
+    await tester.tap(find.text('Thử lại'));
+    await pumpUntilSettled(tester);
+
+    expect(repo.getAllDatesCalls, greaterThanOrEqualTo(2));
   });
 
   testWidgets('empty state ẩn khi có ít nhất 1 post', (tester) async {

--- a/apps/mobile/test/features/streak/presentation/widgets/streak_calendar_test.dart
+++ b/apps/mobile/test/features/streak/presentation/widgets/streak_calendar_test.dart
@@ -15,10 +15,10 @@ void main() {
         createdAt: createdAt,
       );
 
-  Widget host(Widget child) => MaterialApp(
+  Widget host(Widget child, {double width = 330}) => MaterialApp(
         home: Scaffold(
           body: Center(
-            child: SizedBox(width: 330, child: child),
+            child: SizedBox(width: width, child: child),
           ),
         ),
       );
@@ -90,7 +90,7 @@ void main() {
     expect(tappedIndex, isIn([0, 1]));
   });
 
-  testWidgets('swipe trái → phải = swipePrev fires', (tester) async {
+  testWidgets('kéo phải→trái = swipePrev fires', (tester) async {
     var prevCalled = false;
     await tester.pumpWidget(
       host(
@@ -103,12 +103,12 @@ void main() {
       ),
     );
     final container = find.byType(StreakCalendar);
-    await tester.fling(container, const Offset(300, 0), 800);
+    await tester.fling(container, const Offset(-300, 0), 800);
     await tester.pumpAndSettle();
     expect(prevCalled, isTrue);
   });
 
-  testWidgets('swipe phải → trái = swipeNext fires', (tester) async {
+  testWidgets('kéo trái→phải = swipeNext fires', (tester) async {
     var nextCalled = false;
     await tester.pumpWidget(
       host(
@@ -121,9 +121,27 @@ void main() {
       ),
     );
     final container = find.byType(StreakCalendar);
-    await tester.fling(container, const Offset(-300, 0), 800);
+    await tester.fling(container, const Offset(300, 0), 800);
     await tester.pumpAndSettle();
     expect(nextCalled, isTrue);
+  });
+
+  testWidgets('calendar không overflow ở mobile widths phổ biến',
+      (tester) async {
+    for (final width in [320.0, 360.0, 430.0]) {
+      await tester.pumpWidget(
+        host(
+          StreakCalendar(
+            viewingMonth: DateTime(2026, 5),
+            monthPosts: const [],
+            today: DateTime(2026, 5, 22),
+          ),
+          width: width,
+        ),
+      );
+      await tester.pump();
+      expect(tester.takeException(), isNull, reason: 'width=$width');
+    }
   });
 
   testWidgets('today highlight chỉ khi viewingMonth chứa today',
@@ -162,22 +180,35 @@ void main() {
 
   testWidgets('today no-post + onTapToday → tap fires CTA callback',
       (tester) async {
-    var ctaCalled = false;
-    await tester.pumpWidget(
-      host(
-        StreakCalendar(
-          viewingMonth: DateTime(2026, 5),
-          monthPosts: const [],
-          today: DateTime(2026, 5, 22),
-          onTapToday: () => ctaCalled = true,
+    final semantics = tester.ensureSemantics();
+    try {
+      var ctaCalled = false;
+      await tester.pumpWidget(
+        host(
+          StreakCalendar(
+            viewingMonth: DateTime(2026, 5),
+            monthPosts: const [],
+            today: DateTime(2026, 5, 22),
+            onTapToday: () => ctaCalled = true,
+          ),
         ),
-      ),
-    );
-    final todayCell = find.byWidgetPredicate(
-      (w) => w is CalendarDayCell && w.isToday,
-    );
-    await tester.tap(todayCell);
-    expect(ctaCalled, isTrue);
+      );
+      final todayCell = find.byWidgetPredicate(
+        (w) => w is CalendarDayCell && w.isToday,
+      );
+      await tester.tap(todayCell);
+      expect(ctaCalled, isTrue);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Semantics &&
+              w.properties.label == 'Chụp khoảnh khắc hôm nay',
+        ),
+        findsOneWidget,
+      );
+    } finally {
+      semantics.dispose();
+    }
   });
 
   testWidgets('today có post → tap mở photo detail (onTapDay), không CTA',

--- a/apps/mobile/test/features/streak/presentation/widgets/streak_stats_pill_test.dart
+++ b/apps/mobile/test/features/streak/presentation/widgets/streak_stats_pill_test.dart
@@ -5,14 +5,14 @@ import 'package:meep/features/streak/presentation/widgets/streak_stats_pill.dart
 void main() {
   Widget host(Widget child) => MaterialApp(home: Scaffold(body: child));
 
-  testWidgets('render N Meep + Xd chuỗi', (tester) async {
+  testWidgets('render N Khoảnh khắc + Xd chuỗi', (tester) async {
     await tester.pumpWidget(
       host(const StreakStatsPill(totalMoments: 12, currentStreak: 7)),
     );
     final richText = tester.widget<RichText>(find.byType(RichText));
     final fullText = richText.text.toPlainText();
     expect(fullText, contains('12'));
-    expect(fullText, contains('Meep'));
+    expect(fullText, contains('Khoảnh khắc'));
     expect(fullText, contains('7d'));
     expect(fullText, contains('chuỗi'));
   });
@@ -23,7 +23,7 @@ void main() {
     );
     final richText = tester.widget<RichText>(find.byType(RichText));
     final fullText = richText.text.toPlainText();
-    expect(fullText, contains('0 Meep'));
+    expect(fullText, contains('0 Khoảnh khắc'));
     expect(fullText, contains('0d chuỗi'));
   });
 }

--- a/apps/mobile/test/shared/widgets/app_taskbar_test.dart
+++ b/apps/mobile/test/shared/widgets/app_taskbar_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:meep/shared/widgets/app_glass_surface.dart';
 import 'package:meep/shared/widgets/app_taskbar.dart';
 
 void main() {
@@ -22,6 +23,7 @@ void main() {
       await tester.pumpWidget(
         wrap(AppTaskbar(activeTab: TaskbarTab.home, onTabSelected: noop)),
       );
+      expect(find.byType(AppGlassSurface), findsOneWidget);
       expect(find.byKey(const Key('taskbarPillIndicator')), findsOneWidget);
     });
 
@@ -98,6 +100,7 @@ void main() {
           ),
         ),
       );
+      expect(find.byType(AppGlassSurface), findsOneWidget);
       expect(find.byKey(const Key('taskbarRingIndicator')), findsOneWidget);
       expect(find.byKey(const Key('taskbarPillIndicator')), findsNothing);
     });

--- a/apps/mobile/test/shared/widgets/photo_detail_screen_test.dart
+++ b/apps/mobile/test/shared/widgets/photo_detail_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,6 +19,19 @@ void main() {
       caption: caption,
       audienceType: AudienceType.all,
       createdAt: createdAt ?? DateTime.utc(2026, 5, 10, 17, 3),
+    );
+  }
+
+  Post dualPost({String id = 'p1'}) {
+    return Post(
+      postId: id,
+      authorId: 'uid-alice',
+      authorName: 'Alice',
+      backImageUrl: 'https://cdn/$id-back.jpg',
+      frontImageUrl: 'https://cdn/$id-front.jpg',
+      isDualCamera: true,
+      audienceType: AudienceType.all,
+      createdAt: DateTime.utc(2026, 5, 10, 17, 3),
     );
   }
 
@@ -92,6 +106,39 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.text('Feeling toasty!'), findsOneWidget);
+  });
+
+  testWidgets('renders dual-camera detail và tap đổi ảnh chính',
+      (tester) async {
+    await tester.pumpWidget(
+      host(
+        PhotoDetailScreen(
+          postId: 'p1',
+          posts: [dualPost()],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    List<String> imageUrls() => tester
+        .widgetList<CachedNetworkImage>(find.byType(CachedNetworkImage))
+        .map((w) => w.imageUrl)
+        .toList();
+
+    expect(imageUrls(), contains('https://cdn/p1-back.jpg'));
+    expect(imageUrls(), contains('https://cdn/p1-front.jpg'));
+    expect(
+      imageUrls().take(2),
+      ['https://cdn/p1-back.jpg', 'https://cdn/p1-front.jpg'],
+    );
+
+    await tester.tap(find.byKey(const ValueKey('photo-detail-dual-p1')));
+    await tester.pump();
+
+    expect(
+      imageUrls().take(2),
+      ['https://cdn/p1-front.jpg', 'https://cdn/p1-back.jpg'],
+    );
   });
 
   testWidgets('borderColorFor non-null → render border quanh ảnh active',

--- a/apps/mobile/test_driver/integration_test.dart
+++ b/apps/mobile/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -147,7 +147,7 @@ service cloud.firestore {
     // ===== /users/{uid} =====
     match /users/{uid} {
       allow get: if isOwner(uid) || isFriend(uid);
-      allow list: if false;
+      allow list: if isAuthed() && request.query.limit <= 1;
       allow create: if isOwner(uid) && isValidUserCreate(uid);
       allow update: if isOwner(uid) && isValidUserUpdate();
       allow delete: if false; // use deleteAccount CF

--- a/firebase/functions/src/feed/onPostCreated.test.ts
+++ b/firebase/functions/src/feed/onPostCreated.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
+import {
+  postFeedRecipients,
+  postNotificationRecipients,
+} from './onPostCreated.js';
+
 // Lightweight unit test — we test the pure fan-out logic, not the CF wrapper.
 // Integration tests require emulators; these run in CI without them.
 
@@ -49,7 +54,7 @@ describe('onPostCreated logic', () => {
   it('recipients always include the author (own-feed visibility)', () => {
     const authorId = 'uid1';
     const friendUids = ['friend1', 'friend2'];
-    const recipientUids = [...new Set([authorId, ...friendUids])];
+    const recipientUids = postFeedRecipients(authorId, friendUids);
     expect(recipientUids).toContain(authorId);
     expect(recipientUids).toHaveLength(3);
   });
@@ -57,15 +62,15 @@ describe('onPostCreated logic', () => {
   it('author appears once even if already in audience (dedupe)', () => {
     const authorId = 'uid1';
     const friendUids = ['uid1', 'friend2'];
-    const recipientUids = [...new Set([authorId, ...friendUids])];
+    const recipientUids = postFeedRecipients(authorId, friendUids);
     expect(recipientUids).toEqual(['uid1', 'friend2']);
   });
 
   it('FCM excludes the author — only friends are notified', () => {
     const authorId = 'uid1';
-    const friendUids = ['friend1', 'friend2'];
-    // FCM uses friendUids, not recipientUids (which includes the author).
-    expect(friendUids).not.toContain(authorId);
+    const friendUids = ['friend1', 'uid1', 'friend2', 'friend2'];
+    const recipientUids = postNotificationRecipients(authorId, friendUids);
+    expect(recipientUids).toEqual(['friend1', 'friend2']);
   });
 
   it('feed doc (friend fan-out) includes spaceIds=[]', () => {

--- a/firebase/functions/src/feed/onPostCreated.ts
+++ b/firebase/functions/src/feed/onPostCreated.ts
@@ -23,6 +23,32 @@ interface PostData {
   createdAt: FirebaseFirestore.Timestamp;
 }
 
+export function postNotificationRecipients(
+  authorId: string,
+  recipientUids: string[],
+): string[] {
+  const seen = new Set<string>();
+  const sanitized: string[] = [];
+
+  for (const uid of recipientUids) {
+    const trimmed = uid.trim();
+    if (trimmed.length === 0 || trimmed === authorId || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    sanitized.push(trimmed);
+  }
+
+  return sanitized;
+}
+
+export function postFeedRecipients(
+  authorId: string,
+  recipientUids: string[],
+): string[] {
+  return [authorId, ...postNotificationRecipients(authorId, recipientUids)];
+}
+
 /**
  * Fan-out feed + increment postCount + FCM notification.
  *
@@ -70,12 +96,16 @@ export const onPostCreated = onDocumentCreated(
 
     // 3. Determine recipients — friends/selected audience PLUS the author
     //    themselves, so the author always sees their own post in their feed.
-    const friendUids = audienceType === 'select'
+    const candidateFriendUids = audienceType === 'select'
       ? audienceUids
       : await _getFriendUids(db, authorId);
+    const friendUids = postNotificationRecipients(
+      authorId,
+      candidateFriendUids,
+    );
 
-    // Dedupe in case the author already appears in the audience list.
-    const recipientUids = [...new Set([authorId, ...friendUids])];
+    // Feed includes the author for own-feed visibility; FCM never does.
+    const recipientUids = postFeedRecipients(authorId, friendUids);
 
     if (recipientUids.length === 0) return;
 

--- a/firebase/functions/src/friend/onFriendshipDeleted.ts
+++ b/firebase/functions/src/friend/onFriendshipDeleted.ts
@@ -2,6 +2,40 @@ import { onDocumentDeleted } from "firebase-functions/v2/firestore";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 
+export interface DeletedFriendshipUids {
+  uid1: string;
+  uid2: string;
+}
+
+export function parseDeletedFriendshipUids(
+  friendshipData: FirebaseFirestore.DocumentData | undefined,
+): DeletedFriendshipUids | null {
+  if (!friendshipData) return null;
+
+  const { uid1, uid2 } = friendshipData;
+  if (
+    typeof uid1 !== "string" ||
+    uid1.length === 0 ||
+    typeof uid2 !== "string" ||
+    uid2.length === 0
+  ) {
+    return null;
+  }
+
+  return { uid1, uid2 };
+}
+
+export function shouldDeleteCrossFeedEntry(
+  entry: { authorId?: unknown; spaceIds?: unknown },
+  formerFriendUid: string,
+): boolean {
+  return (
+    entry.authorId === formerFriendUid &&
+    Array.isArray(entry.spaceIds) &&
+    entry.spaceIds.length === 0
+  );
+}
+
 /**
  * Clean up friend-related data when a friendship is deleted.
  *
@@ -21,14 +55,14 @@ export const onFriendshipDeleted = onDocumentDeleted(
   async (event) => {
     const pairId = event.params.pairId;
     const friendshipData = event.data?.data();
+    const uids = parseDeletedFriendshipUids(friendshipData);
 
-    if (!friendshipData) {
+    if (!uids) {
       logger.warn(`onFriendshipDeleted: no data for ${pairId}`);
       return;
     }
 
-    const uid1 = String(friendshipData.uid1);
-    const uid2 = String(friendshipData.uid2);
+    const { uid1, uid2 } = uids;
     const db = getFirestore();
 
     // Step 1: Decrement friendCount for both users (idempotent with FieldValue.increment)

--- a/firebase/functions/src/friend/searchUserByUsername.ts
+++ b/firebase/functions/src/friend/searchUserByUsername.ts
@@ -1,0 +1,159 @@
+import { getFirestore } from 'firebase-admin/firestore';
+import { logger } from 'firebase-functions/v2';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { z } from 'zod';
+
+import {
+  buildPublicProfileData,
+  publicProfileSourceSchema,
+} from '../user/publicProfile.js';
+
+const searchUserByUsernameSchema = z
+  .object({
+    username: z.string().min(1).max(64),
+  })
+  .strict();
+
+export interface SearchUserProfile {
+  uid: string;
+  displayName: string;
+  username: string;
+  avatarUrl: string | null;
+  bio: string | null;
+  isSearchable: boolean;
+  updatedAtMillis: number;
+}
+
+export function normalizeSearchUsername(raw: string): string | null {
+  const username = raw.toLowerCase().trim();
+  return /^[a-z0-9_]{3,20}$/.test(username) ? username : null;
+}
+
+function timestampToMillis(value: unknown): number {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'toMillis' in value &&
+    typeof (value as { toMillis?: unknown }).toMillis === 'function'
+  ) {
+    return (value as { toMillis: () => number }).toMillis();
+  }
+  return Date.now();
+}
+
+export function buildSearchUserProfile(
+  uid: string,
+  data: z.infer<typeof publicProfileSourceSchema>,
+  updatedAt: unknown,
+): SearchUserProfile | null {
+  if (data.isSearchable === false) {
+    return null;
+  }
+
+  return {
+    uid,
+    displayName: data.displayName,
+    username: data.username,
+    avatarUrl: data.avatarUrl ?? null,
+    bio: data.bio ?? null,
+    isSearchable: data.isSearchable ?? true,
+    updatedAtMillis: timestampToMillis(updatedAt),
+  };
+}
+
+async function resolveUserDocByExactUsername(
+  db: FirebaseFirestore.Firestore,
+  username: string,
+): Promise<FirebaseFirestore.DocumentSnapshot | null> {
+  const usernameDoc = await db.collection('usernames').doc(username).get();
+  if (usernameDoc.exists) {
+    const usernameData = usernameDoc.data() as
+      | Record<string, unknown>
+      | undefined;
+    const uid = usernameData?.uid;
+    if (typeof uid === 'string' && uid.length > 0) {
+      const userDoc = await db.collection('users').doc(uid).get();
+      if (userDoc.exists) return userDoc;
+    } else {
+      logger.warn('friendSearch: invalid username doc');
+    }
+  }
+
+  // Exact fallback only: repairs accounts created before /usernames or
+  // public/profile were populated. This is NOT prefix/fuzzy search.
+  const usersSnap = await db
+    .collection('users')
+    .where('username', '==', username)
+    .limit(1)
+    .get();
+
+  return usersSnap.empty ? null : usersSnap.docs[0] ?? null;
+}
+
+/**
+ * Exact username lookup for friend discovery.
+ *
+ * Uses /usernames as the source of truth because it is written synchronously
+ * during signup; /users/{uid}/public/profile is still repaired opportunistically
+ * so existing collection-group reads recover after one successful search.
+ */
+export const searchUserByUsername = onCall(
+  { region: 'asia-southeast1' },
+  async (request): Promise<{ profile: SearchUserProfile | null }> => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Login required');
+    }
+
+    const parsed = searchUserByUsernameSchema.safeParse(request.data);
+    if (!parsed.success) {
+      throw new HttpsError('invalid-argument', parsed.error.message);
+    }
+
+    const username = normalizeSearchUsername(parsed.data.username);
+    if (username == null) {
+      return { profile: null };
+    }
+
+    const db = getFirestore();
+    const userDoc = await resolveUserDocByExactUsername(db, username);
+    if (userDoc == null) {
+      return { profile: null };
+    }
+    const uid = userDoc.id;
+
+    const userData = userDoc.data();
+    if (userData == null) {
+      return { profile: null };
+    }
+
+    const publicFields = publicProfileSourceSchema.safeParse(userData);
+    if (!publicFields.success || publicFields.data.username !== username) {
+      logger.warn(
+        {
+          uid,
+          fields: publicFields.success
+            ? ['username']
+            : publicFields.error.issues.map((issue) => issue.path.join('.')),
+        },
+        'friendSearch: user doc cannot be projected',
+      );
+      return { profile: null };
+    }
+
+    const projection = buildPublicProfileData(uid, publicFields.data);
+    await Promise.all([
+      db.collection('usernames').doc(username).set({ uid }, { merge: false }),
+      userDoc.ref.collection('public').doc('profile').set(projection, {
+        merge: false,
+      }),
+    ]);
+
+    return {
+      profile: buildSearchUserProfile(
+        uid,
+        publicFields.data,
+        userData.updatedAt ?? userData.createdAt,
+      ),
+    };
+  },
+);

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -74,6 +74,7 @@ export const sendFriendRequest = onCall((request) => {
 
 export { acceptFriendRequest } from "./friend/acceptFriendRequest.js";
 export { onFriendshipDeleted } from "./friend/onFriendshipDeleted.js";
+export { searchUserByUsername } from "./friend/searchUserByUsername.js";
 
 // ===== Settings module stubs =====
 

--- a/firebase/functions/src/storage.rules.test.ts
+++ b/firebase/functions/src/storage.rules.test.ts
@@ -22,7 +22,40 @@ let testEnv: RulesTestEnvironment;
 const RULES_PATH = resolve(__dirname, '../../storage.rules');
 const FIRESTORE_RULES_PATH = resolve(__dirname, '../../firestore.rules');
 
+function emulatorEndpoint(
+  envNames: string[],
+  fallback: { host: string; port: number },
+): { host: string; port: number } {
+  for (const envName of envNames) {
+    const value = process.env[envName];
+    if (!value) {
+      continue;
+    }
+
+    try {
+      const url = new URL(value.match(/^https?:\/\//) ? value : `http://${value}`);
+      const port = Number.parseInt(url.port, 10);
+      if (url.hostname && Number.isFinite(port)) {
+        return { host: url.hostname, port };
+      }
+    } catch {
+      // Fall back to the default emulator endpoint below.
+    }
+  }
+
+  return fallback;
+}
+
 beforeAll(async () => {
+  const storage = emulatorEndpoint(
+    ['FIREBASE_STORAGE_EMULATOR_HOST', 'STORAGE_EMULATOR_HOST'],
+    { host: '127.0.0.1', port: 9199 },
+  );
+  const firestore = emulatorEndpoint(['FIRESTORE_EMULATOR_HOST'], {
+    host: '127.0.0.1',
+    port: 9999,
+  });
+
   testEnv = await initializeTestEnvironment({
     // Project ID khớp emulator launch (--project demo-meep-test) +
     // singleProjectMode để cross-service firestore.get/exists từ storage rule
@@ -30,21 +63,21 @@ beforeAll(async () => {
     projectId: 'demo-meep-test',
     storage: {
       rules: readFileSync(RULES_PATH, 'utf8'),
-      host: '127.0.0.1',
-      port: 9199,
+      host: storage.host,
+      port: storage.port,
     },
     // Storage rules đọc cross-service /posts + /diary + /friendships để mirror
     // friend boundary (STORAGE-001/002) → cần firestore emulator chạy cùng.
     firestore: {
       rules: readFileSync(FIRESTORE_RULES_PATH, 'utf8'),
-      host: '127.0.0.1',
-      port: 9999,
+      host: firestore.host,
+      port: firestore.port,
     },
   });
 });
 
 afterAll(async () => {
-  await testEnv.cleanup();
+  await testEnv?.cleanup();
 });
 
 beforeEach(async () => {

--- a/firebase/functions/test/feed/feed.rules.test.ts
+++ b/firebase/functions/test/feed/feed.rules.test.ts
@@ -10,9 +10,56 @@
 
 import { describe, it, expect } from 'vitest';
 
-// NOTE: Full emulator-based rules tests require @firebase/rules-unit-testing.
-// These are spec-level assertions that document expected behaviour.
-// Wire up with initializeTestEnvironment() when running in emulator CI.
+interface PostReadRuleInput {
+  requestUid: string | null;
+  authorId: string;
+  hasFriendship?: boolean;
+  hasFeedDoc?: boolean;
+  isSpaceMember?: boolean;
+}
+
+function canReadPost(input: PostReadRuleInput): boolean {
+  if (input.requestUid == null) return false;
+  return (
+    input.requestUid === input.authorId ||
+    input.hasFriendship === true ||
+    input.isSpaceMember === true ||
+    input.hasFeedDoc === true
+  );
+}
+
+function canCreatePost(input: {
+  requestUid: string | null;
+  authorId: string;
+  authorName: string;
+  audienceType: string;
+  caption?: string;
+  hasSingleImage?: boolean;
+  hasDualImages?: boolean;
+}): boolean {
+  if (input.requestUid !== input.authorId) return false;
+  if (input.authorName.length === 0 || input.authorName.length > 50) {
+    return false;
+  }
+  if (input.audienceType !== 'all' && input.audienceType !== 'select') {
+    return false;
+  }
+  if (input.caption != null && input.caption.length > 200) return false;
+  return input.hasSingleImage === true || input.hasDualImages === true;
+}
+
+function canWritePostImage(input: {
+  requestUid: string | null;
+  ownerUid: string;
+  sizeBytes: number;
+  contentType: string;
+}): boolean {
+  return (
+    input.requestUid === input.ownerUid &&
+    input.sizeBytes < 10 * 1024 * 1024 &&
+    input.contentType.startsWith('image/')
+  );
+}
 
 describe('Firestore rules — /posts/{postId}', () => {
   it('author can read own post', () => {
@@ -23,35 +70,71 @@ describe('Firestore rules — /posts/{postId}', () => {
   });
 
   it('recipient with feed doc can read post', () => {
-    // allow read if exists(.../users/$(request.auth.uid)/feed/$(postId))
-    // Emulator test would call: assertSucceeds(recipientDb.doc('posts/p1').get())
-    expect(true).toBe(true); // placeholder — requires emulator
+    expect(
+      canReadPost({
+        requestUid: 'uid2',
+        authorId: 'uid1',
+        hasFeedDoc: true,
+      }),
+    ).toBe(true);
   });
 
   it('non-recipient cannot read post', () => {
-    // Stranger without feed doc → permission-denied
-    expect(true).toBe(true); // placeholder — requires emulator
+    expect(
+      canReadPost({
+        requestUid: 'uid3',
+        authorId: 'uid1',
+        hasFeedDoc: false,
+        hasFriendship: false,
+        isSpaceMember: false,
+      }),
+    ).toBe(false);
   });
 
   it('Space member can read post trong Space (non-friend author)', () => {
-    // allow read: ('spaceId' in resource.data && isMember(resource.data.spaceId))
-    // User is member of Space X, post author là người lạ (không friend).
-    // isMember(spaceId) check /space_members/{spaceId}/members/{uid}.
-    // 'spaceId' in resource.data guard prevents crash on All-friends posts
-    // (missing field sau removeWhere(null) khi createPost).
-    expect(true).toBe(true); // placeholder — requires emulator
+    expect(
+      canReadPost({
+        requestUid: 'uid2',
+        authorId: 'uid1',
+        isSpaceMember: true,
+      }),
+    ).toBe(true);
   });
 
   it('non-Space-member cannot read Space post', () => {
-    // User không phải member Space X, không phải friend của author,
-    // không có feed doc → cả 4 nhánh thất bại → permission-denied.
-    expect(true).toBe(true); // placeholder — requires emulator
+    expect(
+      canReadPost({
+        requestUid: 'uid2',
+        authorId: 'uid1',
+        isSpaceMember: false,
+      }),
+    ).toBe(false);
   });
 
   it('create rejected if caption > 200 chars', () => {
-    const caption = 'x'.repeat(201);
-    // Storage rule: caption.size() <= 200
-    expect(caption.length > 200).toBe(true);
+    expect(
+      canCreatePost({
+        requestUid: 'uid1',
+        authorId: 'uid1',
+        authorName: 'Alice',
+        audienceType: 'all',
+        caption: 'x'.repeat(201),
+        hasSingleImage: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('create accepted with owner, valid audience, and image payload', () => {
+    expect(
+      canCreatePost({
+        requestUid: 'uid1',
+        authorId: 'uid1',
+        authorName: 'Alice',
+        audienceType: 'select',
+        caption: 'hello',
+        hasSingleImage: true,
+      }),
+    ).toBe(true);
   });
 
   it('update is always rejected (posts are immutable)', () => {
@@ -80,25 +163,47 @@ describe('Firestore rules — /users/{uid}/feed/{postId}', () => {
 });
 
 describe('Storage rules — /posts/{uid}/{postId}/{filename}', () => {
-  it('owner can write image < 5MB', () => {
-    const sizeBytes = 4 * 1024 * 1024;
-    const maxBytes = 5 * 1024 * 1024;
-    expect(sizeBytes < maxBytes).toBe(true);
+  it('owner can write image < 10MB', () => {
+    expect(
+      canWritePostImage({
+        requestUid: 'uid1',
+        ownerUid: 'uid1',
+        sizeBytes: 9 * 1024 * 1024,
+        contentType: 'image/jpeg',
+      }),
+    ).toBe(true);
   });
 
-  it('reject write if > 5MB', () => {
-    const sizeBytes = 6 * 1024 * 1024;
-    const maxBytes = 5 * 1024 * 1024;
-    expect(sizeBytes < maxBytes).toBe(false);
+  it('reject write if >= 10MB', () => {
+    expect(
+      canWritePostImage({
+        requestUid: 'uid1',
+        ownerUid: 'uid1',
+        sizeBytes: 10 * 1024 * 1024,
+        contentType: 'image/jpeg',
+      }),
+    ).toBe(false);
   });
 
   it('reject non-image content type', () => {
-    const contentType = 'application/pdf';
-    expect(contentType.startsWith('image/')).toBe(false);
+    expect(
+      canWritePostImage({
+        requestUid: 'uid1',
+        ownerUid: 'uid1',
+        sizeBytes: 1024,
+        contentType: 'application/pdf',
+      }),
+    ).toBe(false);
   });
 
   it('accept image/jpeg', () => {
-    const contentType = 'image/jpeg';
-    expect(contentType.startsWith('image/')).toBe(true);
+    expect(
+      canWritePostImage({
+        requestUid: 'uid1',
+        ownerUid: 'uid1',
+        sizeBytes: 1024,
+        contentType: 'image/jpeg',
+      }),
+    ).toBe(true);
   });
 });

--- a/firebase/functions/test/friend/onFriendshipDeleted.test.ts
+++ b/firebase/functions/test/friend/onFriendshipDeleted.test.ts
@@ -1,21 +1,42 @@
 import { describe, it, expect } from 'vitest';
 
-describe('onFriendshipDeleted', () => {
-  it('placeholder - CF trigger requires emulator for proper testing', () => {
-    // onFriendshipDeleted is a Firestore trigger (onDocumentDeleted)
-    // Testing requires Firebase emulator + proper event structure
-    expect(true).toBe(true);
+import {
+  parseDeletedFriendshipUids,
+  shouldDeleteCrossFeedEntry,
+} from '../../src/friend/onFriendshipDeleted.js';
+
+describe('onFriendshipDeleted helpers', () => {
+  it('parses valid deleted friendship payload', () => {
+    expect(
+      parseDeletedFriendshipUids({ uid1: 'uid-a', uid2: 'uid-b' }),
+    ).toEqual({ uid1: 'uid-a', uid2: 'uid-b' });
+  });
+
+  it('rejects missing or malformed deleted friendship payload', () => {
+    expect(parseDeletedFriendshipUids(undefined)).toBeNull();
+    expect(parseDeletedFriendshipUids({ uid1: 'uid-a' })).toBeNull();
+    expect(parseDeletedFriendshipUids({ uid1: '', uid2: 'uid-b' })).toBeNull();
+    expect(parseDeletedFriendshipUids({ uid1: 'uid-a', uid2: 123 })).toBeNull();
+  });
+
+  it('deletes only former-friend non-Space feed entries', () => {
+    expect(
+      shouldDeleteCrossFeedEntry(
+        { authorId: 'uid-b', spaceIds: [] },
+        'uid-b',
+      ),
+    ).toBe(true);
+    expect(
+      shouldDeleteCrossFeedEntry(
+        { authorId: 'uid-b', spaceIds: ['space-1'] },
+        'uid-b',
+      ),
+    ).toBe(false);
+    expect(
+      shouldDeleteCrossFeedEntry(
+        { authorId: 'uid-c', spaceIds: [] },
+        'uid-b',
+      ),
+    ).toBe(false);
   });
 });
-
-// TODO(#92/ThienPDM): Add integration tests with Firebase emulator
-// - Test friendCount decrement for both users
-// - Test conversation status update to 'unfriended'
-// - Test cross-feed cleanup (non-Space posts only)
-// - Test Space posts preservation (spaceId != null)
-// - Test idempotency (re-run after partial failure)
-//
-// Integration tests require Firebase emulator setup:
-// 1. Start emulator: firebase emulators:start --only firestore,functions
-// 2. Use @firebase/rules-unit-testing for test setup
-// 3. Create test friendship doc → delete → verify cleanup

--- a/firebase/functions/test/friend/searchUserByUsername.test.ts
+++ b/firebase/functions/test/friend/searchUserByUsername.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildSearchUserProfile,
+  normalizeSearchUsername,
+} from '../../src/friend/searchUserByUsername.js';
+import { publicProfileSourceSchema } from '../../src/user/publicProfile.js';
+
+describe('searchUserByUsername helpers', () => {
+  it('normalizes exact username search', () => {
+    expect(normalizeSearchUsername('  ThienPDM  ')).toBe('thienpdm');
+    expect(normalizeSearchUsername('ab')).toBeNull();
+    expect(normalizeSearchUsername('invalid-name')).toBeNull();
+  });
+
+  it('builds a public search profile without private fields', () => {
+    const source = publicProfileSourceSchema.parse({
+      email: 'alice@example.com',
+      displayName: 'Alice Nguyen',
+      username: 'alice',
+      avatarUrl: null,
+      bio: 'Meep user',
+      friendCount: 10,
+      isSearchable: true,
+    });
+
+    const profile = buildSearchUserProfile('uid-alice', source, {
+      toMillis: () => 123,
+    });
+
+    expect(profile).toEqual({
+      uid: 'uid-alice',
+      displayName: 'Alice Nguyen',
+      username: 'alice',
+      avatarUrl: null,
+      bio: 'Meep user',
+      isSearchable: true,
+      updatedAtMillis: 123,
+    });
+    expect(profile).not.toHaveProperty('email');
+    expect(profile).not.toHaveProperty('friendCount');
+  });
+
+  it('returns null for users who opted out of username search', () => {
+    const source = publicProfileSourceSchema.parse({
+      displayName: 'Alice Nguyen',
+      username: 'alice',
+      isSearchable: false,
+    });
+
+    expect(buildSearchUserProfile('uid-alice', source, Date.now())).toBeNull();
+  });
+});


### PR DESCRIPTION
## Tóm tắt

PR gồm 2 mảng: (1) tìm bạn qua username bằng Cloud Function, (2) hoàn thiện tests & quality phase 2.

## Thay đổi chính

**Friend search qua Cloud Function**
- Thêm CF `searchUserByUsername`: tìm exact username qua `/usernames` collection (source of truth), fallback sang `/users` query khi doc chưa có; repair `public/profile` sau khi tìm thành công.
- `FriendRepository` gọi CF trước, fallback `public/profile` → user doc khi CF chưa deploy hoặc trả `not-found`.
- `UserRepository`: fallback đọc `/users/{uid}` khi `public/profile` chưa có.
- `main.dart`: dedup `FirebaseFunctions` instance, thêm emulator support.
- `firestore.rules`: cho phép `list /users` với `limit <= 1` (phục vụ username search).

**Profile & quality**
- `profile_screen`: fix post count drift — dùng grid count thật thay vì counter field (vốn drift được khi CF miss/race).
- Hoàn thiện kiểm thử & quality phase 2 (commit `8b5915f`).

## Test

- `searchUserByUsername.test.ts`: normalize username, build public profile (loại private fields), opt-out search.
- `profile_screen_test.dart`: cập nhật theo logic post count mới.
- Pre-commit pass: dart format, flutter analyze (No issues), ESLint.

## Lưu ý

- CF `searchUserByUsername` cần deploy trước khi client phụ thuộc hoàn toàn; hiện client vẫn fallback an toàn khi CF chưa có.

🤖 Generated with [Claude Code](https://claude.com/claude-code)